### PR TITLE
Add missing IDE GH Actions to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,6 +116,8 @@
 /dev/preview/workflow @gitpod-io/engineering-security-infrastructure-and-delivery
 
 .github/workflows/ide-*.yml @gitpod-io/engineering-ide
+.github/workflows/jetbrains-*.yml @gitpod-io/engineering-ide
+.github/workflows/code-nightly.yml @gitpod-io/engineering-ide
 
 #
 # Automation


### PR DESCRIPTION
## Description
Currently (if my understanding of basic algebra is correct), our [`CODEOWNERS` section](https://github.com/gitpod-io/gitpod/blob/main/.github/CODEOWNERS#L118) for GitHub Action workflows only catches one file - https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/ide-integration-tests.yml. This PR includes the rest that we own

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
