### PR TITLE
Add `x-client` in ide-metrics component

### DIFF
--- a/components/ide-metrics-api/go/config/config.go
+++ b/components/ide-metrics-api/go/config/config.go
@@ -19,6 +19,8 @@ type LabelAllowList struct {
 	DefaultValue string   `json:"defaultValue"`
 }
 
+type ClientAllowList = LabelAllowList
+
 type MetricsServerConfiguration struct {
 	Port                       int                             `json:"port"`
 	RateLimits                 map[string]grpc.RateLimit       `json:"ratelimits"`
@@ -32,6 +34,7 @@ type CounterMetricsConfiguration struct {
 	Name   string           `json:"name"`
 	Help   string           `json:"help"`
 	Labels []LabelAllowList `json:"labels"`
+	Client *ClientAllowList `json:"client"`
 }
 
 type HistogramMetricsConfiguration struct {
@@ -39,6 +42,7 @@ type HistogramMetricsConfiguration struct {
 	Help    string           `json:"help"`
 	Labels  []LabelAllowList `json:"labels"`
 	Buckets []float64        `json:"buckets"`
+	Client  *ClientAllowList `json:"client"`
 }
 
 type ErrorReportingConfiguration struct {

--- a/components/ide-metrics/config-example.json
+++ b/components/ide-metrics/config-example.json
@@ -11,6 +11,22 @@
             "allowValues": ["vscode", "idea", "goland", "pycharm"],
             "defaultValue": "intellij"
           }
+        ],
+        "client": {
+          "name": "metric_client",
+          "allowValues": ["vscode", "supervisor"],
+          "defaultValue": "supervisor"
+        }
+      },
+      {
+        "name": "gitpod_test_another_counter",
+        "help": "help",
+        "labels": [
+          {
+            "name": "ide",
+            "allowValues": ["vscode", "idea", "goland", "pycharm"],
+            "defaultValue": "intellij"
+          }
         ]
       }
     ],
@@ -24,7 +40,12 @@
             "allowValues": ["idea", "goland", "pycharm"]
           }
         ],
-        "buckets": [1, 10, 100]
+        "buckets": [1, 10, 100],
+        "client": {
+          "name": "metric_client",
+          "allowValues": ["jetbrains"],
+          "defaultValue": "jetbrains"
+        }
       }
     ],
     "errorReporting": {

--- a/components/ide-metrics/pkg/server/server.go
+++ b/components/ide-metrics/pkg/server/server.go
@@ -139,7 +139,13 @@ func newAllowListCollector(allowList []config.LabelAllowList, allowClient *confi
 	for _, l := range allowList {
 		labels = append(labels, l.Name)
 		allowLabelValues[l.Name] = l.AllowValues
-		allowLabelDefaultValues[l.Name] = l.DefaultValue
+		if l.DefaultValue != "" {
+			// we only add default values if they are not empty
+			// which means requests cannot have label with empty string value
+			// empty will fallback to default
+			// it's because `string` type in golang is not nullable and we cannot distinguish between empty and nil
+			allowLabelDefaultValues[l.Name] = l.DefaultValue
+		}
 	}
 	if allowClient != nil {
 		labels = append(labels, allowClient.Name)

--- a/components/ide-metrics/pkg/server/server_test.go
+++ b/components/ide-metrics/pkg/server/server_test.go
@@ -7,6 +7,8 @@ package server
 import (
 	"reflect"
 	"testing"
+
+	"github.com/gitpod-io/gitpod/ide-metrics-api/config"
 )
 
 func Test_allowListCollector_Reconcile(t *testing.T) {
@@ -135,6 +137,75 @@ func Test_allowListCollector_Reconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := c.Reconcile("foo", tt.args.labels); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("allowListCollector.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newAllowListCollector(t *testing.T) {
+	type args struct {
+		allowList   []config.LabelAllowList
+		allowClient *config.ClientAllowList
+	}
+	type want struct {
+		AllowLabelValues        map[string][]string
+		AllowLabelDefaultValues map[string]string
+		ClientLabel             string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *want
+	}{
+		{
+			name: "HappyPath",
+			args: args{
+				allowList: []config.LabelAllowList{
+					{
+						Name:        "hello",
+						AllowValues: []string{"world"},
+					},
+				},
+				allowClient: &config.LabelAllowList{
+					Name:         "gitpod",
+					AllowValues:  []string{"awesome", "gitpod"},
+					DefaultValue: "gitpod",
+				},
+			},
+			want: &want{
+				AllowLabelValues:        map[string][]string{"hello": {"world"}, "gitpod": {"awesome", "gitpod"}},
+				AllowLabelDefaultValues: map[string]string{"gitpod": "gitpod"},
+				ClientLabel:             "gitpod",
+			},
+		},
+		{
+			name: "ClientLabelIsNotDefined",
+			args: args{
+				allowList: []config.LabelAllowList{
+					{
+						Name:        "hello",
+						AllowValues: []string{"world"},
+					},
+				},
+				allowClient: nil,
+			},
+			want: &want{
+				AllowLabelValues:        map[string][]string{"hello": {"world"}},
+				AllowLabelDefaultValues: map[string]string{},
+				ClientLabel:             "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newAllowListCollector(tt.args.allowList, tt.args.allowClient)
+			got := &want{
+				AllowLabelValues:        instance.AllowLabelValues,
+				AllowLabelDefaultValues: instance.AllowLabelDefaultValues,
+				ClientLabel:             instance.ClientLabel,
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newAllowListCollector() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/components/supervisor/pkg/metrics/reporter.go
+++ b/components/supervisor/pkg/metrics/reporter.go
@@ -174,7 +174,16 @@ func doAddCounter(gitpodHost string, name string, labels map[string]string, valu
 		return
 	}
 	url := fmt.Sprintf("https://ide.%s/metrics-api/metrics/counter/add/%s", gitpodHost, name)
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		log.WithError(err).Error("supervisor: grpc metric: failed to create request")
+		return
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Client", "supervisor")
+	resp, err := http.DefaultClient.Do(request)
 	var statusCode int
 	if resp != nil {
 		statusCode = resp.StatusCode
@@ -217,7 +226,16 @@ func doAddHistogram(gitpodHost string, name string, labels map[string]string, co
 		return
 	}
 	url := fmt.Sprintf("https://ide.%s/metrics-api/metrics/histogram/add/%s", gitpodHost, name)
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		log.WithError(err).Error("supervisor: grpc metric: failed to create request")
+		return
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Client", "supervisor")
+	resp, err := http.DefaultClient.Do(request)
 	var statusCode int
 	if resp != nil {
 		statusCode = resp.StatusCode

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -4076,7 +4076,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -4103,7 +4104,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -4130,7 +4132,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -4157,7 +4160,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4179,7 +4183,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4193,12 +4198,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4230,7 +4237,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4769,7 +4777,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4796,7 +4805,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4830,7 +4848,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4864,7 +4891,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4886,7 +4914,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4930,7 +4959,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4954,7 +4984,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4981,7 +5012,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -5017,7 +5049,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9251,7 +9292,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3517,7 +3517,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3544,7 +3545,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3571,7 +3573,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3598,7 +3601,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3620,7 +3624,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -3634,12 +3639,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -3671,7 +3678,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4210,7 +4218,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4237,7 +4246,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4271,7 +4289,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4305,7 +4332,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4327,7 +4355,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4371,7 +4400,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4395,7 +4425,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4422,7 +4453,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4458,7 +4490,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -8272,7 +8313,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3893,7 +3893,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3920,7 +3921,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3947,7 +3949,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3974,7 +3977,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3996,7 +4000,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4010,12 +4015,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4047,7 +4054,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4586,7 +4594,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4613,7 +4622,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4647,7 +4665,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4681,7 +4708,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4703,7 +4731,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4747,7 +4776,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4771,7 +4801,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4798,7 +4829,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4834,7 +4866,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9068,7 +9109,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4450,7 +4450,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -4477,7 +4478,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -4504,7 +4506,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -4531,7 +4534,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4553,7 +4557,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4567,12 +4572,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4604,7 +4611,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -5143,7 +5151,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -5170,7 +5179,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -5204,7 +5222,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -5238,7 +5265,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -5260,7 +5288,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -5304,7 +5333,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -5328,7 +5358,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -5355,7 +5386,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -5391,7 +5423,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9842,7 +9883,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: b412b24494cba05f0480f767e407b5351094c34472d0966722428f0b23d05ff7
+        gitpod.io/checksum_config: 3ab282a2bf183e7b07712d4d3334a9a1ee299c876bc69d790a34093ecc1d2a05
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3727,7 +3727,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3754,7 +3755,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3781,7 +3783,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3808,7 +3811,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3830,7 +3834,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -3844,12 +3849,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -3881,7 +3888,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4420,7 +4428,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4447,7 +4456,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4481,7 +4499,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4515,7 +4542,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4537,7 +4565,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4581,7 +4610,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4605,7 +4635,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4632,7 +4663,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4668,7 +4700,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -8788,7 +8829,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3554,7 +3554,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3581,7 +3582,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3608,7 +3610,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3635,7 +3638,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3657,7 +3661,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -3671,12 +3676,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -3708,7 +3715,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4247,7 +4255,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4274,7 +4283,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4308,7 +4326,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4342,7 +4369,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4364,7 +4392,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4408,7 +4437,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4432,7 +4462,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4459,7 +4490,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4495,7 +4527,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -8401,7 +8442,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3896,7 +3896,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3923,7 +3924,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3950,7 +3952,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3977,7 +3980,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3999,7 +4003,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4013,12 +4018,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4050,7 +4057,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4589,7 +4597,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4616,7 +4625,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4650,7 +4668,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4684,7 +4711,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4706,7 +4734,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4750,7 +4779,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4774,7 +4804,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4801,7 +4832,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4837,7 +4869,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9712,7 +9753,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3909,7 +3909,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3936,7 +3937,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3963,7 +3965,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3990,7 +3993,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4012,7 +4016,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4026,12 +4031,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4063,7 +4070,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4602,7 +4610,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4629,7 +4638,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4663,7 +4681,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4697,7 +4724,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4719,7 +4747,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4763,7 +4792,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4787,7 +4817,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4814,7 +4845,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4850,7 +4882,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9088,7 +9129,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1522,7 +1522,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -1549,7 +1550,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -1576,7 +1578,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -1603,7 +1606,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -1625,7 +1629,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -1639,12 +1644,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -1676,7 +1683,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -2215,7 +2223,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -2242,7 +2251,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -2276,7 +2294,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -2310,7 +2337,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -2332,7 +2360,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -2376,7 +2405,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -2400,7 +2430,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -2427,7 +2458,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -2463,7 +2495,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -3330,7 +3371,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2910,7 +2910,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -2937,7 +2938,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -2964,7 +2966,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -2991,7 +2994,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3013,7 +3017,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -3027,12 +3032,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -3064,7 +3071,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -3603,7 +3611,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -3630,7 +3639,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -3664,7 +3682,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -3698,7 +3725,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -3720,7 +3748,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -3764,7 +3793,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -3788,7 +3818,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -3815,7 +3846,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -3851,7 +3883,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -6409,7 +6450,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3896,7 +3896,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3923,7 +3924,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3950,7 +3952,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3977,7 +3980,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3999,7 +4003,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4013,12 +4018,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4050,7 +4057,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4589,7 +4597,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4616,7 +4625,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4650,7 +4668,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4684,7 +4711,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4706,7 +4734,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4750,7 +4779,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4774,7 +4804,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4801,7 +4832,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4837,7 +4869,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9071,7 +9112,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3893,7 +3893,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3920,7 +3921,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3947,7 +3949,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3974,7 +3977,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3996,7 +4000,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4010,12 +4015,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4047,7 +4054,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4586,7 +4594,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4613,7 +4622,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4647,7 +4665,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4681,7 +4708,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4703,7 +4731,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4747,7 +4776,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4771,7 +4801,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4798,7 +4829,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4834,7 +4866,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9068,7 +9109,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3891,7 +3891,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3918,7 +3919,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3945,7 +3947,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3972,7 +3975,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3994,7 +3998,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4008,12 +4013,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4045,7 +4052,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4584,7 +4592,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4611,7 +4620,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4645,7 +4663,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4679,7 +4706,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4701,7 +4729,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4745,7 +4774,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4769,7 +4799,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4796,7 +4827,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4832,7 +4864,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9078,7 +9119,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3900,7 +3900,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3927,7 +3928,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3954,7 +3956,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3981,7 +3984,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4003,7 +4007,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4017,12 +4022,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4054,7 +4061,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4593,7 +4601,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4620,7 +4629,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4654,7 +4672,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4688,7 +4715,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4710,7 +4738,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4754,7 +4783,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4778,7 +4808,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4805,7 +4836,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4841,7 +4873,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9075,7 +9116,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3893,7 +3893,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3920,7 +3921,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3947,7 +3949,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3974,7 +3977,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3996,7 +4000,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4010,12 +4015,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4047,7 +4054,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4586,7 +4594,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4613,7 +4622,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4647,7 +4665,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4681,7 +4708,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4703,7 +4731,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4747,7 +4776,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4771,7 +4801,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4798,7 +4829,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4834,7 +4866,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9068,7 +9109,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3905,7 +3905,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3932,7 +3933,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3959,7 +3961,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3986,7 +3989,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4008,7 +4012,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4022,12 +4027,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4059,7 +4066,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4598,7 +4606,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4625,7 +4634,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4659,7 +4677,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4693,7 +4720,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4715,7 +4743,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4759,7 +4788,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4783,7 +4813,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4810,7 +4841,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4846,7 +4878,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9080,7 +9121,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3896,7 +3896,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3923,7 +3924,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3950,7 +3952,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3977,7 +3980,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3999,7 +4003,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4013,12 +4018,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4050,7 +4057,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4589,7 +4597,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4616,7 +4625,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4650,7 +4668,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4684,7 +4711,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4706,7 +4734,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4750,7 +4779,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4774,7 +4804,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4801,7 +4832,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4837,7 +4869,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9071,7 +9112,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4226,7 +4226,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -4253,7 +4254,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -4280,7 +4282,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -4307,7 +4310,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -4329,7 +4333,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4343,12 +4348,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4380,7 +4387,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4919,7 +4927,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4946,7 +4955,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4980,7 +4998,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -5014,7 +5041,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -5036,7 +5064,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -5080,7 +5109,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -5104,7 +5134,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -5131,7 +5162,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -5167,7 +5199,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9512,7 +9553,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3896,7 +3896,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3923,7 +3924,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3950,7 +3952,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3977,7 +3980,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3999,7 +4003,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4013,12 +4018,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4050,7 +4057,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4589,7 +4597,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4616,7 +4625,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4650,7 +4668,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4684,7 +4711,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4706,7 +4734,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4750,7 +4779,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4774,7 +4804,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4801,7 +4832,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4837,7 +4869,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9059,7 +9100,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3896,7 +3896,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_received_total",
@@ -3923,7 +3924,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_msg_sent_total",
@@ -3950,7 +3952,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_server_started_total",
@@ -3977,7 +3980,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_error_total",
@@ -3999,7 +4003,8 @@ data:
                 ],
                 "defaultValue": "Unknown"
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_web_load_total",
@@ -4013,12 +4018,14 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
-            "labels": null
+            "labels": null,
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_operation_total",
@@ -4050,7 +4057,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_total",
@@ -4589,7 +4597,8 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_started_total",
@@ -4616,7 +4625,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           },
           {
             "name": "grpc_client_handled_total",
@@ -4650,7 +4668,16 @@ data:
                 ],
                 "defaultValue": ""
               }
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "histogramMetrics": [
@@ -4684,7 +4711,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           },
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
@@ -4706,7 +4734,8 @@ data:
               10,
               15,
               30
-            ]
+            ],
+            "client": null
           }
         ],
         "aggregatedHistogramMetrics": [
@@ -4750,7 +4779,8 @@ data:
               120,
               240,
               600
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_ide_ready_duration_total",
@@ -4774,7 +4804,8 @@ data:
               2.5,
               5,
               10
-            ]
+            ],
+            "client": null
           },
           {
             "name": "supervisor_initializer_bytes_second",
@@ -4801,7 +4832,8 @@ data:
               536870912,
               1073741824,
               2147483648
-            ]
+            ],
+            "client": null
           },
           {
             "name": "grpc_client_handling_seconds",
@@ -4837,7 +4869,16 @@ data:
               2,
               5,
               10
-            ]
+            ],
+            "client": {
+              "name": "metric_client",
+              "allowValues": [
+                "vscode-desktop-extension",
+                "supervisor",
+                "unknown"
+              ],
+              "defaultValue": "unknown"
+            }
           }
         ],
         "errorReporting": {
@@ -9071,7 +9112,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -200,6 +200,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					AllowValues: []string{"*"},
 				},
 			},
+			Client: &config.ClientAllowList{
+				Name:         "metric_client",
+				AllowValues:  []string{"vscode-desktop-extension", "supervisor", "unknown"},
+				DefaultValue: "unknown",
+			},
 		}, {
 			Name: "grpc_client_handled_total",
 			Help: "Total number of RPCs completed by the client, regardless of success or failure.",
@@ -220,6 +225,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Name:        "grpc_code",
 					AllowValues: []string{"*"},
 				},
+			},
+			Client: &config.ClientAllowList{
+				Name:         "metric_client",
+				AllowValues:  []string{"vscode-desktop-extension", "supervisor", "unknown"},
+				DefaultValue: "unknown",
 			},
 		},
 	}
@@ -313,6 +323,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 10},
+			Client: &config.ClientAllowList{
+				Name:         "metric_client",
+				AllowValues:  []string{"vscode-desktop-extension", "supervisor", "unknown"},
+				DefaultValue: "unknown",
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add `x-client` a global setting in ide-metrics

## TODOs
- [ ] ‼️ After this PR, supervisor public api metrics will be broken, so we need to change ide supervisor public api SLO

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check also test results https://github.com/gitpod-io/gitpod/pull/16701#issuecomment-1457867144

- Open workspace in preview env https://hw-metrics-client.preview.gitpod-dev.com/workspaces
- `ide-metrics` in preview env should correctly setup `metric_client` for supervisor public api metrics

**debug mode**
- Open this PR with Gitpod
- Exec commands below
```
cd components/ide-metrics
# start metric server
go run main.go run --config config-example.json --json-log=false --verbose

# post curl
curl -X "POST" "http://localhost:3000/metrics-api/metrics/counter/add/gitpod_test_counter" \
     -H 'x-client: vscode' \
     -H 'Content-Type: application/json; charset=utf-8' 
```
- `/metrics` endpoint at port 9500 should have `metric_client` field with vscode

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
