### PR TITLE
Report ErrorBoundary from Dashboard

### DIFF
--- a/components/dashboard/src/components/ErrorBoundary.tsx
+++ b/components/dashboard/src/components/ErrorBoundary.tsx
@@ -7,6 +7,7 @@
 import { FC } from "react";
 import { ErrorBoundary, FallbackProps, ErrorBoundaryProps } from "react-error-boundary";
 import gitpodIcon from "../icons/gitpod.svg";
+import { getGitpodService } from "../service/service";
 
 export const GitpodErrorBoundary: FC = ({ children }) => {
     return (
@@ -43,8 +44,11 @@ export const handleReset: ErrorBoundaryProps["onReset"] = () => {
     window.location.reload();
 };
 
-export const handleError: ErrorBoundaryProps["onError"] = (error, info) => {
-    // TODO: send metric for error boundary event
-    console.error(error);
-    console.info(info);
+export const handleError: ErrorBoundaryProps["onError"] = async (error, info) => {
+    const url = window.location.toString();
+    try {
+        await getGitpodService().server.reportErrorBoundary(url, error.message);
+    } catch (e) {
+        console.error(e);
+    }
 };

--- a/components/dashboard/src/components/ErrorBoundary.tsx
+++ b/components/dashboard/src/components/ErrorBoundary.tsx
@@ -35,7 +35,7 @@ export const DefaultErrorFallback: FC<FallbackProps> = ({ error, resetErrorBound
             <div>
                 <button onClick={resetErrorBoundary}>Reload</button>
             </div>
-            <pre>{error.message}</pre>
+            {error.message && <pre>{error.message}</pre>}
         </div>
     );
 };
@@ -47,7 +47,7 @@ export const handleReset: ErrorBoundaryProps["onReset"] = () => {
 export const handleError: ErrorBoundaryProps["onError"] = async (error, info) => {
     const url = window.location.toString();
     try {
-        await getGitpodService().server.reportErrorBoundary(url, error.message);
+        await getGitpodService().server.reportErrorBoundary(url, error.message || "Unknown Error");
     } catch (e) {
         console.error(e);
     }

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -84,6 +84,7 @@ const WorkspacesPage: FunctionComponent = () => {
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
+
             {deleteModalVisible && (
                 <ConfirmationModal
                     title="Delete Inactive Workspaces"

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -20,7 +20,6 @@ import { WorkspacesSearchBar } from "./WorkspacesSearchBar";
 import { hoursBefore, isDateSmallerOrEqual } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { useDeleteInactiveWorkspacesMutation } from "../data/workspaces/delete-inactive-workspaces-mutation";
 import { useFeatureFlags } from "../contexts/FeatureFlagContext";
-import { Button } from "../components/Button";
 
 const WorkspacesPage: FunctionComponent = () => {
     const user = useCurrentUser();
@@ -32,7 +31,6 @@ const WorkspacesPage: FunctionComponent = () => {
     const isOnboardingUser = useMemo(() => user && User.isOnboardingUser(user), [user]);
     const deleteInactiveWorkspaces = useDeleteInactiveWorkspacesMutation();
     const { newSignupFlow } = useFeatureFlags();
-    const [error, setError] = useState(false);
 
     // Sort workspaces into active/inactive groups
     const { activeWorkspaces, inactiveWorkspaces } = useMemo(() => {
@@ -83,14 +81,9 @@ const WorkspacesPage: FunctionComponent = () => {
         setDeleteModalVisible(false);
     }, [deleteInactiveWorkspaces, inactiveWorkspaces]);
 
-    if (error) {
-        throw new Error();
-    }
-
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
-            <Button onClick={() => setError(true)}>Boom</Button>
             {deleteModalVisible && (
                 <ConfirmationModal
                     title="Delete Inactive Workspaces"

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -20,6 +20,7 @@ import { WorkspacesSearchBar } from "./WorkspacesSearchBar";
 import { hoursBefore, isDateSmallerOrEqual } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { useDeleteInactiveWorkspacesMutation } from "../data/workspaces/delete-inactive-workspaces-mutation";
 import { useFeatureFlags } from "../contexts/FeatureFlagContext";
+import { Button } from "../components/Button";
 
 const WorkspacesPage: FunctionComponent = () => {
     const user = useCurrentUser();
@@ -31,6 +32,7 @@ const WorkspacesPage: FunctionComponent = () => {
     const isOnboardingUser = useMemo(() => user && User.isOnboardingUser(user), [user]);
     const deleteInactiveWorkspaces = useDeleteInactiveWorkspacesMutation();
     const { newSignupFlow } = useFeatureFlags();
+    const [error, setError] = useState(false);
 
     // Sort workspaces into active/inactive groups
     const { activeWorkspaces, inactiveWorkspaces } = useMemo(() => {
@@ -81,10 +83,14 @@ const WorkspacesPage: FunctionComponent = () => {
         setDeleteModalVisible(false);
     }, [deleteInactiveWorkspaces, inactiveWorkspaces]);
 
+    if (error) {
+        throw new Error();
+    }
+
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
-
+            <Button onClick={() => setError(true)}>Boom</Button>
             {deleteModalVisible && (
                 <ConfirmationModal
                     title="Delete Inactive Workspaces"

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -314,6 +314,11 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      */
     getNotifications(): Promise<AppNotification[]>;
 
+    /**
+     * Frontend metrics
+     */
+    reportErrorBoundary(url: string, message: string): Promise<void>;
+
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
     maySetTimeout(): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -236,8 +236,8 @@ const defaultFunctions: FunctionsConfig = {
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
     maySetTimeout: { group: "default", points: 1 },
     updateWorkspaceTimeoutSetting: { group: "default", points: 1 },
-
     getIDToken: { group: "default", points: 1 },
+    reportErrorBoundary: { group: "default", points: 1 },
 };
 
 function getConfig(config: RateLimiterConfig): RateLimiterConfig {

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -24,6 +24,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(imageBuildsCompletedTotal);
     registry.registerMetric(centralizedPermissionsValidationsTotal);
     registry.registerMetric(spicedbClientLatency);
+    registry.registerMetric(dashboardErrorBoundary);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -229,11 +230,8 @@ export function observespicedbClientLatency(
 export const dashboardErrorBoundary = new prometheusClient.Counter({
     name: "gitpod_dashboard_error_boundary_total",
     help: "Total number of errors caught by an error boundary in the dashboard",
-    labelNames: ["url"],
 });
 
-export function increaseDashboardErrorBoundaryCounter(url: string) {
-    dashboardErrorBoundary.inc({
-        url,
-    });
+export function increaseDashboardErrorBoundaryCounter() {
+    dashboardErrorBoundary.inc();
 }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -225,3 +225,15 @@ export function observespicedbClientLatency(
         durationInSeconds,
     );
 }
+
+export const dashboardErrorBoundary = new prometheusClient.Counter({
+    name: "gitpod_dashboard_error_boundary_total",
+    help: "Total number of errors caught by an error boundary in the dashboard",
+    labelNames: ["url"],
+});
+
+export function increaseDashboardErrorBoundaryCounter(url: string) {
+    dashboardErrorBoundary.inc({
+        url,
+    });
+}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -203,7 +203,7 @@ import {
     WriteOrganizationMembers,
     WriteOrganizationMetadata,
 } from "../authorization/checks";
-import { reportCentralizedPermsValidation } from "../prometheus-metrics";
+import { increaseDashboardErrorBoundaryCounter, reportCentralizedPermsValidation } from "../prometheus-metrics";
 import { RegionService } from "./region-service";
 import { isWorkspaceRegion, WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { EnvVarService } from "./env-var-service";
@@ -3598,6 +3598,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getNotifications(ctx: TraceContext): Promise<AppNotification[]> {
         this.checkAndBlockUser("getNotifications");
         return [];
+    }
+
+    async reportErrorBoundary(ctx: TraceContextWithSpan, url: string, message: string): Promise<void> {
+        log.info("dashboard error boundary", { message, url, userId: this.user?.id });
+        increaseDashboardErrorBoundaryCounter(url);
     }
 
     protected mapGrpcError(err: Error): Error {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3601,8 +3601,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async reportErrorBoundary(ctx: TraceContextWithSpan, url: string, message: string): Promise<void> {
-        log.info("dashboard error boundary", { message, url, userId: this.user?.id });
-        increaseDashboardErrorBoundaryCounter(url);
+        // Cap message and url length so the entries aren't of unbounded length
+        log.warn("dashboard error boundary", {
+            message: (message || "").substring(0, 200),
+            url: (url || "").substring(0, 200),
+            userId: this.user?.id,
+        });
+        increaseDashboardErrorBoundaryCounter();
     }
 
     protected mapGrpcError(err: Error): Error {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adding a method for the dashbaord to report an error boundary via a new `reportErrorBoundary` rpc method. Internaly it:

* does a `log.info()` call w/ some metadata about the error (`url`, `message` and `userId`)
* increments a new prometheus counter, `gitpod_dashboard_error_boundary_total`, which has a `url` label.

## How to test
<!-- Provide steps to test this PR -->
I was able to manually test this by forwarding the metrics server port to my workspace, and curl'ing the `/metrics` endpoint (hat-tip @geropl for the pointer).
```
kubectl port-forward deployment/server 9500 &
```
```
curl localhost:9500/metrics
```
After manually "breaking" it a few times by injecting some code that throws errors in a component render, was able to see the counters increment, and verify the `url` label is set as expected.
```
gitpod_dashboard_error_boundary_total{url="https://bmh-report12cfdef066.preview.gitpod-dev.com/workspaces"} 1
gitpod_dashboard_error_boundary_total{url="https://bmh-report12cfdef066.preview.gitpod-dev.com/workspaces?foo=bar"} 2
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
