### PR TITLE
[server] Mount admin-credentials 

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -41,7 +41,7 @@ export type Config = Omit<
     admin: {
         loginKey?: string;
         // Absolute file path pointing to a file which contains admin credentials, encoded as JSON.
-        credentialsFilePath: string;
+        credentialsPath: string;
     };
 };
 
@@ -154,6 +154,7 @@ export interface ConfigSerialized {
     adminLoginKeyFile?: string;
     admin: {
         grantFirstUserAdminRole: boolean;
+        credentialsPath: string;
     };
 
     /** defaultBaseImageRegistryWhitelist is the list of registryies users get acces to by default */
@@ -359,7 +360,7 @@ export namespace ConfigFile {
             admin: {
                 ...config.admin,
                 loginKey: adminLoginKey,
-                credentialsFilePath: "",
+                credentialsPath: config.admin.credentialsPath,
             },
         };
     }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -905,7 +905,7 @@ export class UserController {
     }
 
     private async readAdminCredentials(): Promise<AdminCredentials> {
-        const credentialsFilePath = this.config.admin.credentialsFilePath;
+        const credentialsFilePath = this.config.admin.credentialsPath;
 
         // Credentials do not have to be present in the system, if admin level sing-in is entirely disabled.
         if (!credentialsFilePath) {

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5555,7 +5555,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10460,7 +10461,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10598,6 +10599,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10709,6 +10713,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4896,7 +4896,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -9273,7 +9274,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e641db8210464747aa714799870c610059b5c4880a288a9da91a843660ae9cb0
+        gitpod.io/checksum_config: 5e1f7a11dab8d9002c8567f2c82f62f7e579052e6d7c55b155f077ae65a83830
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9411,6 +9412,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9522,6 +9526,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5372,7 +5372,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10277,7 +10278,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 39d3eba34aee9b750a147454c59cc518708d37c10eb67ea51e7f25c825a63001
+        gitpod.io/checksum_config: 0081c90b9b1737448e6dc66ea15b1f3bdaa301a519262cd4272572b36d900412
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10415,6 +10416,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10526,6 +10530,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5964,7 +5964,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -11121,7 +11122,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: bd1abec4fc8b94c536ffa2f49b5973514fa5312e26118b91586341dad4028ca9
+        gitpod.io/checksum_config: 9d1ffc612cd159d1872289c18d776d2daf5480b3d6dbe44e42f23c737576ce76
         hello: world
       creationTimestamp: null
       labels:
@@ -11262,6 +11263,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11373,6 +11377,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5152,7 +5152,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -9900,7 +9901,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10038,6 +10039,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10149,6 +10153,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4923,7 +4923,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -9390,7 +9391,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bd821d26b89c21e21f9cdfd552b0202e07684f85a91a4f2c9ea03e6133222677
+        gitpod.io/checksum_config: 2fd2d6fe6c1d71f5cf231db838f262be11177fae1e952750c46baae49e010e14
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9522,6 +9523,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9627,6 +9631,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5375,7 +5375,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -11442,7 +11443,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11621,6 +11622,9 @@ spec:
           readOnly: true
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
+          readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
           readOnly: true
       - args:
         - --logtostderr
@@ -11853,6 +11857,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -5388,7 +5388,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10299,7 +10300,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10437,6 +10438,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10548,6 +10552,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -4292,7 +4292,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -7461,7 +7462,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7596,6 +7597,9 @@ spec:
         - mountPath: /twilio-config
           name: twilio-secret-volume
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -7704,6 +7708,10 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager-bridge

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2344,7 +2344,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -4572,7 +4573,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4707,6 +4708,9 @@ spec:
         - mountPath: /twilio-config
           name: twilio-secret-volume
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -4815,6 +4819,10 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager-bridge

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5375,7 +5375,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10280,7 +10281,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10418,6 +10419,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10529,6 +10533,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5372,7 +5372,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10277,7 +10278,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10415,6 +10416,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10526,6 +10530,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5370,7 +5370,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10287,7 +10288,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10425,6 +10426,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10536,6 +10540,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5379,7 +5379,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10284,7 +10285,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10422,6 +10423,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10533,6 +10537,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5372,7 +5372,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10277,7 +10278,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1cbc27f47f6fd77248e1d48e029b52338da69c5a3abe4e15d2cd976008189aa8
+        gitpod.io/checksum_config: b4a82ff6031d4295a8b7d5949c90dbf79d3545d72de98f7ba633657246a7c25a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10415,6 +10416,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10526,6 +10530,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5384,7 +5384,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10289,7 +10290,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10427,6 +10428,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10538,6 +10542,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5375,7 +5375,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10280,7 +10281,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10418,6 +10419,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10529,6 +10533,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5705,7 +5705,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10721,7 +10722,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10859,6 +10860,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10970,6 +10974,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5375,7 +5375,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10268,7 +10269,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10406,6 +10407,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10517,6 +10521,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5375,7 +5375,8 @@ data:
         "resources": null
       },
       "admin": {
-        "grantFirstUserAdminRole": true
+        "grantFirstUserAdminRole": true,
+        "credentialsPath": "/credentials/admin/admin.json"
       },
       "adminLoginKeyFile": "",
       "prebuildLimiter": {
@@ -10280,7 +10281,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
+        gitpod.io/checksum_config: c929d9663d6775337cd6d6c0a1fdf590af09ad71c0b3247c78f26501653d1256
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10418,6 +10419,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /credentials/admin
+          name: admin-credentials
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10529,6 +10533,10 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-credentials
+        secret:
+          optional: true
+          secretName: admin-credentials
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -201,7 +201,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	_, _, adminCredentialsPath := getAdminCredentials(cfg)
+	_, _, adminCredentialsPath := getAdminCredentials()
 
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -28,4 +28,8 @@ const (
 	AdminSecretName                        = "server-admin-secret"
 	AdminSecretLoginKeyName                = "login-key"
 	AdminSecretMountPath                   = "/admin"
+
+	AdminCredentialsSecretName      = "admin-credentials"
+	AdminCredentialsSecretMountPath = "/credentials/admin"
+	AdminCredentialsSecretKey       = "admin.json"
 )

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -335,6 +335,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
+	adminCredentialsVolume, adminCredentialsMount, _ := getAdminCredentials()
+	volumes = append(volumes, adminCredentialsVolume)
+	volumeMounts = append(volumeMounts, adminCredentialsMount)
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -175,4 +175,7 @@ type PrebuildRateLimiterConfig struct {
 
 type AdminConfig struct {
 	GrantFirstUserAdminRole bool `json:"grantFirstUserAdminRole"`
+
+	// Absolute path to a file containg credentials (as JSON) which can be used to log-in as admin
+	CredentialsPath string `json:"credentialsPath"`
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We mount the `admin-credentials` secret onto server, and provide the file path. If that secret does not exist, we do not fail (marked as optional) and the login-as-admin feature remains disabled.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16223

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
