### PR TITLE
[dashboard] keep start button disabled

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -44,6 +44,10 @@ export function CreateWorkspacePage() {
     const history = useHistory();
     const props = StartWorkspaceOptions.parseSearchParams(location.search);
     const createWorkspaceMutation = useCreateWorkspaceMutation();
+    const isStarting =
+        createWorkspaceMutation.isLoading ||
+        !!createWorkspaceMutation.data?.workspaceURL ||
+        !!createWorkspaceMutation.data?.createdWorkspaceId;
 
     const [useLatestIde, setUseLatestIde] = useState(
         props.ideSettings?.useLatestVersion !== undefined
@@ -174,14 +178,10 @@ export function CreateWorkspacePage() {
                 <div className="w-full flex justify-end mt-6 space-x-2 px-6">
                     <Button
                         onClick={onClickCreate}
-                        loading={createWorkspaceMutation.isLoading || isLoading}
+                        loading={isStarting || isLoading}
                         disabled={!repo || repo.length === 0 || !!errorIde || !!errorWsClass}
                     >
-                        {isLoading
-                            ? "Loading ..."
-                            : createWorkspaceMutation.isLoading
-                            ? "Creating Workspace ..."
-                            : "New Workspace"}
+                        {isLoading ? "Loading ..." : isStarting ? "Creating Workspace ..." : "New Workspace"}
                     </Button>
                 </div>
                 <div>
@@ -196,6 +196,7 @@ export function CreateWorkspacePage() {
                 <ExistingWorkspaceModal
                     existingWorkspaces={existingWorkspaces}
                     createWorkspace={createWorkspace}
+                    isStarting={isStarting}
                     onClose={() => setExistingWorkspaces([])}
                 />
             )}
@@ -315,12 +316,14 @@ const StatusMessage: FunctionComponent<StatusMessageProps> = ({ error, setSelect
 interface ExistingWorkspaceModalProps {
     existingWorkspaces: WorkspaceInfo[];
     onClose: () => void;
+    isStarting: boolean;
     createWorkspace: (opts: Omit<GitpodServer.CreateWorkspaceOptions, "contextUrl">) => void;
 }
 
 const ExistingWorkspaceModal: FunctionComponent<ExistingWorkspaceModalProps> = ({
     existingWorkspaces,
     onClose,
+    isStarting,
     createWorkspace,
 }) => {
     return (
@@ -358,9 +361,12 @@ const ExistingWorkspaceModal: FunctionComponent<ExistingWorkspaceModalProps> = (
                 <button className="secondary" onClick={onClose}>
                     Cancel
                 </button>
-                <button onClick={() => createWorkspace({ ignoreRunningWorkspaceOnSameCommit: true })}>
-                    New Workspace
-                </button>
+                <Button
+                    loading={isStarting}
+                    onClick={() => createWorkspace({ ignoreRunningWorkspaceOnSameCommit: true })}
+                >
+                    {isStarting ? "Creating Workspace ..." : "New Workspace"}
+                </Button>
             </ModalFooter>
         </Modal>
     );


### PR DESCRIPTION
Keeps the button state disabled when a workspace was started, so that user's canot start multiple workspaces by clicking multiple times.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16752

## How to test
<!-- Provide steps to test this PR -->

Try creating more than one workspace from within the create workspace page by hammering any of the "Create Workspace" buttons.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
