### PR TITLE
[gha] fix concurrency groups and preview name for multiple events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ jobs:
     name: Configure job parameters
     runs-on: [ self-hosted ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-configuration
+      # github.head_ref is set by a pull_request event - contains the name of the source branch of the PR
+      # github.ref_name is set if the event is NOT a pull_request - it contains only the branch name.
+      group: ${{ github.head_ref || github.ref_name }}-configuration
       cancel-in-progress: true
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
@@ -77,7 +79,7 @@ jobs:
       (needs.configuration.outputs.preview_enable == 'true')
     needs: [ configuration ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-build-previewctl
+      group: ${{ github.head_ref || github.ref_name }}-build-previewctl
       # see comment in build-gitpod below for context
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: [ self-hosted ]
@@ -116,14 +118,14 @@ jobs:
       (needs.configuration.outputs.is_main_branch != 'true')
     runs-on: [ self-hosted ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-infrastructure
+      group: ${{ github.head_ref || github.ref_name }}-infrastructure
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
         id: create
         uses: ./.github/actions/preview-create
         with:
-          name: ${{ github.head_ref || github.ref }}
+          name: ${{ github.head_ref || github.ref_name }}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -137,7 +139,7 @@ jobs:
       (needs.configuration.outputs.pr_no_diff_skip != 'true')
     runs-on: [ self-hosted ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-build-gitpod
+      group: ${{ github.head_ref || github.ref_name }}-build-gitpod
       # For the main branch we always want the build job to run to completion
       # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
@@ -266,7 +268,7 @@ jobs:
     needs: [ configuration, build-previewctl, build-gitpod, infrastructure ]
     runs-on: [ self-hosted ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-install
+      group: ${{ github.head_ref || github.ref_name }}-install
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -274,7 +276,7 @@ jobs:
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
-          name: ${{ github.head_ref || github.ref }}
+          name: ${{ github.head_ref || github.ref_name }}
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -290,7 +292,7 @@ jobs:
     needs: [ infrastructure, build-previewctl ]
     runs-on: [ self-hosted ]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-monitoring
+      group: ${{ github.head_ref || github.ref_name }}-monitoring
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
What it says

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
