### PR TITLE
[prebuild] Log github app user errors as info

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -38,7 +38,8 @@ import { asyncHandler } from "../../../src/express-util";
 import { ContextParser } from "../../../src/workspace/context-parser-service";
 import { HostContextProvider } from "../../../src/auth/host-context-provider";
 import { RepoURL } from "../../../src/repohost";
-import { ErrorCodes, ResponseError } from "vscode-ws-jsonrpc";
+import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 /**
  * GitHub app urls:

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -38,6 +38,7 @@ import { asyncHandler } from "../../../src/express-util";
 import { ContextParser } from "../../../src/workspace/context-parser-service";
 import { HostContextProvider } from "../../../src/auth/host-context-provider";
 import { RepoURL } from "../../../src/repohost";
+import { ErrorCodes, ResponseError } from "vscode-ws-jsonrpc";
 
 /**
  * GitHub app urls:
@@ -674,7 +675,14 @@ export class GithubApp {
 }
 
 function catchError<R>(p: Promise<R>): void {
-    p.catch((err) => log.warn("Failed to handle github event", err));
+    p.catch((err) => {
+        let logger = log.error;
+        if (err instanceof ResponseError) {
+            logger = ErrorCodes.isUserError(err.code) ? log.info : log.error;
+        }
+
+        logger("Failed to handle github event", err);
+    });
 }
 
 export namespace GithubApp {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Avoid logging prebuild errors which are caused by legacy prebuild setup as errors

[See errors here](https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%20:%20%2528%22server%22%2529%0A%22Running%20prebuilds%20without%20a%20project%20is%20no%20longer%20supported.%22;timeRange=PT1H;cursorTimestamp=2023-03-02T11:03:31.770Z?authuser=0&project=gitpod-191109)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
