### PR TITLE
[gha] fix comment ops

### DIFF
--- a/.github/workflows/comment-ops.yaml
+++ b/.github/workflows/comment-ops.yaml
@@ -15,7 +15,8 @@ jobs:
     # Otherwise they can execute arbitrary code if the triggered workflow (i.e. the build) is modified, as it's being run by the github-actions bot, and it always has permissions
     if: |
       (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER') &&
-      (github.event.issue.pull_request && contains(github.event.comment.body, '/gh run'))
+      (github.event.issue.pull_request && contains(github.event.comment.body, '/gh run')) &&
+      (contains(github.event.comment.body, 'recreate-vm'))
     runs-on: [ self-hosted ]
     # Technically we don't need these here, as we don't reuse them between jobs, but it's good to have them in a single place
     outputs:
@@ -45,7 +46,7 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'build.yaml',
+              workflow_id: 'build.yml',
               ref: '${{ steps.comment-branch.outputs.head_ref }}',
               inputs: {
                 "recreate_vm": '${{ steps.configure.outputs.recreate-vm }}'
@@ -71,19 +72,23 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: ${{ github.event.issue.number }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `#### Comment triggered a workflow run
+            let commentBody = '${{ github.event.comment.body }}'
+            commentBody += `\n\n#### Comment triggered a workflow run
 
               Started workflow run: [${{ needs.configure.outputs.run_id }}](${{ needs.configure.outputs.run_url }})
               * \`recreate_vm: ${{ steps.configure.outputs.recreate-vm }}\``
+            github.rest.issues.updateComment({
+              issue_number: ${{ github.event.issue.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ github.event.comment.id }},
+              body: commentBody
             })
 
   # Comment if this job failed, so there's some feedback
   comment-fail:
-    if: failure()
+    if: (always() && contains(needs.*.result, 'failure'))
+    needs: [ configure ]
     runs-on: [ self-hosted ]
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Fix typo in the dispatched workflow
* Update the comment, instead of adding a new one
* Only trigger if `recreate-vm` is in the comment

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
