### PR TITLE
[loading screen] don't send  close timeout if not owner

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -70,6 +70,7 @@ export function getIDEFrontendService(workspaceID: string, sessionId: string, se
 
 export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
     private instanceID: string | undefined;
+    private ownerId: string | undefined;
     private user: User | undefined;
     private ideCredentials!: string;
 
@@ -103,6 +104,9 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             if (!this.instanceID) {
                 return;
             }
+            if (this.ownerId !== this.user?.id) {
+                return;
+            }
             // send last heartbeat (wasClosed: true)
             const data = { sessionId: this.sessionId };
             const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
@@ -125,6 +129,8 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             this.latestInfo = info;
             const oldInstanceID = this.instanceID;
             this.instanceID = info.instanceId;
+            this.ownerId = info.ownerId;
+
             if (info.instanceId && oldInstanceID !== info.instanceId) {
                 this.auth();
             }
@@ -148,6 +154,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             workspaceDescription: workspace.workspace.description,
             workspaceType: workspace.workspace.type,
             credentialsToken: this.ideCredentials,
+            ownerId: workspace.workspace.ownerId,
         };
     }
 

--- a/components/gitpod-protocol/src/frontend-dashboard-service.ts
+++ b/components/gitpod-protocol/src/frontend-dashboard-service.ts
@@ -45,6 +45,7 @@ export namespace IDEFrontendDashboardService {
     export interface Info {
         workspaceID: string;
         loggedUserId: string;
+        ownerId: string;
 
         instanceId?: string;
         ideUrl?: string;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[loading screen] don't send  close timeout if not owner

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
