### PR TITLE
[dashboard] reloading browser reloads the orgs

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -19,12 +19,12 @@ const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 // Top level Dashboard App component
 const App: FunctionComponent = () => {
     const { user, isSetupRequired, loading } = useUserAndTeamsLoader();
-    const currentOrg = useCurrentOrg().data;
+    const currentOrgQuery = useCurrentOrg();
 
     // Setup analytics/tracking
     useAnalyticsTracking();
 
-    if (loading) {
+    if (loading || currentOrgQuery.isLoading) {
         return <AppLoading />;
     }
 
@@ -56,7 +56,7 @@ const App: FunctionComponent = () => {
     return (
         <Suspense fallback={<AppLoading />}>
             {/* Use org id as key to force re-render on org change */}
-            <AppRoutes key={currentOrg?.id ?? "no-org"} />
+            <AppRoutes key={currentOrgQuery.data?.id ?? "no-org"} />
         </Suspense>
     );
 };

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -13,6 +13,7 @@ import { publicApiTeamMembersToProtocol, publicApiTeamToProtocol, teamsService }
 import { getGitpodService } from "../../service/service";
 import { useCurrentUser, UserContext } from "../../user-context";
 import { getUserBillingModeQueryKey } from "../billing-mode/user-billing-mode-query";
+import { noPersistence } from "../setup";
 
 export interface OrganizationInfo extends Organization {
     members: OrgMemberInfo[];
@@ -72,7 +73,7 @@ export function useOrganizations() {
 }
 
 function getQueryKey(user?: User) {
-    return ["organizations", user?.id];
+    return noPersistence(["organizations", user?.id]);
 }
 
 // Custom hook to return the current org if one is selected

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -11,7 +11,7 @@ import {
     PersistQueryClientProvider,
     PersistQueryClientProviderProps,
 } from "@tanstack/react-query-persist-client";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryKey } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { FunctionComponent } from "react";
 
@@ -19,6 +19,13 @@ import { FunctionComponent } from "react";
 // If data we cache changes in a non-backwards compatible way, increment this version
 // That will bust any previous cache versions a client may have stored
 const CACHE_VERSION = "1";
+
+export function noPersistence(queryKey: QueryKey): QueryKey {
+    return [...queryKey, "no-persistence"];
+}
+export function isNoPersistence(queryKey: QueryKey): boolean {
+    return queryKey.some((e) => e === "no-persistence");
+}
 
 export const setupQueryClientProvider = () => {
     const client = new QueryClient();
@@ -30,6 +37,11 @@ export const setupQueryClientProvider = () => {
         // Individual queries may expire prior to this though
         maxAge: 1000 * 60 * 60 * 24, // 24 hours
         buster: CACHE_VERSION,
+        dehydrateOptions: {
+            shouldDehydrateQuery: (query) => {
+                return !isNoPersistence(query.queryKey) && query.state.status === "success";
+            },
+        },
     };
 
     // Return a wrapper around PersistQueryClientProvider w/ the query client options we setp


### PR DESCRIPTION
## Description
Excludes the orgs query from being cached across reloads.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16743

## How to test
<!-- Provide steps to test this PR -->
Create an org invite someone, when they have joined reload the members page and verify that the members list is correct

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
