### PR TITLE
[gp] track git event with instanceId

### DIFF
--- a/components/gitpod-cli/cmd/git-track-command.go
+++ b/components/gitpod-cli/cmd/git-track-command.go
@@ -57,8 +57,11 @@ var gitTrackCommand = &cobra.Command{
 		defer client.Close()
 
 		type GitEventParams struct {
-			Command             string `json:"command,omitempty"`
-			WorkspaceId         string `json:"workspaceId,omitempty"`
+			Command     string `json:"command,omitempty"`
+			WorkspaceId string `json:"workspaceId,omitempty"`
+			// most often used across all events
+			InstanceId string `json:"instanceId,omitempty"`
+			// deprecated for backward compatibility
 			WorkspaceInstanceId string `json:"workspaceInstanceId,omitempty"`
 			Timestamp           int64  `json:"timestamp,omitempty"`
 		}
@@ -66,6 +69,7 @@ var gitTrackCommand = &cobra.Command{
 		params := &GitEventParams{
 			Command:             gitTrackCommandOpts.GitCommand,
 			WorkspaceId:         wsInfo.WorkspaceId,
+			InstanceId:          wsInfo.InstanceId,
 			WorkspaceInstanceId: wsInfo.InstanceId,
 			Timestamp:           time.Now().Unix(),
 		}
@@ -76,6 +80,7 @@ var gitTrackCommand = &cobra.Command{
 		log.WithField("command", gitTrackCommandOpts.GitCommand).
 			Info("tracking the GitCommand event")
 
+		// TODO(ak) use segment directly + supervisor info to get workspace and isntance IDs, don't use server
 		err = client.TrackEvent(ctx, event)
 		if err != nil {
 			log.WithError(err).Fatal("error tracking git event")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

instead of workspaceInstanceId to allow cross events matching in Mixpanel

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open this PR on gitpod.io
- Run validate.sh from components/supervisor
- In started workspace use git push/fetch etc.
- Open Mixpanel for Gitpod go to Events view and filter out by `git_comman` event with `instanceId` property matching to instance id from `gp info`. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
