### PR TITLE
[server] Log empty origin header in debug, attach origin to other log

### DIFF
--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -24,7 +24,7 @@ export const query = (...tuples: [string, string][]) => {
 export const isAllowedWebsocketDomain = (originHeader: string, gitpodHostName: string, strict: boolean): boolean => {
     if (!originHeader) {
         // TODO(gpl) Can we get rid of this dependency alltogether?
-        log.warn("Origin header check not applied because of empty Origin header!");
+        log.debug("Origin header check not applied because of empty Origin header!");
         return true;
     }
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -177,7 +177,9 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 if (info.req.url === "/v1") {
                     // Connection attempt with Bearer-Token: be less strict for now
                     if (!verifyOrigin(info.origin, false)) {
-                        log.warn("Websocket connection attempt with non-matching Origin header: " + info.origin);
+                        log.warn("Websocket connection attempt with non-matching Origin header.", {
+                            origin: info.origin,
+                        });
                         return callback(false, 403);
                     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The follow logs are always logged in pairs. We reduce the verbosity of one, and attach the origin as structured data on the log.
```
Origin header check not applied because of empty Origin header! 
Websocket connection attempt with non-matching Origin header: ...
```

There are [4.5M occurrences of the former](https://console.cloud.google.com/errors?referrer=search&project=gitpod-191109)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
