### PR TITLE
[public-api] Correctly map 401 to Unathenticated

### DIFF
--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -33,7 +33,7 @@ func categorizeRPCError(err error) *connect.Error {
 			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(rpcErr.Message))
 		// components/gitpod-protocol/src/messaging/error.ts
 		case 401:
-			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
+			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf(rpcErr.Message))
 		// components/gitpod-protocol/src/messaging/error.ts
 		case 403:
 			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -36,6 +36,13 @@ func TestConvertError(t *testing.T) {
 		},
 		{
 			Input: &jsonrpc2.Error{
+				Code:    401,
+				Message: "user is not authenticated",
+			},
+			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("user is not authenticated")),
+		},
+		{
+			Input: &jsonrpc2.Error{
 				Code:    -32603,
 				Message: "Request getWorkspace failed with message: No workspace with id 'some-id' found.",
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
