### PR TITLE
[server] lower the heartbeat limit

### DIFF
--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -14,7 +14,7 @@ type GitpodServerMethodType =
     | keyof Omit<GitpodServer, "dispose" | "setClient">
     | typeof accessCodeSyncStorage
     | typeof accessHeadlessLogs;
-type GroupKey = "default" | "startWorkspace" | "createWorkspace" | "phoneVerification";
+type GroupKey = "default" | "startWorkspace" | "createWorkspace" | "phoneVerification" | "sendHeartBeat";
 type GroupsConfig = {
     [key: string]: {
         points: number;
@@ -79,7 +79,7 @@ const defaultFunctions: FunctionsConfig = {
     setWorkspaceDescription: { group: "default", points: 1 },
     controlAdmission: { group: "default", points: 1 },
     updateWorkspaceUserPin: { group: "default", points: 1 },
-    sendHeartBeat: { group: "default", points: 1 },
+    sendHeartBeat: { group: "sendHeartBeat", points: 1 },
     watchWorkspaceImageBuildLogs: { group: "default", points: 1 },
     isPrebuildDone: { group: "default", points: 1 },
     getHeadlessLog: { group: "default", points: 1 },
@@ -258,6 +258,10 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         phoneVerification: {
             points: 10,
             durationsSec: 10,
+        },
+        sendHeartbeat: {
+            points: 10, // 10 heartbeats per user per 60s
+            durationsSec: 60,
         },
     };
 


### PR DESCRIPTION
## Description
The sendHartbeat was in the default bucket, which means it added to a limit of 60,000 calls per user minute. This PR changes it to 10 calls per minute per user. Reduces the amount of allowed heartbeat calls to 10 per minute per user

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
