### PR TITLE
[ws-manager-mk2] Add duration validation

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -88,6 +88,8 @@ type GitSpec struct {
 }
 
 type TimeoutSpec struct {
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	Time *metav1.Duration `json:"time,omitempty"`
 }
 

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
@@ -262,6 +262,7 @@ spec:
               timeout:
                 properties:
                   time:
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               type:


### PR DESCRIPTION
## Description

Add validation on the duration field. The `format=duration` annotation is too lenient and still accepts some duration formats that can't be parsed by `time.ParseDuration`, so instead we can set a regex as described in https://github.com/kubernetes/apiextensions-apiserver/issues/56

Fixes an invalid duration breaking the controller list/watch, stopping reconciliation of all workspace resources.

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test
<!-- Provide steps to test this PR -->

In a preview env:
- `gp set timeout 2h`, try for various timeout values/units, and observe all succeed
- `kubectl edit workspace <name>` and manually set an invalid timeout value in `spec.timeout.time`, and check that the update gets rejected by the API server

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
