### PR TITLE
[redis] Add prometheus exporter

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -10268,7 +10268,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -10264,6 +10264,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -9164,6 +9164,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -9168,7 +9168,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -10081,6 +10081,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.mydomain.com/namespace/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -10085,7 +10085,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.mydomain.com/namespace/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -10914,6 +10914,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -10918,7 +10918,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -9791,6 +9791,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -9795,7 +9795,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -9281,6 +9281,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -9285,7 +9285,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -11246,6 +11246,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -11250,7 +11250,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -10107,7 +10107,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -10103,6 +10103,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -7277,7 +7277,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -7273,6 +7273,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -4431,7 +4431,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -4427,6 +4427,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -10084,6 +10084,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -10088,7 +10088,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -10085,7 +10085,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -10081,6 +10081,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -10091,6 +10091,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -10095,7 +10095,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -10092,7 +10092,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -10088,6 +10088,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -10085,7 +10085,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -10081,6 +10081,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -10097,7 +10097,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -10093,6 +10093,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -10084,6 +10084,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -10088,7 +10088,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -10529,7 +10529,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -10525,6 +10525,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -10072,6 +10072,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -10076,7 +10076,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -10084,6 +10084,28 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - env:
+        - name: REDIS_ADDR
+          value: redis://localhost:6379
+        - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+          value: "9500"
+        - name: REDIS_EXPORTER_LOG_FORMAT
+          value: json
+        image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9500
+          name: exporter
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 5M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       priorityClassName: system-node-critical

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -10088,7 +10088,7 @@ spec:
         - name: REDIS_ADDR
           value: redis://localhost:6379
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: "9500"
+          value: :9500
         - name: REDIS_EXPORTER_LOG_FORMAT
           value: json
         image: registry.hub.docker.com/oliver006/redis_exporter:v1.48.0

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -18,4 +18,10 @@ const (
 	ImageTag      = "7.0.8"
 
 	ContainerName = "redis"
+
+	ExporterRegistryImage = " oliver006/redis_exporter"
+	ExporterImageTag      = "v1.48.0"
+	ExporterContainerName = "exporter"
+	ExporterPortName      = "exporter"
+	ExporterPort          = 9500
 )

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -19,7 +19,7 @@ const (
 
 	ContainerName = "redis"
 
-	ExporterRegistryImage = " oliver006/redis_exporter"
+	ExporterRegistryImage = "oliver006/redis_exporter"
 	ExporterImageTag      = "v1.48.0"
 	ExporterContainerName = "exporter"
 	ExporterPortName      = "exporter"

--- a/install/installer/pkg/components/redis/deployment.go
+++ b/install/installer/pkg/components/redis/deployment.go
@@ -112,7 +112,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 										},
 										{
 											Name:  "REDIS_EXPORTER_WEB_LISTEN_ADDRESS",
-											Value: fmt.Sprintf("%d", ExporterPort),
+											Value: fmt.Sprintf(":%d", ExporterPort),
 										},
 										{
 											Name:  "REDIS_EXPORTER_LOG_FORMAT",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a prometheus-exporter as a sidecar to the redis deployment

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Both redis, and the exporter sidecar come up in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
