### PR TITLE
[migrations] Make workspace cluster name the PK, drop composite PK on (name, appCluster)

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -88,13 +88,13 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
     })
     admissionConstraints?: AdmissionConstraint[];
 
-    @PrimaryColumn({
+    @Column({
         type: "varchar",
         length: 60,
     })
     applicationCluster: string;
 
-    @PrimaryColumn({
+    @Column({
         type: "varchar",
         length: 60,
     })

--- a/components/gitpod-db/src/typeorm/migration/1678365331415-WorkspaceClustersNamePK.ts
+++ b/components/gitpod-db/src/typeorm/migration/1678365331415-WorkspaceClustersNamePK.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WorkspaceClustersNamePK1678365331415 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `d_b_workspace_cluster` DROP PRIMARY KEY, ADD PRIMARY KEY (name)");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "ALTER TABLE `d_b_workspace_cluster` DROP PRIMARY KEY, ADD PRIMARY KEY (name, applicationCluster)",
+        );
+    }
+}

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -23,7 +23,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         return (await this.typeORM.getConnection()).manager;
     }
 
-    protected async getRepo(): Promise<Repository<DBWorkspaceCluster>> {
+    public async getRepo(): Promise<Repository<DBWorkspaceCluster>> {
         return (await this.getEntityManager()).getRepository(DBWorkspaceCluster);
     }
 

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -57,9 +57,6 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const all = await (await this.typeORM.getConnection()).manager.getRepository(DBWorkspaceCluster).find();
-        console.log("all", all);
-
         const result = await this.db.findByName("eu71", "us02");
         expect(result).not.to.be.undefined;
         expect((result as WorkspaceCluster).name).to.equal("eu71");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We no longer need the applicationCluster column. Prior to removing it, we need to adjust the PK to be on the `name` property again.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
