### PR TITLE
User Preferences page cleanup

### DIFF
--- a/components/dashboard/src/data/current-user/may-set-timeout-query.ts
+++ b/components/dashboard/src/data/current-user/may-set-timeout-query.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentUser } from "../../user-context";
+
+export const useUserMaySetTimeout = () => {
+    const user = useCurrentUser();
+
+    return useQuery<boolean>({
+        queryKey: getUserMaySetTimeoutQueryKey(user?.id ?? ""),
+        queryFn: async () => {
+            if (!user) {
+                throw new Error("No current user");
+            }
+
+            return !!(await getGitpodService().server.maySetTimeout());
+        },
+        enabled: !!user,
+    });
+};
+
+export const getUserMaySetTimeoutQueryKey = (userId: string) => ["may-set-timeout", { userId }];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Making a few updates and some cleanup for the User Preferences page.

* Pulling the result of if a user may set a timeout into react-query so it's cached
* Wrap Dotfiles and Timeout inputs w/ forms - allows enter key to submit
* Drop in new Button components
* Fix how we update when setting `dotfilesRepo` so we don't mutate state directly

## How to test
<!-- Provide steps to test this PR -->
* Go to the User Preferences page
* Try setting and clearing your dotfiles repo
* Try setting and clearing a custom timeout

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
