### PR TITLE
[server] Remove admin OTS create/use flow

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -28,7 +28,6 @@ export type Config = Omit<
     | "stripeConfigFile"
     | "licenseFile"
     | "patSigningKeyFile"
-    | "adminLoginKeyFile"
 > & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
@@ -151,7 +150,6 @@ export interface ConfigSerialized {
 
     showSetupModal: boolean;
 
-    adminLoginKeyFile?: string;
     admin: {
         grantFirstUserAdminRole: boolean;
         credentialsPath: string;
@@ -331,15 +329,6 @@ export namespace ConfigFile {
             }
         }
 
-        let adminLoginKey: string | undefined = undefined;
-        if (config.adminLoginKeyFile) {
-            try {
-                adminLoginKey = fs.readFileSync(filePathTelepresenceAware(config.adminLoginKeyFile), "utf-8").trim();
-            } catch (error) {
-                log.error("Could not load admin login key", error);
-            }
-        }
-
         return {
             ...config,
             hostUrl,
@@ -359,7 +348,6 @@ export namespace ConfigFile {
             patSigningKey,
             admin: {
                 ...config.admin,
-                loginKey: adminLoginKey,
                 credentialsPath: config.admin.credentialsPath,
             },
         };

--- a/components/server/src/installation-admin/installation-admin-controller.ts
+++ b/components/server/src/installation-admin/installation-admin-controller.ts
@@ -4,30 +4,15 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as crypto from "crypto";
 import { injectable, inject } from "inversify";
 import * as express from "express";
 import * as opentracing from "opentracing";
 import { InstallationAdminTelemetryDataProvider } from "./telemetry-data-provider";
-import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { OneTimeSecretServer } from "../one-time-secret-server";
-import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { BUILTIN_INSTLLATION_ADMIN_USER_ID, UserDB } from "@gitpod/gitpod-db/lib/user-db";
-import { Config } from "../config";
 
 @injectable()
 export class InstallationAdminController {
     @inject(InstallationAdminTelemetryDataProvider)
     protected readonly telemetryDataProvider: InstallationAdminTelemetryDataProvider;
-
-    @inject(OneTimeSecretServer)
-    protected readonly otsServer: OneTimeSecretServer;
-
-    @inject(Config)
-    protected readonly config: Config;
-
-    @inject(UserDB)
-    protected readonly userDb: UserDB;
 
     public create(): express.Application {
         const app = express();
@@ -40,46 +25,6 @@ export class InstallationAdminController {
                 res.status(200).json(await this.telemetryDataProvider.getTelemetryData());
             } finally {
                 span.finish();
-            }
-        });
-
-        const adminUserCreateLoginTokenRoute = "/admin-user/login-token/create";
-        app.post(adminUserCreateLoginTokenRoute, async (req: express.Request, res: express.Response) => {
-            const span = TraceContext.startSpan(adminUserCreateLoginTokenRoute);
-            const ctx = { span };
-
-            log.info(`${adminUserCreateLoginTokenRoute} received.`);
-            try {
-                // In case there is no/an empty key specified: Nobody should be able to call this so they are not able to guess values here
-                if (!this.config.admin.loginKey) {
-                    throw new Error("Cannot handle request");
-                }
-
-                // Unblock the admin-user: it's blocked initially!
-                const user = await this.userDb.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID);
-                if (!user) {
-                    throw new Error("Cannot find builtin admin-user");
-                }
-                user.blocked = false;
-                await this.userDb.storeUser(user);
-
-                // Create a fresh token
-                // TODO(gpl): Would be nice if we could invalidate all other tokens here!
-                const secretHash = crypto
-                    .createHash("sha256")
-                    .update(BUILTIN_INSTLLATION_ADMIN_USER_ID + this.config.admin.loginKey)
-                    .digest("hex");
-                const oneDay = new Date();
-                oneDay.setDate(oneDay.getDate() + 1);
-                const ots = await this.otsServer.serveToken(ctx, secretHash, oneDay);
-
-                res.send(ots.token).status(200);
-                log.info(`${adminUserCreateLoginTokenRoute} done.`);
-            } catch (err) {
-                TraceContext.setError(ctx, err);
-                span.finish();
-                log.error(`${adminUserCreateLoginTokenRoute} error`, err);
-                res.sendStatus(500);
             }
         });
 

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -191,38 +191,6 @@ export class UserController {
         });
 
         router.get(
-            "/login/ots/admin-user/:key",
-            loginUserWithOts(async (req: express.Request, res: express.Response, user: User, secret: string) => {
-                // In case there is no/an empty key specified: Nobody should be able to call this so they are not able to guess values here
-                if (!this.config.admin.loginKey) {
-                    throw new ResponseError(500, "No admin login key configured, cannot login as admin-user");
-                }
-
-                // Counterpart is here: https://github.com/gitpod-io/gitpod/blob/478a75e744a642d9b764de37cfae655bc8b29dd5/components/server/src/installation-admin/installation-admin-controller.ts#L38
-                const secretHash = crypto
-                    .createHash("sha256")
-                    .update(user.id + this.config.admin.loginKey)
-                    .digest("hex");
-                if (secretHash !== secret) {
-                    throw new ResponseError(401, "OTS secret not verified");
-                }
-
-                // Login this user (sets cookie as side-effect)
-                await new Promise<void>((resolve, reject) => {
-                    req.login(user, (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    });
-                });
-
-                // Simply redirect to the app for now
-                res.redirect("/orgs/new", 307);
-            }, BUILTIN_INSTLLATION_ADMIN_USER_ID),
-        );
-        router.get(
             "/login/ots/:userId/:key",
             loginUserWithOts(async (req: express.Request, res: express.Response, user: User, secret: string) => {
                 // This mechanism is used by integration tests, cmp. https://github.com/gitpod-io/gitpod/blob/478a75e744a642d9b764de37cfae655bc8b29dd5/test/tests/ide/vscode/python_ws_test.go#L105

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -303,8 +303,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			GrantFirstUserAdminRole: true, // existing default
 			CredentialsPath:         adminCredentialsPath,
 		},
-		AdminLoginKeyFile: AdminLoginKeyFile(ctx),
-		ShowSetupModal:    showSetupModal,
+		ShowSetupModal: showSetupModal,
 	}
 
 	fc, err := common.ToJSONString(scfg)
@@ -326,13 +325,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 	}, nil
-}
-
-func AdminLoginKeyFile(ctx *common.RenderContext) string {
-	if ctx.Config.AdminLoginSecret == nil {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s", AdminSecretMountPath, AdminSecretLoginKeyName)
 }
 
 func getPersonalAccessTokenSigningKey(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMount, string, bool) {

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -25,9 +25,6 @@ const (
 	DebugNodePortName                      = "debugnode"
 	ServicePort                            = 3000
 	personalAccessTokenSigningKeyMountPath = "/secrets/personal-access-token-signing-key"
-	AdminSecretName                        = "server-admin-secret"
-	AdminSecretLoginKeyName                = "login-key"
-	AdminSecretMountPath                   = "/admin"
 
 	AdminCredentialsSecretName      = "admin-credentials"
 	AdminCredentialsSecretMountPath = "/credentials/admin"

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -318,23 +318,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
-	// admin secret
-	if ctx.Config.AdminLoginSecret != nil {
-		volumes = append(volumes, corev1.Volume{
-			Name: "admin-login-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: ctx.Config.AdminLoginSecret.Name,
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "admin-login-key",
-			MountPath: AdminSecretMountPath,
-			ReadOnly:  true,
-		})
-	}
-
 	adminCredentialsVolume, adminCredentialsMount, _ := getAdminCredentials()
 	volumes = append(volumes, adminCredentialsVolume)
 	volumeMounts = append(volumeMounts, adminCredentialsMount)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

No longer needed, as it's super-seeded by the admin-credentials file flow

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/16760/files
* Part of https://github.com/gitpod-io/gitpod/issues/16223

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
