### PR TITLE
[ws-man-bridge] Correct name for Workspace Instance Controller var

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -449,7 +449,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
     }
 
     public async findRunningInstancesWithWorkspaces(
-        installation?: string,
+        workspaceClusterName?: string,
         userId?: string,
         includeStopping: boolean = false,
     ): Promise<RunningWorkspaceInfo[]> {
@@ -459,8 +459,8 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             // This excludes instances in a 'stopping' phase
             conditions.push("wsi.phasePersisted != 'stopping'");
         }
-        if (installation) {
-            params.region = installation;
+        if (workspaceClusterName) {
+            params.region = workspaceClusterName;
             conditions.push("wsi.region = :region");
         }
         const joinParams: any = {};

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -151,7 +151,7 @@ export interface WorkspaceDB {
 
     findRegularRunningInstances(userId?: string): Promise<WorkspaceInstance[]>;
     findRunningInstancesWithWorkspaces(
-        installation?: string,
+        workspaceClusterName?: string,
         userId?: string,
         includeStopping?: boolean,
     ): Promise<RunningWorkspaceInfo[]>;

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -81,7 +81,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                 const span = TraceContext.startSpan("controlInstances");
                 const ctx = { span };
                 try {
-                    log.debug("Controlling instances...", { installation: workspaceClusterName });
+                    log.debug("Controlling instances...", { workspaceClusterName });
 
                     const nonStoppedInstances = await this.workspaceDB
                         .trace(ctx)
@@ -101,8 +101,8 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                         disconnectStarted = Number.MAX_SAFE_INTEGER; // Reset disconnect period
                     } catch (err) {
                         if (durationLongerThanSeconds(disconnectStarted, controllerMaxDisconnectSeconds)) {
-                            log.warn("Error while controlling installation's workspaces", err, {
-                                installation: workspaceClusterName,
+                            log.warn("Error while controlling workspace cluster's workspaces", err, {
+                                workspaceClusterName,
                             });
                         } else if (disconnectStarted > Date.now()) {
                             disconnectStarted = Date.now();
@@ -116,11 +116,11 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                         workspaceClusterName,
                     );
 
-                    log.debug("Done controlling instances.", { installation: workspaceClusterName });
+                    log.debug("Done controlling instances.", { workspaceClusterName });
                 } catch (err) {
                     TraceContext.setError(ctx, err);
-                    log.error("Error while controlling installation's workspaces", err, {
-                        installation: workspaceClusterName,
+                    log.error("Error while controlling workspace cluster's workspaces", err, {
+                        workspaceClusterName,
                     });
                 } finally {
                     span.finish();
@@ -144,7 +144,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         const span = TraceContext.startSpan("controlNonStoppedWSManagerManagedInstances", parentCtx);
         const ctx = { span };
         try {
-            log.debug("Controlling ws-manager managed instances...", { workspaceClusterName: workspaceClusterName });
+            log.debug("Controlling ws-manager managed instances...", { workspaceClusterName });
 
             const runningInstancesIdx = new Map<string, RunningWorkspaceInfo>();
             runningInstances.forEach((i) => runningInstancesIdx.set(i.latestInstance.id, i));
@@ -173,7 +173,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                     log.info(
                         { instanceId, workspaceId: instance.workspaceId },
                         "Database says the instance is present, but ws-man does not know about it. Marking as stopped in database.",
-                        { installation: workspaceClusterName, phase },
+                        { workspaceClusterName, phase },
                     );
                     await this.markWorkspaceInstanceAsStopped(ctx, ri, new Date());
                     continue;
@@ -186,7 +186,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                 });
             }
 
-            log.debug("Done controlling ws-manager managed instances.", { installation: workspaceClusterName });
+            log.debug("Done controlling ws-manager managed instances.", { workspaceClusterName });
         } catch (err) {
             TraceContext.setError(ctx, err);
             throw err; // required by caller
@@ -204,21 +204,21 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
     async controlNotStoppedAppClusterManagedInstanceTimeouts(
         parentCtx: TraceContext,
         runningInstances: RunningWorkspaceInfo[],
-        installation: string,
+        applicationClusterName: string,
     ) {
         const span = TraceContext.startSpan("controlNotStoppedAppClusterManagedInstanceTimeouts", parentCtx);
         const ctx = { span };
         try {
-            log.debug("Controlling app cluster managed instances...", { installation });
+            log.debug("Controlling app cluster managed instances...", { applicationClusterName });
 
             await Promise.all(
                 runningInstances.map((info) => this.controlNotStoppedAppClusterManagedInstance(ctx, info)),
             );
 
-            log.debug("Done controlling app cluster managed instances.", { installation });
+            log.debug("Done controlling app cluster managed instances.", { applicationClusterName });
         } catch (err) {
             log.error("Error while controlling app cluster managed instances:", err, {
-                installation,
+                applicationClusterName,
             });
             TraceContext.setError(ctx, err);
         } finally {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Because the installation variable cost me about 15 minutes of confusion...

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
