### PR TITLE
Adding Typography components for Headings/Subheadings

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -139,7 +139,7 @@ export function Login() {
 
     return (
         <div id="login-container" className="z-50 flex w-screen h-screen">
-            {!showWelcome ? (
+            {showWelcome ? (
                 <div id="feature-section" className="flex-grow bg-gray-100 dark:bg-gray-800 w-1/2 hidden lg:block">
                     <div id="feature-section-column" className="flex max-w-xl h-full mx-auto pt-6">
                         <div className="flex flex-col px-8 my-auto ml-auto">

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -24,6 +24,7 @@ import exclamation from "./images/exclamation.svg";
 import { getURLHash } from "./utils";
 import ErrorMessage from "./components/ErrorMessage";
 import { publicApiTeamsToProtocol, teamsService } from "./service/public-api";
+import { Heading1, Heading2, Subheading } from "./components/typography/headings";
 
 function Item(props: { icon: string; iconSize?: string; text: string }) {
     const iconSize = props.iconSize || 28;
@@ -138,7 +139,7 @@ export function Login() {
 
     return (
         <div id="login-container" className="z-50 flex w-screen h-screen">
-            {showWelcome ? (
+            {!showWelcome ? (
                 <div id="feature-section" className="flex-grow bg-gray-100 dark:bg-gray-800 w-1/2 hidden lg:block">
                     <div id="feature-section-column" className="flex max-w-xl h-full mx-auto pt-6">
                         <div className="flex flex-col px-8 my-auto ml-auto">
@@ -147,11 +148,11 @@ export function Login() {
                                 <img src={gitpodDark} className="h-8 hidden dark:block" alt="Gitpod dark theme logo" />
                             </div>
                             <div className="mb-10">
-                                <h1 className="text-5xl mb-3">Welcome to Gitpod</h1>
-                                <div className="text-gray-400 text-lg">
+                                <Heading1 className="text-5xl mb-3">Welcome to Gitpod</Heading1>
+                                <Subheading className="text-gray-400 text-lg">
                                     Spin up fresh cloud development environments for each task, fully automated, in
                                     seconds.
-                                </div>
+                                </Subheading>
                             </div>
                             <div className="flex mb-10">
                                 <Item icon={code} iconSize="16" text="Always Ready&#x2011;To&#x2011;Code" />
@@ -190,15 +191,15 @@ export function Login() {
                             <div className="mx-auto text-center pb-8 space-y-2">
                                 {providerFromContext ? (
                                     <>
-                                        <h2 className="text-xl text-black dark:text-gray-50 font-semibold">
-                                            Open a cloud development environment
-                                        </h2>
-                                        <h2 className="text-xl">for the repository {repoPathname?.slice(1)}</h2>
+                                        <Heading2>Open a cloud development environment</Heading2>
+                                        <Subheading>for the repository {repoPathname?.slice(1)}</Subheading>
                                     </>
                                 ) : (
                                     <>
-                                        <h1 className="text-3xl">Log in{showWelcome ? "" : " to Gitpod"}</h1>
-                                        <h2 className="uppercase text-sm text-gray-400">ALWAYS READY-TO-CODE</h2>
+                                        <Heading1>Log in{showWelcome ? "" : " to Gitpod"}</Heading1>
+                                        <Subheading className="uppercase text-sm text-gray-400">
+                                            ALWAYS READY-TO-CODE
+                                        </Subheading>
                                     </>
                                 )}
                             </div>

--- a/components/dashboard/src/Setup.tsx
+++ b/components/dashboard/src/Setup.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useState } from "react";
-import Modal from "./components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "./components/Modal";
 import { getGitpodService, gitpodHostUrl } from "./service/service";
 import { GitIntegrationModal } from "./user-settings/Integrations";
 
@@ -40,8 +40,8 @@ export default function Setup() {
             {!showModal && (
                 // TODO: Use title and buttons props
                 <Modal visible={true} onClose={() => {}} closeable={false}>
-                    <h3 className="pb-2">Welcome to Gitpod 🎉</h3>
-                    <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                    <ModalHeader>Welcome to Gitpod 🎉</ModalHeader>
+                    <ModalBody>
                         <p className="pb-4 text-gray-500 text-base">
                             To start using Gitpod, you will need to set up a Git integration.
                         </p>
@@ -59,12 +59,12 @@ export default function Setup() {
                                 .
                             </span>
                         </div>
-                    </div>
-                    <div className="flex justify-end mt-6">
+                    </ModalBody>
+                    <ModalFooter>
                         <button className={"ml-2"} onClick={() => acceptAndContinue()}>
                             Continue
                         </button>
-                    </div>
+                    </ModalFooter>
                 </Modal>
             )}
             {showModal && (

--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -9,6 +9,7 @@ import { Project } from "@gitpod/gitpod-protocol";
 import Prebuilds from "../projects/Prebuilds";
 import Property from "./Property";
 import dayjs from "dayjs";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function ProjectDetail(props: { project: Project; owner: string | undefined }) {
     return (
@@ -17,10 +18,10 @@ export default function ProjectDetail(props: { project: Project; owner: string |
                 <div className="flex mt-8">
                     <div className="flex-1">
                         <div className="flex">
-                            <h3>{props.project.name}</h3>
+                            <Heading2>{props.project.name}</Heading2>
                             <span className="my-auto"></span>
                         </div>
-                        <p>{props.project.cloneUrl}</p>
+                        <Subheading>{props.project.cloneUrl}</Subheading>
                     </div>
                 </div>
                 <div className="flex flex-col w-full">

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -14,6 +14,7 @@ import InfoBox from "../components/InfoBox";
 import { isGitpodIo } from "../utils";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getAdminTabs, getAdminSettingsMenu } from "./admin.routes";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export function SettingsLayout(props: { children: React.ReactNode }) {
     return (
@@ -53,11 +54,11 @@ export default function Settings() {
     return (
         <div>
             <SettingsLayout>
-                <h3>Usage Statistics</h3>
-                <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                <Heading2>Usage Statistics</Heading2>
+                <Subheading className="pb-4 max-w-2xl">
                     We collect usage telemetry to gain insights on how you use your Gitpod instance, so we can provide a
                     better overall experience.
-                </p>
+                </Subheading>
                 <p>
                     <a className="gp-link" href="https://www.gitpod.io/privacy">
                         Read our Privacy Policy
@@ -94,7 +95,7 @@ export default function Settings() {
                         } as InstallationAdminSettings)
                     }
                 />
-                <h3 className="mt-4">Telemetry preview</h3>
+                <Heading2 className="mt-4">Telemetry preview</Heading2>
                 <InfoBox>
                     <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
                 </InfoBox>

--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -17,6 +17,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { CostCenterJSON, CostCenter_BillingStrategy } from "@gitpod/gitpod-protocol/lib/usage";
 import Modal from "../components/Modal";
+import { Heading2 } from "../components/typography/headings";
 
 export default function TeamDetail(props: { team: Team }) {
     const { team } = props;
@@ -72,7 +73,7 @@ export default function TeamDetail(props: { team: Team }) {
             <div className="flex mt-8">
                 <div className="flex-1">
                     <div className="flex">
-                        <h3>{team.name}</h3>
+                        <Heading2>{team.name}</Heading2>
                         {team.markedDeleted && (
                             <span className="mt-2">
                                 <Label text="Deleted" color="red" />

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -27,6 +27,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import CaretDown from "../icons/CaretDown.svg";
 import ContextMenu from "../components/ContextMenu";
 import { CostCenterJSON, CostCenter_BillingStrategy } from "@gitpod/gitpod-protocol/lib/usage";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function UserDetail(p: { user: User }) {
     const [activity, setActivity] = useState(false);
@@ -263,18 +264,18 @@ export default function UserDetail(p: { user: User }) {
                     <div className="flex mt-8">
                         <div className="flex-1">
                             <div className="flex">
-                                <h3>{user.fullName}</h3>
+                                <Heading2>{user.fullName}</Heading2>
                                 {user.blocked ? <Label text="Blocked" color="red" /> : null}{" "}
                                 {user.markedDeleted ? <Label text="Deleted" color="red" /> : null}
                                 {user.lastVerificationTime ? <Label text="Verified" color="green" /> : null}
                             </div>
-                            <p>
+                            <Subheading>
                                 {user.identities
                                     .map((i) => i.primaryEmail)
                                     .filter((e) => !!e)
                                     .join(", ")}
                                 {user.verificationPhoneNumber ? ` — ${user.verificationPhoneNumber}` : null}
-                            </p>
+                            </Subheading>
                         </div>
                         {!user.lastVerificationTime ? (
                             <button className="secondary ml-3" disabled={activity} onClick={verifyUser}>

--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -9,6 +9,7 @@ import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url"
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { Heading2, Subheading } from "../components/typography/headings";
 import { getGitpodService } from "../service/service";
 import { getProjectPath } from "../workspaces/WorkspaceEntry";
 import { WorkspaceStatusIndicator } from "../workspaces/WorkspaceStatusIndicator";
@@ -49,12 +50,12 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                 <div className="flex mt-8">
                     <div className="flex-1">
                         <div className="flex">
-                            <h3>{workspace.workspaceId}</h3>
+                            <Heading2>{workspace.workspaceId}</Heading2>
                             <span className="my-auto ml-3">
                                 <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(workspace)} />
                             </span>
                         </div>
-                        <p>{getProjectPath(WorkspaceAndInstance.toWorkspace(workspace))}</p>
+                        <Subheading>{getProjectPath(WorkspaceAndInstance.toWorkspace(workspace))}</Subheading>
                     </div>
                     <button
                         className="secondary ml-3"

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -48,6 +48,7 @@ import { WebsocketClients } from "./WebsocketClients";
 import { StartWorkspaceOptions } from "../start/start-workspace-options";
 import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import { FORCE_ONBOARDING_PARAM, FORCE_ONBOARDING_PARAM_VALUE } from "../onboarding/UserOnboarding";
+import { Heading1, Subheading } from "../components/typography/headings";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "../Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));
@@ -241,8 +242,8 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     </Route>
                     <Route path="/sorry" exact>
                         <div className="mt-48 text-center">
-                            <h1 className="text-gray-500 text-3xl">Oh, no! Something went wrong!</h1>
-                            <p className="mt-4 text-lg text-gitpod-red">{decodeURIComponent(getURLHash())}</p>
+                            <Heading1 color="light">Oh, no! Something went wrong!</Heading1>
+                            <Subheading className="mt-4 text-gitpod-red">{decodeURIComponent(getURLHash())}</Subheading>
                         </div>
                     </Route>
                     <Route exact path="/teams">
@@ -312,8 +313,8 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                                 (window.location.host = "www.gitpod.io")
                             ) : (
                                 <div className="mt-48 text-center">
-                                    <h1 className="text-gray-500 text-3xl">404</h1>
-                                    <p className="mt-4 text-lg">Page not found.</p>
+                                    <Heading1>404</Heading1>
+                                    <Subheading className="mt-4">Page not found.</Subheading>
                                 </div>
                             );
                         }}

--- a/components/dashboard/src/app/Blocked.tsx
+++ b/components/dashboard/src/app/Blocked.tsx
@@ -5,20 +5,23 @@
  */
 
 import { FunctionComponent } from "react";
+import { Heading1, Subheading } from "../components/typography/headings";
 import gitpodIcon from "../icons/gitpod.svg";
 
 export const Blocked: FunctionComponent = () => {
     return (
         <div className="mt-48 text-center">
             <img src={gitpodIcon} className="h-16 mx-auto" alt="Gitpod's logo" />
-            <h1 className="mt-12 text-gray-500 text-3xl">Your account has been blocked.</h1>
-            <p className="mt-4 mb-8 text-lg w-96 mx-auto">
+            <Heading1 color="light" className="mt-12">
+                Your account has been blocked.
+            </Heading1>
+            <Subheading className="mt-4 mb-8 w-96 mx-auto">
                 Please contact support if you think this is an error. See also{" "}
                 <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://www.gitpod.io/terms/">
                     terms of service
                 </a>
                 .
-            </p>
+            </Subheading>
             <a className="mx-auto" href="mailto:support@gitpod.io?Subject=Blocked">
                 <button className="secondary">Contact Support</button>
             </a>

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -14,6 +14,7 @@ import SelectableCardSolid from "../components/SelectableCardSolid";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import Alert from "./Alert";
 import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { Subheading } from "./typography/headings";
 
 export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const { user, setUser } = useContext(UserContext);
@@ -96,7 +97,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             {teamsAvailableForAttribution === undefined && <Spinner className="m-2 h-5 w-5 animate-spin" />}
             {teamsAvailableForAttribution && (
                 <div>
-                    <h2 className="text-gray-500">
+                    <Subheading className="text-gray-500">
                         Associate usage without a project to the billing account below.{" "}
                         <a
                             className="gp-link"
@@ -106,7 +107,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                         >
                             Learn more
                         </a>
-                    </h2>
+                    </Subheading>
                     <div className="mt-4 max-w-2xl grid grid-cols-3 gap-3">
                         {!user?.additionalData?.isMigratedToTeamOnlyAttribution && (
                             <SelectableCardSolid

--- a/components/dashboard/src/components/ErrorBoundary.tsx
+++ b/components/dashboard/src/components/ErrorBoundary.tsx
@@ -8,6 +8,7 @@ import { FC } from "react";
 import { ErrorBoundary, FallbackProps, ErrorBoundaryProps } from "react-error-boundary";
 import gitpodIcon from "../icons/gitpod.svg";
 import { getGitpodService } from "../service/service";
+import { Heading1, Subheading } from "./typography/headings";
 
 export const GitpodErrorBoundary: FC = ({ children }) => {
     return (
@@ -24,14 +25,14 @@ export const DefaultErrorFallback: FC<FallbackProps> = ({ error, resetErrorBound
     return (
         <div role="alert" className="app-container mt-14 flex flex-col items-center justify-center space-y-6">
             <img src={gitpodIcon} className="h-16 mx-auto" alt="Gitpod's logo" />
-            <h1>Oh, no! Something went wrong!</h1>
-            <p className="text-lg">
+            <Heading1>Oh, no! Something went wrong!</Heading1>
+            <Subheading>
                 Please try reloading the page. If the issue continues, please{" "}
                 <a className="gp-link" href={`mailto:support@gitpod.io?Subject=${emailSubject}&Body=${emailBody}`}>
                     get in touch
                 </a>
                 .
-            </p>
+            </Subheading>
             <div>
                 <button onClick={resetErrorBoundary}>Reload</button>
             </div>

--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 import { useLocation } from "react-router";
 import { Separator } from "./Separator";
 import TabMenuItem from "./TabMenuItem";
+import { Heading1, Subheading } from "./typography/headings";
 
 export interface HeaderProps {
     title: string | React.ReactElement;
@@ -33,8 +34,12 @@ export default function Header(p: HeaderProps) {
         <div className="app-container border-gray-200 dark:border-gray-800">
             <div className="flex pb-8 pt-6">
                 <div className="">
-                    {typeof p.title === "string" ? <h1 className="tracking-tight">{p.title}</h1> : p.title}
-                    {typeof p.subtitle === "string" ? <h2 className="tracking-wide">{p.subtitle}</h2> : p.subtitle}
+                    {typeof p.title === "string" ? <Heading1>{p.title}</Heading1> : p.title}
+                    {typeof p.subtitle === "string" ? (
+                        <Subheading className="tracking-wide">{p.subtitle}</Subheading>
+                    ) : (
+                        p.subtitle
+                    )}
                 </div>
             </div>
             <nav className="flex">

--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -34,9 +34,9 @@ export default function Header(p: HeaderProps) {
         <div className="app-container border-gray-200 dark:border-gray-800">
             <div className="flex pb-8 pt-6">
                 <div className="">
-                    {typeof p.title === "string" ? <Heading1>{p.title}</Heading1> : p.title}
+                    {typeof p.title === "string" ? <Heading1 tracking="tight">{p.title}</Heading1> : p.title}
                     {typeof p.subtitle === "string" ? (
-                        <Subheading className="tracking-wide">{p.subtitle}</Subheading>
+                        <Subheading tracking="wide">{p.subtitle}</Subheading>
                     ) : (
                         p.subtitle
                     )}

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -7,6 +7,7 @@
 import { ReactNode, useEffect } from "react";
 import cn from "classnames";
 import { getGitpodService } from "../service/service";
+import { Heading2 } from "./typography/headings";
 
 type CloseModalManner = "esc" | "enter" | "x";
 
@@ -112,7 +113,7 @@ type ModalHeaderProps = {
 };
 
 export const ModalHeader = ({ children }: ModalHeaderProps) => {
-    return <h3 className="pb-2">{children}</h3>;
+    return <Heading2 className="pb-2">{children}</Heading2>;
 };
 
 type ModalBodyProps = {

--- a/components/dashboard/src/components/ThemeSelector.tsx
+++ b/components/dashboard/src/components/ThemeSelector.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import { FC, useCallback, useContext, useState } from "react";
 import { ThemeContext } from "../theme-context";
 import SelectableCardSolid from "./SelectableCardSolid";
+import { Heading2, Subheading } from "./typography/headings";
 
 type Theme = "light" | "dark" | "system";
 
@@ -37,8 +38,8 @@ export const ThemeSelector: FC<Props> = ({ className }) => {
 
     return (
         <div className={classNames(className)}>
-            <h3>Theme</h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
+            <Heading2>Theme</Heading2>
+            <Subheading>Early bird or night owl? Choose your side.</Subheading>
             <div className="mt-4 flex items-center flex-wrap">
                 <SelectableCardSolid
                     className="w-36 h-32 m-1"

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -21,6 +21,7 @@ import Alert from "./Alert";
 import dayjs from "dayjs";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { Heading2, Subheading } from "./typography/headings";
 
 const BASE_USAGE_LIMIT_FOR_STRIPE_USERS = 1000;
 
@@ -167,11 +168,11 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
 
     return (
         <div className="mb-16">
-            <p className="text-gray-500 text-base">
+            <Subheading>
                 {attributionId && AttributionId.parse(attributionId)?.kind === "user"
                     ? "Manage billing for your personal account."
                     : "Manage billing for your organization."}
-            </p>
+            </Subheading>
             <div className="max-w-xl flex flex-col">
                 {errorMessage && (
                     <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">
@@ -349,7 +350,7 @@ export function BillingSetupModal(props: { attributionId: string; onClose: () =>
 
     return (
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="flex">Upgrade Plan</h3>
+            <Heading2 className="flex">Upgrade Plan</Heading2>
             <div className="border-t border-gray-200 dark:border-gray-700 mt-4 pt-2 -mx-6 px-6 flex flex-col">
                 {(!stripePromise || !stripeSetupIntentClientSecret) && (
                     <div className="h-80 flex items-center justify-center">
@@ -492,7 +493,7 @@ function UpdateLimitModal(props: {
 
     return (
         <Modal visible={true} onClose={props.onClose} onEnter={() => false}>
-            <h3 className="mb-4">Usage Limit</h3>
+            <Heading2 className="mb-4">Usage Limit</Heading2>
             <form onSubmit={onSubmit}>
                 <div className="border-t border-b border-gray-200 dark:border-gray-700 -mx-6 px-6 py-4 flex flex-col">
                     <p className="pb-4 text-gray-500 text-base">Set usage limit in total credits per month.</p>

--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -11,6 +11,7 @@ import { settingsPathBilling } from "../user-settings/settings.routes";
 import { useTeams } from "../teams/teams-context";
 import Alert from "./Alert";
 import Modal from "./Modal";
+import { Heading2 } from "./typography/headings";
 
 export function UsageLimitReachedModal(p: { hints: any }) {
     const teams = useTeams();
@@ -32,9 +33,9 @@ export function UsageLimitReachedModal(p: { hints: any }) {
     const billingLink = attributedTeam ? "/billing" : settingsPathBilling;
     return (
         <Modal visible={true} closeable={false} onClose={() => {}}>
-            <h3 className="flex">
+            <Heading2 className="flex">
                 <span className="flex-grow">Usage Limit Reached</span>
-            </h3>
+            </Heading2>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-6">
                 <Alert type="error" className="app-container rounded-md">
                     You have reached the <strong>usage limit</strong> of your billing account.

--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -28,6 +28,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import "./react-datepicker.css";
 import { useLocation } from "react-router";
 import dayjs from "dayjs";
+import { Heading1, Subheading } from "./typography/headings";
 
 interface UsageViewProps {
     attributionId: AttributionId;
@@ -208,13 +209,13 @@ function UsageView({ attributionId }: UsageViewProps) {
             <Header
                 title={
                     <div className="flex items-baseline">
-                        <h1 className="tracking-tight">Usage</h1>
-                        <h2 className="ml-3">(updated every 15 minutes).</h2>
+                        <Heading1 tracking="tight">Usage</Heading1>
+                        <Subheading className="ml-3">(updated every 15 minutes).</Subheading>
                     </div>
                 }
                 subtitle={
                     <div className="tracking-wide flex mt-3 items-center">
-                        <h2 className="mr-1">Showing usage from </h2>
+                        <Subheading className="mr-1">Showing usage from </Subheading>
                         <DatePicker
                             selected={startDate.toDate()}
                             onChange={(date) => date && setStartDate(dayjs(date))}
@@ -225,7 +226,7 @@ function UsageView({ attributionId }: UsageViewProps) {
                             customInput={<DateDisplay />}
                             dateFormat={"MMM d, yyyy"}
                         />
-                        <h2 className="mx-1">to</h2>
+                        <Subheading className="mx-1">to</Subheading>
                         <DatePicker
                             selected={endDate.toDate()}
                             onChange={(date) => date && setEndDate(dayjs(date))}

--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -28,7 +28,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import "./react-datepicker.css";
 import { useLocation } from "react-router";
 import dayjs from "dayjs";
-import { Heading1, Subheading } from "./typography/headings";
+import { Heading1, Heading2, Subheading } from "./typography/headings";
 
 interface UsageViewProps {
     attributionId: AttributionId;
@@ -275,15 +275,15 @@ function UsageView({ attributionId }: UsageViewProps) {
                             (usagePage === undefined || currentPaginatedResults.length === 0) &&
                             !errorMessage && (
                                 <div className="flex flex-col w-full mb-8">
-                                    <h3 className="text-center text-gray-500 mt-8">No sessions found.</h3>
-                                    <p className="text-center text-gray-500 mt-1">
+                                    <Heading2 className="text-center mt-8">No sessions found.</Heading2>
+                                    <Subheading className="text-center mt-1">
                                         Have you started any
                                         <a className="gp-link" href={gitpodHostUrl.asWorkspacePage().toString()}>
                                             {" "}
                                             workspaces
                                         </a>{" "}
                                         in {startDate.format("MMMM YYYY")} or checked your other organizations?
-                                    </p>
+                                    </Subheading>
                                 </div>
                             )}
                         {isLoading && (

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -43,6 +43,14 @@ export const Heading2: FC<HeadingProps> = ({ color, tracking, className, childre
     );
 };
 
+export const Heading3: FC<HeadingProps> = ({ color, tracking, className, children }) => {
+    return (
+        <h3 className={classNames(getHeadingColor(color), getTracking(tracking), "font-semibold text-lg", className)}>
+            {children}
+        </h3>
+    );
+};
+
 // Intended to be placed beneath a heading to provide more context
 export const Subheading: FC<HeadingProps> = ({ tracking, className, children }) => {
     return (

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -8,14 +8,60 @@ import classNames from "classnames";
 import { FC } from "react";
 
 type HeadingProps = {
+    tracking?: "tight" | "wide";
+    color?: "light" | "dark";
     className?: string;
 };
 
-export const Heading1: FC<HeadingProps> = ({ className, children }) => {
-    return <h1 className={classNames("text-gray-900 dark:text-gray-100 font-bold text-4xl", className)}>{children}</h1>;
+export const Heading1: FC<HeadingProps> = ({ color, tracking, className, children }) => {
+    return (
+        <h1
+            className={classNames(
+                getHeadingColor(color),
+                getTracking(tracking),
+                "font-bold text-5xl leading-64",
+                className,
+            )}
+        >
+            {children}
+        </h1>
+    );
+};
+
+export const Heading2: FC<HeadingProps> = ({ color, tracking, className, children }) => {
+    return (
+        <h2
+            className={classNames(
+                getHeadingColor(color),
+                getTracking(tracking),
+                "leading-9 font-semibold text-2xl",
+                className,
+            )}
+        >
+            {children}
+        </h2>
+    );
 };
 
 // Intended to be placed beneath a heading to provide more context
-export const Subheading: FC<HeadingProps> = ({ className, children }) => {
-    return <p className={classNames("text-base text-gray-500 dark:text-gray-600", className)}>{children}</p>;
+export const Subheading: FC<HeadingProps> = ({ tracking, className, children }) => {
+    return (
+        <p className={classNames("text-base text-gray-500 dark:text-gray-600", getTracking(tracking), className)}>
+            {children}
+        </p>
+    );
 };
+
+function getHeadingColor(color: HeadingProps["color"] = "dark") {
+    return color === "dark" ? "text-gray-800 dark:text-gray-100" : "text-gray-500 dark:text-gray-400";
+}
+
+function getTracking(tracking: HeadingProps["tracking"]) {
+    if (tracking === "wide") {
+        return "tracking-wide";
+    } else if (tracking === "tight") {
+        return "tracking-tight";
+    }
+
+    return null;
+}

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FC } from "react";
+
+type HeadingProps = {
+    className?: string;
+};
+
+export const Heading1: FC<HeadingProps> = ({ className, children }) => {
+    return <h1 className={classNames("text-gray-900 dark:text-gray-100 font-bold text-4xl", className)}>{children}</h1>;
+};
+
+// Intended to be placed beneath a heading to provide more context
+export const Subheading: FC<HeadingProps> = ({ className, children }) => {
+    return <p className={classNames("text-base text-gray-500 dark:text-gray-600", className)}>{children}</p>;
+};

--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -11,6 +11,7 @@ import meh from "../images/feedback/meh-emoji.svg";
 import crying from "../images/feedback/crying-emoji.svg";
 import { trackEvent, TrackFeedback } from "../Analytics";
 import { StartWorkspaceError } from "../start/StartPage";
+import { Heading2 } from "../components/typography/headings";
 
 function FeedbackComponent(props: {
     onClose?: () => void;
@@ -76,7 +77,7 @@ function FeedbackComponent(props: {
 
     return (
         <>
-            {props.isModal && !isFeedbackSubmitted && <h3 className="mb-4">Send Feedback</h3>}
+            {props.isModal && !isFeedbackSubmitted && <Heading2 className="mb-4">Send Feedback</Heading2>}
             {minimisedFirstView && (
                 <div
                     className={

--- a/components/dashboard/src/onboarding/OnboardingStep.tsx
+++ b/components/dashboard/src/onboarding/OnboardingStep.tsx
@@ -7,7 +7,7 @@
 import { FC, FormEvent, useCallback } from "react";
 import Alert from "../components/Alert";
 import { Button } from "../components/Button";
-import { Heading1, Subheading } from "../components/typography/headings";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 type Props = {
     title: string;
@@ -40,7 +40,8 @@ export const OnboardingStep: FC<Props> = ({
 
     return (
         <div className="flex flex-col items-center justify-center max-w-full">
-            <Heading1>{title}</Heading1>
+            {/* Intentionally adjusting the size of the heading here */}
+            <Heading2 className="text-4xl">{title}</Heading2>
             <Subheading>{subtitle}</Subheading>
 
             <form className="mt-8 mb-14 max-w-lg" onSubmit={handleSubmit}>

--- a/components/dashboard/src/onboarding/OnboardingStep.tsx
+++ b/components/dashboard/src/onboarding/OnboardingStep.tsx
@@ -7,6 +7,7 @@
 import { FC, FormEvent, useCallback } from "react";
 import Alert from "../components/Alert";
 import { Button } from "../components/Button";
+import { Heading1, Subheading } from "../components/typography/headings";
 
 type Props = {
     title: string;
@@ -39,9 +40,8 @@ export const OnboardingStep: FC<Props> = ({
 
     return (
         <div className="flex flex-col items-center justify-center max-w-full">
-            {/* TODO: Fix our base heading styles so we don't have to override */}
-            <h2 className="text-3xl text-gray-900 dark:text-gray-100 font-bold">{title}</h2>
-            <p className="text-base text-gray-500 dark:text-gray-400">{subtitle}</p>
+            <Heading1>{title}</Heading1>
+            <Subheading>{subtitle}</Subheading>
 
             <form className="mt-8 mb-14 max-w-lg" onSubmit={handleSubmit}>
                 {/* Form contents provided as children */}

--- a/components/dashboard/src/onboarding/StepPersonalize.tsx
+++ b/components/dashboard/src/onboarding/StepPersonalize.tsx
@@ -8,6 +8,7 @@ import { User } from "@gitpod/gitpod-protocol";
 import { FC, useCallback, useState } from "react";
 import SelectIDEComponent from "../components/SelectIDEComponent";
 import { ThemeSelector } from "../components/ThemeSelector";
+import { Heading2, Subheading } from "../components/typography/headings";
 import { OnboardingStep } from "./OnboardingStep";
 
 type Props = {
@@ -32,8 +33,8 @@ export const StepPersonalize: FC<Props> = ({ user, onComplete }) => {
             isValid={isValid}
             onSubmit={handleSubmitted}
         >
-            <h3>Choose an editor</h3>
-            <p>You can change this later in your user preferences.</p>
+            <Heading2>Choose an editor</Heading2>
+            <Subheading className="mb-2">You can change this later in your user preferences.</Subheading>
             <SelectIDEComponent
                 onSelectionChange={(ide, latest) => {
                     setIDE(ide);

--- a/components/dashboard/src/projects/Events.tsx
+++ b/components/dashboard/src/projects/Events.tsx
@@ -17,6 +17,7 @@ import { openAuthorizeWindow } from "../provider-utils";
 import { useCurrentProject } from "./project-context";
 import { toRemoteURL } from "./render-utils";
 import { Redirect } from "react-router";
+import { Subheading } from "../components/typography/headings";
 
 export default function EventsPage() {
     const { project, loading } = useCurrentProject();
@@ -112,13 +113,13 @@ export default function EventsPage() {
             <Header
                 title="Prebuild Events"
                 subtitle={
-                    <h2 className="tracking-wide">
+                    <Subheading tracking="wide">
                         View recent prebuild events for{" "}
                         <a className="gp-link" href={project?.cloneUrl!}>
                             {toRemoteURL(project?.cloneUrl || "")}
                         </a>
                         .
-                    </h2>
+                    </Subheading>
                 }
             />
             <div className="app-container">

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -22,6 +22,7 @@ import ErrorMessage from "../components/ErrorMessage";
 import Spinner from "../icons/Spinner.svg";
 import { useRefreshProjects } from "../data/projects/list-projects-query";
 import { projectsPathNew } from "./projects.routes";
+import { Heading1, Subheading } from "../components/typography/headings";
 
 export default function NewProject() {
     const currentTeam = useCurrentTeam();
@@ -288,7 +289,7 @@ export default function NewProject() {
 
         const projectText = () => {
             return (
-                <p className="text-gray-500 text-center text-base">
+                <Subheading className="text-center">
                     Projects allow you to manage prebuilds and workspaces for your repository.{" "}
                     <a
                         href="https://www.gitpod.io/docs/configure/projects"
@@ -298,7 +299,7 @@ export default function NewProject() {
                     >
                         Learn more
                     </a>
-                </p>
+                </Subheading>
             );
         };
 
@@ -507,7 +508,7 @@ export default function NewProject() {
         return (
             <div className="flex flex-col w-96 mt-24 mx-auto items-center">
                 <>
-                    <h1>New Project</h1>
+                    <Heading1>New Project</Heading1>
 
                     {!selectedRepo && renderSelectRepository()}
                 </>
@@ -530,15 +531,15 @@ export default function NewProject() {
         return (
             <div className="flex flex-col w-96 mt-24 mx-auto items-center">
                 <>
-                    <h1>Project Created</h1>
+                    <Heading1>Project Created</Heading1>
 
-                    <p className="mt-2 text-gray-500 text-center text-base">
+                    <Subheading className="mt-2 text-center">
                         Created{" "}
                         <a className="gp-link" href={projectLink}>
                             {project.name}
                         </a>{" "}
                         {location}
-                    </p>
+                    </Subheading>
 
                     <div className="mt-12">
                         <button onClick={onNewWorkspace}>New Workspace</button>

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -14,6 +14,7 @@ import Spinner from "../icons/Spinner.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { shortCommitMessage } from "./render-utils";
 import { useCurrentProject } from "./project-context";
+import { Heading1, Subheading } from "../components/typography/headings";
 
 export default function PrebuildPage() {
     const history = useHistory();
@@ -52,7 +53,7 @@ export default function PrebuildPage() {
         if (!prebuild) {
             return "unknown prebuild";
         }
-        return <h1 className="tracking-tight">{prebuild.info.branch} </h1>;
+        return <Heading1>{prebuild.info.branch} </Heading1>;
     };
 
     const renderSubtitle = () => {
@@ -69,9 +70,9 @@ export default function PrebuildPage() {
         return (
             <div className="flex">
                 <div className="my-auto">
-                    <p>
+                    <Subheading>
                         {startedByAvatar}Triggered {dayjs(prebuild.info.startedAt).fromNow()}
-                    </p>
+                    </Subheading>
                 </div>
                 <p className="mx-2 my-auto">·</p>
                 <div className="my-auto">

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -12,6 +12,7 @@ import { Redirect, useHistory } from "react-router";
 import Alert from "../components/Alert";
 import Header from "../components/Header";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
+import { Subheading } from "../components/typography/headings";
 import NoAccess from "../icons/NoAccess.svg";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { openAuthorizeWindow } from "../provider-utils";
@@ -195,13 +196,13 @@ export default function ProjectsPage() {
             <Header
                 title={project?.name || "Loading..."}
                 subtitle={
-                    <h2 className="tracking-wide">
+                    <Subheading tracking="wide">
                         View recent active branches for{" "}
                         <a target="_blank" rel="noreferrer noopener" className="gp-link" href={project?.cloneUrl!}>
                             {toRemoteURL(project?.cloneUrl || "")}
                         </a>
                         .
-                    </h2>
+                    </Subheading>
                 }
                 tabs={getProjectTabs(project)}
             />

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -19,6 +19,7 @@ import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
 import { RemoveProjectModal } from "./RemoveProjectModal";
 import { getProjectSettingsMenu, getProjectTabs } from "./projects.routes";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export function ProjectSettingsPage(props: { project?: Project; children?: React.ReactNode }) {
     return (
@@ -93,10 +94,8 @@ export default function ProjectSettingsView() {
 
     return (
         <ProjectSettingsPage project={project}>
-            <h3>Prebuilds</h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">
-                Choose the workspace machine type for your prebuilds.
-            </p>
+            <Heading2>Prebuilds</Heading2>
+            <Subheading>Choose the workspace machine type for your prebuilds.</Subheading>
             {BillingMode.canSetWorkspaceClass(billingMode) ? (
                 <SelectWorkspaceClass
                     workspaceClass={project.settings?.workspaceClasses?.prebuild}
@@ -203,10 +202,8 @@ export default function ProjectSettingsView() {
                 </div>
             </div>
             <div>
-                <h3 className="mt-12">Workspaces</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">
-                    Choose the workspace machine type for your workspaces.
-                </p>
+                <Heading2 className="mt-12">Workspaces</Heading2>
+                <Subheading>Choose the workspace machine type for your workspaces.</Subheading>
                 {BillingMode.canSetWorkspaceClass(billingMode) ? (
                     <SelectWorkspaceClass
                         workspaceClass={project.settings?.workspaceClasses?.regular}
@@ -240,11 +237,11 @@ export default function ProjectSettingsView() {
                 )}
             </div>
             <div className="">
-                <h3 className="mt-12">Remove Project</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400 pb-4">
+                <Heading2 className="mt-12">Remove Project</Heading2>
+                <Subheading className="pb-4">
                     This will delete the project and all project-level environment variables you've set for this
                     project.
-                </p>
+                </Subheading>
                 <button className="danger secondary" onClick={() => setShowRemoveModal(true)}>
                     Remove Project
                 </button>

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -12,6 +12,7 @@ import CheckBox from "../components/CheckBox";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
+import { Heading2, Subheading } from "../components/typography/headings";
 import { getGitpodService } from "../service/service";
 import { useCurrentProject } from "./project-context";
 import { ProjectSettingsPage } from "./ProjectSettings";
@@ -57,18 +58,18 @@ export default function ProjectVariablesPage() {
             )}
             <div className="mb-2 flex">
                 <div className="flex-grow">
-                    <h3>Environment Variables</h3>
-                    <h2 className="text-gray-500">Manage project-specific environment variables.</h2>
+                    <Heading2>Environment Variables</Heading2>
+                    <Subheading>Manage project-specific environment variables.</Subheading>
                 </div>
                 {envVars.length > 0 && <button onClick={() => setShowAddVariableModal(true)}>New Variable</button>}
             </div>
             {envVars.length === 0 ? (
-                <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full py-28 flex flex-col items-center">
-                    <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Environment Variables</h3>
-                    <p className="text-center pb-6 text-gray-500 text-base w-96">
+                <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full py-28 flex flex-col items-center justify-center space-y-3">
+                    <Heading2 color="light">No Environment Variables</Heading2>
+                    <Subheading className="text-center w-96">
                         All <strong>project-specific environment variables</strong> will be visible in prebuilds and
                         optionally in workspaces for this project.
-                    </p>
+                    </Subheading>
                     <button onClick={() => setShowAddVariableModal(true)}>New Variable</button>
                 </div>
             ) : (

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -11,7 +11,7 @@ import Alert from "../components/Alert";
 import CheckBox from "../components/CheckBox";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { getGitpodService } from "../service/service";
 import { useCurrentProject } from "./project-context";
@@ -136,8 +136,8 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
                 return false;
             }}
         >
-            <h3 className="mb-4">New Variable</h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+            <ModalHeader>New Variable</ModalHeader>
+            <ModalBody>
                 <Alert type="warning">
                     <strong>Project environment variables can be exposed.</strong>
                     <br />
@@ -186,15 +186,15 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
                         </InfoBox>
                     </div>
                 )}
-            </div>
-            <div className="flex justify-end mt-6">
+            </ModalBody>
+            <ModalFooter>
                 <button className="secondary" onClick={props.onClose}>
                     Cancel
                 </button>
                 <button className="ml-2" onClick={addVariable}>
                     Add Variable
                 </button>
-            </div>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -19,6 +19,7 @@ import { SpinnerLoader } from "../components/Loader";
 import { useListProjectsQuery } from "../data/projects/list-projects-query";
 import { projectsPathNew } from "./projects.routes";
 import search from "../icons/search.svg";
+import { Heading2 } from "../components/typography/headings";
 
 export default function ProjectsPage() {
     const history = useHistory();
@@ -67,7 +68,7 @@ export default function ProjectsPage() {
                         role="presentation"
                         src={isDark ? projectsEmptyDark : projectsEmpty}
                     />
-                    <h3 className="text-center text-gray-500 mt-8">No Recent Projects</h3>
+                    <Heading2 className="text-center mt-8">No Recent Projects</Heading2>
                     <p className="text-center text-base text-gray-500 mt-4">
                         Add projects to enable and manage Prebuilds.
                         <br />

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -13,7 +13,7 @@ import {
     GitpodServer,
 } from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser, UserContext } from "../user-context";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
@@ -242,8 +242,8 @@ export function CreateWorkspace({ contextUrl }: CreateWorkspaceProps) {
         statusMessage = (
             // TODO: Use title and buttons props
             <Modal visible={true} closeable={false} onClose={() => {}}>
-                <h3>Running Workspaces</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                <ModalHeader>Running Workspaces</ModalHeader>
+                <ModalBody>
                     <p className="mt-1 mb-2 text-base">
                         You already have running workspaces with the same context. You can open an existing one or open
                         a new workspace.
@@ -277,12 +277,12 @@ export function CreateWorkspace({ contextUrl }: CreateWorkspaceProps) {
                             );
                         })}
                     </>
-                </div>
-                <div className="flex justify-end mt-6">
+                </ModalBody>
+                <ModalFooter>
                     <button onClick={() => createWorkspace({ ignoreRunningWorkspaceOnSameCommit: true })}>
                         New Workspace
                     </button>
-                </div>
+                </ModalFooter>
             </Modal>
         );
     } else if (result?.runningWorkspacePrebuild) {

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -7,6 +7,7 @@
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { useEffect } from "react";
 import Alert from "../components/Alert";
+import { Heading2 } from "../components/typography/headings";
 import { UsageLimitReachedModal } from "../components/UsageLimitReachedModal";
 import gitpodIconUA from "../icons/gitpod.svg";
 import { gitpodHostUrl } from "../service/service";
@@ -105,7 +106,7 @@ export function StartPage(props: StartPageProps) {
                         error || phase === StartPhase.Stopped || phase === StartPhase.IdeReady ? "" : "animate-bounce"
                     }`}
                 />
-                <h3 className="mt-8 text-xl">{title}</h3>
+                <Heading2 className="mt-8">{title}</Heading2>
                 {typeof phase === "number" && phase < StartPhase.IdeReady && (
                     <ProgressBar phase={phase} error={!!error} />
                 )}

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -11,7 +11,7 @@ import { useHistory } from "react-router";
 import Header from "../components/Header";
 import DropDown from "../components/DropDown";
 import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import Tooltip from "../components/Tooltip";
 import copy from "../images/copy.svg";
 import { UserContext } from "../user-context";
@@ -287,8 +287,8 @@ export default function MembersPage() {
             {genericInviteId && showInviteModal && (
                 // TODO: Use title and buttons props
                 <Modal visible={true} onClose={() => setShowInviteModal(false)}>
-                    <h3 className="mb-4">Invite Members</h3>
-                    <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+                    <ModalHeader>Invite Members</ModalHeader>
+                    <ModalBody>
                         <label htmlFor="inviteUrl" className="font-medium">
                             Invite URL
                         </label>
@@ -315,15 +315,15 @@ export default function MembersPage() {
                         <p className="mt-1 text-gray-500 text-sm">
                             Use this URL to join this organization as a member.
                         </p>
-                    </div>
-                    <div className="flex justify-end mt-6 space-x-2">
+                    </ModalBody>
+                    <ModalFooter>
                         <button className="secondary" onClick={() => resetInviteLink()}>
                             Reset Invite Link
                         </button>
                         <button className="secondary" onClick={() => setShowInviteModal(false)}>
                             Close
                         </button>
-                    </div>
+                    </ModalFooter>
                 </Modal>
             )}
         </>

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -9,7 +9,7 @@ import { useHistory } from "react-router-dom";
 import { TeamsContext } from "./teams-context";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { ConnectError } from "@bufbuild/connect-web";
-import { Heading1, Subheading } from "../components/typography/headings";
+import { Heading1, Heading2, Heading3, Subheading } from "../components/typography/headings";
 
 export default function NewTeamPage() {
     const { setTeams } = useContext(TeamsContext);
@@ -57,8 +57,8 @@ export default function NewTeamPage() {
             </Subheading>
             <form className="mt-16" onSubmit={createTeam}>
                 <div className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
-                    <h3 className="text-left text-lg">You're creating a new organization</h3>
-                    <p className="text-gray-500">After creating an organization, you can invite others to join.</p>
+                    <Heading3>You're creating a new organization</Heading3>
+                    <Subheading>After creating an organization, you can invite others to join.</Subheading>
                     <br />
                     <h4>Organization Name</h4>
                     <input

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -9,6 +9,7 @@ import { useHistory } from "react-router-dom";
 import { TeamsContext } from "./teams-context";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { ConnectError } from "@bufbuild/connect-web";
+import { Heading1, Subheading } from "../components/typography/headings";
 
 export default function NewTeamPage() {
     const { setTeams } = useContext(TeamsContext);
@@ -43,8 +44,8 @@ export default function NewTeamPage() {
 
     return (
         <div className="flex flex-col w-96 mt-24 mx-auto items-center">
-            <h1>New&nbsp;Organization</h1>
-            <p className="text-gray-500 text-center text-base">
+            <Heading1>New&nbsp;Organization</Heading1>
+            <Subheading className="text-center">
                 <a href="https://www.gitpod.io/docs/configure/teams" className="gp-link">
                     Organizations
                 </a>{" "}
@@ -53,7 +54,7 @@ export default function NewTeamPage() {
                     projects
                 </a>{" "}
                 and collaborate with other members.
-            </p>
+            </Subheading>
             <form className="mt-16" onSubmit={createTeam}>
                 <div className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
                     <h3 className="text-left text-lg">You're creating a new organization</h3>

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -16,6 +16,7 @@ import Modal from "../components/Modal";
 import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
 import { OrgSettingsPage } from "./OrgSettingsPage";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function SSO() {
     const team = useCurrentTeam();
@@ -86,8 +87,8 @@ function OIDCClients(props: { organizationId: string }) {
 
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
-                    <h3>Single sign sign-on with OIDC</h3>
-                    <h2>Setup SSO for your organization.</h2>
+                    <Heading2>Single sign sign-on with OIDC</Heading2>
+                    <Subheading>Setup SSO for your organization.</Subheading>
                 </div>
                 {clientConfigs.length !== 0 ? (
                     <div className="mt-3 flex mt-0">

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -13,6 +13,7 @@ import Card from "../components/Card";
 import DropDown from "../components/DropDown";
 import PillLabel from "../components/PillLabel";
 import SolidCard from "../components/SolidCard";
+import { Heading2, Subheading } from "../components/typography/headings";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useOrgMembers } from "../data/organizations/org-members-query";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
@@ -149,8 +150,8 @@ const TeamBilling: FunctionComponent = () => {
     function renderTeamBilling(): JSX.Element {
         return (
             <>
-                <h3>{!teamPlan ? "Select Plan" : "Current Plan"}</h3>
-                <h2 className="text-gray-500">
+                <Heading2>{!teamPlan ? "Select Plan" : "Current Plan"}</Heading2>
+                <Subheading>
                     {!teamPlan ? (
                         <div className="flex space-x-1">
                             <span>Currency:</span>
@@ -175,7 +176,7 @@ const TeamBilling: FunctionComponent = () => {
                             This organization is currently on the <strong>{teamPlan.name}</strong> plan.
                         </span>
                     )}
-                </h2>
+                </Subheading>
                 <div className="mt-4 space-x-4 flex">
                     {isLoading && (
                         <>

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -9,6 +9,7 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import React, { useCallback, useContext, useState } from "react";
 import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
+import { Heading2, Subheading } from "../components/typography/headings";
 import { teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
@@ -111,10 +112,10 @@ export default function TeamSettings() {
     return (
         <>
             <OrgSettingsPage>
-                <h3>Organization Name</h3>
-                <p className="text-base text-gray-500 max-w-2xl">
+                <Heading2>Organization Name</Heading2>
+                <Subheading className="max-w-2xl">
                     This is your organization's visible name within Gitpod. For example, the name of your company.
-                </p>
+                </Subheading>
                 {errorMessage && (
                     <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
                         {errorMessage}
@@ -143,11 +144,11 @@ export default function TeamSettings() {
                     </button>
                 </div>
 
-                <h3 className="pt-12">Delete Organization</h3>
-                <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                <Heading2 className="pt-12">Delete Organization</Heading2>
+                <Subheading className="pb-4 max-w-2xl">
                     Deleting this organization will also remove all associated data, including projects and workspaces.
                     Deleted organizations cannot be restored!
-                </p>
+                </Subheading>
                 <button className="danger secondary" onClick={() => setModal(true)}>
                     Delete Organization
                 </button>

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -10,6 +10,7 @@ import { useCurrentTeam } from "./teams-context";
 import { getGitpodService } from "../service/service";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { Heading2 } from "../components/typography/headings";
 
 export default function TeamUsageBasedBilling() {
     const team = useCurrentTeam();
@@ -30,7 +31,7 @@ export default function TeamUsageBasedBilling() {
 
     return (
         <>
-            <h3>Organization Billing</h3>
+            <Heading2>Organization Billing</Heading2>
             <UsageBasedBillingConfig attributionId={team && AttributionId.render({ kind: "team", teamId: team.id })} />
         </>
     );

--- a/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
@@ -6,6 +6,7 @@
 
 import { FunctionComponent } from "react";
 import { SpinnerLoader } from "../../components/Loader";
+import { Heading2, Subheading } from "../../components/typography/headings";
 import { useOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
 import { GitIntegrationsList } from "./GitIntegrationsList";
 
@@ -16,8 +17,10 @@ export const GitIntegrations: FunctionComponent = () => {
         <div>
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
-                    <h3>Git Integrations</h3>
-                    <h2>Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.</h2>
+                    <Heading2>Git Integrations</Heading2>
+                    <Subheading>
+                        Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.
+                    </Subheading>
                 </div>
             </div>
 

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -7,6 +7,7 @@
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useState } from "react";
 import { ItemsList } from "../../components/ItemsList";
+import { Heading2 } from "../../components/typography/headings";
 import { GitIntegrationListItem } from "./GitIntegrationListItem";
 import { GitIntegrationModal } from "./GitIntegrationModal";
 
@@ -24,7 +25,9 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
             {providers.length === 0 ? (
                 <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
                     <div className="m-auto text-center px-8">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Git Integrations</h3>
+                        <Heading2 color="light" className="self-center mb-4">
+                            No Git Integrations
+                        </Heading2>
                         <div className="text-gray-500 mb-6 max-w-md">
                             In addition to the default Git Providers you can authorize with a self-hosted instance of a
                             provider.

--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -12,6 +12,7 @@ import ConfirmationModal from "../components/ConfirmationModal";
 import ProfileInformation, { ProfileState } from "./ProfileInformation";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { Button } from "../components/Button";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function Account() {
     const { user, setUser } = useContext(UserContext);
@@ -68,7 +69,7 @@ export default function Account() {
             </ConfirmationModal>
 
             <PageWithSettingsSubMenu>
-                <h3>Profile</h3>
+                <Heading2>Profile</Heading2>
                 <form
                     onSubmit={(e) => {
                         saveProfileState();
@@ -89,10 +90,8 @@ export default function Account() {
                         </div>
                     </ProfileInformation>
                 </form>
-                <h3 className="mt-12">Delete Account</h3>
-                <p className="text-base text-gray-500 pb-4">
-                    This action will remove all the data associated with your account in Gitpod.
-                </p>
+                <Heading2 className="mt-12">Delete Account</Heading2>
+                <Subheading>This action will remove all the data associated with your account in Gitpod.</Subheading>
                 <Button type="danger.secondary" onClick={() => setModal(true)}>
                     Delete Account
                 </Button>

--- a/components/dashboard/src/user-settings/Billing.tsx
+++ b/components/dashboard/src/user-settings/Billing.tsx
@@ -7,6 +7,7 @@
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Redirect } from "react-router";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
+import { Heading2 } from "../components/typography/headings";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import { useCurrentUser } from "../user-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
@@ -20,11 +21,11 @@ export default function Billing() {
     return (
         <PageWithSettingsSubMenu>
             <div>
-                <h3>Default Billing Account</h3>
+                <Heading2>Default Billing Account</Heading2>
                 <BillingAccountSelector />
                 {!user?.additionalData?.isMigratedToTeamOnlyAttribution && (
                     <>
-                        <h3 className="mt-12">Personal Billing</h3>
+                        <Heading2 className="mt-12">Personal Billing</Heading2>
                         <UsageBasedBillingConfig
                             attributionId={user && AttributionId.render({ kind: "user", userId: user.id })}
                         />

--- a/components/dashboard/src/user-settings/ChargebeeTeams.tsx
+++ b/components/dashboard/src/user-settings/ChargebeeTeams.tsx
@@ -24,6 +24,7 @@ import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function ChargebeeTeams() {
     return (
@@ -456,8 +457,8 @@ function AllTeams() {
         <div>
             <div className="flex flex-row">
                 <div className="flex-grow ">
-                    <h3 className="self-center">All Team Plans</h3>
-                    <h2>Manage team plans and members.</h2>
+                    <Heading2 className="self-center">All Team Plans</Heading2>
+                    <Subheading>Manage team plans and members.</Subheading>
                 </div>
                 <div className="flex flex-end space-x-3">
                     {isChargebeeCustomer && (

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -13,6 +13,7 @@ import { getGitpodService } from "../service/service";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { EnvironmentVariableEntry } from "./EnvironmentVariableEntry";
 import { Button } from "../components/Button";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -221,8 +222,8 @@ export default function EnvVars() {
             )}
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
-                    <h3>Environment Variables</h3>
-                    <h2 className="text-gray-500">
+                    <Heading2>Environment Variables</Heading2>
+                    <Subheading>
                         Variables are used to store information like passwords.{" "}
                         <a
                             className="gp-link"
@@ -232,7 +233,7 @@ export default function EnvVars() {
                         >
                             Learn more
                         </a>
-                    </h2>
+                    </Subheading>
                 </div>
                 {envVars.length !== 0 ? (
                     <div className="mt-3 flex mt-0">

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -246,11 +246,13 @@ export default function EnvVars() {
             {envVars.length === 0 ? (
                 <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full h-96">
                     <div className="pt-28 flex flex-col items-center w-96 m-auto">
-                        <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Environment Variables</h3>
-                        <div className="text-center pb-6 text-gray-500">
+                        <Heading2 color="light" className="text-center pb-3">
+                            No Environment Variables
+                        </Heading2>
+                        <Subheading className="text-center pb-6">
                             In addition to user-specific environment variables you can also pass variables through a
                             workspace creation URL.
-                        </div>
+                        </Subheading>
                         <button onClick={add}>New Variable</button>
                     </div>
                 </div>

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -14,6 +14,7 @@ import { ContextMenuEntry } from "../components/ContextMenu";
 import InfoBox from "../components/InfoBox";
 import { ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalHeader, ModalFooter } from "../components/Modal";
+import { Heading2, Subheading } from "../components/typography/headings";
 import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
 import { openAuthorizeWindow } from "../provider-utils";
@@ -323,8 +324,8 @@ function GitProviders() {
                 </Modal>
             )}
 
-            <h3>Git Providers</h3>
-            <h2 className="text-gray-500">
+            <Heading2>Git Providers</Heading2>
+            <Subheading>
                 Manage permissions for Git providers.{" "}
                 <a
                     className="gp-link"
@@ -334,7 +335,7 @@ function GitProviders() {
                 >
                     Learn more
                 </a>
-            </h2>
+            </Subheading>
             <ItemsList className="pt-6">
                 {authProviders &&
                     authProviders.map((ap) => (
@@ -431,8 +432,10 @@ function GitIntegrations() {
 
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
-                    <h3>Git Integrations</h3>
-                    <h2>Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.</h2>
+                    <Heading2>Git Integrations</Heading2>
+                    <Subheading>
+                        Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.
+                    </Subheading>
                 </div>
                 {providers.length !== 0 ? (
                     <div className="mt-3 flex mt-0">
@@ -446,11 +449,13 @@ function GitIntegrations() {
             {providers && providers.length === 0 && (
                 <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
                     <div className="m-auto text-center">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Git Integrations</h3>
-                        <div className="text-gray-500 mb-6">
+                        <Heading2 color="light" className="self-center mb-4">
+                            No Git Integrations
+                        </Heading2>
+                        <Subheading className="text-gray-500 mb-6">
                             In addition to the default Git Providers you can authorize
                             <br /> with a self-hosted instance of a provider.
-                        </div>
+                        </Subheading>
                         <button className="self-center" onClick={() => setModal({ mode: "new" })}>
                             New Integration
                         </button>

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -722,7 +722,7 @@ export function GitIntegrationModal(
     return (
         // TODO: Use title and buttons props
         <Modal visible={!!props} onClose={onClose} closeable={props.closeable}>
-            <h3 className="pb-2">{mode === "new" ? "New Git Integration" : "Git Integration"}</h3>
+            <Heading2 className="pb-2">{mode === "new" ? "New Git Integration" : "Git Integration"}</Heading2>
             <div className="space-y-4 border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
                 {mode === "edit" && providerEntry?.status !== "verified" && (
                     <Alert type="warning">You need to activate this integration.</Alert>

--- a/components/dashboard/src/user-settings/Notifications.tsx
+++ b/components/dashboard/src/user-settings/Notifications.tsx
@@ -10,6 +10,7 @@ import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
 import { identifyUser } from "../Analytics";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
+import { Heading2 } from "../components/typography/headings";
 
 export default function Notifications() {
     const { user, setUser } = useContext(UserContext);
@@ -81,7 +82,7 @@ export default function Notifications() {
     return (
         <div>
             <PageWithSettingsSubMenu>
-                <h3>Email Notification Preferences</h3>
+                <Heading2>Email Notification Preferences</Heading2>
                 <CheckBox
                     title="Account Notifications [required]"
                     desc="Receive essential emails about changes to your account"

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -22,6 +22,7 @@ import { SpinnerLoader } from "../components/Loader";
 import TokenEntry from "./TokenEntry";
 import ShowTokenModal from "./ShowTokenModal";
 import Pagination from "../Pagination/Pagination";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function PersonalAccessTokens() {
     const { enablePersonalAccessTokens } = useContext(FeatureFlagContext);
@@ -148,15 +149,15 @@ function ListAccessTokensView() {
         <>
             <div className="flex items-center sm:justify-between mb-4">
                 <div>
-                    <h3>
+                    <Heading2>
                         Access Tokens{" "}
                         <PillLabel type="warn" className="font-semibold self-center py-0.5 px-1.5">
                             <a href="https://www.gitpod.io/docs/references/gitpod-releases">
                                 <span className="text-xs">BETA</span>
                             </a>
                         </PillLabel>
-                    </h3>
-                    <h2 className="text-gray-500">
+                    </Heading2>
+                    <Subheading>
                         Create or regenerate access tokens.{" "}
                         <a
                             className="gp-link"
@@ -175,7 +176,7 @@ function ListAccessTokensView() {
                         >
                             Send feedback
                         </a>
-                    </h2>
+                    </Subheading>
                 </div>
                 {tokens.length > 0 && (
                     <Link to={settingsPathPersonalAccessTokenCreate}>
@@ -252,9 +253,9 @@ function ListAccessTokensView() {
                     ) : (
                         <>
                             <div className="px-3 py-3 flex justify-between space-x-2 text-sm text-gray-400 mb-2 bg-gray-100 dark:bg-gray-800 rounded-xl">
-                                <h2 className="w-4/12">Token Name</h2>
-                                <h2 className="w-4/12">Permissions</h2>
-                                <h2 className="w-3/12">Expires</h2>
+                                <Subheading className="w-4/12">Token Name</Subheading>
+                                <Subheading className="w-4/12">Permissions</Subheading>
+                                <Subheading className="w-3/12">Expires</Subheading>
                                 <div className="w-1/12"></div>
                             </div>
                             {tokens.map((t: PersonalAccessToken) => (

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -242,10 +242,12 @@ function ListAccessTokensView() {
                 <>
                     {tokens.length === 0 ? (
                         <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full py-28 flex flex-col items-center">
-                            <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Access Tokens</h3>
-                            <p className="text-center pb-6 text-gray-500 text-base w-96">
+                            <Heading2 color="light" className="text-center pb-3">
+                                No Access Tokens
+                            </Heading2>
+                            <Subheading className="text-center pb-6 w-96">
                                 Generate an access token for applications that need access to the Gitpod API.{" "}
-                            </p>
+                            </Subheading>
                             <Link to={settingsPathPersonalAccessTokenCreate}>
                                 <button>New Access Token</button>
                             </Link>

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -21,6 +21,7 @@ import { settingsPathPersonalAccessTokens } from "./settings.routes";
 import ShowTokenModal from "./ShowTokenModal";
 import { Timestamp } from "@bufbuild/protobuf";
 import arrowDown from "../images/sort-arrow.svg";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 interface EditPATData {
     name: string;
@@ -192,13 +193,13 @@ function PersonalAccessTokenCreateView() {
                 <SpinnerOverlayLoader content="loading access token" loading={loading}>
                     <div className="mb-6">
                         <div className="flex flex-col mb-4">
-                            <h3>{isEditing ? "Edit" : "New"} Access Token</h3>
+                            <Heading2>{isEditing ? "Edit" : "New"} Access Token</Heading2>
                             {isEditing ? (
-                                <h2 className="text-gray-500 dark:text-gray-400">
+                                <Subheading>
                                     Update token name, expiration date, permissions, or regenerate token.
-                                </h2>
+                                </Subheading>
                             ) : (
-                                <h2 className="text-gray-500 dark:text-gray-400">Create a new access token.</h2>
+                                <Subheading>Create a new access token.</Subheading>
                             )}
                         </div>
                         <div className="flex flex-col gap-4">

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -13,6 +13,7 @@ import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { ThemeSelector } from "../components/ThemeSelector";
 import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
@@ -50,8 +51,8 @@ export default function Preferences() {
     return (
         <div>
             <PageWithSettingsSubMenu>
-                <h3>Editor</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">
+                <Heading2>Editor</Heading2>
+                <Subheading>
                     Choose the editor for opening workspaces.{" "}
                     <a
                         className="gp-link"
@@ -61,13 +62,13 @@ export default function Preferences() {
                     >
                         Learn more
                     </a>
-                </p>
+                </Subheading>
                 <SelectIDE location="preferences" />
 
                 <ThemeSelector className="mt-12" />
 
-                <h3 className="mt-12">Dotfiles </h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
+                <Heading2 className="mt-12">Dotfiles</Heading2>
+                <Subheading>Customize workspaces using dotfiles.</Subheading>
                 <div className="mt-4 max-w-xl">
                     <h4>Repository URL</h4>
                     <span className="flex">
@@ -91,10 +92,8 @@ export default function Preferences() {
                     </div>
                 </div>
 
-                <h3 className="mt-12">Timeouts</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">
-                    Workspaces will stop after a period of inactivity without any user input.
-                </p>
+                <Heading2 className="mt-12">Timeouts</Heading2>
+                <Subheading>Workspaces will stop after a period of inactivity without any user input.</Subheading>
                 <div className="mt-4 max-w-xl">
                     <h4>Default Workspace Timeout</h4>
 

--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -13,7 +13,7 @@ import { SSHPublicKeyValue, UserSSHPublicKeyValue } from "@gitpod/gitpod-protoco
 import { getGitpodService } from "../service/service";
 import dayjs from "dayjs";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
-import { Subheading } from "../components/typography/headings";
+import { Heading2, Subheading } from "../components/typography/headings";
 
 interface AddModalProps {
     value: SSHPublicKeyValue;
@@ -188,7 +188,7 @@ export default function SSHKeys() {
             )}
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
-                    <h3>SSH Keys</h3>
+                    <Heading2>SSH Keys</Heading2>
                     <Subheading>
                         Create and manage SSH keys.{" "}
                         <a
@@ -212,11 +212,13 @@ export default function SSHKeys() {
             {dataList.length === 0 ? (
                 <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full h-96">
                     <div className="pt-28 flex flex-col items-center w-112 m-auto">
-                        <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No SSH Keys</h3>
-                        <div className="text-center pb-6 text-gray-500">
+                        <Heading2 color="light" className="text-center pb-3 text-gray-500 dark:text-gray-400">
+                            No SSH Keys
+                        </Heading2>
+                        <Subheading className="pb-6">
                             SSH keys allow you to establish a <b>secure connection</b> between your <b>computer</b> and{" "}
                             <b>workspaces</b>.
-                        </div>
+                        </Subheading>
                         <button onClick={addOne}>New SSH Key</button>
                     </div>
                 </div>

--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -13,6 +13,7 @@ import { SSHPublicKeyValue, UserSSHPublicKeyValue } from "@gitpod/gitpod-protoco
 import { getGitpodService } from "../service/service";
 import dayjs from "dayjs";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
+import { Subheading } from "../components/typography/headings";
 
 interface AddModalProps {
     value: SSHPublicKeyValue;
@@ -188,7 +189,7 @@ export default function SSHKeys() {
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
                     <h3>SSH Keys</h3>
-                    <h2 className="text-gray-500">
+                    <Subheading>
                         Create and manage SSH keys.{" "}
                         <a
                             className="gp-link"
@@ -198,7 +199,7 @@ export default function SSHKeys() {
                         >
                             Learn more
                         </a>
-                    </h2>
+                    </Subheading>
                 </div>
                 {dataList.length !== 0 ? (
                     <div className="mt-3 flex">

--- a/components/dashboard/src/user-settings/SelectAccountModal.tsx
+++ b/components/dashboard/src/user-settings/SelectAccountModal.tsx
@@ -8,7 +8,7 @@ import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { useEffect, useState } from "react";
 import { gitpodHostUrl } from "../service/service";
 import InfoBox from "../components/InfoBox";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import SelectableCard from "../components/SelectableCard";
 
 export function SelectAccountModal(
@@ -47,8 +47,8 @@ export function SelectAccountModal(
     return (
         // TODO: Use title and buttons props
         <Modal visible={true} onClose={props.close}>
-            <h3 className="pb-2">Select Account</h3>
-            <div className="border-t border-b border-gray-200 mt-2 -mx-6 px-6 py-4">
+            <ModalHeader>Select Account</ModalHeader>
+            <ModalBody>
                 <p className="pb-2 text-gray-500 text-base">
                     You are trying to authorize a provider that is already connected with another account on Gitpod.
                 </p>
@@ -96,9 +96,9 @@ export function SelectAccountModal(
                         </div>
                     </SelectableCard>
                 </div>
-            </div>
+            </ModalBody>
 
-            <div className="flex justify-end mt-6">
+            <ModalFooter>
                 <button
                     className={"ml-2"}
                     onClick={() => {
@@ -111,7 +111,7 @@ export function SelectAccountModal(
                 >
                     Continue
                 </button>
-            </div>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/whatsnew/WhatsNew.tsx
+++ b/components/dashboard/src/whatsnew/WhatsNew.tsx
@@ -5,7 +5,7 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import Modal from "../components/Modal";
+import Modal, { ModalHeader } from "../components/Modal";
 import { WhatsNewEntry202104 } from "./WhatsNew-2021-04";
 import { WhatsNewEntry202106 } from "./WhatsNew-2021-06";
 import { UserContext } from "../user-context";
@@ -70,7 +70,7 @@ export function WhatsNew(props: { onClose: () => void }) {
     return (
         // TODO: Use title and buttons props
         <Modal visible={!!visibleEntry} onClose={internalClose}>
-            <h3 className="pb-4">What's New 🎁</h3>
+            <ModalHeader>What's New 🎁</ModalHeader>
             <>{visibleEntry && user ? visibleEntry.children(user, setUser) : <></>}</>
             {hasNext() ? (
                 <>

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -26,6 +26,7 @@ import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import { useCurrentTeam } from "../teams/teams-context";
 import { useCreateWorkspaceMutation } from "../data/workspaces/create-workspace-mutation";
 import { Button } from "../components/Button";
+import { Heading1 } from "../components/typography/headings";
 
 export const useNewCreateWorkspacePage = () => {
     const { startWithOptions } = useFeatureFlags();
@@ -121,7 +122,7 @@ export function CreateWorkspacePage() {
     return (
         <div className="flex flex-col mt-32 mx-auto ">
             <div className="flex flex-col max-h-screen max-w-lg mx-auto items-center w-full">
-                <h1>New Workspace</h1>
+                <Heading1>New Workspace</Heading1>
                 <div className="text-gray-500 text-center text-base">
                     Start a new workspace with the following options.
                 </div>

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useContext } from "react";
+import { Heading2 } from "../components/typography/headings";
 import { StartWorkspaceModalContext, StartWorkspaceModalKeyBinding } from "./start-workspace-modal-context";
 
 export const EmptyWorkspacesContent = () => {
@@ -15,7 +16,9 @@ export const EmptyWorkspacesContent = () => {
             <div className="px-6 py-3 flex flex-col text-gray-400 border-t border-gray-200 dark:border-gray-800">
                 <div className="flex flex-col items-center justify-center h-96 w-96 mx-auto">
                     <>
-                        <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Workspaces</h3>
+                        <Heading2 color="light" className="text-center pb-3">
+                            No Workspaces
+                        </Heading2>
                         <div className="text-center pb-6 text-gray-500">
                             Prefix any Git repository URL with {window.location.host}/# or create a new workspace for a
                             recently used project.{" "}

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -50,6 +50,9 @@ module.exports = {
                 // TODO(andreafalzetti): remove custom ide-modal class once we implement https://github.com/gitpod-io/gitpod/issues/13116
                 51.5: "51.5rem",
             },
+            lineHeight: {
+                64: "64px",
+            },
         },
         fontFamily: {
             sans: [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introducing a set of typography components to normalize how we render Headings and Subheadings. This also aims to fix many places where we've used `<h2>` tags instead of a normal `<p>` tag, and update most of our uses of `<h3>` tags to be an `<h2>`. Many uses of heading tags aren't correctly handling dark mode, so this also addresses that. Lastly, having components for typography related elements allows us to standardize any variations we might want to offer, such as slight color or tracking variations.

I've approached this by creating the following components.

* `<Heading1>` 
* `<Heading2>` 
* `<Heading3>` 
* `<Subheading>`

I didn't replace all of the existing uses of plain html heading elements (`<h1|2|3|4>`), but tried to get most of the ones that were easy to test. Eventually we can refactor remaining tags to use the components as well. Then we can decide if we want to just remove our global styles for headings in the `index.css` file.

## How to test
<!-- Provide steps to test this PR -->
Most of the changes are found in User and Project settings. Clicking around to the various pages and ensuring headings and subheadings look correct should be a sufficient test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
