### PR TITLE
[gha] fix comment ops p4

### DIFF
--- a/.github/workflows/comment-ops.yaml
+++ b/.github/workflows/comment-ops.yaml
@@ -23,7 +23,7 @@ jobs:
       branch: ${{ steps.comment-branch.outputs.head_ref }}
       run_url: ${{ fromJSON(steps.run_outputs.outputs.result).html_url }}
       run_id: ${{ fromJSON(steps.run_outputs.outputs.result).id }}
-      recreate_vm: ${{ steps.configure.outputs.recreate-vm }}
+      recreate_vm: ${{ steps.configure.outputs.recreate_vm }}
     steps:
       # In order for us to find out from which PR the comment originates, we use the `xt0rted/pull-request-comment-branch@v1` action
       - uses: xt0rted/pull-request-comment-branch@v1
@@ -33,7 +33,7 @@ jobs:
         id: outputs
         run: |
           {
-            echo "recreate-vm=${{ contains(github.event.comment.body, 'recreate-vm') }}"
+            echo "recreate_vm=${{ contains(github.event.comment.body, 'recreate-vm') }}"
           } >> $GITHUB_OUTPUT
       # Trigger the build workflow with the input we got from the comment
       # In the triggered job (build), we'll combine the information from the PR description, with the input we pass here
@@ -49,7 +49,7 @@ jobs:
               workflow_id: 'build.yml',
               ref: '${{ steps.comment-branch.outputs.head_ref }}',
               inputs: {
-                "recreate_vm": '${{ steps.configure.outputs.recreate-vm }}'
+                "recreate_vm": '${{ steps.outputs.outputs.recreate_vm }}'
               }
             })
       # Getting the ID of the workflow we triggered above is a bit tricky, as it's async :(
@@ -88,7 +88,7 @@ jobs:
             commentBody += `\n\n#### Comment triggered a workflow run
 
               Started workflow run: [${{ fromJSON(steps.run_outputs.outputs.result).id }}](${{ fromJSON(steps.run_outputs.outputs.result).html_url }})
-              * \`recreate_vm: ${{ steps.configure.outputs.recreate-vm }}\``
+              * \`recreate_vm: ${{ steps.outputs.outputs.recreate_vm }}\``
             github.rest.issues.updateComment({
               issue_number: ${{ github.event.issue.number }},
               owner: context.repo.owner,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
