### PR TITLE
[Switch to PAYG] Switch Org context for TS2 links

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2649,7 +2649,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 continue;
             }
             const url = switchToPAYG
-                ? `/switch-to-payg?teamSubscription2=${team.id}` /** yes, team.id */
+                ? `/switch-to-payg?org=${team.id}&teamSubscription2=${team.id}` /** yes, team.id */
                 : "https://www.gitpod.io/docs/configure/billing#configure-organization-billing";
             result.unshift({
                 message: `Your '${plan.name}' subscription for Organization '${team.name}' will be discontinued on March, 31st.`,


### PR DESCRIPTION
## Description
When following the link to `Switch to pay-as-you-go` here ...

<img width="1417" alt="Screenshot 2023-03-09 at 18 34 29" src="https://user-images.githubusercontent.com/914497/224110469-dd4fef02-b623-484f-a99c-fdc585f49834.png">

... the Org context is changed accordingly, see 

<img width="1417" alt="Screenshot 2023-03-09 at 18 34 38" src="https://user-images.githubusercontent.com/914497/224110480-662edfca-5680-45d9-97ff-2acaca73b1fd.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16776

## How to test
1. create a couple of Orgs
2. use the `/components/server/reset-chargebee-test-subs.sh` script (needs proper kubectx) and create a TS2 setup of one of the Orgs
3. switch context to the other Org
4. check that the notification's URL includes the `org` param
5. see that the context is switch to the target Org

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
