### PR TITLE
[ws-daemon] Check connection to containerd socket

### DIFF
--- a/components/ws-daemon/pkg/container/containerd.go
+++ b/components/ws-daemon/pkg/container/containerd.go
@@ -149,6 +149,7 @@ func (s *Containerd) start() {
 
 			evts, errchan := s.Client.Subscribe(context.Background())
 			log.Info("containerd subscription established")
+		LOOP:
 			for {
 				select {
 				case evt := <-evts:
@@ -161,7 +162,7 @@ func (s *Containerd) start() {
 				case err := <-errchan:
 					log.WithError(err).Error("lost connection to containerd - will attempt to reconnect")
 					time.Sleep(reconnectionInterval)
-					break
+					break LOOP
 				}
 			}
 		}()

--- a/install/installer/cmd/config_files_containerd.go
+++ b/install/installer/cmd/config_files_containerd.go
@@ -32,7 +32,7 @@ var configNodeContainerdCmd = &cobra.Command{
 		log.Infof("containerd socket location detected as %s", *socket)
 
 		cfg.Workspace.Runtime.ContainerDRuntimeDir = containerd.String()
-		cfg.Workspace.Runtime.ContainerDSocket = socket.String()
+		cfg.Workspace.Runtime.ContainerDSocketDir = socket.String()
 
 		return saveConfigFile(cfg)
 	},

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -1673,7 +1673,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5568,7 +5568,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -8119,7 +8119,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8199,7 +8199,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8332,8 +8332,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -1356,7 +1356,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -4909,7 +4909,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7287,7 +7287,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e6e11d48535594ca80445b80d84c85d02d2d9bc1b55dcb753278ec854d1551ea
+        gitpod.io/checksum_config: 573f5fc567df7be7fba63ecdc681e3aa5f059daa207992586a41bba4106d2545
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7367,7 +7367,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -7503,8 +7503,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -1490,7 +1490,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5385,7 +5385,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7936,7 +7936,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8016,7 +8016,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8149,8 +8149,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1648,7 +1648,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5982,7 +5982,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -8664,7 +8664,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: be72c62763153fb9c55d26e0670331729facf447fb5420478d96fb82dfa997bf
+        gitpod.io/checksum_config: e72f036b19d3287feece7409ecc0991d1c4f58ad96da7b901ce565b0f5208039
         hello: world
       creationTimestamp: null
       labels:
@@ -8747,7 +8747,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8880,8 +8880,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1424,7 +1424,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5165,7 +5165,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7656,7 +7656,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7736,7 +7736,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -7869,8 +7869,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -1352,7 +1352,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -4936,7 +4936,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7346,7 +7346,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e44a17e9c14547d1b951cead22d929256cd76afcb8f1386ee99fbdc5a05d8b6a
+        gitpod.io/checksum_config: eb4dd48f0756c6343cc7b91acd5ec6e881b6d1f97547b217b5ce52d5e6669e91
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7426,7 +7426,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -7562,8 +7562,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -1493,7 +1493,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5388,7 +5388,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -8180,7 +8180,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8300,7 +8300,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8513,8 +8513,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -1502,7 +1502,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5401,7 +5401,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7956,7 +7956,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8036,7 +8036,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8169,8 +8169,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -484,7 +484,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -1073,7 +1073,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -807,7 +807,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -654,7 +654,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -1805,7 +1805,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -3238,7 +3238,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3318,7 +3318,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -3451,8 +3451,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -1493,7 +1493,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5388,7 +5388,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7939,7 +7939,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8019,7 +8019,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8152,8 +8152,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1490,7 +1490,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5385,7 +5385,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7936,7 +7936,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8016,7 +8016,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8149,8 +8149,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -1488,7 +1488,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5383,7 +5383,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7946,7 +7946,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8026,7 +8026,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8159,8 +8159,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -1497,7 +1497,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5392,7 +5392,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7943,7 +7943,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8023,7 +8023,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8156,8 +8156,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -1490,7 +1490,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5385,7 +5385,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7936,7 +7936,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8016,7 +8016,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8149,8 +8149,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1502,7 +1502,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5397,7 +5397,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7948,7 +7948,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8028,7 +8028,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8161,8 +8161,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -1493,7 +1493,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5388,7 +5388,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7939,7 +7939,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8019,7 +8019,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8152,8 +8152,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1712,7 +1712,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5718,7 +5718,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -8380,7 +8380,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8460,7 +8460,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8593,8 +8593,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -1493,7 +1493,7 @@ data:
           memory: 2Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5388,7 +5388,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7939,7 +7939,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8019,7 +8019,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8152,8 +8152,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1493,7 +1493,7 @@ data:
           memory: 42Gi
       runtime:
         containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
-        containerdSocket: /run/containerd/containerd.sock
+        containerdSocketDir: /run/containerd
         fsShiftMethod: fuse
   versions.json: |-
     {
@@ -5388,7 +5388,7 @@ data:
             },
             "runtime": "containerd",
             "containerd": {
-              "socket": "/mnt/containerd.sock"
+              "socket": "/mnt/containerd/containerd.sock"
             }
           },
           "kubeconfig": "",
@@ -7939,7 +7939,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d78571b1e710efaaec72a70727b26bd4e0906743ef9d7c8fc019ad773f0a3d7e
+        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8019,7 +8019,7 @@ spec:
           name: working-area
         - mountPath: /config
           name: config
-        - mountPath: /mnt/containerd.sock
+        - mountPath: /mnt/containerd
           name: containerd-socket
         - mountPath: /mnt/node0
           name: node-fs0
@@ -8152,8 +8152,7 @@ spec:
           name: ws-daemon
         name: config
       - hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
+          path: /run/containerd
         name: containerd-socket
       - hostPath:
           path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -118,7 +118,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						ProcLoc: "/mnt/mounts",
 					},
 					Containerd: &container.ContainerdConfig{
-						SocketPath: "/mnt/containerd.sock",
+						SocketPath: "/mnt/containerd/containerd.sock",
 					},
 				},
 			},

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -92,8 +92,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		{
 			Name: "containerd-socket",
 			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-				Path: ctx.Config.Workspace.Runtime.ContainerDSocket,
-				Type: func() *corev1.HostPathType { r := corev1.HostPathSocket; return &r }(),
+				Path: ctx.Config.Workspace.Runtime.ContainerDSocketDir,
 			}},
 		},
 		{
@@ -156,7 +155,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		{
 			Name:      "containerd-socket",
-			MountPath: "/mnt/containerd.sock",
+			MountPath: "/mnt/containerd",
 		},
 		{
 			Name:      "node-fs0",

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -71,7 +71,7 @@ func (v version) Defaults(in interface{}) error {
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
 	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
-	cfg.Workspace.Runtime.ContainerDSocket = containerd.ContainerdSocketLocationDefault.String()
+	cfg.Workspace.Runtime.ContainerDSocketDir = containerd.ContainerdSocketLocationDefault.String()
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = containerd.ContainerdLocationDefault.String()
 	cfg.Workspace.MaxLifetime = util.Duration(36 * time.Hour)
 	cfg.Workspace.PrebuildPVC.Size = resource.MustParse("30Gi")
@@ -311,7 +311,7 @@ type WorkspaceRuntime struct {
 	// The location of containerd socket on the host machine
 	ContainerDRuntimeDir string `json:"containerdRuntimeDir" validate:"required,startswith=/"`
 	// The location of containerd socket on the host machine
-	ContainerDSocket string `json:"containerdSocket" validate:"required,startswith=/"`
+	ContainerDSocketDir string `json:"containerdSocketDir" validate:"required,startswith=/"`
 }
 
 type WorkspaceResources struct {

--- a/install/installer/pkg/containerd/k3s.go
+++ b/install/installer/pkg/containerd/k3s.go
@@ -7,7 +7,7 @@ package containerd
 // k3s stores both socket and containerd in a different location
 const (
 	ContainerdLocationK3s       ContainerdLocation       = "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io"
-	ContainerdSocketLocationK3s ContainerdSocketLocation = "/run/k3s/containerd/containerd.sock"
+	ContainerdSocketLocationK3s ContainerdSocketLocation = "/run/k3s/containerd"
 )
 
 func init() {

--- a/install/installer/pkg/containerd/location.go
+++ b/install/installer/pkg/containerd/location.go
@@ -18,7 +18,7 @@ var (
 
 // This is the default location - this will be used for most installations
 const (
-	ContainerdSocketLocationDefault ContainerdSocketLocation = "/run/containerd/containerd.sock"
+	ContainerdSocketLocationDefault ContainerdSocketLocation = "/run/containerd"
 	ContainerdLocationDefault       ContainerdLocation       = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 )
 


### PR DESCRIPTION
## Description

Mounting only the socket makes ws-daemon unavailable if containerd restarts:
- [current behavior](https://www.loom.com/share/9e750f927d8c4a11a30414c05c18bfa9)
- [with the change](https://www.loom.com/share/d1b6206c89474bbfb5e857bc36b75f30)

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod-dedicated/issues/874

## How to test
- Integration tests should pass
- Restart `containerd` and check` ws-daemon` stays in ready
- Kill `ws-daemon` pod, and while is still starting, restart containerd. Check the pod to get ready state and not crash loop:
```
kubectl delete pods --force -l component=ws-daemon;sleep 2; \
    systemctl restart containerd;sleep 5; \
    kubectl logs -l component=ws-daemon -c ws-daemon -f
```
- Workspaces should open after the previous test

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
