### PR TITLE
[ws-manager-mk2] Fix race where pod gets recreated in Stopped phase

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -708,9 +708,6 @@ func newStartWorkspaceContext(ctx context.Context, cfg *config.Configuration, ws
 	span, _ := tracing.FromContext(ctx, "newStartWorkspaceContext")
 	defer tracing.FinishSpan(span, &err)
 
-	// Can't read ws.Status yet at this point (to e.g. get the headless status),
-	// as it very likely hasn't been set yet by the controller.
-	isHeadless := ws.Spec.Type != workspacev1.WorkspaceTypeRegular
 	return &startWorkspaceContext{
 		Labels: map[string]string{
 			"app":                  "gitpod",
@@ -720,13 +717,13 @@ func newStartWorkspaceContext(ctx context.Context, cfg *config.Configuration, ws
 			wsk8s.OwnerLabel:       ws.Spec.Ownership.Owner,
 			wsk8s.TypeLabel:        strings.ToLower(string(ws.Spec.Type)),
 			instanceIDLabel:        ws.Name,
-			headlessLabel:          strconv.FormatBool(isHeadless),
+			headlessLabel:          strconv.FormatBool(ws.IsHeadless()),
 		},
 		Config:         cfg,
 		Workspace:      ws,
 		IDEPort:        23000,
 		SupervisorPort: 22999,
-		Headless:       isHeadless,
+		Headless:       ws.IsHeadless(),
 	}, nil
 }
 

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -150,9 +150,11 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 				return ctrl.Result{}, err
 			}
 
+			log.Info("creating workspace Pod for Workspace")
 			err = r.Create(ctx, pod)
 			if errors.IsAlreadyExists(err) {
 				// pod exists, we're good
+				log.Info("Workspace Pod already exists")
 			} else if err != nil {
 				log.Error(err, "unable to create Pod for Workspace", "pod", pod)
 				return ctrl.Result{Requeue: true}, err

--- a/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
+++ b/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
@@ -3485,7 +3485,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 37,
   "style": "dark",
   "tags": [
@@ -3497,10 +3497,10 @@
         "current": {
           "selected": true,
           "text": [
-            "ephemeral-wv"
+            "All"
           ],
           "value": [
-            "ephemeral-wv"
+            "$__all"
           ]
         },
         "datasource": {


### PR DESCRIPTION
## Description

Fixes an issue where, if the controller fails to increment and store `workspace.Status.PodStarts` upon creating the Pod (e.g. due to a conflict), the workspace will briefly re-create the Pod in the Stopped phase (as it believes the Pod hadn't been created yet).

Was caught by the metric tests failing in https://github.com/gitpod-io/gitpod/actions/runs/4302950638/jobs/7502085462, and reproduced locally by not incrementing PodStarts.

Fixed by retrying the PodStarts update on conflict

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #16247 

## How to test
<!-- Provide steps to test this PR -->

Run ws-manager-mk2 unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
