### PR TITLE
[dashboard] fix missing billing entry

### DIFF
--- a/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
@@ -6,7 +6,7 @@
 
 import { User } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { UserContext } from "../user-context";
@@ -33,12 +33,12 @@ export function PageWithSettingsSubMenu({ children }: PageWithAdminSubMenuProps)
     const { userBillingMode, user } = useContext(UserContext);
     const { enablePersonalAccessTokens } = useContext(FeatureFlagContext);
 
+    const settingsMenu = useMemo(() => {
+        return getSettingsMenu(user, userBillingMode, enablePersonalAccessTokens);
+    }, [user, userBillingMode, enablePersonalAccessTokens]);
+
     return (
-        <PageWithSubMenu
-            subMenu={getSettingsMenu(user, userBillingMode, enablePersonalAccessTokens)}
-            title="User Settings"
-            subtitle="Manage your personal account settings."
-        >
+        <PageWithSubMenu subMenu={settingsMenu} title="User Settings" subtitle="Manage your personal account settings.">
             {children}
         </PageWithSubMenu>
     );


### PR DESCRIPTION
## Description
Ensures the settings menu gets rerendered when the dependent state changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
ensure the billing menu is shown in user settings

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
