### PR TITLE
[rebuild] fix open with VS Code Desktop actions

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: d679df305517663331f4f7d7346722a436e8fab2
+  codeCommit: b3e87fd56f3d781f19865c315ac4f372bf5fd31a
   codeVersion: 1.76.0
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3838,7 +3838,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3279,7 +3279,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3655,7 +3655,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
               "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4207,7 +4207,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3489,7 +3489,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3316,7 +3316,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3671,7 +3671,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1284,7 +1284,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2672,7 +2672,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3655,7 +3655,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3653,7 +3653,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3662,7 +3662,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3655,7 +3655,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3667,7 +3667,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3988,7 +3988,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-04bd87195c105125fbf6ebdb3283e7bac07cba81",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
               "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-ae0ad032337978e1cdf293d13102696e8975f65b",

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-0f3f6b068fc5aba9abdf02af45a8cfda067cb6d0" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-04bd87195c105125fbf6ebdb3283e7bac07cba81" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
 	CodeWebExtensionVersion     = "commit-ae0ad032337978e1cdf293d13102696e8975f65b" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR aligns CSP policies between workspaces started regularly and via gp rebuild to allow redirection to arbitrary custom schemes.

When VS Code Server is running from sources it has very strict CSP policies, i.e. with gp rebuild. Regular workspace though does not have any. The trouble with CSP policies that they should specify exactly which custom schemes are supported. In our case we don't actually know them in advance since IDEs can change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open this PR on gitpod.io
- Run components/supervisor/validate.sh
- In opened workspace that actions `Open With VS Code Desktop` are working now.

Important: It does not add support of opening VS Code Desktop as default IDE!

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
