### PR TITLE
[dashboard] cache get SupportedWorkspaceClasses

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -22,13 +22,13 @@ import Spinner from "../icons/Spinner.svg";
 import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
 import { toRemoteURL } from "../projects/render-utils";
 import { WorkspaceType } from "@gitpod/gitpod-protocol";
-import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import "./react-datepicker.css";
 import { useLocation } from "react-router";
 import dayjs from "dayjs";
 import { Heading1, Heading2, Subheading } from "./typography/headings";
+import { useWorkspaceClasses } from "../data/workspaces/workspace-classes-query";
 
 interface UsageViewProps {
     attributionId: AttributionId;
@@ -42,7 +42,7 @@ function UsageView({ attributionId }: UsageViewProps) {
     const [endDate, setEndDate] = useState(dayjs());
     const [totalCreditsUsed, setTotalCreditsUsed] = useState<number>(0);
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [supportedClasses, setSupportedClasses] = useState<SupportedWorkspaceClass[]>([]);
+    const supportedClasses = useWorkspaceClasses();
 
     const location = useLocation();
     useEffect(() => {
@@ -55,10 +55,6 @@ function UsageView({ attributionId }: UsageViewProps) {
                 console.error(e);
             }
         }
-        (async () => {
-            const classes = await getGitpodService().server.getSupportedWorkspaceClasses();
-            setSupportedClasses(classes);
-        })();
     }, [location]);
 
     const loadPage = useCallback(
@@ -114,7 +110,7 @@ function UsageView({ attributionId }: UsageViewProps) {
     };
 
     const getDisplayName = (workspaceClass: string) => {
-        const workspaceDisplayName = supportedClasses.find((wc) => wc.id === workspaceClass)?.displayName;
+        const workspaceDisplayName = supportedClasses.data?.find((wc) => wc.id === workspaceClass)?.displayName;
         if (!workspaceDisplayName) {
             return workspaceClass;
         }

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+export const useWorkspaceClasses = () => {
+    return useQuery<SupportedWorkspaceClass[]>({
+        queryKey: ["workspace-classes"],
+        queryFn: async () => {
+            return getGitpodService().server.getSupportedWorkspaceClasses();
+        },
+        cacheTime: 1000 * 60 * 60, // 1h
+        staleTime: 1000 * 60 * 60, // 1h
+    });
+};

--- a/components/dashboard/src/user-settings/selectClass.tsx
+++ b/components/dashboard/src/user-settings/selectClass.tsx
@@ -9,6 +9,7 @@ import { getGitpodService } from "../service/service";
 import { trackEvent } from "../Analytics";
 import WorkspaceClass from "../components/WorkspaceClass";
 import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
+import { useWorkspaceClasses } from "../data/workspaces/workspace-classes-query";
 
 interface SelectWorkspaceClassProps {
     workspaceClass?: string;
@@ -17,6 +18,7 @@ interface SelectWorkspaceClassProps {
 
 export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
     const [workspaceClass, setWorkspaceClass] = useState<string | undefined>(props.workspaceClass);
+    const supportedClasses = useWorkspaceClasses();
     const actuallySetWorkspaceClass = async (value: string) => {
         const previousValue = await props.setWorkspaceClass(value);
         if (previousValue !== value) {
@@ -28,25 +30,9 @@ export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
         }
     };
 
-    const [supportedClasses, setSupportedClasses] = useState<SupportedWorkspaceClass[]>([]);
-
-    useEffect(() => {
-        const fetchClasses = async () => {
-            const classes = await getGitpodService().server.getSupportedWorkspaceClasses();
-            setSupportedClasses(classes);
-
-            if (!workspaceClass) {
-                setWorkspaceClass(classes.find((c) => c.isDefault)?.id || "");
-            }
-        };
-
-        fetchClasses().catch(console.error);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
     return (
         <div className="mt-4 space-x-3 flex">
-            {supportedClasses.map((c) => {
+            {supportedClasses.data?.map((c) => {
                 return (
                     <WorkspaceClass
                         additionalStyles="w-80"


### PR DESCRIPTION
## Description
Cache the supportedWorkspaceClasses on the client

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
