### PR TITLE
Updating company size labels

### DIFF
--- a/components/dashboard/src/onboarding/StepOrgInfo.tsx
+++ b/components/dashboard/src/onboarding/StepOrgInfo.tsx
@@ -210,7 +210,7 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
             {explorationReasons.includes(EXPLORE_REASON_WORK) && (
                 <SelectInputField
                     value={companySize}
-                    label="How large is your engineering team?"
+                    label="How large is your engineering organization?"
                     onChange={setCompanySize}
                     error={companySizeError.message}
                     onBlur={companySizeError.onBlur}

--- a/components/dashboard/src/onboarding/StepOrgInfo.tsx
+++ b/components/dashboard/src/onboarding/StepOrgInfo.tsx
@@ -210,7 +210,7 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
             {explorationReasons.includes(EXPLORE_REASON_WORK) && (
                 <SelectInputField
                     value={companySize}
-                    label="Company size"
+                    label="How large is your engineering team?"
                     onChange={setCompanySize}
                     error={companySizeError.message}
                     onBlur={companySizeError.onBlur}

--- a/components/dashboard/src/onboarding/company-size.ts
+++ b/components/dashboard/src/onboarding/company-size.ts
@@ -7,9 +7,9 @@
 export const getCompanySizeOptions = () => {
     return [
         { label: "Please select one", value: "" },
-        { label: "less than 50", value: "less_than_50" },
-        { label: "51 - 250", value: "51_to_250" },
-        { label: "251 - 1000", value: "251_to_1000" },
-        { label: "more than 1000", value: "more_than_1000" },
+        { label: "1-50", value: "1_to_50" },
+        { label: "51-250", value: "51_to_250" },
+        { label: "251-1000", value: "251_to_1000" },
+        { label: "1000+", value: "more_than_1000" },
     ];
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the onboarding company size labels.

* Biggest callout, I noticed our label for `less than 50` was wrong, as it reads that it excludes 50. Rather than lengthen it to `less than or equal to 50`, figured I'd simplify the option labels some. I did opt to correct the value for that first option so it isn't incorrect as well, but this will mean a slight change in the value we're sending from the ~ 24 hours it was live where it equaled `less_than_50`, now it will be `1_to_50`

![image](https://user-images.githubusercontent.com/367275/222248073-ff08ee95-8ab7-42b6-8abf-a234478fd185.png)
![image](https://user-images.githubusercontent.com/367275/222248145-85317dc0-18dc-46a5-991b-fecfc2a29c79.png)


## How to test
<!-- Provide steps to test this PR -->
* https://bmh-companb28805c983.preview.gitpod-dev.com/workspaces?onboarding=force
* Check onboarding flow on preview environment, 
* Select `For work` for the `I'm exploring Gitpod...` question
* Ensure Company Size labels are updated

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
