### PR TITLE
[gha] fix comment ops gh url

### DIFF
--- a/.github/workflows/comment-ops.yaml
+++ b/.github/workflows/comment-ops.yaml
@@ -21,8 +21,8 @@ jobs:
     # Technically we don't need these here, as we don't reuse them between jobs, but it's good to have them in a single place
     outputs:
       branch: ${{ steps.comment-branch.outputs.head_ref }}
-      run_url: ${{ steps.run_outputs.outputs.run_url }}
-      run_id: ${{ steps.run_outputs.outputs.run_id }}
+      run_url: ${{ fromJSON(steps.run_outputs.outputs.result).html_url }}
+      run_id: ${{ fromJSON(steps.run_outputs.outputs.result).id }}
       recreate_vm: ${{ steps.configure.outputs.recreate-vm }}
     steps:
       # In order for us to find out from which PR the comment originates, we use the `xt0rted/pull-request-comment-branch@v1` action
@@ -57,16 +57,27 @@ jobs:
       # But it's an overkill for now
       # Instead, we wait a little, and grab the last job that was triggered by a `workflow_dispatch` event, AND is not completed, and we hope for the best 🤞
       - name: Get run URL
+        uses: actions/github-script@v6
         id: run_outputs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          sleep 5
-          url=$(gh run list --repo '${{ github.repository }}' --workflow build.yaml -b ${{ steps.comment-branch.outputs.head_ref }} --json event,url,status -q '[.[] | select(.event=="workflow_dispatch") | select(.status!="completed").url][0]')
-          {
-            echo "run_url=${url}"
-            echo "run_id=${url##*/}"
-          } >> $GITHUB_OUTPUT
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await new Promise(r => setTimeout(r, 5000));
+            let result = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yml',
+              branch: '${{ steps.comment-branch.outputs.head_ref }}',
+              event: 'workflow_dispatch',
+              per_page: 10
+            });
+
+            var url = result.data.workflow_runs
+              .filter(function (e) {
+                return e.status != 'completed' && e.status != 'skipped'
+            });
+
+            return url[0];
       # Comment with a link to the job that got triggered
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`gh` is not available in the self-hosted runner 🙄 
instead of installing it or including it in the runner's image, use the api to grab the run id.

also 🤮 
```
await new Promise(r => setTimeout(r, 5000));
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
