### PR TITLE
Remind Gitpodders to use Dogfood instance.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -67,6 +67,21 @@ tasks:
           ./components/gitpod-protocol/go/scripts/generate-config.sh
           leeway exec --filter-type go -v -- go mod verify
       openMode: split-right
+    - name: Dogfood Check
+      command: |
+        if [ "$GITPOD_HOST" == "https://gitpod.io" ] && [[ "$GITPOD_GIT_USER_EMAIL" =~ .*@gitpod.io ]]
+        then
+          echo ""
+          echo "!!! Please use our dogfooding instance !!!"
+          echo ""
+          for i in {30..1}
+          do
+            echo "This workspace will stop in $i sec. Press CTRL+C to abort shutdown.".
+            sleep 1.
+          done
+          gp stop
+        fi
+        exit 0
 vscode:
     extensions:
         - EditorConfig.EditorConfig


### PR DESCRIPTION
## Description
This PR initiates a countdown to stop your workspace if you run it on gitpod.io and have a gitpod.io email addr. 
You can abort the countdown with CTRL+C.

This PR is half-serious. The idea was too easy to not do it. If this is not useful, feel free to close the PR.

Example output:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/239422/223769187-f758fc09-4062-49d9-84a6-a67bf5f93dea.png">



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
