### PR TITLE
[supervisor] instance update fatal if no permission

### DIFF
--- a/components/supervisor/pkg/serverapi/publicapi.go
+++ b/components/supervisor/pkg/serverapi/publicapi.go
@@ -293,6 +293,10 @@ func (s *Service) onInstanceUpdates(ctx context.Context) {
 				if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
 					continue
 				}
+				code := status.Code(err)
+				if code == codes.PermissionDenied {
+					log.WithError(err).Fatalf("failed to on instance update: have no permission")
+				}
 				log.WithField("method", "InstanceUpdates").WithError(err).Error("failed to listen")
 				cancel()
 				time.Sleep(time.Second * 2)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See [grafana](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28grpc_client_handled_total%7Bgrpc_code%3D%5C%22PermissionDenied%5C%22,%20job%3D%5C%22ide-metrics%5C%22%7D%29%20by%20%28grpc_code,%20grpc_method%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D)

Those three increase are caused by three different workspaces. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Find no way to test, we can approve to see if grafana goes well

[gcp log](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-02-28T08:35:09.765987024Z;query=resource.labels.container_name%3D%22workspace%22%0A%22failed%20to%20listen%22;timeRange=2023-02-28T08:26:37.987Z%2F2023-02-28T08:35:37.987Z?project=workspace-clusters)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
