### PR TITLE
[gha] all gha run on self-hosted

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
 
     container: eu.gcr.io/gitpod-core-dev/dev/changelog:0.0.36
 

--- a/.github/workflows/check-gitpodyaml.yml
+++ b/.github/workflows/check-gitpodyaml.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify:
     name: Build and upload model
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - name: Notify
         uses: KeisukeYamashita/create-comment@v1

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/configcat.yml
+++ b/.github/workflows/configcat.yml
@@ -5,7 +5,7 @@ on:
 name: Configcat code references
 jobs:
   scan-repo:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     name: Scan repository for configcat code references
     steps:
     - name: Checkout

--- a/.github/workflows/dashboard-sync.yml
+++ b/.github/workflows/dashboard-sync.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/.github/workflows/delete-kots-channel.yml
+++ b/.github/workflows/delete-kots-channel.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   delete:
     if: github.event.ref_type == 'branch'
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     continue-on-error: true
     steps:
       - name: Install Replicated CLI

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   update-jetbrains:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -16,7 +16,7 @@ on:
         required: true
 jobs:
   jetbrains-smoke-test-linux:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/jetbrains-update-backend-latest.yml
+++ b/.github/workflows/jetbrains-update-backend-latest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -25,7 +25,7 @@ on:
 jobs:
     update-plugin-platform:
         name: Update Platform Version from ${{ inputs.pluginName }}
-        runs-on: ubuntu-latest
+        runs-on: [ self-hosted ]
         env:
             SNAPSHOTS_HTML_FILENAME: snapshots.html
         steps:

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     update-jetbrains:
-        runs-on: ubuntu-latest
+        runs-on: [ self-hosted ]
         steps:
             - uses: actions/checkout@v3
             - name: Check for updates

--- a/.github/workflows/permissions.yml
+++ b/.github/workflows/permissions.yml
@@ -5,7 +5,7 @@ on:
     - install/installer/pkg/components/spicedb/data/schema.yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
     - uses: actions/checkout@v3
     - uses: "authzed/action-spicedb-validate@v1"

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -5,7 +5,7 @@ on:
     - components/public-api/**
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
What it says on the tin

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
