### PR TITLE
[dev image] update to Jammy

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: [ self-hosted ]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
@@ -148,7 +148,7 @@ jobs:
         ports:
           - 23306:23306
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
         name: Configuration
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
         outputs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
@@ -89,7 +89,7 @@ jobs:
         needs: [configuration, infrastructure]
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
             volumes:
               - /var/tmp:/var/tmp
               - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -8,7 +8,7 @@ jobs:
         name: "Find stale preview environments"
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
         outputs:
             names: ${{ steps.set-matrix.outputs.names }}
             count: ${{ steps.set-matrix.outputs.count }}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -34,7 +34,7 @@ defaultVariant:
       - "**/node_modules/**"
   config:
     go:
-      lintCommand: ["sh", "-c", "golangci-lint run --disable govet,errcheck,typecheck,staticcheck,structcheck --allow-parallel-runners --timeout 5m"]
+      lintCommand: ["sh", "-c", "golangci-lint run --disable govet,errcheck,typecheck,staticcheck,structcheck --allow-parallel-runners --timeout 15m"]
 variants:
   - name: oss
     srcs:

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -310,7 +310,6 @@ func (s *Workspace) UpdateGitStatus(ctx context.Context, persistentVolumeClaim b
 	err = s.Persist()
 	if err != nil {
 		log.WithError(err).WithFields(s.OWI()).Warn("cannot persist latest Git status")
-		err = nil
 	}
 
 	return s.LastGitStatus, nil

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -893,6 +893,7 @@ func (m *Manager) deleteWorkspacePVC(ctx context.Context, pvcName string) error 
 	return nil
 }
 
+//nolint:unused
 func (m *Manager) deleteWorkspaceSecrets(ctx context.Context, podName string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1586,6 +1587,7 @@ func (m *Manager) connectToWorkspaceDaemon(ctx context.Context, wso workspaceObj
 	return wsdaemon.NewWorkspaceContentServiceClient(conn), nil
 }
 
+//nolint:unused
 func (m *Manager) createWorkspaceSnapshotFromPVC(ctx context.Context, pvcName string, pvcVolumeSnapshotName string, pvcVolumeSnapshotClassName string, workspaceID string, labels map[string]string) error {
 	// create snapshot object out of PVC
 	volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
@@ -1611,6 +1613,7 @@ func (m *Manager) createWorkspaceSnapshotFromPVC(ctx context.Context, pvcName st
 	return nil
 }
 
+//nolint:unused
 func (m *Manager) waitForWorkspaceVolumeSnapshotReady(ctx context.Context, pvcVolumeSnapshotName string, log *logrus.Entry) (pvcVolumeSnapshotContentName string, readyVolumeSnapshot bool, err error) {
 	log = log.WithField("VolumeSnapshot.Name", pvcVolumeSnapshotName)
 

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -62,6 +62,7 @@ var (
 	// wsdaemonRetryInterval is the time in between attempts to work with ws-daemon.
 	//
 	// Note: this is a variable rather than a constant so that tests can modify this value.
+	//nolint:unused
 	wsdaemonRetryInterval = 5 * time.Second
 )
 
@@ -75,8 +76,10 @@ type Monitor struct {
 
 	probeMap sync.Map
 
+	//nolint:unused
 	initializerMap sync.Map
-	finalizerMap   sync.Map
+	//nolint:unused
+	finalizerMap sync.Map
 
 	act actingManager
 
@@ -505,6 +508,7 @@ type actingManager interface {
 	modifyFinalizer(ctx context.Context, workspaceID string, finalizer string, add bool) error
 }
 
+//nolint:unused
 func (m *Monitor) clearInitializerFromMap(podName string) {
 	m.initializerMap.Delete(podName)
 }
@@ -602,6 +606,8 @@ func (m *Monitor) traceWorkspaceState(state string, wso *workspaceObjects) opent
 }
 
 // waitForWorkspaceReady waits until the workspace's content and Theia to become available.
+//
+//nolint:unused
 func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (err error) {
 	span, ctx := tracing.FromContext(ctx, "waitForWorkspaceReady")
 	defer tracing.FinishSpan(span, &err)
@@ -715,6 +721,8 @@ func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (e
 
 // probeWorkspaceReady continually HTTP GETs a workspace's ready URL until we've tried a certain number of times
 // or the workspace responded with status code 200.
+//
+//nolint:unused
 func (m *Monitor) probeWorkspaceReady(ctx context.Context, pod *corev1.Pod) (result *WorkspaceProbeResult, err error) {
 	span, ctx := tracing.FromContext(ctx, "probeWorkspaceReady")
 	defer tracing.FinishSpan(span, &err)
@@ -775,6 +783,8 @@ func (m *Monitor) probeWorkspaceReady(ctx context.Context, pod *corev1.Pod) (res
 // initializeWorkspaceContent talks to a ws-daemon daemon on the node of the pod and initializes the workspace content.
 // If we're already initializing the workspace, thus function will return immediately. If we were not initializing,
 // prior to this call this function returns once initialization is complete.
+//
+//nolint:unused
 func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Pod) (err error) {
 	span, ctx := tracing.FromContext(ctx, "initializeWorkspaceContent")
 	defer tracing.FinishSpan(span, &err)
@@ -939,6 +949,8 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 }
 
 // retryIfUnavailable makes multiple attempts to execute op if op returns an UNAVAILABLE gRPC status code
+//
+//nolint:unused
 func retryIfUnavailable(ctx context.Context, op func(ctx context.Context) error) (err error) {
 	for i := 0; i < wsdaemonMaxAttempts; i++ {
 		err := op(ctx)
@@ -959,6 +971,7 @@ func retryIfUnavailable(ctx context.Context, op func(ctx context.Context) error)
 	return grpc_status.Error(codes.Unavailable, "workspace content initialization is currently unavailable")
 }
 
+//nolint:unused
 func shouldDisableRemoteStorage(pod *corev1.Pod) bool {
 	wso := &workspaceObjects{Pod: pod}
 	tpe, err := wso.WorkspaceType()
@@ -975,6 +988,8 @@ func shouldDisableRemoteStorage(pod *corev1.Pod) bool {
 }
 
 // finalizeWorkspaceContent talks to a ws-daemon daemon on the node of the pod and creates a backup of the workspace content.
+//
+//nolint:unused
 func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceObjects) {
 	span, ctx := tracing.FromContext(ctx, "finalizeWorkspaceContent")
 	defer tracing.FinishSpan(span, nil)
@@ -1407,6 +1422,7 @@ func workspaceObjectListOptions(namespace string) *client.ListOptions {
 	}
 }
 
+//nolint:unused
 func handleGRPCError(ctx context.Context, err error) error {
 	if err == nil {
 		return err

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM gitpod/workspace-full:2022-11-09-13-54-49
+FROM gitpod/workspace-full:2023-03-06-18-43-51
 
 ENV TRIGGER_REBUILD 26
 
@@ -163,7 +163,6 @@ ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 # Install tools for gsutil
 RUN sudo install-packages \
     gcc \
-    python-dev \
     python-setuptools
 
 RUN sudo python3 -m pip uninstall crcmod; sudo python3 -m pip install --no-cache-dir -U crcmod

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -151,7 +151,7 @@ ARG GCS_DIR=/opt/google-cloud-sdk
 ENV PATH=$GCS_DIR/bin:$PATH
 RUN sudo chown gitpod: /opt \
     && mkdir $GCS_DIR \
-    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-400.0.0-linux-x86_64.tar.gz \
+    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-420.0.0-linux-x86_64.tar.gz \
     | tar -xzvC /opt \
     && /opt/google-cloud-sdk/install.sh --quiet --usage-reporting=false --bash-completion=true \
     --additional-components gke-gcloud-auth-plugin docker-credential-gcr alpha beta \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update our dev image to support Jammy

Ref: https://github.com/gitpod-io/workspace-images/pull/1017

Some changes were necessary in `ws-manager- and `ws-daemon` to avoid linter errors (assumption: the newer version of go has changes that improve linting):
1. 2aad8120a309bd00b46cdfc1258c6456f671a547
2. ca2df6fbbf77b681d69eb5b7be6ad2f5c077cdc4

Additionally, the linter was timing out on `registry-facade`: 24a28b8b8af202e84ce7a43d8d776142d0622514

And I updated `gcloud` because ours was getting "old": 663ea050f4007dfb2f29748105b334989e3245b3

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
```
# test you can build
cd dev/image
docker build . --tag foo:bar
# assert there are no errors on run
docker run --rm -it foo:bar
```

4. [Test in the preview environment by starting the Gitpod mono repo from a preview environment](https://kylos101-j2dabf45871.preview.gitpod-dev.com/?editor=code#https://github.com/gitpod-io/gitpod/pull/16718).
![image](https://user-images.githubusercontent.com/1272076/223611937-483543d9-c18d-4ecb-9bf9-f2f359482e84.png)

5. Tests pass - https://werft.gitpod-dev.com/job/gitpod-build-kylos101-jam-dev-image.9

6. Node and Go versions:
```
gitpod /workspace/gitpod (kylos101/jam-dev-image) $ which node
/home/gitpod/.nvm/versions/node/v16.19.0/bin/node
gitpod /workspace/gitpod (kylos101/jam-dev-image) $ node --version
v16.19.0
gitpod /workspace/gitpod (kylos101/jam-dev-image) $ which go
/home/gitpod/go/bin/go
gitpod /workspace/gitpod (kylos101/jam-dev-image) $ go version
go version go1.19.5 linux/amd64
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
