### PR TITLE
[server] Only show notifications for not-cancelled subscriptions

### DIFF
--- a/components/gitpod-protocol/src/team-subscription-protocol.ts
+++ b/components/gitpod-protocol/src/team-subscription-protocol.ts
@@ -31,6 +31,9 @@ export namespace TeamSubscription {
     export const isActive = (ts: TeamSubscription, date: string): boolean => {
         return ts.startDate <= date && (ts.endDate === undefined || date < ts.endDate);
     };
+    export function isCancelled(s: TeamSubscription, date: string): boolean {
+        return (!!s.cancellationDate && s.cancellationDate < date) || (!!s.endDate && s.endDate < date); // This edge case is meant to handle bad data: If for whatever reason cancellationDate has not been set: treat endDate as such
+    }
 }
 
 export interface TeamSubscription2 {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2516,13 +2516,20 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const cbSubscriptions = await this.subscriptionService.getActivePaidSubscription(user.id, now);
         // Personal subscription
         const cbPersonalSubscriptions = cbSubscriptions.filter(
-            (s) => Plans.isPersonalPlan(s.planId) && !Plans.isFreePlan(s.planId),
+            (s) =>
+                Plans.isPersonalPlan(s.planId) &&
+                !Plans.isFreePlan(s.planId) &&
+                !Subscription.isCancelled(s, now.toISOString()), // We only care about existing, active, not-yet-cancelled subs
         );
 
         // Old "Team Subscription"
         const cbOwnedTeamSubscriptions = (
             await this.teamSubscriptionDB.findTeamSubscriptions({ userId: user.id })
-        ).filter((ts) => TeamSubscription.isActive(ts, now.toISOString()));
+        ).filter(
+            (ts) =>
+                TeamSubscription.isActive(ts, now.toISOString()) &&
+                !TeamSubscription.isCancelled(ts, now.toISOString()),
+        );
 
         // "Team Subscription 2" (already attached to an Organization)
         const cbOwnedTeamSubscriptions2 = [];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
