### PR TITLE
bump up gitpod-code to pick up fixes for rebuild hints

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3841,11 +3841,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3282,11 +3282,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3658,11 +3658,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4210,11 +4210,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3492,11 +3492,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3319,11 +3319,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3661,11 +3661,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3674,11 +3674,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1287,11 +1287,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2675,11 +2675,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3661,11 +3661,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3658,11 +3658,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3656,11 +3656,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3665,11 +3665,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3658,11 +3658,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3670,11 +3670,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3661,11 +3661,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3991,11 +3991,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3661,11 +3661,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3661,11 +3661,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-266edb36ec96f3f0613715c6967fd4591fdd0569" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-ae0ad032337978e1cdf293d13102696e8975f65b" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

bump up gitpod-code to pick up fixes for rebuild hints

- GH action: https://github.com/gitpod-io/gitpod-code/actions/runs/4346862414

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- You can test it by starting a workspace on gitpod.io from a commit associated with GH action, then configured couple teams on gitpod.io and check that you still have hints.
- In preview envs you should not have any hints by default.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
