### PR TITLE
Remove SID as default owner of installer/installer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,6 @@
 /components/installation-telemetry @gitpod-io/engineering-security-infrastructure-and-delivery
 /components/kots-config-check @gitpod-io/engineering-security-infrastructure-and-delivery
 /install @gitpod-io/engineering-security-infrastructure-and-delivery
-/install/installer @gitpod-io/engineering-security-infrastructure-and-delivery
 # For testdata a single review from anyone who is allowed to review PRs is sufficent.
 /install/installer/cmd/testdata
 # Allow everyone to approve config changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,10 +30,8 @@
 /components/installation-telemetry @gitpod-io/engineering-security-infrastructure-and-delivery
 /components/kots-config-check @gitpod-io/engineering-security-infrastructure-and-delivery
 /install @gitpod-io/engineering-security-infrastructure-and-delivery
-# For testdata a single review from anyone who is allowed to review PRs is sufficent.
-/install/installer/cmd/testdata
-# Allow everyone to approve config changes
-/install/installer/pgk/config
+# By default anything in in /install/installer is shared.
+/install/installer
 /install/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
 /install/installer/pkg/components/blobserve @gitpod-io/engineering-ide
 /install/installer/pkg/components/components-ide @gitpod-io/engineering-ide


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In the interest of reducing unnecessary required PR reviews form SID I'd like to remove us as the default owners of `install/installer`

A recent example PR is https://github.com/gitpod-io/gitpod/pull/16633 where `install/installer/pkg/common` was changed. There are no explicit CODEOWNERS for  that folder, so i falls back to the owner of `install/installer` which is us. 

We could add an entry of `install/installer/pkg/common <blank>` to CODEOWNERS to remove us, but I'd rather remove us as the default owner so we don't have to list ever current (and future) folder in install/installer where we have shared ownership.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
