### PR TITLE
Making top nav menu responsive

### DIFF
--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect } from "react";
 import { useLocation } from "react-router";
-import Separator from "./Separator";
+import { Separator } from "./Separator";
 import TabMenuItem from "./TabMenuItem";
 
 export interface HeaderProps {

--- a/components/dashboard/src/components/Separator.tsx
+++ b/components/dashboard/src/components/Separator.tsx
@@ -4,6 +4,16 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-export default function Separator() {
-    return <div className="border-gray-200 dark:border-gray-800 border-b absolute left-0 w-full"></div>;
-}
+import classNames from "classnames";
+import { FC } from "react";
+
+type Props = {
+    className?: string;
+};
+export const Separator: FC<Props> = ({ className }) => {
+    return (
+        <div
+            className={classNames("border-gray-200 dark:border-gray-800 border-b absolute left-0 w-full", className)}
+        />
+    );
+};

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -35,7 +35,7 @@
     }
 
     .app-container {
-        @apply lg:px-28 px-10;
+        @apply lg:px-28 px-4;
     }
     .btn-login {
         @apply rounded-md border-none bg-gray-100 hover:bg-gray-200 text-gray-500 dark:text-gray-200 dark:bg-gray-800 dark:hover:bg-gray-600;

--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -5,7 +5,7 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import { useContext, useEffect, useState } from "react";
+import { FC, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useLocation } from "react-router";
 import { Location } from "history";
@@ -13,14 +13,15 @@ import { countries } from "countries-list";
 import gitpodIcon from "../icons/gitpod.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
-import ContextMenu from "../components/ContextMenu";
-import Separator from "../components/Separator";
+import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
+import { Separator } from "../components/Separator";
 import PillMenuItem from "../components/PillMenuItem";
 import { PaymentContext } from "../payment-context";
 import FeedbackFormModal from "../feedback-form/FeedbackModal";
 import { isGitpodIo } from "../utils";
 import OrganizationSelector from "./OrganizationSelector";
 import { getAdminTabs } from "../admin/admin.routes";
+import classNames from "classnames";
 
 interface Entry {
     title: string;
@@ -34,12 +35,6 @@ export default function Menu() {
     const { setCurrency, setIsStudent, setIsChargebeeCustomer } = useContext(PaymentContext);
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
-    function isSelected(entry: Entry, location: Location<any>) {
-        const all = [entry.link, ...(entry.alternatives || [])].map((l) => l.toLowerCase());
-        const path = location.pathname.toLowerCase();
-        return all.some((n) => n === path || n + "/" === path);
-    }
-
     useEffect(() => {
         const { server } = getGitpodService();
         Promise.all([
@@ -52,64 +47,49 @@ export default function Menu() {
         ]).then((setters) => setters.forEach((s) => s()));
     }, [setCurrency, setIsChargebeeCustomer, setIsStudent]);
 
-    const leftMenu: Entry[] = [
-        {
-            title: "Workspaces",
-            link: "/workspaces",
-            alternatives: ["/"],
-        },
-        {
-            title: "Projects",
-            link: `/projects`,
-            alternatives: [] as string[],
-        },
-    ];
+    const adminMenu: Entry = useMemo(
+        () => ({
+            title: "Admin",
+            link: "/admin",
+            alternatives: [
+                ...getAdminTabs().reduce(
+                    (prevEntry, currEntry) =>
+                        currEntry.alternatives
+                            ? [...prevEntry, ...currEntry.alternatives, currEntry.link]
+                            : [...prevEntry, currEntry.link],
+                    [] as string[],
+                ),
+            ],
+        }),
+        [],
+    );
 
-    const adminMenu: Entry = {
-        title: "Admin",
-        link: "/admin",
-        alternatives: [
-            ...getAdminTabs().reduce(
-                (prevEntry, currEntry) =>
-                    currEntry.alternatives
-                        ? [...prevEntry, ...currEntry.alternatives, currEntry.link]
-                        : [...prevEntry, currEntry.link],
-                [] as string[],
-            ),
-        ],
-    };
-
-    const handleFeedbackFormClick = () => {
+    const handleFeedbackFormClick = useCallback(() => {
         setFeedbackFormVisible(true);
-    };
+    }, []);
 
-    const onFeedbackFormClose = () => {
+    const onFeedbackFormClose = useCallback(() => {
         setFeedbackFormVisible(false);
-    };
+    }, []);
 
     return (
         <>
-            <header className="app-container flex flex-col pt-4 space-y-4" data-analytics='{"button_type":"menu"}'>
-                <div className="flex h-10 mb-3">
-                    <div className="flex justify-between items-center pr-3">
-                        <Link to="/" className="pr-3 w-10">
+            <header className="app-container flex flex-col pt-4" data-analytics='{"button_type":"menu"}'>
+                <div className="flex justify-between h-10 mb-3 w-full">
+                    <div className="flex items-center">
+                        {/* hidden on smaller screens */}
+                        <Link to="/" className="hidden md:inline pr-3 w-10">
                             <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
                         </Link>
                         <OrganizationSelector />
-                        <div className="pl-2 text-base text-gray-500 dark:text-gray-400 flex max-w-lg overflow-hidden">
-                            {leftMenu.map((entry) => (
-                                <div className="p-1" key={entry.title}>
-                                    <PillMenuItem
-                                        name={entry.title}
-                                        selected={isSelected(entry, location)}
-                                        link={entry.link}
-                                    />
-                                </div>
-                            ))}
+                        {/* hidden on smaller screens (in it's own menu below on smaller screens) */}
+                        <div className="hidden md:block pl-2">
+                            <OrgPagesNav />
                         </div>
                     </div>
-                    <div className="flex-1 flex items-center w-auto" id="menu">
-                        <nav className="flex-1">
+                    <div className="flex items-center w-auto" id="menu">
+                        {/* hidden on smaller screens - TODO: move to user menu on smaller screen */}
+                        <nav className="hidden md:block flex-1">
                             <ul className="flex flex-1 items-center justify-between text-base text-gray-500 dark:text-gray-400 space-x-2">
                                 <li className="flex-1"></li>
                                 {user?.rolesOrPermissions?.includes("admin") && (
@@ -128,52 +108,146 @@ export default function Menu() {
                                 )}
                             </ul>
                         </nav>
-                        <div
-                            className="ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium flex-shrink-0"
-                            data-analytics='{"label":"Account"}'
-                        >
-                            <ContextMenu
-                                menuEntries={[
-                                    {
-                                        title: (user && (User.getPrimaryEmail(user) || user?.name)) || "User",
-                                        customFontStyle: "text-gray-400",
-                                        separator: true,
-                                    },
-                                    {
-                                        title: "User Settings",
-                                        link: "/user/settings",
-                                    },
-                                    {
-                                        title: "Docs",
-                                        href: "https://www.gitpod.io/docs/",
-                                        target: "_blank",
-                                        rel: "noreferrer",
-                                    },
-                                    {
-                                        title: "Help",
-                                        href: "https://www.gitpod.io/support/",
-                                        target: "_blank",
-                                        rel: "noreferrer",
-                                        separator: true,
-                                    },
-                                    {
-                                        title: "Logout",
-                                        href: gitpodHostUrl.asApiLogout().toString(),
-                                    },
-                                ]}
-                            >
-                                <img
-                                    className="rounded-full w-6 h-6"
-                                    src={user?.avatarUrl || ""}
-                                    alt={user?.name || "Anonymous"}
-                                />
-                            </ContextMenu>
-                        </div>
+                        {/* Hide normal user menu on small screens */}
+                        <UserMenu user={user} className="hidden md:block" />
+                        {/* Show a user menu w/ admin & feedback links on small screens */}
+                        <UserMenu
+                            user={user}
+                            className="md:hidden"
+                            withAdminLink
+                            withFeedbackLink
+                            onFeedback={handleFeedbackFormClick}
+                        />
                     </div>
                     {isFeedbackFormVisible && <FeedbackFormModal onClose={onFeedbackFormClose} />}
                 </div>
             </header>
             <Separator />
+            {/* only shown on small screens */}
+            <OrgPagesNav className="md:hidden app-container flex justify-start py-2" />
+            {/* only shown on small screens */}
+            <Separator className="md:hidden" />
         </>
     );
+}
+
+type OrgPagesNavProps = {
+    className?: string;
+};
+const OrgPagesNav: FC<OrgPagesNavProps> = ({ className }) => {
+    const location = useLocation();
+
+    const leftMenu: Entry[] = useMemo(
+        () => [
+            {
+                title: "Workspaces",
+                link: "/workspaces",
+                alternatives: ["/"],
+            },
+            {
+                title: "Projects",
+                link: `/projects`,
+                alternatives: [] as string[],
+            },
+        ],
+        [],
+    );
+
+    return (
+        <div
+            className={classNames(
+                "text-base text-gray-500 dark:text-gray-400 flex items-center space-x-1 py-1",
+                className,
+            )}
+        >
+            {leftMenu.map((entry) => (
+                <div key={entry.title}>
+                    <PillMenuItem name={entry.title} selected={isSelected(entry, location)} link={entry.link} />
+                </div>
+            ))}
+        </div>
+    );
+};
+
+type UserMenuProps = {
+    user?: User;
+    className?: string;
+    withAdminLink?: boolean;
+    withFeedbackLink?: boolean;
+    onFeedback?: () => void;
+};
+const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, withFeedbackLink, onFeedback }) => {
+    const extraSection = useMemo(() => {
+        const items: ContextMenuEntry[] = [];
+
+        if (withAdminLink && user?.rolesOrPermissions?.includes("admin")) {
+            items.push({
+                title: "Admin",
+                link: "/admin",
+            });
+        }
+        if (withFeedbackLink && isGitpodIo()) {
+            items.push({
+                title: "Feedback",
+                onClick: onFeedback,
+            });
+        }
+
+        // Add a separator to the last item
+        if (items.length > 0) {
+            items[items.length - 1].separator = true;
+        }
+
+        return items;
+    }, [onFeedback, user?.rolesOrPermissions, withAdminLink, withFeedbackLink]);
+
+    return (
+        <div
+            className={classNames(
+                "ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium flex-shrink-0",
+                className,
+            )}
+            data-analytics='{"label":"Account"}'
+        >
+            <ContextMenu
+                menuEntries={[
+                    {
+                        title: (user && (User.getPrimaryEmail(user) || user?.name)) || "User",
+                        customFontStyle: "text-gray-400",
+                        separator: true,
+                    },
+                    {
+                        title: "User Settings",
+                        link: "/user/settings",
+                    },
+                    {
+                        title: "Docs",
+                        href: "https://www.gitpod.io/docs/",
+                        target: "_blank",
+                        rel: "noreferrer",
+                    },
+                    {
+                        title: "Help",
+                        href: "https://www.gitpod.io/support/",
+                        target: "_blank",
+                        rel: "noreferrer",
+                        separator: true,
+                    },
+                    ...extraSection,
+                    {
+                        title: "Logout",
+                        href: gitpodHostUrl.asApiLogout().toString(),
+                    },
+                ]}
+            >
+                <img className="rounded-full w-8 h-8" src={user?.avatarUrl || ""} alt={user?.name || "Anonymous"} />
+            </ContextMenu>
+        </div>
+    );
+};
+
+function isSelected(entry: Entry, location: Location<any>) {
+    const all = [entry.link, ...(entry.alternatives || [])].map((l) => l.toLowerCase());
+    const path = location.pathname.toLowerCase();
+    return all.some((n) => n === path || n + "/" === path);
 }

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -7,7 +7,7 @@
 import { User } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useContext, useState } from "react";
 import gitpodIcon from "../icons/gitpod.svg";
-import Separator from "../components/Separator";
+import { Separator } from "../components/Separator";
 import { useHistory, useLocation } from "react-router";
 import { StepUserInfo } from "./StepUserInfo";
 import { UserContext } from "../user-context";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This makes some updates to the top nav menu so it's more responsive, stems from a discussion @gtsiolis and I had about improving responsiveness. Main changes are:

### For smaller screens
* Gitpod Logo Hidden - Done to reduce the visual elements in the header for mobile. We probably have room for it if we want to keep it though.
* `Workspaces | Projects` menu items shifted down to their own row
* `Admin | Feedback` links moved into User Menu

| a | b |
|--|--|
| ![image](https://user-images.githubusercontent.com/367275/222014013-59a2a186-448e-4791-b860-75cceff9cce2.png) | ![image](https://user-images.githubusercontent.com/367275/222014076-bbe990f9-350f-4955-bea2-ee34a1fce036.png) |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #4050

## How to test
<!-- Provide steps to test this PR -->
* https://bmh-respon75dad9d5f5.preview.gitpod-dev.com/workspaces
* Load the preview in your browser, try adjust various viewports to see them.
* Bonus points for loading it on your phone

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
