### PR TITLE
fix: Improved Integrations UX

### DIFF
--- a/components/dashboard/src/user-settings/AuthEntryItem.tsx
+++ b/components/dashboard/src/user-settings/AuthEntryItem.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
+import { useState } from "react";
+import { ContextMenuEntry } from "../components/ContextMenu";
+import { Item, ItemFieldIcon, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
+
+interface AuthEntryItemParams {
+    ap: AuthProviderInfo;
+    isConnected: (authProviderId: string) => boolean;
+    getUsername: (authProviderId: string) => string | undefined;
+    getPermissions: (authProviderId: string) => string[] | undefined;
+    gitProviderMenu: (provider: AuthProviderInfo) => ContextMenuEntry[];
+}
+
+export const AuthEntryItem = (props: AuthEntryItemParams) => {
+    const [menuVisible, setMenuVisible] = useState<boolean>(false);
+
+    const changeMenuState = (state: boolean) => {
+        setMenuVisible(state);
+    };
+
+    return (
+        <Item key={"ap-" + props.ap.authProviderId} className="h-16" solid={menuVisible}>
+            <ItemFieldIcon>
+                <div
+                    className={
+                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                        (props.isConnected(props.ap.authProviderId) ? "bg-green-500" : "bg-gray-400")
+                    }
+                >
+                    &nbsp;
+                </div>
+            </ItemFieldIcon>
+            <ItemField className="w-4/12 xl:w-3/12 flex flex-col my-auto">
+                <span className="my-auto font-medium truncate overflow-ellipsis">{props.ap.authProviderType}</span>
+                <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis dark:text-gray-500">
+                    {props.ap.host}
+                </span>
+            </ItemField>
+            <ItemField className="w-6/12 xl:w-3/12 flex flex-col my-auto">
+                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
+                    {props.getUsername(props.ap.authProviderId) || "–"}
+                </span>
+                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Username</span>
+            </ItemField>
+            <ItemField className="hidden xl:w-5/12 xl:flex xl:flex-col my-auto">
+                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
+                    {props.getPermissions(props.ap.authProviderId)?.join(", ") || "–"}
+                </span>
+                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Permissions</span>
+            </ItemField>
+            <ItemFieldContextMenu changeMenuState={changeMenuState} menuEntries={props.gitProviderMenu(props.ap)} />
+        </Item>
+    );
+};

--- a/components/dashboard/src/user-settings/IntegrationItemEntry.tsx
+++ b/components/dashboard/src/user-settings/IntegrationItemEntry.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { ContextMenuEntry } from "../components/ContextMenu";
+import { Item, ItemFieldIcon, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
+
+export const IntegrationEntryItem = (props: {
+    ap: AuthProviderEntry;
+    gitProviderMenu: (provider: AuthProviderEntry) => ContextMenuEntry[];
+}) => {
+    return (
+        <Item key={"ap-" + props.ap.id} className="h-16">
+            <ItemFieldIcon>
+                <div
+                    className={
+                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                        (props.ap.status === "verified" ? "bg-green-500" : "bg-gray-400")
+                    }
+                >
+                    &nbsp;
+                </div>
+            </ItemFieldIcon>
+            <ItemField className="w-3/12 flex flex-col my-auto">
+                <span className="font-medium truncate overflow-ellipsis">{props.ap.type}</span>
+            </ItemField>
+            <ItemField className="w-7/12 flex flex-col my-auto">
+                <span className="my-auto truncate text-gray-500 overflow-ellipsis">{props.ap.host}</span>
+            </ItemField>
+            <ItemFieldContextMenu menuEntries={props.gitProviderMenu(props.ap)} />
+        </Item>
+    );
+};

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -12,7 +12,7 @@ import CheckBox from "../components/CheckBox";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import InfoBox from "../components/InfoBox";
-import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
+import { ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalHeader, ModalFooter } from "../components/Modal";
 import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
@@ -20,6 +20,8 @@ import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { isGitpodIo } from "../utils";
+import { AuthEntryItem } from "./AuthEntryItem";
+import { IntegrationEntryItem } from "./IntegrationItemEntry";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { SelectAccountModal } from "./SelectAccountModal";
 
@@ -336,39 +338,13 @@ function GitProviders() {
             <ItemsList className="pt-6">
                 {authProviders &&
                     authProviders.map((ap) => (
-                        <Item key={"ap-" + ap.authProviderId} className="h-16">
-                            <ItemFieldIcon>
-                                <div
-                                    className={
-                                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
-                                        (isConnected(ap.authProviderId) ? "bg-green-500" : "bg-gray-400")
-                                    }
-                                >
-                                    &nbsp;
-                                </div>
-                            </ItemFieldIcon>
-                            <ItemField className="w-4/12 xl:w-3/12 flex flex-col my-auto">
-                                <span className="my-auto font-medium truncate overflow-ellipsis">
-                                    {ap.authProviderType}
-                                </span>
-                                <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis dark:text-gray-500">
-                                    {ap.host}
-                                </span>
-                            </ItemField>
-                            <ItemField className="w-6/12 xl:w-3/12 flex flex-col my-auto">
-                                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
-                                    {getUsername(ap.authProviderId) || "–"}
-                                </span>
-                                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Username</span>
-                            </ItemField>
-                            <ItemField className="hidden xl:w-5/12 xl:flex xl:flex-col my-auto">
-                                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
-                                    {getPermissions(ap.authProviderId)?.join(", ") || "–"}
-                                </span>
-                                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Permissions</span>
-                            </ItemField>
-                            <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
-                        </Item>
+                        <AuthEntryItem
+                            isConnected={isConnected}
+                            gitProviderMenu={gitProviderMenu}
+                            getUsername={getUsername}
+                            getPermissions={getPermissions}
+                            ap={ap}
+                        />
                     ))}
             </ItemsList>
         </div>
@@ -482,28 +458,7 @@ function GitIntegrations() {
                 </div>
             )}
             <ItemsList className="pt-6">
-                {providers &&
-                    providers.map((ap) => (
-                        <Item key={"ap-" + ap.id} className="h-16">
-                            <ItemFieldIcon>
-                                <div
-                                    className={
-                                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
-                                        (ap.status === "verified" ? "bg-green-500" : "bg-gray-400")
-                                    }
-                                >
-                                    &nbsp;
-                                </div>
-                            </ItemFieldIcon>
-                            <ItemField className="w-3/12 flex flex-col my-auto">
-                                <span className="font-medium truncate overflow-ellipsis">{ap.type}</span>
-                            </ItemField>
-                            <ItemField className="w-7/12 flex flex-col my-auto">
-                                <span className="my-auto truncate text-gray-500 overflow-ellipsis">{ap.host}</span>
-                            </ItemField>
-                            <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
-                        </Item>
-                    ))}
+                {providers && providers.map((ap) => <IntegrationEntryItem ap={ap} gitProviderMenu={gitProviderMenu} />)}
             </ItemsList>
         </div>
     );


### PR DESCRIPTION
## Description
The below issues propose improvement for the UX of Integration Settings, by keeping the hovered effect ( the background colors ) of the workspace items till the ItemOverflowMenu is expanded. Please refer the below graphics for reference of the improvement.

https://user-images.githubusercontent.com/72302948/222713089-d453bd89-33c0-48fc-9902-f66cf17aa8d4.mov

## Related Issue(s)
Fixes #4635 

## How to test
- Change your directory from /gitpod to /gitpod/component/dashboard
- Add your host and token as given in the readme
- Start the development server by yarn run start and check on http://localhost:3000 for checking the dashboard

## Release Notes
```release-note
Added `Auth Entry Component` along with `Integration Entry Component` linking with `Integrations.tsx` and associated it with Item List Context Menu, with ChangeMenuState Function, to keep the hovered effect
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
