### PR TITLE
[billing] place a hold on cards before subscribing

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -128,7 +128,11 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
             } catch (error) {
                 console.error("Could not subscribe to Stripe", error);
                 setPendingStripeSubscription(undefined);
-                setErrorMessage(`Could not subscribe to Stripe. ${error?.message || String(error)}`);
+                setErrorMessage(
+                    `Could not subscribe: ${
+                        error?.message || String(error)
+                    } Contact support@gitpod.io if you believe this is a system error.`,
+                );
             }
         })();
     }, [attrId?.kind, attributionId, currentOrg, location.pathname, location.search, refreshSubscriptionDetails]);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Additional credit card verification by placing a hold on the provided card before subscribing.

<img width="633" alt="Screenshot 2023-03-10 at 19 57 36" src="https://user-images.githubusercontent.com/372735/224402932-89dcb75c-08fd-4b8c-8a45-8fe9f69deb7f.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- use credit card: 4000000000000341 and see it failing
- use credit card: 4242424242424242 and see it succeeding

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
