### PR TITLE
[ws-manager-mk2] Protect tokens

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -52,7 +52,7 @@ MATCHES="$(grep -c -- --- k8s.yaml)"
 # get the read number of K8s manifest docs
 # K8s object names and kinds are duplicated in a config map to faciliate deletion
 # subtract one (the config map) and then divide by 2 to get the actual # of docs we'll loop through
-DOCS="$((((MATCHES - 1) / 2) + 1))"
+DOCS="$(((MATCHES - 1) / 2))"
 documentIndex=0
 
 while [ "$documentIndex" -le "$DOCS" ]; do

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -42,6 +42,7 @@ type RuntimeConfig struct {
 	Container           *container.Config `json:"containerRuntime"`
 	Kubeconfig          string            `json:"kubeconfig"`
 	KubernetesNamespace string            `json:"namespace"`
+	SecretsNamespace    string            `json:"secretsNamespace"`
 }
 
 type IOLimitConfig struct {

--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -77,6 +77,8 @@ type ServiceConfiguration struct {
 type Configuration struct {
 	// Namespace is the kubernetes namespace the workspace manager operates in
 	Namespace string `json:"namespace"`
+	// SecretsNamespace is the kubernetes namespace which contains workspace secrets
+	SecretsNamespace string `json:"secretsNamespace"`
 	// SchedulerName is the name of the workspace scheduler all pods are created with
 	SchedulerName string `json:"schedulerName"`
 	// SeccompProfile names the seccomp profile workspaces will use

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -50,7 +50,6 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	log := log.FromContext(ctx).WithValues("configMap", req.NamespacedName)
 
 	if req.Name != configMapName {
-		log.Info("ignoring unexpected ConfigMap")
 		return ctrl.Result{}, nil
 	}
 

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -358,6 +358,11 @@ func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *wo
 	if err != nil {
 		log.Error(err, "could not delete environment secret", "workspace", ws.Name)
 	}
+
+	err = r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "tokens"), r.Config.SecretsNamespace)
+	if err != nil {
+		log.Error(err, "could not delete token secret", "workspace", ws.Name)
+	}
 }
 
 func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace string) error {

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -109,16 +109,7 @@ func main() {
 		HealthProbeBindAddress: cfg.Health.Addr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ws-manager-mk2-leader.gitpod.io",
-		Namespace:              cfg.Manager.Namespace,
-		NewCache: func(conf *rest.Config, opts cache.Options) (cache.Cache, error) {
-			// Only watch the maintenance mode ConfigMap.
-			opts.SelectorsByObject = cache.SelectorsByObject{
-				&corev1.ConfigMap{}: cache.ObjectSelector{
-					Label: labels.SelectorFromSet(labels.Set{controllers.LabelMaintenance: "true"}),
-				},
-			}
-			return cache.New(conf, opts)
-		},
+		NewCache:               cache.MultiNamespacedCacheBuilder([]string{cfg.Manager.Namespace, cfg.Manager.SecretsNamespace}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -18,12 +18,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -204,6 +205,8 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 	userEnvVars, envData := extractWorkspaceUserEnv(envSecretName, req.Spec.Envvars, req.Spec.SysEnvvars)
 	sysEnvVars := extractWorkspaceSysEnv(req.Spec.SysEnvvars)
 
+	tokenData, _ := extractWorkspaceTokenData(req.Spec)
+
 	ws := workspacev1.Workspace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: workspacev1.GroupVersion.String(),
@@ -254,6 +257,11 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 	err = wsm.createWorkspaceSecret(ctx, &ws, envSecretName, wsm.Config.Namespace, envData)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create env secret for workspace %s: %w", req.Id, err)
+	}
+
+	err = wsm.createWorkspaceSecret(ctx, &ws, fmt.Sprintf("%s-%s", req.Id, "tokens"), wsm.Config.SecretsNamespace, tokenData)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create token secret for workspace %s: %w", req.Id, err)
 	}
 
 	wsm.metrics.recordWorkspaceStart(&ws)
@@ -855,6 +863,15 @@ func extractWorkspaceSysEnv(sysEnvs []*wsmanapi.EnvironmentVariable) []corev1.En
 	}
 
 	return envs
+}
+
+func extractWorkspaceTokenData(spec *wsmanapi.StartWorkspaceSpec) (secrets map[string]string, secretsLen int) {
+	secrets = make(map[string]string)
+	for k, v := range csapi.GatherSecretsFromInitializer(spec.Initializer) {
+		secrets[k] = v
+		secretsLen += len(v)
+	}
+	return secrets, secretsLen
 }
 
 func extractWorkspaceStatus(ws *workspacev1.Workspace) *wsmanapi.WorkspaceStatus {

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5709,7 +5709,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8370,7 +8371,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3146,6 +3146,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3201,6 +3211,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5809,6 +5826,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6756,6 +6774,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7225,6 +7263,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10983,7 +11037,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2759,6 +2759,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -2814,6 +2824,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5154,6 +5171,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6067,6 +6085,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6518,6 +6556,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9796,7 +9850,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7da41879471e13b5f45ca5d34265974ed68c3c77c93f8d9b6c0d188ac9724e5
+        gitpod.io/checksum_config: 9e4ebf60455939d2a4b5781c2c4e3b84c9029ee7f841dfcb5f3ccc8f7179599e
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -5050,7 +5050,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -7538,7 +7539,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 573f5fc567df7be7fba63ecdc681e3aa5f059daa207992586a41bba4106d2545
+        gitpod.io/checksum_config: a23a04a77f794df58d7dffe59383242db628f6da2c0e4bac7620b1d968996243
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5526,7 +5526,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8187,7 +8188,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -2963,6 +2963,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3018,6 +3028,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5626,6 +5643,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6573,6 +6591,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7042,6 +7080,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10800,7 +10854,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3427,6 +3427,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3497,6 +3507,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -6248,6 +6265,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -7210,6 +7228,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7679,6 +7717,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11685,7 +11739,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 6ea687679b10a3046a6840985edd56495c512b0d5bf4b5a9f85d46f41de49036
+        gitpod.io/checksum_config: 14b2091d899fef2d7a41550f7baf02deebc76d64734f5d9b812acd7f937eed88
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -6143,7 +6143,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8940,7 +8941,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: e72f036b19d3287feece7409ecc0991d1c4f58ad96da7b901ce565b0f5208039
+        gitpod.io/checksum_config: 0f892bd4e952cbaa5d71eaaea340ba2838a5763f0caca3f2e6f1b1591c104000
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2857,6 +2857,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -2912,6 +2922,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5406,6 +5423,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6334,6 +6352,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6785,6 +6823,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10423,7 +10477,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5306,7 +5306,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -7907,7 +7908,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -5077,7 +5077,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -7597,7 +7598,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: eb4dd48f0756c6343cc7b91acd5ec6e881b6d1f97547b217b5ce52d5e6669e91
+        gitpod.io/checksum_config: c9e4e386dff69815d3f4617c1255e1fc80fdf92a2406c6511ca690df3d54e12d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2796,6 +2796,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -2851,6 +2861,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5176,6 +5193,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6084,6 +6102,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -6553,6 +6591,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9901,7 +9955,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e2866e24a01f026d164c591d5c649a0a5589feea38a0d90d785d1167483cd02e
+        gitpod.io/checksum_config: eb8ba5a842ba7a2f4e7650963e3143422148261199e4d15fbbc03016e8c3acff
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5529,7 +5529,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8391,7 +8392,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2966,6 +2966,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3021,6 +3031,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5629,6 +5646,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6576,6 +6594,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7045,6 +7083,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12127,7 +12181,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -5542,7 +5542,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8207,7 +8208,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -2979,6 +2979,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3034,6 +3044,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5642,6 +5659,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6589,6 +6607,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7058,6 +7096,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10822,7 +10876,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -1900,7 +1900,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -3443,7 +3444,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -1189,6 +1189,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -1244,6 +1254,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -2000,6 +2017,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -2625,6 +2643,26 @@ rules:
   - get
   - update
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2804,6 +2842,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3985,7 +4039,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 220f4f84d031d4a23cf0177b3e94a85a25707d132a8313a51602a3d8b9255414
+        gitpod.io/checksum_config: 04d0c84ff10675d023182a24beb2171cdf9b88568eb96032394819e8566b3c00
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -2966,6 +2966,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3021,6 +3031,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5629,6 +5646,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6576,6 +6594,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7045,6 +7083,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10803,7 +10857,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5529,7 +5529,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8190,7 +8191,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5526,7 +5526,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8187,7 +8188,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2963,6 +2963,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3018,6 +3028,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5626,6 +5643,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6573,6 +6591,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7042,6 +7080,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10800,7 +10854,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -2961,6 +2961,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3016,6 +3026,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5624,6 +5641,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6571,6 +6589,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7040,6 +7078,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10810,7 +10864,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5524,7 +5524,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8197,7 +8198,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5533,7 +5533,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8194,7 +8195,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -2970,6 +2970,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3025,6 +3035,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5633,6 +5650,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6580,6 +6598,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7049,6 +7087,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10807,7 +10861,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5526,7 +5526,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8187,7 +8188,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2963,6 +2963,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3018,6 +3028,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5626,6 +5643,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6573,6 +6591,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7042,6 +7080,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10800,7 +10854,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b86c15b7ccf53d8f812d381760022c16e8bf00aa5385b5cf2acd870f0bc901db
+        gitpod.io/checksum_config: 7a5265597622304d09dd82531a4f224e0f16d39da5899000916b146dd370cfde
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2975,6 +2975,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3030,6 +3040,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5638,6 +5655,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6585,6 +6603,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7054,6 +7092,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10812,7 +10866,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5538,7 +5538,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8199,7 +8200,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -2966,6 +2966,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3021,6 +3031,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5629,6 +5646,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6576,6 +6594,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7045,6 +7083,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10803,7 +10857,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5529,7 +5529,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8190,7 +8191,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3287,6 +3287,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3342,6 +3352,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5959,6 +5976,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -7017,6 +7035,26 @@ rules:
   verbs:
   - use
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7486,6 +7524,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11244,7 +11298,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5859,7 +5859,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8631,7 +8632,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2966,6 +2966,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3021,6 +3031,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5629,6 +5646,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6576,6 +6594,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7045,6 +7083,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10791,7 +10845,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6bccb0af0666fedca427bf7e904bb6ad0760871f8272d37c095015b1917a8a3b
+        gitpod.io/checksum_config: 4a4578809a4c2f9cfbbd2781d720a47df569cc4e3b54be23b5c41f56c0296e77
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5529,7 +5529,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8190,7 +8191,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5529,7 +5529,8 @@ data:
             }
           },
           "kubeconfig": "",
-          "namespace": "default"
+          "namespace": "default",
+          "secretsNamespace": "workspace-secrets"
         },
         "content": {
           "workingArea": "/mnt/workingarea",
@@ -8190,7 +8191,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c3f063b20c86e50d84ab6b62d85d5042146c1748f01c42dd37581239a888b9d8
+        gitpod.io/checksum_config: 96b5a68d5c5c49ae0d0c9f68e9d28d40b15481832f04c7686a092963380f1093
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2966,6 +2966,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: workspace-secrets
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       creationTimestamp: null
@@ -3021,6 +3031,13 @@ data:
         app: gitpod
         component: ws-daemon
       name: default-ws-daemon-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: ws-daemon
+      namespace: workspace-secrets
     ---
     apiVersion: v1
     kind: Service
@@ -5629,6 +5646,7 @@ data:
     {
       "manager": {
         "namespace": "default",
+        "secretsNamespace": "",
         "schedulerName": "",
         "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
         "timeouts": {
@@ -6576,6 +6594,26 @@ rules:
   - patch
   - watch
 ---
+# rbac.authorization.k8s.io/v1/Role ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: workspace-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -7045,6 +7083,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: ws-daemon
+  namespace: workspace-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10803,7 +10857,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 903ddd6b5567f5831d07f643a85942f7c7891ec40745b0aeb508a7c115389511
+        gitpod.io/checksum_config: 8f78e0c49b70bc845b8c69ddc215fc3d1999be738c385173ffd48a84c8303fa5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -664,7 +664,7 @@ var DeploymentStrategy = appsv1.DeploymentStrategy{
 var (
 	TypeMetaNamespace = metav1.TypeMeta{
 		APIVersion: "v1",
-		Kind:       "namespace",
+		Kind:       "Namespace",
 	}
 	TypeMetaStatefulSet = metav1.TypeMeta{
 		APIVersion: "apps/v1",

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -59,6 +59,7 @@ const (
 	DBCaFileName                    = "ca.crt"
 	DBCaBasePath                    = "/db-ssl"
 	DBCaPath                        = DBCaBasePath + "/" + DBCaFileName
+	WorkspaceSecretsNamespace       = "workspace-secrets"
 
 	AnnotationConfigChecksum = "gitpod.io/checksum_config"
 

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -112,6 +112,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Daemon: daemon.Config{
 			Runtime: daemon.RuntimeConfig{
 				KubernetesNamespace: ctx.Namespace,
+				SecretsNamespace:    common.WorkspaceSecretsNamespace,
 				Container: &container.Config{
 					Runtime: container.RuntimeContainerd,
 					Mapping: runtimeMapping,

--- a/install/installer/pkg/components/ws-daemon/objects.go
+++ b/install/installer/pkg/components/ws-daemon/objects.go
@@ -9,6 +9,7 @@ import (
 )
 
 var Objects = common.CompositeRenderFunc(
+	role,
 	clusterrole,
 	configmap,
 	common.DefaultServiceAccount(Component),

--- a/install/installer/pkg/components/ws-daemon/role.go
+++ b/install/installer/pkg/components/ws-daemon/role.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func role(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&rbacv1.Role{
+			TypeMeta: common.TypeMetaRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: common.WorkspaceSecretsNamespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/ws-daemon/rolebinding.go
+++ b/install/installer/pkg/components/ws-daemon/rolebinding.go
@@ -54,5 +54,25 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Namespace: ctx.Namespace,
 			}},
 		},
+
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: common.WorkspaceSecretsNamespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     Component,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Component,
+					Namespace: ctx.Namespace,
+				},
+			},
+		},
 	}, nil
 }

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -185,7 +185,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
 			Namespace:        ctx.Namespace,
-			SecretsNamespace: WorkspaceSecretsNamespace,
+			SecretsNamespace: common.WorkspaceSecretsNamespace,
 			SchedulerName:    schedulerName,
 			SeccompProfile:   fmt.Sprintf("workspace_default_%s.json", ctx.VersionManifest.Version),
 			WorkspaceDaemon: config.WorkspaceDaemonConfiguration{

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -184,9 +184,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
-			Namespace:      ctx.Namespace,
-			SchedulerName:  schedulerName,
-			SeccompProfile: fmt.Sprintf("workspace_default_%s.json", ctx.VersionManifest.Version),
+			Namespace:        ctx.Namespace,
+			SecretsNamespace: WorkspaceSecretsNamespace,
+			SchedulerName:    schedulerName,
+			SeccompProfile:   fmt.Sprintf("workspace_default_%s.json", ctx.VersionManifest.Version),
 			WorkspaceDaemon: config.WorkspaceDaemonConfiguration{
 				Port: 8080,
 				TLS: struct {

--- a/install/installer/pkg/components/ws-manager-mk2/constants.go
+++ b/install/installer/pkg/components/ws-manager-mk2/constants.go
@@ -19,4 +19,5 @@ const (
 	WorkspaceTemplatePath      = "/workspace-templates"
 	WorkspaceTemplateConfigMap = "workspace-templates"
 	LabelMaintenanceConfig     = "gitpod.io/maintenanceConfig"
+	WorkspaceSecretsNamespace  = "workspace-secrets"
 )

--- a/install/installer/pkg/components/ws-manager-mk2/constants.go
+++ b/install/installer/pkg/components/ws-manager-mk2/constants.go
@@ -19,5 +19,4 @@ const (
 	WorkspaceTemplatePath      = "/workspace-templates"
 	WorkspaceTemplateConfigMap = "workspace-templates"
 	LabelMaintenanceConfig     = "gitpod.io/maintenanceConfig"
-	WorkspaceSecretsNamespace  = "workspace-secrets"
 )

--- a/install/installer/pkg/components/ws-manager-mk2/namespace.go
+++ b/install/installer/pkg/components/ws-manager-mk2/namespace.go
@@ -16,7 +16,7 @@ func namespace(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&v1.Namespace{
 			TypeMeta: common.TypeMetaNamespace,
 			ObjectMeta: metav1.ObjectMeta{
-				Name: WorkspaceSecretsNamespace,
+				Name: common.WorkspaceSecretsNamespace,
 			},
 		},
 	}, nil

--- a/install/installer/pkg/components/ws-manager-mk2/namespace.go
+++ b/install/installer/pkg/components/ws-manager-mk2/namespace.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package wsmanagermk2
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func namespace(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&v1.Namespace{
+			TypeMeta: common.TypeMetaNamespace,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: WorkspaceSecretsNamespace,
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/ws-manager-mk2/objects.go
+++ b/install/installer/pkg/components/ws-manager-mk2/objects.go
@@ -23,6 +23,7 @@ var Objects common.RenderFunc = func(cfg *common.RenderContext) ([]runtime.Objec
 	}
 
 	return common.CompositeRenderFunc(
+		namespace,
 		crd,
 		configmap,
 		deployment,

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -145,7 +145,7 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 			TypeMeta: common.TypeMetaRole,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
-				Namespace: WorkspaceSecretsNamespace,
+				Namespace: common.WorkspaceSecretsNamespace,
 				Labels:    labels,
 			},
 			Rules: controllerRules,

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -87,10 +87,6 @@ var controllerRules = []rbacv1.PolicyRule{
 			"watch",
 		},
 	},
-}
-
-// ConfigMap, Leases, and Events access is required for leader-election.
-var leaderElectionRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
 		Resources: []string{"configmaps"},
@@ -104,6 +100,10 @@ var leaderElectionRules = []rbacv1.PolicyRule{
 			"watch",
 		},
 	},
+}
+
+// ConfigMap, Leases, and Events access is required for leader-election.
+var leaderElectionRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{"coordination.k8s.io"},
 		Resources: []string{"leases"},

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -12,6 +12,121 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var controllerRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"patch",
+			"update",
+			"watch",
+		},
+	},
+	{
+		Verbs:     []string{"get"},
+		APIGroups: []string{""},
+		Resources: []string{"pod/status"},
+	},
+	{
+		APIGroups: []string{"workspace.gitpod.io"},
+		Resources: []string{"workspaces"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"patch",
+			"update",
+			"watch",
+		},
+	},
+	{
+		Verbs:     []string{"update"},
+		APIGroups: []string{"workspace.gitpod.io"},
+		Resources: []string{"workspaces/finalizers"},
+	},
+	{
+		APIGroups: []string{"workspace.gitpod.io"},
+		Resources: []string{"workspaces/status"},
+		Verbs: []string{
+			"get",
+			"patch",
+			"update",
+		},
+	},
+	{
+		APIGroups: []string{"workspace.gitpod.io"},
+		Resources: []string{"snapshots"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"watch",
+		},
+	},
+	{
+		APIGroups: []string{"workspace.gitpod.io"},
+		Resources: []string{"snapshots/status"},
+		Verbs: []string{
+			"get",
+		},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"secrets"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"watch",
+		},
+	},
+}
+
+// ConfigMap, Leases, and Events access is required for leader-election.
+var leaderElectionRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"configmaps"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"patch",
+			"update",
+			"watch",
+		},
+	},
+	{
+		APIGroups: []string{"coordination.k8s.io"},
+		Resources: []string{"leases"},
+		Verbs: []string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"patch",
+			"update",
+			"watch",
+		},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"events"},
+		Verbs: []string{
+			"create",
+			"patch",
+		},
+	},
+}
+
 func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
@@ -23,117 +138,17 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"patch",
-						"update",
-						"watch",
-					},
-				},
-				{
-					Verbs:     []string{"get"},
-					APIGroups: []string{""},
-					Resources: []string{"pod/status"},
-				},
-				{
-					APIGroups: []string{"workspace.gitpod.io"},
-					Resources: []string{"workspaces"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"patch",
-						"update",
-						"watch",
-					},
-				},
-				{
-					Verbs:     []string{"update"},
-					APIGroups: []string{"workspace.gitpod.io"},
-					Resources: []string{"workspaces/finalizers"},
-				},
-				{
-					APIGroups: []string{"workspace.gitpod.io"},
-					Resources: []string{"workspaces/status"},
-					Verbs: []string{
-						"get",
-						"patch",
-						"update",
-					},
-				},
-				{
-					APIGroups: []string{"workspace.gitpod.io"},
-					Resources: []string{"snapshots"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{"workspace.gitpod.io"},
-					Resources: []string{"snapshots/status"},
-					Verbs: []string{
-						"get",
-					},
-				},
-				// ConfigMap, Leases, and Events access is required for leader-election.
-				{
-					APIGroups: []string{""},
-					Resources: []string{"configmaps"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"patch",
-						"update",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{"coordination.k8s.io"},
-					Resources: []string{"leases"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"patch",
-						"update",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events"},
-					Verbs: []string{
-						"create",
-						"patch",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"secrets"},
-					Verbs: []string{
-						"create",
-						"delete",
-						"get",
-						"list",
-						"watch",
-					},
-				},
+			Rules: append(controllerRules, leaderElectionRules...),
+		},
+
+		&rbacv1.Role{
+			TypeMeta: common.TypeMetaRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: WorkspaceSecretsNamespace,
+				Labels:    labels,
 			},
+			Rules: controllerRules,
 		},
 	}, nil
 }

--- a/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
+++ b/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
@@ -62,7 +62,7 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 			TypeMeta: common.TypeMetaRoleBinding,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
-				Namespace: WorkspaceSecretsNamespace,
+				Namespace: common.WorkspaceSecretsNamespace,
 				Labels:    labels,
 			},
 			RoleRef: rbacv1.RoleRef{

--- a/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
+++ b/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
@@ -51,8 +51,30 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Subjects: []rbacv1.Subject{
 				{
-					Kind: "ServiceAccount",
-					Name: Component,
+					Kind:      "ServiceAccount",
+					Name:      Component,
+					Namespace: ctx.Namespace,
+				},
+			},
+		},
+
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: WorkspaceSecretsNamespace,
+				Labels:    labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     Component,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Component,
+					Namespace: ctx.Namespace,
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Store sensitive workspace data (tokens) in short lived Kubernetes secrets. When a workspace start is requested we create a secret (named workspaceid-tokens) that contains the tokens extracted from the content initializer. The tokens will be removed from the content initializer. 

The secret itself will live in a separate namespace so that we can narrow down the scope of permissions we need to give to ws-daemon so that it can access the secrets. When the content init happens in ws-daemon the secrets will be injected into the initializer again and the secret will be deleted once the workspace reaches the `running` phase but latest when it reaches the `stopped` phase.

## Related Issue(s)
n.a.

## How to test
- Open workspace for a private repository

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
## Build Options:

- [x] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
