### PR TITLE
[dashboard] make new workspace aware of project

### DIFF
--- a/components/dashboard/src/data/workspaces/resolve-context-query.ts
+++ b/components/dashboard/src/data/workspaces/resolve-context-query.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { WorkspaceContext } from "@gitpod/gitpod-protocol";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+export function useWorkspaceContext(contextUrl?: string) {
+    const query = useQuery<WorkspaceContext, Error>(
+        ["workspace-context", contextUrl],
+        () => {
+            if (!contextUrl) {
+                throw new Error("no contextURL. Query should be disabled.");
+            }
+            return getGitpodService().server.resolveContext(contextUrl);
+        },
+        {
+            enabled: !!contextUrl,
+        },
+    );
+    return query;
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -29,6 +29,7 @@ import {
     IDESettings,
     EnvVarWithValue,
     WorkspaceTimeoutSetting,
+    WorkspaceContext,
 } from "./protocol";
 import {
     Team,
@@ -132,6 +133,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     deleteWorkspace(id: string): Promise<void>;
     setWorkspaceDescription(id: string, desc: string): Promise<void>;
     controlAdmission(id: string, level: GitpodServer.AdmissionLevel): Promise<void>;
+    resolveContext(contextUrl: string): Promise<WorkspaceContext>;
 
     updateWorkspaceUserPin(id: string, action: GitpodServer.PinAction): Promise<void>;
     sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -137,6 +137,7 @@ const defaultFunctions: FunctionsConfig = {
     getSnapshots: { group: "default", points: 1 },
     guessGitTokenScopes: { group: "default", points: 1 },
     getUsageBalance: { group: "default", points: 1 },
+    resolveContext: { group: "default", points: 1 },
 
     adminGetUsers: { group: "default", points: 1 },
     adminGetUser: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3675,4 +3675,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async getIDToken(): Promise<void> {}
+    public async resolveContext(ctx: TraceContextWithSpan, contextUrl: string): Promise<WorkspaceContext> {
+        const user = this.checkAndBlockUser("resolveContext");
+        return this.contextParser.handle(ctx, user, contextUrl);
+    }
 }


### PR DESCRIPTION
## Description
The new workspace page now resolves the given contextURl and uses the resulting context to lookup the project and preselect the right workspace class.
Going forward we can display more information from the context object and the project.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16727

## How to test
<!-- Provide steps to test this PR -->
- Configure a project and choose a small workspace size for its workspaces.
- try starting a workspace on that project and verify that the new workspace page has the small workspace class preselected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
