### PR TITLE
[ws-manager-mk2] Fix prebuild update events

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -13,6 +13,7 @@ import (
 	glog "github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/iws"
@@ -213,6 +214,15 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 	}
 
 	disposeStart := time.Now()
+	var snapshotName string
+	if ws.Spec.Type == workspacev1.WorkspaceTypeRegular {
+		snapshotName = storage.DefaultBackup
+	} else {
+		_, snapshotName, err = wsc.operations.SnapshotIDs(ws.Name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	alreadyDisposing, gitStatus, disposeErr := wsc.operations.DisposeWorkspace(ctx, DisposeOptions{
 		Meta: WorkspaceMeta{
 			Owner:       ws.Spec.Ownership.Owner,
@@ -220,7 +230,9 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 			InstanceId:  ws.Name,
 		},
 		WorkspaceLocation: ws.Spec.WorkspaceLocation,
+		SnapshotName:      snapshotName,
 		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
+		UpdateGitStatus:   ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
 	})
 
 	if alreadyDisposing {

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -850,6 +850,7 @@ func extractWorkspaceStatus(ws *workspacev1.Workspace) *wsmanapi.WorkspaceStatus
 			OwnerToken: ws.Status.OwnerToken,
 		},
 	}
+
 	return res
 }
 
@@ -865,16 +866,14 @@ func getConditionMessageIfTrue(conds []metav1.Condition, tpe string) string {
 func convertCondition(conds []metav1.Condition, tpe string) wsmanapi.WorkspaceConditionBool {
 	res := wsk8s.GetCondition(conds, tpe)
 	if res == nil {
-		return wsmanapi.WorkspaceConditionBool_EMPTY
+		return wsmanapi.WorkspaceConditionBool_FALSE
 	}
 
 	switch res.Status {
 	case metav1.ConditionTrue:
 		return wsmanapi.WorkspaceConditionBool_TRUE
-	case metav1.ConditionFalse:
-		return wsmanapi.WorkspaceConditionBool_FALSE
 	default:
-		return wsmanapi.WorkspaceConditionBool_EMPTY
+		return wsmanapi.WorkspaceConditionBool_FALSE
 	}
 }
 


### PR DESCRIPTION
## Description
- Change the snapshot name to be in the format snapshot-[timestamp].tar as was the case with mk1
- During prebuild updates ws-manager-mk2 sends an empty boolean if no condition is set (e.g. for aborted). On ws-manager-bridge in Typescript this is interpreted as true :grimacing:  which leads to ws-manager-bridge thinking that the prebuild has been aborted even though that is not the case
- ws-manager-bridge uses the stopping phase to determine the status of the prebuild and ignores updates for the stopped phase. This means we need to set the snapshot url during the stopping phase otherwise ws-manager-bridge does not register that the snapshot url is available

## Related Issue(s)
n.a.

## How to test
- Start prebuild in [preview environment](https://fo-mk2-preca90815df7.preview.gitpod-dev.com/workspaces)
- Start a workspace from that prebuild

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
