### PR TITLE
Switch to Pay-as-you-go

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -119,3 +119,7 @@ function convertToAppNotification(array: string[] | AppNotification[] | any): Ap
     }
     return notifications;
 }
+
+export const resetAllNotifications = () => {
+    removeLocalStorageObject(KEY_APP_NOTIFICATIONS);
+};

--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -10,11 +10,20 @@ import { useCurrentUser } from "./user-context";
 import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
 import { BillingSetupModal } from "./components/UsageBasedBillingConfig";
 import { SpinnerLoader } from "./components/Loader";
-import { teamsService } from "./service/public-api";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { getGitpodService } from "./service/service";
 import Alert from "./components/Alert";
 import { useLocalStorage } from "./hooks/use-local-storage";
+import { Subscription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
+import { TeamSubscription, TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
+import { useConfetti } from "./contexts/ConfettiContext";
+import { resetAllNotifications } from "./AppNotifications";
+import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
+import ContextMenu, { ContextMenuEntry } from "./components/ContextMenu";
+import CaretDown from "./icons/CaretDown.svg";
+import { TeamsContext, useCurrentTeam } from "./teams/teams-context";
+import { Team } from "@gitpod/gitpod-protocol";
+import { OrgEntry } from "./menu/OrganizationSelector";
 
 /**
  * Keys of known page params
@@ -29,13 +38,19 @@ const KEY_STRIPE_REDIRECT_STATUS = "redirect_status";
 
 type SubscriptionType = typeof KEY_PERSONAL_SUB | typeof KEY_TEAM1_SUB | typeof KEY_TEAM2_SUB;
 type PageParams = {
-    oldSubscriptionId: string;
+    oldSubscriptionOrTeamId: string;
     type: SubscriptionType;
     setupIntentId?: string;
 };
 type PageState = {
+    phase: "call-to-action" | "trigger-signup" | "wait-for-signup" | "cleanup" | "done";
     attributionId?: string;
-    result?: string;
+    setupIntentId?: string;
+    old?: {
+        planName: string;
+        planDetails: string;
+        subscriptionId: string;
+    };
 };
 
 function SwitchToPAYG() {
@@ -43,88 +58,342 @@ function SwitchToPAYG() {
     const user = useCurrentUser();
     const location = useLocation();
     const pageParams = parseSearchParams(location.search);
-    const [pageState, setPageState] = useLocalStorage<PageState>(getLocalStorageKey(pageParams), {});
+    const [pageState, setPageState] = useLocalStorage<PageState>(getLocalStorageKey(pageParams), {
+        phase: "call-to-action",
+    });
 
+    const currentOrg = useCurrentTeam();
+    const { teams } = useContext(TeamsContext);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
-    // const [stripeSubscriptionId, setStripeSubscriptionId] = useState<string | undefined>();
+    const [selectedOrganization, setSelectedOrganization] = useState<Team | undefined>(undefined);
     const [showBillingSetupModal, setShowBillingSetupModal] = useState<boolean>(false);
     const [pendingStripeSubscription, setPendingStripeSubscription] = useState<boolean>(false);
+    const [droppedConfetti, setDroppedConfetti] = useState<boolean>(false);
+    const { dropConfetti } = useConfetti();
 
     useEffect(() => {
-        const { attributionId } = pageState;
-        const oldSubscriptionId = pageParams?.oldSubscriptionId;
-        const setupIntentId = pageParams?.setupIntentId;
-        if (!attributionId || !setupIntentId || !oldSubscriptionId) {
+        setSelectedOrganization(currentOrg);
+    }, [currentOrg, setSelectedOrganization]);
+
+    useEffect(() => {
+        const { phase, attributionId, setupIntentId } = pageState;
+        if (phase !== "trigger-signup") {
+            return;
+        }
+        console.log("phase: " + phase);
+
+        // We're back from the Stripe modal: (safely) trigger the signup
+        if (!attributionId) {
+            console.error("Signup, but attributionId not set!");
+            return;
+        }
+        if (!setupIntentId) {
+            console.error("Signup, but setupIntentId not set!");
+            setPageState((s) => ({ ...s, phase: "call-to-action" }));
             return;
         }
 
-        // remove
-        // deleteSearchParams([KEY_STRIPE_SETUP_INTENT, KEY_STRIPE_REDIRECT_STATUS, KEY_STRIPE_IGNORED]);
-
+        let cancelled = false;
         (async () => {
+            // At this point we're coming back from the Stripe modal, and have the intent to setup a new subscription.
+            // Technically, we have to guard against:
+            //  - reloads
+            //  - unmounts (for whatever reason)
+
+            // Do we already have a subscription (co-owner, me in another tab, reload, etc.)?
+            let subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
+            if (subscriptionId) {
+                console.log(`${attributionId} already has a subscription! Moving to cleanup`);
+                // We're happy!
+                if (!cancelled) {
+                    setPageState((s) => ({ ...s, phase: "cleanup" }));
+                }
+                return;
+            }
+
+            // Now we want to signup for sure
             setPendingStripeSubscription(true);
             try {
+                if (cancelled) return;
+
                 const limit = 1000;
+                console.log("SUBSCRIBE TO STRIPE");
                 await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
+                // Here we go off the effect handler due to the await
+                if (!cancelled) {
+                    setPageState((s) => ({ ...s, phase: "wait-for-signup" }));
+                }
             } catch (error) {
+                if (cancelled) return;
+
                 setErrorMessage(`Could not subscribe to Stripe. ${error?.message || String(error)}`);
                 setPendingStripeSubscription(false);
                 return;
             }
+        })().catch(console.error);
 
-            // unfortunately, we need to poll for the subscription
-            let subscriptionId: string | undefined;
-            for (let i = 1; i <= 10; i++) {
-                try {
-                    subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
-                    if (subscriptionId) {
-                        break;
-                    }
-                } catch (error) {
-                    console.error("Search for subscription failed.", error);
+        return () => {
+            cancelled = true;
+        };
+    }, [pageState, setPageState]);
+
+    useEffect(() => {
+        const { phase, attributionId, old } = pageState;
+        const { setupIntentId, type, oldSubscriptionOrTeamId } = pageParams || {};
+        if (phase === "trigger-signup") {
+            // Handled in separate effect
+            return;
+        }
+
+        if (!type) {
+            setErrorMessage("Error during params parsing: type not set!");
+            return;
+        }
+        if (!oldSubscriptionOrTeamId) {
+            setErrorMessage("Error during params parsing: oldSubscriptionOrTeamId not set!");
+            return;
+        }
+
+        console.log("phase: " + phase);
+        switch (phase) {
+            case "call-to-action": {
+                // Check: Can we progress?
+                if (setupIntentId) {
+                    setPageState((s) => ({ ...s, setupIntentId, phase: "trigger-signup" }));
+                    return;
                 }
-                await new Promise((resolve) => setTimeout(resolve, 1000));
-            }
-            setPendingStripeSubscription(false);
-            if (subscriptionId) {
-                // setStripeSubscriptionId(subscriptionId);
-                cancelOldSubscription(pageParams.type, oldSubscriptionId);
 
-                setPageState((s) => ({ ...s, result: "done" }));
-            } else {
-                setErrorMessage(`Could not find the subscription.`);
+                // Just verify and display information
+                let cancelled = false;
+                (async () => {
+                    // Old Subscription still active?
+                    let derivedAttributionId: string | undefined = undefined;
+                    let old: PageState["old"];
+                    switch (type) {
+                        case "personalSubscription": {
+                            const oldSubscriptionId = oldSubscriptionOrTeamId;
+                            const statement = await getGitpodService().server.getAccountStatement({});
+                            if (!statement) {
+                                console.error("No AccountStatement!");
+                                break;
+                            }
+                            const sub = statement.subscriptions.find((s) => s.uid === oldSubscriptionId);
+                            if (!sub) {
+                                console.error(`No personal subscription ${oldSubscriptionId}!`);
+                                break;
+                            }
+                            const now = new Date().toISOString();
+                            if (Subscription.isCancelled(sub, now) || !Subscription.isActive(sub, now)) {
+                                // We're happy!
+                                if (!cancelled) {
+                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                }
+                                return;
+                            }
+                            old = {
+                                subscriptionId: sub.uid,
+                                planName: Plans.getById(sub.planId!)!.name,
+                                planDetails: "personal",
+                            };
+                            derivedAttributionId = AttributionId.render({ kind: "user", userId: sub.userId });
+                            break;
+                        }
+
+                        case "teamSubscription": {
+                            const oldSubscriptionId = oldSubscriptionOrTeamId;
+                            const tss = await getGitpodService().server.tsGet();
+                            const ts = tss.find((s) => s.id === oldSubscriptionId);
+                            if (!ts) {
+                                console.error(`No TeamSubscription ${oldSubscriptionId}!`);
+                                break;
+                            }
+                            const now = new Date().toISOString();
+                            if (TeamSubscription.isCancelled(ts, now) || !TeamSubscription.isActive(ts, now)) {
+                                // We're happy!
+                                if (!cancelled) {
+                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                }
+                                return;
+                            }
+                            old = {
+                                subscriptionId: ts.id,
+                                planName: Plans.getById(ts.planId!)!.name,
+                                planDetails: `${ts.quantity} Members`,
+                            };
+                            // User has to select/create new org
+                            if (selectedOrganization) {
+                                derivedAttributionId = AttributionId.render({
+                                    kind: "team",
+                                    teamId: selectedOrganization.id,
+                                });
+                            }
+                            break;
+                        }
+
+                        case "teamSubscription2": {
+                            const teamId = oldSubscriptionOrTeamId;
+                            const ts2 = await getGitpodService().server.getTeamSubscription(teamId);
+                            if (!ts2) {
+                                console.error(`No TeamSubscription2 for team ${teamId}!`);
+                                break;
+                            }
+                            const now = new Date().toISOString();
+                            if (TeamSubscription2.isCancelled(ts2, now) || !TeamSubscription2.isActive(ts2, now)) {
+                                // We're happy!
+                                if (!cancelled) {
+                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                }
+                                return;
+                            }
+                            old = {
+                                subscriptionId: ts2.id,
+                                planName: Plans.getById(ts2.planId!)!.name,
+                                planDetails: `${ts2.quantity} Members`,
+                            };
+                            derivedAttributionId = AttributionId.render({ kind: "team", teamId });
+                            break;
+                        }
+                    }
+                    if (!cancelled && !attributionId) {
+                        setPageState((s) => {
+                            const attributionId = s.attributionId || derivedAttributionId;
+                            return { ...s, attributionId, old };
+                        });
+                    }
+                })().catch(console.error);
+
+                return () => {
+                    cancelled = true;
+                };
             }
-        })();
+
+            case "wait-for-signup": {
+                // Wait for the singup to be completed
+                if (!attributionId) {
+                    console.error("Signup, but attributionId not set!");
+                    return;
+                }
+                setPendingStripeSubscription(true);
+
+                let cancelled = false;
+                (async () => {
+                    // We need to poll for the subscription to appear
+                    let subscriptionId: string | undefined;
+                    for (let i = 1; i <= 10; i++) {
+                        if (cancelled) {
+                            break;
+                        }
+
+                        try {
+                            subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
+                            if (subscriptionId) {
+                                break;
+                            }
+                        } catch (error) {
+                            console.error("Search for subscription failed.", error);
+                        }
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                    }
+                    if (cancelled) {
+                        return;
+                    }
+
+                    setPendingStripeSubscription(false);
+                    if (!subscriptionId) {
+                        setErrorMessage(`Could not find the subscription.`);
+                        return;
+                    }
+                    setPageState((s) => ({ ...s, phase: "cleanup" }));
+                })().catch(console.error);
+
+                return () => {
+                    cancelled = true;
+                };
+            }
+
+            case "cleanup": {
+                const oldSubscriptionId = old?.subscriptionId;
+                if (!oldSubscriptionId) {
+                    setErrorMessage("Error during cleanup: old.oldSubscriptionId not set!");
+                    return;
+                }
+
+                switch (type) {
+                    case "personalSubscription":
+                        getGitpodService()
+                            .server.subscriptionCancel(oldSubscriptionId)
+                            .catch((error) => {
+                                console.error(
+                                    "Failed to cancel old subscription. We should take care of that async.",
+                                    error,
+                                );
+                            });
+                        break;
+
+                    case "teamSubscription":
+                        const attrId = AttributionId.parse(attributionId || "");
+                        if (attrId?.kind === "team") {
+                            // This should always be the case
+                            getGitpodService()
+                                .server.tsAddMembersToOrg(oldSubscriptionId, attrId.teamId)
+                                .catch((error) => {
+                                    console.error("Failed to move members to new org.", error);
+                                });
+                        }
+
+                        getGitpodService()
+                            .server.tsCancel(oldSubscriptionId)
+                            .catch((error) => {
+                                console.error(
+                                    "Failed to cancel old subscription. We should take care of that async.",
+                                    error,
+                                );
+                            });
+                        break;
+
+                    case "teamSubscription2":
+                        getGitpodService()
+                            .server.cancelTeamSubscription(oldSubscriptionId)
+                            .catch((error) => {
+                                console.error(
+                                    "Failed to cancel old subscription. We should take care of that async.",
+                                    error,
+                                );
+                            });
+                        break;
+                }
+                setPageState((s) => ({ ...s, phase: "done" }));
+                return;
+            }
+
+            case "done":
+                // Hooray and confetti!
+                resetAllNotifications();
+                if (!droppedConfetti) {
+                    setDroppedConfetti(true);
+                    dropConfetti();
+                }
+                return;
+        }
     }, [
         location.search,
-        pageParams?.oldSubscriptionId,
-        pageParams?.setupIntentId,
-        pageParams?.type,
+        pageParams,
         pageState,
         setPageState,
+        pendingStripeSubscription,
+        setPendingStripeSubscription,
+        selectedOrganization,
+        dropConfetti,
+        droppedConfetti,
     ]);
 
     const onUpgradePlan = useCallback(async () => {
-        if (!user || !pageParams?.type || pageState.result) {
+        if (pageState.phase !== "call-to-action" || !pageState.attributionId) {
             return;
         }
-        setShowBillingSetupModal(true);
 
-        let attributionId: string;
-        if (pageParams.type === KEY_PERSONAL_SUB) {
-            attributionId = AttributionId.render({ kind: "user", userId: user.id });
-        } else {
-            // TODO(at) orgs should be selectable eventually.
-            // for now always create new dummy Org
-            const response = await teamsService.createTeam({ name: `${user?.name || "Unknown"}'s Org` });
-            const teamId = response.team?.id;
-            if (!teamId) {
-                return;
-            }
-            attributionId = AttributionId.render({ kind: "team", teamId });
-        }
-        setPageState((s) => ({ ...s, attributionId }));
-    }, [pageParams?.type, pageState, setPageState, user]);
+        setShowBillingSetupModal(true);
+    }, [pageState.phase, pageState.attributionId]);
 
     if (!switchToPAYG || !user || !pageParams) {
         return (
@@ -137,7 +406,7 @@ function SwitchToPAYG() {
         );
     }
 
-    if (pageState.result === "done") {
+    if (pageState.phase === "done") {
         return (
             <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full">
                 <Alert className="w-full mt-2" closable={false} showIcon={true} type="success">
@@ -147,33 +416,122 @@ function SwitchToPAYG() {
         );
     }
 
+    let titleModifier = "";
+    if (pageParams?.type === "personalSubscription") {
+        titleModifier = "personal plan";
+    } else if (pageParams?.type === "teamSubscription") {
+        titleModifier = "team plan";
+    } else if (pageParams?.type === "teamSubscription2") {
+        titleModifier = "organization's plan";
+    }
+
+    const planName = pageState.old?.planName || "Legacy Plan";
+    const planDescription = pageState.old?.planDetails || "";
+    const selectorEntries = getOrganizationSelectorEntries(teams || [], setSelectedOrganization);
     return (
-        <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full mt-32">
-            <h1>Switch to pay-as-you-go</h1>
+        <div className="flex flex-col max-h-screen max-w-3xl mx-auto items-center w-full mt-24">
+            <h1>{`Update your ${titleModifier}`}</h1>
             <div className="w-full text-gray-500 text-center">
-                Your account still manages one or more obsolete team plans.
+                Switch to the new pricing model to keep uninterrupted access and get <strong>large workspaces</strong>{" "}
+                and <strong>custom timeouts</strong>.{" "}
+                <a
+                    className="gp-link"
+                    href="https://www.gitpod.io/blog/introducing-workspace-classes-and-flexible-pricing"
+                >
+                    Learn more →
+                </a>
             </div>
-            <div className="w-96 mt-6 text-sm">
-                <Alert className="w-full mt-2" closable={false} showIcon={true} type="warning">
-                    Obsolete plans have to switch to the new pay-as-you-go pricing before <strong>Mar 31, 2023</strong>.
-                </Alert>
-                <div className="w-full h-h96 rounded-xl text-center text-gray-500 bg-gray-50 dark:bg-gray-800"></div>
-                <div className="mt-6 w-full text-center">
-                    Switch to the new pricing model to access <strong>large workspaces</strong> and{" "}
-                    <strong>pay-as-you-go</strong>.{" "}
-                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/org-plans">
-                        Learn more →
-                    </a>
+            <div className="mt-6 space-x-3 flex">
+                {renderCard({
+                    headline: "LEGACY PLAN",
+                    title: planName,
+                    description: planDescription,
+                    selected: false,
+                    action: (
+                        <Alert type="error">
+                            Discontinued on <strong>March 31st</strong>
+                        </Alert>
+                    ),
+                    additionalStyles: "",
+                })}
+                {renderCard({
+                    headline: "NEW PLAN",
+                    title: "$9 / month (1,000 credits)",
+                    description: "Pay-as-you-go after that for $0.036 per credit.",
+                    selected: true,
+                    action: (
+                        <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
+                            Estimate costs
+                        </a>
+                    ),
+                    additionalStyles: "",
+                })}
+            </div>
+            <div className="w-full grid justify-items-center">
+                <div className="w-96 mt-8 text-center">
+                    {pageParams?.type === "teamSubscription" && (
+                        <div className="w-full">
+                            <p className="text-gray-500 text-center text-base">
+                                Select organization or{" "}
+                                <a className="gp-link" target="_blank" href="/orgs/new">
+                                    create a new one
+                                </a>
+                            </p>
+                            <div className="mt-2 flex-col w-full">
+                                <div className="px-8 flex flex-col space-y-2">
+                                    <ContextMenu
+                                        customClasses="w-full left-0 cursor-pointer"
+                                        menuEntries={selectorEntries}
+                                    >
+                                        <div>
+                                            {selectedOrganization ? (
+                                                <OrgEntry
+                                                    id={selectedOrganization.id}
+                                                    title={selectedOrganization.name}
+                                                    subtitle=""
+                                                    iconSize="small"
+                                                />
+                                            ) : (
+                                                <input
+                                                    className="w-full px-12 cursor-pointer font-semibold"
+                                                    readOnly
+                                                    type="text"
+                                                    value={selectedOrganization}
+                                                ></input>
+                                            )}
+                                            <img
+                                                src={CaretDown}
+                                                title="Select Account"
+                                                className="filter-grayscale absolute top-1/2 right-3"
+                                                alt="down caret icon"
+                                            />
+                                        </div>
+                                    </ContextMenu>
+                                </div>
+                            </div>
+                            <div className="mt-2 text-sm text-gray-500 w-full text-center">
+                                Legacy Team Subscription <strong>members</strong> will be moved to the selected
+                                organization, and the new plan will cover all organization usage.
+                            </div>
+                        </div>
+                    )}
                 </div>
-                {pendingStripeSubscription && (
-                    <div className="w-full mt-6 text-center">
-                        <SpinnerLoader small={false} content="Creating subscription with Stripe" />
-                    </div>
-                )}
-                <div className="w-full mt-10 text-center">
-                    <button onClick={onUpgradePlan} disabled={showBillingSetupModal || pendingStripeSubscription}>
+                <div className="w-96 mt-8 text-center">
+                    {pendingStripeSubscription && (
+                        <div className="w-full text-center mb-2">
+                            <SpinnerLoader small={true} content="Creating subscription with Stripe" />
+                        </div>
+                    )}
+                    <button
+                        className="w-full"
+                        onClick={onUpgradePlan}
+                        disabled={pageState.phase !== "call-to-action" || !pageState.attributionId}
+                    >
                         Switch to pay-as-you-go
                     </button>
+                    <div className="mt-2 text-sm text-gray-500 w-full text-center">
+                        Remaining legacy subscription time will be refunded.
+                    </div>
                 </div>
                 {errorMessage && (
                     <Alert className="w-full mt-10" closable={false} showIcon={true} type="error">
@@ -194,34 +552,77 @@ function SwitchToPAYG() {
     );
 }
 
-/**
- * We do that in background, so no need to bother with potential error cases.
- */
-function cancelOldSubscription(type: SubscriptionType, id: string) {
-    if (type === KEY_PERSONAL_SUB) {
-        getGitpodService()
-            .server.subscriptionCancel(id)
-            .catch((error) => {
-                console.error("Failed to cancel old subscription. We should take care of that async.", error);
-            });
+function getOrganizationSelectorEntries(organizations: Team[], setSelectedOrganization: (org: Team) => void) {
+    const result: ContextMenuEntry[] = [];
+    for (const org of organizations) {
+        result.push({
+            title: org.name,
+            customContent: <OrgEntry id={org.id} title={org.name} subtitle="" iconSize="small" />,
+            onClick: () => setSelectedOrganization(org),
+        });
     }
-    if (type === KEY_TEAM1_SUB) {
-        getGitpodService()
-            .server.tsCancel(id)
-            .catch((error) => {
-                console.error("Failed to cancel old subscription. We should take care of that async.", error);
-            });
-    }
-    if (type === KEY_TEAM2_SUB) {
-        console.error("Cancellation of Team Subscription 2 is not implemented. ");
-    }
+    return result;
+}
+
+function renderCard(props: {
+    headline: string;
+    title: string;
+    description: string;
+    action: JSX.Element;
+    selected: boolean;
+    additionalStyles?: string;
+}) {
+    return (
+        <div
+            className={`rounded-xl px-3 py-3 flex flex-col cursor-pointer group transition ease-in-out ${
+                props.selected ? "bg-gray-800 dark:bg-gray-100" : "bg-gray-100 dark:bg-gray-800"
+            } ${props.additionalStyles || ""}`}
+        >
+            <div className="flex items-center">
+                <p
+                    className={`w-full pl-1 text-sm font-normal truncate ${
+                        props.selected ? "text-gray-400 dark:text-gray-400" : "text-gray-400 dark:text-gray-500"
+                    }`}
+                    title={props.headline}
+                >
+                    {props.headline}
+                </p>
+                <input className="opacity-0" type="radio" checked={props.selected} />
+            </div>
+            <div className="pl-1 grid auto-rows-auto">
+                <div
+                    className={`text-xl font-semibold mt-1 mb-4 ${
+                        props.selected ? "text-gray-100 dark:text-gray-600" : "text-gray-700 dark:text-gray-300"
+                    }`}
+                >
+                    {props.title}
+                </div>
+                <div
+                    className={`text-sm font-normal truncate w-full ${
+                        props.selected ? "text-gray-300 dark:text-gray-500" : "text-gray-500 dark:text-gray-400"
+                    }`}
+                >
+                    {props.description}
+                </div>
+                <div className="text-xl my-1 flex-row flex align-middle items-end">
+                    <div
+                        className={`text-sm font-normal truncate w-full ${
+                            props.selected ? "text-gray-300 dark:text-gray-500" : "text-gray-500 dark:text-gray-400"
+                        }`}
+                    >
+                        {props.action}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 function getLocalStorageKey(p: PageParams | undefined) {
     if (!p) {
         return "switch-to-paygo-broken-key";
     }
-    return `switch-to-paygo--old-sub-${p.oldSubscriptionId}`;
+    return `switch-to-paygo--old-sub-${p.oldSubscriptionOrTeamId}`;
 }
 
 function parseSearchParams(search: string): PageParams | undefined {
@@ -234,18 +635,11 @@ function parseSearchParams(search: string): PageParams | undefined {
         if (id) {
             return {
                 type: key as any,
-                oldSubscriptionId: id,
+                oldSubscriptionOrTeamId: id,
                 setupIntentId,
             };
         }
     }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function deleteSearchParams(keys: string[]) {
-    const newURL = new URL(window.location.href);
-    keys.forEach((key) => newURL.searchParams.delete(key));
-    window.history.pushState({ path: newURL.toString() }, "", newURL.toString());
 }
 
 export default SwitchToPAYG;

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -183,7 +183,7 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
             <div className="container">
                 <Menu />
                 {isLocalPreview() && <LocalPreviewAlert />}
-                <AppNotifications />
+                {!location.pathname.startsWith("/switch-to-payg") && <AppNotifications />}
                 <Switch>
                     <Route path="/new" exact component={CreateWorkspacePage} />
                     <Route path={projectsPathNew} exact component={NewProject} />

--- a/components/dashboard/src/components/org-icon/OrgIcon.tsx
+++ b/components/dashboard/src/components/org-icon/OrgIcon.tsx
@@ -19,13 +19,13 @@ const TEXT_SIZE_CLASSES = {
     medium: "text-xl",
 };
 
-type Props = {
+export type OrgIconProps = {
     id: string;
     name: string;
     size?: keyof typeof SIZE_CLASSES;
     className?: string;
 };
-export const OrgIcon: FunctionComponent<Props> = ({ id, name, size = "medium", className }) => {
+export const OrgIcon: FunctionComponent<OrgIconProps> = ({ id, name, size = "medium", className }) => {
     const logoBGClass = consistentClassname(id);
     const initials = getOrgInitials(name);
     const sizeClasses = SIZE_CLASSES[size];

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -6,7 +6,7 @@
 
 import { FunctionComponent, useMemo } from "react";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
-import { OrgIcon } from "../components/org-icon/OrgIcon";
+import { OrgIcon, OrgIconProps } from "../components/org-icon/OrgIcon";
 import { useCurrentTeam, useTeamMemberInfos, useTeams } from "../teams/teams-context";
 import { useCurrentOrgMember } from "../data/organizations/org-members-query";
 import { useCurrentUser } from "../user-context";
@@ -227,11 +227,12 @@ type OrgEntryProps = {
     id: string;
     title: string;
     subtitle: string;
+    iconSize?: OrgIconProps["size"];
 };
-const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle }) => {
+export const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle, iconSize }) => {
     return (
         <div className="w-full text-gray-400 flex items-center">
-            <OrgIcon id={id} name={title} className="mr-4" />
+            <OrgIcon id={id} name={title} className="mr-4" size={iconSize} />
             <div className="flex flex-col">
                 <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
                 <span>{subtitle}</span>

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1718,7 +1718,8 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         try {
             const allTS = await this.teamSubscriptionDB.findTeamSubscriptionsForUser(user.id, new Date().toISOString());
-            if (!allTS.find((ts) => ts.id === teamSubscriptionId)) {
+            const ts = allTS.find((ts) => ts.id === teamSubscriptionId);
+            if (!ts) {
                 log.error({ userId: user.id }, "Cannot cancel: unknown Team Subscription (legacy)", {
                     teamSubscriptionId,
                 });
@@ -1726,7 +1727,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             }
 
             await this.chargebeeService.cancelSubscription(
-                teamSubscriptionId,
+                ts.paymentReference,
                 {},
                 {
                     teamSubscriptionId,
@@ -2648,7 +2649,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 continue;
             }
             const url = switchToPAYG
-                ? `/switch-to-payg?teamSubscription2=${ownedTeamSubscription2.id}`
+                ? `/switch-to-payg?teamSubscription2=${team.id}` /** yes, team.id */
                 : "https://www.gitpod.io/docs/configure/billing#configure-organization-billing";
             result.unshift({
                 message: `Your '${plan.name}' subscription for Organization '${team.name}' will be discontinued on March, 31st.`,


### PR DESCRIPTION
## Description

Changes:
- made re-entry safe
- check: old subscription already cancelled
- check: stripe subscription already exists
- cancel all kinds of subscriptions
- migrate members for TeamSubscription
- choose org for TeamSubscription
- don't show notification on PAYG page
- show confetti at the end :-)

### Personal
![image](https://user-images.githubusercontent.com/32448529/223139857-1b6c0778-5477-44b4-8b4d-ec2caac13904.png)


### TeamSubscription
![image](https://user-images.githubusercontent.com/32448529/223133003-0951e29e-22a1-4383-bab9-03fd82bc64e1.png)
![image](https://user-images.githubusercontent.com/32448529/223137320-5d7dcedb-aa9d-4b73-ac73-e56ab74f2046.png)
![image](https://user-images.githubusercontent.com/32448529/223137620-97d2f60f-4ae8-44ca-88cf-2feed5f4e361.png)
![image](https://user-images.githubusercontent.com/32448529/223137798-3fb7d961-bbe6-4d22-8edd-2169b032a693.png)
![image](https://user-images.githubusercontent.com/32448529/223137899-aeaaaa9e-4467-44b0-9d9f-7a15bdc123c9.png)
![image](https://user-images.githubusercontent.com/32448529/223138005-04469f74-ea2e-4954-80eb-a93af23a7806.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/8564

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
