### PR TITLE
Reuse context from the reconciler

### DIFF
--- a/components/ws-manager/pkg/manager/pod_controller.go
+++ b/components/ws-manager/pkg/manager/pod_controller.go
@@ -34,7 +34,7 @@ type PodReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var pod corev1.Pod
-	err := r.Client.Get(context.Background(), req.NamespacedName, &pod)
+	err := r.Client.Get(ctx, req.NamespacedName, &pod)
 	if errors.IsNotFound(err) {
 		// pod is gone - that's ok
 		if pod, ok := r.Pods[req.NamespacedName]; ok {


### PR DESCRIPTION
## Description

Use context from the reconciler

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
