### PR TITLE
Adding a company size question to new user onboarding flow

### DIFF
--- a/components/dashboard/src/onboarding/company-size.ts
+++ b/components/dashboard/src/onboarding/company-size.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export const getCompanySizeOptions = () => {
+    return [
+        { label: "Please select one", value: "" },
+        { label: "less than 50", value: "less_than_50" },
+        { label: "51 - 250", value: "51_to_250" },
+        { label: "251 - 1000", value: "251_to_1000" },
+        { label: "more than 1000", value: "more_than_1000" },
+    ];
+};

--- a/components/dashboard/src/onboarding/exploration-reasons.ts
+++ b/components/dashboard/src/onboarding/exploration-reasons.ts
@@ -3,10 +3,11 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
+export const EXPLORE_REASON_WORK = "explore-professional";
 
 export const getExplorationReasons = () => {
     return [
-        { value: "explore-professional", label: "For work" },
+        { value: EXPLORE_REASON_WORK, label: "For work" },
         { value: "explore-personal", label: "For personal projects or open-source" },
         {
             value: "replace-remote-dev",

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -201,7 +201,7 @@ export namespace User {
 
     // TODO: refactor where this is referenced so it's more clearly tied to just analytics-tracking
     // Let other places rely on the ProfileDetails type since that's what we store
-    // The actual Profile of a User
+    // This is the profile data we send to our Segment analytics tracking pipeline
     export interface Profile {
         name: string;
         email: string;
@@ -214,6 +214,7 @@ export namespace User {
         signupGoals?: string[];
         signupGoalsOther?: string;
         onboardedTimestamp?: string;
+        companySize?: string;
     }
     export namespace Profile {
         export function hasChanges(before: Profile, after: Profile) {
@@ -227,7 +228,8 @@ export namespace User {
                 before.jobRoleOther !== after.jobRoleOther ||
                 // not checking explorationReasons or signupGoals atm as it's an array - need to check deep equality
                 before.signupGoalsOther !== after.signupGoalsOther ||
-                before.onboardedTimestamp !== after.onboardedTimestamp
+                before.onboardedTimestamp !== after.onboardedTimestamp ||
+                before.companySize !== after.companySize
             );
         }
     }
@@ -292,6 +294,8 @@ export interface ProfileDetails {
     signupGoalsOther?: string;
     // Set after a user completes the onboarding flow
     onboardedTimestamp?: string;
+    // Onboarding question about a user's company size
+    companySize?: string;
 }
 
 export interface EmailNotificationSettings {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -167,6 +167,7 @@ export namespace User {
             explorationReasons: user?.additionalData?.profile?.explorationReasons,
             signupGoals: user?.additionalData?.profile?.signupGoals,
             signupGoalsOther: user?.additionalData?.profile?.signupGoalsOther,
+            companySize: user?.additionalData?.profile?.companySize,
             onboardedTimestamp: user?.additionalData?.profile?.onboardedTimestamp,
         };
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adding a `Company Size` question to the onboarding flow when a user selects their exploring `For work`.

* Adds `companySize` to user profile that we save, and send to Segment.

| overview | options |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/367275/221991819-ffe8479b-5abf-4526-9187-937c618dc151.png) | ![image](https://user-images.githubusercontent.com/367275/221991867-9cf514d8-1a60-46fd-8a50-195958329131.png)

## How to test
<!-- Provide steps to test this PR -->
* Go through the onboarding flow: `https://<tbd>.preview.gitpod-dev.com/workspaces`
* On Step 3, select "I'm exploring Gitpod" "For work"
* Ensure the Company size field shows up. You should not be able to submit w/o a value here if you select "For Work"
* Select a value
* Hit Continue
* You can verify your selection persisted by forcing the onboarding flow again - `https://<tbd>.preview.gitpod-dev.com/workspaces?onboarding=force`
* On step 3, it should have your company size value prefilled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] /werft analytics=segment