### PR TITLE
[tests] continue running workspace integ tests on werft for the short term

### DIFF
--- a/.werft/workspace-run-integration-tests.sh
+++ b/.werft/workspace-run-integration-tests.sh
@@ -122,7 +122,7 @@ REVISION=$(git show -s --format="%h" HEAD)
     git checkout -B "${BRANCH}" && \
     git commit -m "${TEMP_COMMIT_MSG}" --allow-empty  && \
     git push --set-upstream origin "${BRANCH}" && \
-    werft run github -a with-preview=true -a with-large-vm=true
+    werft run github -a with-preview=true -a with-large-vm=true -a with-werft=true
 ) | werft log slice "build preview environment"
 
 for signal in SIGINT SIGTERM EXIT; do


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
W/o this change, it tries using GHA and fails.

This is a short term change to unblock our release. Later this week or early next we'll migrate to Github Actions (once the secrets are added to the mono repo).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Trigger tests using the werft CLI via this branch like so:
```
./.werft/workspace-run-integration-tests.yaml \
> -a with-integration-tests=workspace \
> -a with-large-vm=true \
> -a with-gce-vm=true \
> -a with-werft=true
```

Example: https://werft.gitpod-dev.com/job/gitpod-custom-kylos101-werft-wk-int-tests.0/raw

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
