### PR TITLE
[dev-image] Set DB_HOST to 127.0.0.1 by default

### DIFF
--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -95,7 +95,7 @@ packages:
         - ${imageRepoBase}/db-migrations:commit-${__git_commit}
 scripts:
 - name: init-testdb
-  description: "Starts a properly initialized MySQL instance to run tests against. Usage: '. $(leeway run components/gitpod-db:db-test-env)'"
+  description: "Starts a properly initialized MySQL instance to run tests against. Usage: '. $(leeway run components/gitpod-db:init-testdb)'"
   deps: []
   script: |
     export DB_HOST=${DB_HOST:-127.0.0.1}

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full:2022-11-09-13-54-49
 
-ENV TRIGGER_REBUILD 25
+ENV TRIGGER_REBUILD 26
 
 USER root
 
@@ -173,7 +173,7 @@ RUN sudo python3 -m pip uninstall crcmod; sudo python3 -m pip install --no-cache
 ARG GCLOUD_CONFIG_DIR=/home/gitpod/.config/gcloud
 COPY --chown=gitpod gcloud-default-config $GCLOUD_CONFIG_DIR/configurations/config_default
 
-ENV DB_HOST=localhost
+ENV DB_HOST=127.0.0.1
 
 # awscliv2
 # See also: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Without this change, the local DB gets stuck in connecting

```
[components/gitpod-db:dbtest-init] waiting for DB...
[components/gitpod-db:dbtest-init] mysqladmin: [Warning] Using a password on the command line interface can be insecure.
[components/gitpod-db:dbtest-init] waiting for DB...
[components/gitpod-db:dbtest-init] mysqladmin: [Warning] Using a password on the command line interface can be insecure.
[components/gitpod-db:dbtest-init] waiting for DB...
[components/gitpod-db:dbtest-init] mysqladmin: [Warning] Using a password on the command line interface can be insecure.
[components/gitpod-db:dbtest-init] waiting for DB...
[components/gitpod-db:dbtest-init] mysqladmin: [Warning] Using a password on the command line interface can be insecure.
[components/gitpod-db:dbtest-init] waiting for DB...
```

Similar to https://gitpod.slack.com/archives/C020VCB0U5A/p1676896296571249, but in a local (non-preview) env

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
