### PR TITLE
[dashboard] cache usage queries

### DIFF
--- a/components/dashboard/src/Pagination/Pagination.tsx
+++ b/components/dashboard/src/Pagination/Pagination.tsx
@@ -48,7 +48,11 @@ function Pagination(props: PaginationProps) {
                 />
                 {calculatedPagination.map((pn, i) => {
                     if (pn === "...") {
-                        return <li className={getClassnames(pn)}>&#8230;</li>;
+                        return (
+                            <li key={i} className={getClassnames(pn)}>
+                                &#8230;
+                            </li>
+                        );
                     }
                     return (
                         <li key={i} className={getClassnames(pn)} onClick={() => typeof pn === "number" && setPage(pn)}>

--- a/components/dashboard/src/data/usage/usage-query.ts
+++ b/components/dashboard/src/data/usage/usage-query.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { ListUsageRequest, ListUsageResponse } from "@gitpod/gitpod-protocol/lib/usage";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+export function useListUsage(request?: ListUsageRequest) {
+    const query = useQuery<ListUsageResponse, Error>(
+        ["usage", request],
+        () => {
+            console.log("Fetching usage... ", request);
+            if (!request) {
+                throw new Error("request is required");
+            }
+            return getGitpodService().server.listUsage(request);
+        },
+        {
+            enabled: !!request,
+            cacheTime: 1000 * 60 * 10, // 10 minutes
+            staleTime: 1000 * 60 * 10, // 10 minutes
+        },
+    );
+    return query;
+}


### PR DESCRIPTION
## Description
Fixes a bug where when on the usage view we send the same request every second and also moves the usage fetching to a react query that is cached 10 mins.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
