### PR TITLE
Allow registry-facade and ws-daemon to run in dedicated GPU node pools

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -8061,6 +8061,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8305,6 +8309,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -7229,6 +7229,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -7476,6 +7480,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -7878,6 +7878,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8122,6 +8126,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -8600,6 +8600,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8853,6 +8857,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7598,6 +7598,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -7842,6 +7846,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -7288,6 +7288,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -7535,6 +7539,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -8122,6 +8122,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8486,6 +8490,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -7898,6 +7898,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8142,6 +8146,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3180,6 +3180,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -3424,6 +3428,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -7881,6 +7881,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8125,6 +8129,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7878,6 +7878,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8122,6 +8126,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -7888,6 +7888,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8132,6 +8136,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -7885,6 +7885,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8129,6 +8133,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -7878,6 +7878,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8122,6 +8126,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7890,6 +7890,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8134,6 +8138,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -7881,6 +7881,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8125,6 +8129,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -8322,6 +8322,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8566,6 +8570,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -7881,6 +7881,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8125,6 +8129,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7881,6 +7881,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: registry-facade
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       volumes:
       - emptyDir: {}
         name: cache
@@ -8125,6 +8129,9 @@ spec:
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
         operator: Exists
       volumes:
       - hostPath:

--- a/install/installer/pkg/common/toleration.go
+++ b/install/installer/pkg/common/toleration.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GPUToleration() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Effect:   corev1.TaintEffectNoSchedule,
+			Key:      "nvidia.com/gpu",
+			Operator: corev1.TolerationOpExists,
+		},
+	}
+}

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -387,6 +387,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						*common.InternalCAVolume(),
 						*common.NewEmptyDirVolume("cacerts"),
 					}, volumes...),
+					Tolerations: common.GPUToleration(),
 				},
 			},
 		},


### PR DESCRIPTION
## Description

GPU support in dedicated runs in a separated node groups defined with taints to avoid scheduling workload not related to GPUs, avoiding the additional cost.

The additional tolerations in the daemonsets have no side effect with existing deployments.

## How to test
- Integration tests should pass
 
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
