### PR TITLE
Update Switch to PAYG success subtitle

### DIFF
--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -18,13 +18,14 @@ import { Subscription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { TeamSubscription, TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
 import { useConfetti } from "./contexts/ConfettiContext";
 import { resetAllNotifications } from "./AppNotifications";
-import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
+import { Currency, Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import ContextMenu, { ContextMenuEntry } from "./components/ContextMenu";
 import CaretDown from "./icons/CaretDown.svg";
 import { Team } from "@gitpod/gitpod-protocol";
 import { OrgEntry } from "./menu/OrganizationSelector";
 import { Heading2, Subheading } from "./components/typography/headings";
 import { useCurrentOrg, useOrganizations } from "./data/organizations/orgs-query";
+import { PaymentContext } from "./payment-context";
 
 /**
  * Keys of known page params
@@ -56,6 +57,8 @@ type PageState = {
 
 function SwitchToPAYG() {
     const { switchToPAYG } = useContext(FeatureFlagContext);
+    const { currency } = useContext(PaymentContext);
+
     const user = useCurrentUser();
     const location = useLocation();
     const pageParams = parseSearchParams(location.search);
@@ -430,7 +433,10 @@ function SwitchToPAYG() {
         return (
             <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full mt-24">
                 <Heading2>You're now on pay-as-you-go! 🎊</Heading2>
-                <Subheading>You are one step away from using larger workspaces and custom timeouts.</Subheading>
+                <Subheading>
+                    New subscriptions are limited to 1000 credits ({Currency.getSymbol(currency)}9 / month) by default.
+                    Change your monthly limit on the billing page if you need more.
+                </Subheading>
 
                 <div className="mt-12">
                     <a href={billingLink}>


### PR DESCRIPTION
## Description
Goal is to warn the user about the monthly limit, and prevent them from being blocked by it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16778

## How to test
<!-- Provide steps to test this PR -->
I'm not sure.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
