### PR TITLE
[ws-manager-mk2] Remove headless field

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -116,7 +116,6 @@ type PortSpec struct {
 // WorkspaceStatus defines the observed state of Workspace
 type WorkspaceStatus struct {
 	PodStarts  int    `json:"podStarts"`
-	Headless   bool   `json:"headless"`
 	URL        string `json:"url,omitempty"`
 	OwnerToken string `json:"ownerToken,omitempty"`
 

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
@@ -501,8 +501,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              headless:
-                type: boolean
               ownerToken:
                 type: string
               phase:
@@ -538,7 +536,6 @@ spec:
               url:
                 type: string
             required:
-            - headless
             - podStarts
             type: object
         type: object

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -219,7 +219,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 	case isWorkspaceBeingDeleted(workspace) && !isPodBeingDeleted(pod):
 		return r.deleteWorkspacePod(ctx, pod, "workspace deleted")
 
-	case workspace.Status.Headless && workspace.Status.Phase == workspacev1.WorkspacePhaseStopped && !isPodBeingDeleted(pod):
+	case workspace.IsHeadless() && workspace.Status.Phase == workspacev1.WorkspacePhaseStopped && !isPodBeingDeleted(pod):
 		// Workspace was requested to be deleted, propagate by deleting the Pod.
 		// The Pod deletion will then trigger workspace disposal steps.
 		err := r.Client.Delete(ctx, pod)


### PR DESCRIPTION
## Description
Finalise cleanup of headless field in status. Replaced by `workspace.IsHeadless()`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
