### PR TITLE
Pull project from useCurrentProject()

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -12,7 +12,7 @@ import { getGitpodService } from "../service/service";
 import { useCurrentTeam } from "../teams/teams-context";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
-import { ProjectContext } from "./project-context";
+import { ProjectContext, useCurrentProject } from "./project-context";
 import SelectWorkspaceClass from "../user-settings/selectClass";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import Alert from "../components/Alert";
@@ -24,7 +24,7 @@ export function ProjectSettingsPage(props: { project?: Project; children?: React
     return (
         <PageWithSubMenu
             subMenu={getProjectSettingsMenu(props.project)}
-            title={props.project?.name || "Unknown project"}
+            title={props.project?.name || "Loading..."}
             subtitle="Manage project settings and configuration"
             tabs={getProjectTabs(props.project)}
         >
@@ -34,7 +34,8 @@ export function ProjectSettingsPage(props: { project?: Project; children?: React
 }
 
 export default function ProjectSettingsView() {
-    const { project, setProject } = useContext(ProjectContext);
+    const { setProject } = useContext(ProjectContext);
+    const { project } = useCurrentProject();
     const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
     const [showRemoveModal, setShowRemoveModal] = useState(false);
     const team = useCurrentTeam();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a bug where Project Settings doesn't load sometimes. If you hard refresh the Project Settings page you would get a mostly white page, discovered in #16540. The bug was due to this page needing to use a new hook for finding the project vs. having it in context already.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #16540

## How to test
<!-- Provide steps to test this PR -->
* https://bmh-projec87461fc221.preview.gitpod-dev.com/workspaces
* Create a project.
* Navigate to the Project Settings page.
* Hard refresh the page. It should load correctly now.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed a bug where the Project Settings page sometimes wouldn't load correctly.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
