### PR TITLE
[preview] Configure OTEL collector

### DIFF
--- a/.github/actions/deploy-monitoring-satellite/entrypoint.sh
+++ b/.github/actions/deploy-monitoring-satellite/entrypoint.sh
@@ -7,10 +7,11 @@ export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev
 # shellcheck disable=SC2155
 export LEEWAY_WORKSPACE_ROOT="$(pwd)"
 export PATH="$PATH:$HOME/bin"
+export TEMPO_BASIC_AUTH_PASSWORD="${INPUT_TEMPO_BASIC_AUTH_PASSWORD:-""}"
 
 mkdir $HOME/bin
 
-echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+echo "${INPUT_SA_KEY}" >"${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
 leeway run dev/preview/previewctl:download
@@ -25,8 +26,8 @@ echo "leeway run dev/preview:deploy-monitoring-satellite"
 leeway run dev/preview:deploy-monitoring-satellite
 
 {
-    echo '<p>Monitoring satellite has been installed in your preview environment.</p>'
-    echo '<ul>'
-    echo '<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/f2938b2bcb0c4c8c99afe1d2b872380e" target="_blank">internal documentation</a> on how to use it.</li>'
-    echo '</ul>'
-} >> "${GITHUB_STEP_SUMMARY}"
+  echo '<p>Monitoring satellite has been installed in your preview environment.</p>'
+  echo '<ul>'
+  echo '<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/f2938b2bcb0c4c8c99afe1d2b872380e" target="_blank">internal documentation</a> on how to use it.</li>'
+  echo '</ul>'
+} >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/deploy-monitoring-satellite/metadata.yml
+++ b/.github/actions/deploy-monitoring-satellite/metadata.yml
@@ -7,6 +7,9 @@ inputs:
     previewctl_hash:
         description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
         required: false
+    tempo_basic_auth_password:
+        description: "Password for tempo"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
       - name: Get Secrets from GCP
         id: 'secrets'
         uses: 'google-github-actions/get-secretmanager-secrets@v1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,8 +144,6 @@ jobs:
       # For the main branch we always want the build job to run to completion
       # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
-    outputs:
-      tempo-preview-password: '${{ steps.secrets.outputs.tempo-preview-password }}'
     services:
       mysql:
         image: mysql:5.7
@@ -318,10 +316,16 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
+      - name: Get Secrets from GCP
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            tempo-preview-password:gitpod-core-dev/tempo-preview-password
       - name: Deploy monitoring satellite to the preview environment
         id: deploy-monitoring-satellite
         uses: ./.github/actions/deploy-monitoring-satellite
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          tempo_basic_auth_password: '${{ needs.build-gitpod.outputs.tempo-preview-password }}'
+          tempo_basic_auth_password: '${{ steps.secrets.outputs.tempo-preview-password }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
             npm-auth-token:gitpod-core-dev/npm-auth-token
             jb-marketplace-publish-token:gitpod-core-dev/jb-marketplace-publish-token
             codecov-token:gitpod-core-dev/codecov
+            tempo-preview-password:gitpod-core-dev/tempo-preview-password
       - name: Dev Build
         id: dev-build
         env:
@@ -321,3 +322,5 @@ jobs:
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
+        env:
+          TEMPO_BASIC_AUTH_PASSWORD: '${{ steps.secrets.outputs.tempo-preview-password }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,8 @@ jobs:
       # For the main branch we always want the build job to run to completion
       # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
+    outputs:
+      tempo-preview-password: '${{ steps.secrets.outputs.tempo-preview-password }}'
     services:
       mysql:
         image: mysql:5.7
@@ -322,5 +324,4 @@ jobs:
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-        env:
-          TEMPO_BASIC_AUTH_PASSWORD: '${{ steps.secrets.outputs.tempo-preview-password }}'
+          tempo_basic_auth_password: '${{ needs.build-gitpod.outputs.tempo-preview-password }}'

--- a/dev/preview/workflow/config/monitoring-satellite.yaml
+++ b/dev/preview/workflow/config/monitoring-satellite.yaml
@@ -5,6 +5,8 @@ tracing:
   honeycombDataset: preview-environments
   extraSpanAttributes:
     preview.name: ${PREVIEW_NAME}
+  tempoBasicUser: ${TEMPO_BASIC_AUTH_USER}
+  tempoBasicPassword: ${TEMPO_BASIC_AUTH_PASSWORD}
 certmanager:
   installServiceMonitors: true
 pyrra:

--- a/dev/preview/workflow/config/monitoring-satellite.yaml
+++ b/dev/preview/workflow/config/monitoring-satellite.yaml
@@ -5,7 +5,7 @@ tracing:
   honeycombDataset: preview-environments
   extraSpanAttributes:
     preview.name: ${PREVIEW_NAME}
-  tempoBasicUser: ${TEMPO_BASIC_AUTH_USER}
+  tempoBasicUser: preview
   tempoBasicPassword: ${TEMPO_BASIC_AUTH_PASSWORD}
 certmanager:
   installServiceMonitors: true

--- a/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
+++ b/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
@@ -63,8 +63,7 @@ mv installer observability-installer
 HONEYCOMB_API_KEY="$(readWerftSecret honeycomb-api-key apikey)" \
 PROM_REMOTE_WRITE_USER="$(readWerftSecret prometheus-remote-write-auth user)" \
 PROM_REMOTE_WRITE_PASSWORD="$(readWerftSecret prometheus-remote-write-auth password)" \
-TEMPO_BASIC_AUTH_USER="$(readWerftSecret tempo-preview-auth user)" \
-TEMPO_BASIC_AUTH_PASSWORD="$(readWerftSecret tempo-preview-auth password)" \
+TEMPO_BASIC_AUTH_PASSWORD="${TEMPO_BASIC_AUTH_PASSWORD:-$(readWerftSecret tempo-preview-auth password)}"
 PREVIEW_NAME="${PREVIEW_NAME}" \
 WORKSPACE_ROOT="${ROOT}" \
 envsubst <"${ROOT}/dev/preview/workflow/config/monitoring-satellite.yaml" \

--- a/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
+++ b/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
@@ -63,6 +63,8 @@ mv installer observability-installer
 HONEYCOMB_API_KEY="$(readWerftSecret honeycomb-api-key apikey)" \
 PROM_REMOTE_WRITE_USER="$(readWerftSecret prometheus-remote-write-auth user)" \
 PROM_REMOTE_WRITE_PASSWORD="$(readWerftSecret prometheus-remote-write-auth password)" \
+TEMPO_BASIC_AUTH_USER="$(readWerftSecret tempo-preview-auth user)" \
+TEMPO_BASIC_AUTH_PASSWORD="$(readWerftSecret tempo-preview-auth password)" \
 PREVIEW_NAME="${PREVIEW_NAME}" \
 WORKSPACE_ROOT="${ROOT}" \
 envsubst <"${ROOT}/dev/preview/workflow/config/monitoring-satellite.yaml" \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
