### PR TITLE
[redis] Fix readiness probe (again)

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -10260,9 +10260,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -9160,9 +9160,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -10077,9 +10077,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -10910,9 +10910,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -9787,9 +9787,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -9277,9 +9277,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -11242,9 +11242,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -10099,9 +10099,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -7251,9 +7251,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -4405,9 +4405,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -10080,9 +10080,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -10077,9 +10077,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -10087,9 +10087,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -10084,9 +10084,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -10077,9 +10077,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -10089,9 +10089,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -10080,9 +10080,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -10521,9 +10521,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -10068,9 +10068,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -10080,9 +10080,11 @@ spec:
         readinessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - redis-cli ping | grep pong
+            - redis-cli
+            - ping
+            - '|'
+            - grep
+            - pong
           failureThreshold: 5
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/installer/pkg/components/redis/deployment.go
+++ b/install/installer/pkg/components/redis/deployment.go
@@ -90,7 +90,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ReadinessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										Exec: &v1.ExecAction{
-											Command: []string{"sh", "-c", "redis-cli ping | grep pong"},
+											Command: []string{"redis-cli", "ping", "|", "grep", "pong"},
 										},
 									},
 									InitialDelaySeconds: 5,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Redis reaches ready in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
