### PR TITLE
[supervisor-frontend] only wait supervisor close in debug workspace

### DIFF
--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -58,6 +58,10 @@ export class SupervisorServiceClient {
                 // bad gateway, supervisor is gone
                 return;
             }
+            if (response.status === 302 && response.headers.get("location")?.includes("/start/")) {
+                // redirect to start page, workspace is closed
+                return;
+            }
             console.debug(
                 `failed to check whether is about to shutdown, trying again...`,
                 response.status,

--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -25,13 +25,20 @@ export class SupervisorServiceClient {
     readonly ideReady = this.supervisorReady.then(() => this.checkReady("ide"));
     readonly contentReady = Promise.all([this.supervisorReady]).then(() => this.checkReady("content"));
     readonly getWorkspaceInfoPromise = this.supervisorReady.then(() => this.getWorkspaceInfo());
-    readonly supervisorWillShutdown = this.supervisorReady.then(() => this.checkWillShutdown());
+    private _supervisorWillShutdown: Promise<void> | undefined;
 
     private constructor() {}
 
+    public get supervisorWillShutdown() {
+        if (!this._supervisorWillShutdown) {
+            this._supervisorWillShutdown = this.supervisorReady.then(() => this.checkWillShutdown());
+        }
+        return this._supervisorWillShutdown;
+    }
+
     private async checkWillShutdown(delay = false): Promise<void> {
         if (delay) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await new Promise((resolve) => setTimeout(resolve, 1000));
         }
         try {
             const wsSupervisorStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href).with((url) => {
@@ -49,7 +56,7 @@ export class SupervisorServiceClient {
             }
             if (response.status === 502) {
                 // bad gateway, supervisor is gone
-                return
+                return;
             }
             console.debug(
                 `failed to check whether is about to shutdown, trying again...`,
@@ -64,7 +71,7 @@ export class SupervisorServiceClient {
         await this.checkWillShutdown(true);
     }
 
-    private async checkReady(kind: "content" | "ide" | "supervisor" , delay?: boolean): Promise<any> {
+    private async checkReady(kind: "content" | "ide" | "supervisor", delay?: boolean): Promise<any> {
         if (delay) {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[supervisor-frontend] only wait supervisor close in debug workspace

and if workspace already stopped, it actually return 302, this PR also add this condition, otherwise, if browser not receive 502 and workspace already closed, it will retry every 1 sec.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/8299500/223376174-e3fe3b40-d84e-4c0e-82f9-f39016b93531.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open a workspace in preview env
2. check network it should not have `supervisor/willShutdown/true` api call in regular workspace
3. try `gp rebuild` it should be work as before

<img width="638" alt="image" src="https://user-images.githubusercontent.com/8299500/223403615-c441dc92-d88c-41f4-9a58-fe227822751a.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
