### PR TITLE
[installer] Add OpenTelemetry env variables to tracing

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -7811,6 +7811,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7926,6 +7928,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8146,6 +8150,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8946,6 +8952,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -9087,6 +9095,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9617,6 +9627,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10445,6 +10457,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10697,6 +10711,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10827,6 +10843,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -11074,6 +11092,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -6979,6 +6979,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7094,6 +7096,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7314,6 +7318,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -7961,6 +7967,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8102,6 +8110,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8638,6 +8648,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -9258,6 +9270,8 @@ spec:
               name: aws-database
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -9510,6 +9524,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -9646,6 +9662,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -9893,6 +9911,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -7628,6 +7628,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7743,6 +7745,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7963,6 +7967,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8763,6 +8769,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: registry.mydomain.com/namespace/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8904,6 +8912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9434,6 +9444,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: registry.mydomain.com/namespace/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10262,6 +10274,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10514,6 +10528,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: registry.mydomain.com/namespace/ws-manager:test
@@ -10644,6 +10660,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10891,6 +10909,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: registry.mydomain.com/namespace/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -8341,6 +8341,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -8465,6 +8467,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8694,6 +8698,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -9512,6 +9518,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -9662,6 +9670,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -10239,6 +10249,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -11109,6 +11121,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -11370,6 +11384,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -11509,6 +11525,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -11765,6 +11783,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7348,6 +7348,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7463,6 +7465,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7683,6 +7687,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8483,6 +8489,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8624,6 +8632,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9154,6 +9164,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -9885,6 +9897,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10137,6 +10151,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10267,6 +10283,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10514,6 +10532,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -7038,6 +7038,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7153,6 +7155,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7373,6 +7377,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8020,6 +8026,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8231,6 +8239,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8767,6 +8777,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -9369,6 +9381,8 @@ spec:
               name: gcp-database
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -9615,6 +9629,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -9751,6 +9767,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -9986,6 +10004,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -7671,6 +7671,8 @@ spec:
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7866,6 +7868,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8247,6 +8251,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -9247,6 +9253,8 @@ spec:
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -9468,6 +9476,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -10318,6 +10328,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -11467,6 +11479,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -11881,6 +11895,8 @@ spec:
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -12091,6 +12107,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -12498,6 +12516,8 @@ spec:
         - name: no_proxy
           value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -7648,6 +7648,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7763,6 +7765,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7983,6 +7987,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8783,6 +8789,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8924,6 +8932,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9456,6 +9466,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10284,6 +10296,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10536,6 +10550,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10666,6 +10682,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10913,6 +10931,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -3227,6 +3227,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -6104,6 +6104,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -6245,6 +6247,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7454,6 +7458,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -7695,6 +7701,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -3728,6 +3728,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/content-service:test
@@ -4608,6 +4610,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -4849,6 +4853,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -2926,6 +2926,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -3041,6 +3043,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -3261,6 +3265,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -3534,6 +3540,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
         name: image-builder-mk3
@@ -3776,6 +3784,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -3915,6 +3925,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -7631,6 +7631,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7746,6 +7748,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7966,6 +7970,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8766,6 +8772,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8907,6 +8915,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9437,6 +9447,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10265,6 +10277,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10517,6 +10531,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10647,6 +10663,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10894,6 +10912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7628,6 +7628,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7743,6 +7745,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7963,6 +7967,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8763,6 +8769,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8904,6 +8912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9434,6 +9444,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10262,6 +10274,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10514,6 +10528,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10644,6 +10660,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10891,6 +10909,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -7638,6 +7638,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7753,6 +7755,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7973,6 +7977,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8773,6 +8779,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8914,6 +8922,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9444,6 +9454,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10272,6 +10284,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10524,6 +10538,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10654,6 +10670,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10901,6 +10919,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -7635,6 +7635,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7750,6 +7752,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7970,6 +7974,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8770,6 +8776,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8911,6 +8919,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9441,6 +9451,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10269,6 +10281,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10521,6 +10535,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10651,6 +10667,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10898,6 +10916,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -7628,6 +7628,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7743,6 +7745,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7963,6 +7967,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8763,6 +8769,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8904,6 +8912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9434,6 +9444,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10262,6 +10274,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10514,6 +10528,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10644,6 +10660,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10891,6 +10909,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7640,6 +7640,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7755,6 +7757,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7975,6 +7979,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8775,6 +8781,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8916,6 +8924,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9446,6 +9456,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10274,6 +10286,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10526,6 +10540,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10656,6 +10672,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10903,6 +10921,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -7631,6 +7631,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7746,6 +7748,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7966,6 +7970,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8766,6 +8772,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8907,6 +8915,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9437,6 +9447,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10265,6 +10277,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10517,6 +10531,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10647,6 +10663,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10894,6 +10912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -8072,6 +8072,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -8187,6 +8189,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -8407,6 +8411,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -9207,6 +9213,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -9348,6 +9356,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9878,6 +9888,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10706,6 +10718,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10958,6 +10972,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -11088,6 +11104,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -11335,6 +11353,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -7631,6 +7631,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7746,6 +7748,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7966,6 +7970,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8754,6 +8760,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8895,6 +8903,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9425,6 +9435,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10253,6 +10265,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10505,6 +10519,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10635,6 +10651,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10882,6 +10900,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7631,6 +7631,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: NODENAME
           valueFrom:
             fieldRef:
@@ -7746,6 +7748,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -7966,6 +7970,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: NODENAME
           valueFrom:
@@ -8766,6 +8772,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -8907,6 +8915,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
@@ -9437,6 +9447,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
         imagePullPolicy: IfNotPresent
@@ -10265,6 +10277,8 @@ spec:
               name: mysql
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
             secretKeyRef:
@@ -10517,6 +10531,8 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "true"
         - name: GRPC_GO_RETRY
           value: "on"
         image: eu.gcr.io/gitpod-core-dev/build/ws-manager:test
@@ -10647,6 +10663,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
           valueFrom:
@@ -10894,6 +10912,8 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: JAEGER_DISABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds env variable configuration for OpenTelemetry. Most config options are 1-1 mapped with the distinction on Username/Password authentication. Given we use a OTEL Collector in SaaS, we don't need to (and indeed do not) set these anyway.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold