### PR TITLE
[ws-manager-mk2] Maintenance mode

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -569,3 +569,7 @@ type CpuResourceLimit struct {
 	MinLimit   string `json:"min"`
 	BurstLimit string `json:"burst"`
 }
+
+type MaintenanceConfig struct {
+	Enabled bool `json:"enabled"`
+}

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -35,7 +35,7 @@ type MaintenanceReconciler struct {
 	enabled bool
 }
 
-func (r *MaintenanceReconciler) MaintenanceEnabled(ctx context.Context, c client.Client, mgr ctrl.Manager) bool {
+func (r *MaintenanceReconciler) IsEnabled() bool {
 	return r.enabled
 }
 

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gitpod-io/gitpod/ws-manager/api/config"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	LabelMaintenance = "gitpod.io/maintenanceConfig"
+	configMapName    = "ws-manager-mk2-maintenance-mode"
+)
+
+func NewMaintenanceReconciler(c client.Client) (*MaintenanceReconciler, error) {
+	return &MaintenanceReconciler{
+		Client:  c,
+		enabled: false,
+	}, nil
+}
+
+type MaintenanceReconciler struct {
+	client.Client
+
+	enabled bool
+}
+
+func (r *MaintenanceReconciler) MaintenanceEnabled(ctx context.Context, c client.Client, mgr ctrl.Manager) bool {
+	return r.enabled
+}
+
+//+kubebuilder:rbac:groups=core,resources=configmap,verbs=get;list;watch
+
+func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx).WithValues("configMap", req.NamespacedName)
+
+	if req.Name != configMapName {
+		log.Info("ignoring unexpected ConfigMap")
+		return ctrl.Result{}, nil
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, req.NamespacedName, &cm); err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap does not exist, disable maintenance mode.
+			r.setEnabled(log, false)
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "unable to fetch configmap")
+		return ctrl.Result{}, err
+	}
+
+	configJson, ok := cm.Data["config.json"]
+	if !ok {
+		log.Info("missing config.json, setting maintenance mode as disabled")
+		r.setEnabled(log, false)
+		return ctrl.Result{}, nil
+	}
+
+	var cfg config.MaintenanceConfig
+	if err := json.Unmarshal([]byte(configJson), &cfg); err != nil {
+		log.Error(err, "failed to unmarshal maintenance config")
+		return ctrl.Result{}, nil
+	}
+
+	r.setEnabled(log, cfg.Enabled)
+	return ctrl.Result{}, nil
+}
+
+func (r *MaintenanceReconciler) setEnabled(log logr.Logger, enabled bool) {
+	if enabled == r.enabled {
+		// Nothing to do.
+		return
+	}
+
+	r.enabled = enabled
+	log.Info("maintenance mode state change", "enabled", enabled)
+}
+
+func (r *MaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("maintenance").
+		// The controller manager filters watch events only to ConfigMaps with the LabelMaintenance label set to "true".
+		// See components/ws-manager-mk2/main.go's NewCache function in the manager options.
+		For(&corev1.ConfigMap{}).
+		Complete(r)
+}

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -24,8 +24,13 @@ const (
 
 func NewMaintenanceReconciler(c client.Client) (*MaintenanceReconciler, error) {
 	return &MaintenanceReconciler{
-		Client:  c,
-		enabled: false,
+		Client: c,
+		// Enable by default, until we observe the ConfigMap with the actual value.
+		// Prevents a race on startup where the workspace reconciler might run before
+		// we observe the maintenance mode ConfigMap. Better be safe and prevent
+		// reconciliation of that workspace until it's certain maintenance mode is
+		// not enabled.
+		enabled: true,
 	}, nil
 }
 

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -75,7 +75,8 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	var cfg config.MaintenanceConfig
 	if err := json.Unmarshal([]byte(configJson), &cfg); err != nil {
-		log.Error(err, "failed to unmarshal maintenance config")
+		log.Error(err, "failed to unmarshal maintenance config, setting maintenance mode as disabled")
+		r.setEnabled(log, false)
 		return ctrl.Result{}, nil
 	}
 

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	conf := newTestConfig()
-	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), &conf, metrics.Registry)
+	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), &conf, metrics.Registry, &fakeMaintenance{enabled: false})
 	wsMetrics = wsReconciler.metrics
 	Expect(err).ToNot(HaveOccurred())
 	Expect(wsReconciler.SetupWithManager(k8sManager)).To(Succeed())
@@ -146,6 +146,14 @@ func newTestConfig() config.Configuration {
 		},
 		WorkspaceURLTemplate: "{{ .ID }}-{{ .Prefix }}-{{ .Host }}",
 	}
+}
+
+type fakeMaintenance struct {
+	enabled bool
+}
+
+func (f *fakeMaintenance) IsEnabled() bool {
+	return f.enabled
 }
 
 var _ = AfterSuite(func() {

--- a/components/ws-manager-mk2/pkg/maintenance/maintenance.go
+++ b/components/ws-manager-mk2/pkg/maintenance/maintenance.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package maintenance
+
+// Maintenance is used to check whether ws-manager-mk2 is in maintenance mode,
+// which prevents pod creation/deletion and snapshots being taken, such that
+// the cluster can be updated in-place.
+type Maintenance interface {
+	IsEnabled() bool
+}

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -97,7 +97,7 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 	defer tracing.FinishSpan(span, &err)
 
 	if wsm.maintenance.IsEnabled() {
-		return &wsmanapi.StartWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance mode")
+		return &wsmanapi.StartWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 
 	if err := validateStartWorkspaceRequest(req); err != nil {
@@ -337,7 +337,7 @@ func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsman
 	defer tracing.FinishSpan(span, &err)
 
 	if wsm.maintenance.IsEnabled() {
-		return &wsmanapi.StopWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance mode")
+		return &wsmanapi.StopWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 
 	gracePeriod := stopWorkspaceNormallyGracePeriod
@@ -575,7 +575,7 @@ func (wsm *WorkspaceManagerServer) TakeSnapshot(ctx context.Context, req *wsmana
 	defer tracing.FinishSpan(span, &err)
 
 	if wsm.maintenance.IsEnabled() {
-		return &wsmanapi.TakeSnapshotResponse{}, status.Error(codes.FailedPrecondition, "under maintenance mode")
+		return &wsmanapi.TakeSnapshotResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 
 	var ws workspacev1.Workspace

--- a/install/installer/pkg/components/ws-manager-mk2/constants.go
+++ b/install/installer/pkg/components/ws-manager-mk2/constants.go
@@ -18,4 +18,5 @@ const (
 	VolumeWorkspaceTemplate    = "workspace-template"
 	WorkspaceTemplatePath      = "/workspace-templates"
 	WorkspaceTemplateConfigMap = "workspace-templates"
+	LabelMaintenanceConfig     = "gitpod.io/maintenanceConfig"
 )


### PR DESCRIPTION
## Description

Add maintenance mode for ws-manager-mk2:
* Create `ws-manager-mk2-maintenance-mode` ConfigMap, which contains a boolean that enables/disables maintenance mode.
  * This ConfigMap is deployed by the installer
* Create a new maintenance `reconciler` that watches this ConfigMap for changes, and keeps track of whether maintenance mode is enabled
  * The controller manager only watches the maintenance ConfigMap events using a label filter
* The API service returns `FailedPrecondition` on the following requests when maintenance mode is enabled:
  * `StartWorkspace`
  * `StopWorkspace`
  * `TakeSnapshot`
* The workspace reconciler stops reconciling in maintenance mode, to prevent starting a workspace shutdown and triggering a backup
  * Any events during maintenance mode get requeued after a minute, such that we do quickly reconcile again when maintenance mode ends

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test
<!-- Provide steps to test this PR -->

In this [preview env](https://wv-mk2-mai9756e7670e.preview.gitpod-dev.com/workspaces):
* Start a workspace
* Edit the `ws-manager-mk2-maintenance-mode` ConfigMap and enable maintenance mode
* Try starting a new workspace, stopping the existing workspace, or taking a snapshot, and observe these operations fail
* Restart ws-manager-mk2 and observe it stays in maintenance mode
* Disable maintenance mode again
* Try the above operations which should now succeed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
