### PR TITLE
Add custom supervisor metrics

### DIFF
--- a/components/supervisor/pkg/metrics/reporter.go
+++ b/components/supervisor/pkg/metrics/reporter.go
@@ -41,9 +41,8 @@ func NewGrpcMetricsReporter(gitpodHost string) *GrpcMetricsReporter {
 			"grpc_server_handling_seconds":        true,
 			"supervisor_ide_ready_duration_total": true,
 			"supervisor_initializer_bytes_second": true,
-			"grpc_client_started_total":           true,
-			"grpc_client_handled_total":           true,
-			"grpc_client_handling_seconds":        true,
+			"supervisor_client_handled_total":     true,
+			"supervisor_client_handling_seconds":  true,
 		},
 		values: make(map[string]float64),
 		addCounter: func(name string, labels map[string]string, value uint64) {

--- a/components/supervisor/pkg/serverapi/metrics.go
+++ b/components/supervisor/pkg/serverapi/metrics.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package serverapi
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	ServerTypeServerAPI = "server-api"
+	ServerTypePublicAPI = "public-api"
+)
+
+type ClientMetrics struct {
+	clientHandledCounter   *prometheus.CounterVec
+	clientHandledHistogram *prometheus.HistogramVec
+}
+
+func NewClientMetrics() *ClientMetrics {
+	return &ClientMetrics{
+		clientHandledCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "supervisor_client_handled_total",
+				Help: "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+				// add server label to identify it's going for server api or public api
+			}, []string{"method", "server", "err_code"}),
+		clientHandledHistogram: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "supervisor_client_handling_seconds",
+				Help: "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+				// it should be aligned with https://github.com/gitpod-io/gitpod/blob/84ed1a0672d91446ba33cb7b504cfada769271a8/install/installer/pkg/components/ide-metrics/configmap.go#L315
+				Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 10},
+			}, []string{"method", "server", "err_code"}),
+	}
+}
+
+func (c *ClientMetrics) ProcessMetrics(usePublicAPI bool, method string, err error, startTime time.Time) {
+	code := status.Code(err)
+	server := ServerTypeServerAPI
+	if usePublicAPI {
+		server = ServerTypePublicAPI
+	}
+	c.clientHandledCounter.WithLabelValues(method, server, code.String()).Inc()
+	c.clientHandledHistogram.WithLabelValues(method, server, code.String()).Observe(time.Since(startTime).Seconds())
+}
+
+// guard to make sure ClientMetrics implement Collector interface
+var _ prometheus.Collector = (*ClientMetrics)(nil)
+
+func (c *ClientMetrics) Collect(ch chan<- prometheus.Metric) {
+	c.clientHandledCounter.Collect(ch)
+	c.clientHandledHistogram.Collect(ch)
+}
+
+func (c *ClientMetrics) Describe(ch chan<- *prometheus.Desc) {
+	c.clientHandledCounter.Describe(ch)
+	c.clientHandledHistogram.Describe(ch)
+}

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -4858,6 +4858,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -5059,6 +5087,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9292,7 +9357,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4299,6 +4299,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4500,6 +4528,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -8313,7 +8378,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -4675,6 +4675,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4876,6 +4904,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9109,7 +9174,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5232,6 +5232,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -5433,6 +5461,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9883,7 +9948,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 3ab282a2bf183e7b07712d4d3334a9a1ee299c876bc69d790a34093ecc1d2a05
+        gitpod.io/checksum_config: d22764951cee6db56ea9a1426f5107d2e4fd0fff420361529795e55e16f1d999
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4509,6 +4509,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4710,6 +4738,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -8829,7 +8894,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4336,6 +4336,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4537,6 +4565,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -8442,7 +8507,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4678,6 +4678,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4879,6 +4907,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9753,7 +9818,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -4691,6 +4691,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4892,6 +4920,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9129,7 +9194,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -2304,6 +2304,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -2505,6 +2533,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -3371,7 +3436,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -3692,6 +3692,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -3893,6 +3921,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -6450,7 +6515,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -4678,6 +4678,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4879,6 +4907,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9112,7 +9177,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4675,6 +4675,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4876,6 +4904,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9109,7 +9174,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -4673,6 +4673,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4874,6 +4902,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9119,7 +9184,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -4682,6 +4682,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4883,6 +4911,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9116,7 +9181,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -4675,6 +4675,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4876,6 +4904,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9109,7 +9174,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4687,6 +4687,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4888,6 +4916,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9121,7 +9186,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -4678,6 +4678,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4879,6 +4907,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9112,7 +9177,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5008,6 +5008,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -5209,6 +5237,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9553,7 +9618,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -4678,6 +4678,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4879,6 +4907,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9100,7 +9165,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4678,6 +4678,34 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handled_total",
+            "help": "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "client": null
           }
         ],
         "histogramMetrics": [
@@ -4879,6 +4907,43 @@ data:
               ],
               "defaultValue": "unknown"
             }
+          },
+          {
+            "name": "supervisor_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+            "labels": [
+              {
+                "name": "method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "server",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "err_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ],
+            "client": null
           }
         ],
         "errorReporting": {
@@ -9112,7 +9177,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1afcd55c5e92bb11d2bee732b987af017404083a008f7227966851accd542a17
+        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -232,6 +232,24 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				DefaultValue: "unknown",
 			},
 		},
+		{
+			Name: "supervisor_client_handled_total",
+			Help: "Total number of supervisor outgoing services completed by the client, regardless of success or failure.",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "method",
+					AllowValues: []string{"*"},
+				},
+				{
+					Name:        "server",
+					AllowValues: []string{"*"},
+				},
+				{
+					Name:        "err_code",
+					AllowValues: []string{"*"},
+				},
+			},
+		},
 	}
 
 	histogramMetrics := []config.HistogramMetricsConfiguration{
@@ -328,6 +346,24 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				AllowValues:  []string{"vscode-desktop-extension", "supervisor", "unknown"},
 				DefaultValue: "unknown",
 			},
+		}, {
+			Name: "supervisor_client_handling_seconds",
+			Help: "Histogram of response latency (seconds) of the supervisor outgoing services until it is finished by the application.",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "method",
+					AllowValues: []string{"*"},
+				},
+				{
+					Name:        "server",
+					AllowValues: []string{"*"},
+				},
+				{
+					Name:        "err_code",
+					AllowValues: []string{"*"},
+				},
+			},
+			Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 10},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add custom supervisor metrics

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
