### PR TITLE
Update containerd self-signed certificate configuration

### DIFF
--- a/components/registry-facade/cmd/setup.go
+++ b/components/registry-facade/cmd/setup.go
@@ -28,15 +28,33 @@ var setupCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		{
 			log.Info("Creating containerd registry directory...")
-			regPath := filepath.Join(hostfs, fmt.Sprintf("/etc/containerd/certs.d/%v:%v", hostname, port))
-			err := os.MkdirAll(regPath, 0644)
+			regDirectory := fmt.Sprintf("/etc/containerd/certs.d/%v:%v", hostname, port)
+
+			fakeRegPath := filepath.Join(hostfs, regDirectory)
+			err := os.MkdirAll(fakeRegPath, 0644)
 			if err != nil {
 				log.Fatalf("cannot create containerd cert directory: %v", err)
 			}
 
-			err = copyFile("/usr/local/share/ca-certificates/gitpod-ca.crt", filepath.Join(regPath, "ca.crt"))
+			caPath := filepath.Join(fakeRegPath, "ca.crt")
+			err = copyFile("/usr/local/share/ca-certificates/gitpod-ca.crt", caPath)
 			if err != nil {
 				log.Fatal(err)
+			}
+
+			// https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+			hostsToml := fmt.Sprintf(`
+server = "https://%v:%v"
+
+[host."https://%v:%v"]
+    capabilities = ["pull", "resolve"]
+    ca = "%v"
+    skip_verify = true
+`, hostname, port, hostname, port, filepath.Join(regDirectory, "ca.crt"))
+
+			err = os.WriteFile(filepath.Join(fakeRegPath, "hosts.toml"), []byte(hostsToml), 0644)
+			if err != nil {
+				log.Fatalf("cannot create hosts.toml file: %v", err)
 			}
 		}
 


### PR DESCRIPTION
## Description

Temporal solution for dedicated. The issue is related to the installer with the field `customCACertificates` and what `registry-facade` uses as CA.

## How to test
- Integration tests should pass
 
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
