### PR TITLE
[dashboard] closeable limit-reached-modal

### DIFF
--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -12,7 +12,7 @@ import Alert from "./Alert";
 import Modal from "./Modal";
 import { Heading2 } from "./typography/headings";
 
-export function UsageLimitReachedModal(p: { hints: any }) {
+export function UsageLimitReachedModal(p: { hints: any; onClose?: () => void }) {
     const orgs = useOrganizations();
     const [attributedTeam, setAttributedTeam] = useState<OrganizationInfo | undefined>();
 
@@ -30,7 +30,7 @@ export function UsageLimitReachedModal(p: { hints: any }) {
     const attributedTeamName = attributedTeam?.name;
     const billingLink = attributedTeam ? "/billing" : settingsPathBilling;
     return (
-        <Modal visible={true} closeable={false} onClose={() => {}}>
+        <Modal visible={true} closeable={!!p.onClose} onClose={p.onClose || (() => {})}>
             <Heading2 className="flex">
                 <span className="flex-grow">Usage Limit Reached</span>
             </Heading2>

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -188,6 +188,9 @@ export function CreateWorkspacePage() {
                     <StatusMessage
                         error={createWorkspaceMutation.error as StartWorkspaceError}
                         setSelectAccountError={setSelectAccountError}
+                        reset={() => {
+                            createWorkspaceMutation.reset();
+                        }}
                         createWorkspace={createWorkspace}
                     />
                 </div>
@@ -231,10 +234,16 @@ function tryAuthorize(host: string, scopes?: string[]): Promise<SelectAccountPay
 
 interface StatusMessageProps {
     error?: StartWorkspaceError;
+    reset: () => void;
     setSelectAccountError: (error?: SelectAccountPayload) => void;
     createWorkspace: (opts: Omit<GitpodServer.CreateWorkspaceOptions, "contextUrl">) => void;
 }
-const StatusMessage: FunctionComponent<StatusMessageProps> = ({ error, setSelectAccountError, createWorkspace }) => {
+const StatusMessage: FunctionComponent<StatusMessageProps> = ({
+    error,
+    reset,
+    setSelectAccountError,
+    createWorkspace,
+}) => {
     if (!error) {
         return <></>;
     }
@@ -298,7 +307,7 @@ const StatusMessage: FunctionComponent<StatusMessageProps> = ({ error, setSelect
                 </div>
             );
         case ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED:
-            return <UsageLimitReachedModal hints={error?.data} />;
+            return <UsageLimitReachedModal onClose={reset} hints={error?.data} />;
         case ErrorCodes.PROJECT_REQUIRED:
             return (
                 <p className="text-base text-gitpod-red w-96">


### PR DESCRIPTION
## Description
Allow closing the limit reached modal when starting a workspace from the new create workspace page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
create an org without credits and try starting a workspace within. See a dialog telling you about limit reached and try closing it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
