### PR TITLE
[server] allow members to leave

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -24,7 +24,7 @@ const App: FunctionComponent = () => {
     // Setup analytics/tracking
     useAnalyticsTracking();
 
-    if (loading || currentOrgQuery.isLoading) {
+    if (loading) {
         return <AppLoading />;
     }
 
@@ -50,6 +50,9 @@ const App: FunctionComponent = () => {
     // At this point if there's no user, they should Login
     if (!user) {
         return <Login />;
+    }
+    if (currentOrgQuery.isLoading) {
+        return <AppLoading />;
     }
 
     // If we made it here, we have a logged in user w/ their teams. Yay.

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2359,7 +2359,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         // The user is leaving a team, if they are removing themselves from the team.
         const userLeavingTeam = user.id === userId;
 
-        if (userLeavingTeam) {
+        if (!userLeavingTeam) {
             await this.guardTeamOperation(teamId, "update", "not_implemented");
         } else {
             await this.guardTeamOperation(teamId, "get", "org_members_write");


### PR DESCRIPTION
## Description
Fixes the permissions for remobing org members
 
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16794

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
