### PR TITLE
Migrate all checkbox inputs to the `CheckBoxInput` component

### DIFF
--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -11,7 +11,7 @@ import { AdminPageHeader } from "./AdminPageHeader";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Modal from "../components/Modal";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInput, CheckBoxInputContainer } from "../components/forms/CheckboxInputField";
 import { ItemFieldContextMenu } from "../components/ItemsList";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import Alert from "../components/Alert";
@@ -299,17 +299,21 @@ function Details(props: {
                     }}
                 />
             </div>
-            <CheckBox
-                title={"Block Users"}
-                desc={"Block any user that tries to open a workspace for a repository URL that matches this RegEx."}
-                checked={props.br.blockUser}
-                disabled={!props.update}
-                onChange={(v) => {
-                    if (!!props.update) {
-                        props.update({ blockUser: v.target.checked });
-                    }
-                }}
-            />
+
+            <CheckBoxInputContainer>
+                <CheckboxInput
+                    value="block"
+                    label="Block Users"
+                    hint="Block any user that tries to open a workspace for a repository URL that matches this RegEx."
+                    checked={props.br.blockUser}
+                    disabled={!props.update}
+                    onChange={(checked) => {
+                        if (!!props.update) {
+                            props.update({ blockUser: checked });
+                        }
+                    }}
+                />
+            </CheckBoxInputContainer>
         </div>
     );
 }

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -302,7 +302,6 @@ function Details(props: {
 
             <CheckboxInputContainer>
                 <CheckboxInput
-                    value="Block Users"
                     label="Block Users"
                     hint="Block any user that tries to open a workspace for a repository URL that matches this RegEx."
                     checked={props.br.blockUser}

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -11,7 +11,7 @@ import { AdminPageHeader } from "./AdminPageHeader";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Modal from "../components/Modal";
-import { CheckboxInput, CheckBoxInputContainer } from "../components/forms/CheckboxInputField";
+import { CheckboxInput, CheckboxInputContainer } from "../components/forms/CheckboxInputField";
 import { ItemFieldContextMenu } from "../components/ItemsList";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import Alert from "../components/Alert";
@@ -300,9 +300,9 @@ function Details(props: {
                 />
             </div>
 
-            <CheckBoxInputContainer>
+            <CheckboxInputContainer>
                 <CheckboxInput
-                    value="block"
+                    value="Block Users"
                     label="Block Users"
                     hint="Block any user that tries to open a workspace for a repository URL that matches this RegEx."
                     checked={props.br.blockUser}
@@ -313,7 +313,7 @@ function Details(props: {
                         }
                     }}
                 />
-            </CheckBoxInputContainer>
+            </CheckboxInputContainer>
         </div>
     );
 }

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -7,7 +7,7 @@
 import React, { useContext } from "react";
 import { TelemetryData, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 import { AdminContext } from "../admin-context";
-import { CheckboxInput, CheckBoxInputContainer } from "../components/forms/CheckboxInputField";
+import { CheckboxInput, CheckboxInputContainer } from "../components/forms/CheckboxInputField";
 import { getGitpodService } from "../service/service";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
@@ -64,9 +64,9 @@ export default function Settings() {
                         Read our Privacy Policy
                     </a>
                 </p>
-                <CheckBoxInputContainer>
+                <CheckboxInputContainer>
                     <CheckboxInput
-                        value="enable"
+                        value="Enable usage telemetry"
                         label="Enable usage telemetry"
                         hint="Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
                         below."
@@ -80,7 +80,7 @@ export default function Settings() {
                     />
 
                     <CheckboxInput
-                        value="include"
+                        value="Include customer ID"
                         label="Include customer ID in telemetry"
                         hint="Include an optional customer ID in usage telemetry to provide individualized support."
                         checked={adminSettings?.sendCustomerID ?? false}
@@ -91,7 +91,7 @@ export default function Settings() {
                             } as InstallationAdminSettings)
                         }
                     />
-                </CheckBoxInputContainer>
+                </CheckboxInputContainer>
                 <Heading2 className="mt-4">Telemetry preview</Heading2>
                 <InfoBox>
                     <pre>{JSON.stringify(telemetryData, null, 2)}</pre>

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -7,7 +7,7 @@
 import React, { useContext } from "react";
 import { TelemetryData, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 import { AdminContext } from "../admin-context";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInput, CheckBoxInputContainer } from "../components/forms/CheckboxInputField";
 import { getGitpodService } from "../service/service";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
@@ -64,37 +64,34 @@ export default function Settings() {
                         Read our Privacy Policy
                     </a>
                 </p>
-                <CheckBox
-                    title="Enable usage telemetry"
-                    desc={
-                        <span>
-                            Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
-                            below.
-                        </span>
-                    }
-                    checked={adminSettings?.sendTelemetry ?? false}
-                    onChange={(evt) =>
-                        actuallySetTelemetryPrefs({
-                            ...adminSettings,
-                            sendTelemetry: evt.target.checked,
-                        } as InstallationAdminSettings)
-                    }
-                />
-                <CheckBox
-                    title="Include customer ID in telemetry"
-                    desc={
-                        <span>
-                            Include an optional customer ID in usage telemetry to provide individualized support.
-                        </span>
-                    }
-                    checked={adminSettings?.sendCustomerID ?? false}
-                    onChange={(evt) =>
-                        actuallySetTelemetryPrefs({
-                            ...adminSettings,
-                            sendCustomerID: evt.target.checked,
-                        } as InstallationAdminSettings)
-                    }
-                />
+                <CheckBoxInputContainer>
+                    <CheckboxInput
+                        value="enable"
+                        label="Enable usage telemetry"
+                        hint="Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
+                        below."
+                        checked={adminSettings?.sendTelemetry ?? false}
+                        onChange={(checked) =>
+                            actuallySetTelemetryPrefs({
+                                ...adminSettings,
+                                sendTelemetry: checked,
+                            } as InstallationAdminSettings)
+                        }
+                    />
+
+                    <CheckboxInput
+                        value="include"
+                        label="Include customer ID in telemetry"
+                        hint="Include an optional customer ID in usage telemetry to provide individualized support."
+                        checked={adminSettings?.sendCustomerID ?? false}
+                        onChange={(checked) =>
+                            actuallySetTelemetryPrefs({
+                                ...adminSettings,
+                                sendCustomerID: checked,
+                            } as InstallationAdminSettings)
+                        }
+                    />
+                </CheckBoxInputContainer>
                 <Heading2 className="mt-4">Telemetry preview</Heading2>
                 <InfoBox>
                     <pre>{JSON.stringify(telemetryData, null, 2)}</pre>

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -453,7 +453,7 @@ export default function UserDetail(p: { user: User }) {
                     label="Edit user permissions by adding or removing roles for this user."
                     className="mt-0"
                 >
-                    {flags.map((e) => (
+                    {rop.map((e) => (
                         <CheckboxInput
                             value="edit user permissions"
                             key={e.title}

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -16,7 +16,6 @@ import { AccountStatement, Subscription } from "@gitpod/gitpod-protocol/lib/acco
 import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import dayjs from "dayjs";
 import { useEffect, useRef, useState } from "react";
-import CheckBox from "../components/CheckBox";
 import Modal from "../components/Modal";
 import { getGitpodService } from "../service/service";
 import { WorkspaceSearch } from "./WorkspacesSearch";
@@ -26,6 +25,7 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import CaretDown from "../icons/CaretDown.svg";
 import ContextMenu from "../components/ContextMenu";
+import { CheckboxInput, CheckboxInputField } from "../components/forms/CheckboxInputField";
 import { CostCenterJSON, CostCenter_BillingStrategy } from "@gitpod/gitpod-protocol/lib/usage";
 import { Heading2, Subheading } from "../components/typography/headings";
 
@@ -424,12 +424,20 @@ export default function UserDetail(p: { user: User }) {
                     </button>,
                 ]}
             >
-                <p>Edit feature access by adding or removing feature flags for this user.</p>
-                <div className="flex flex-col">
+                <CheckboxInputField
+                    label="Edit feature access by adding or removing feature flags for this user."
+                    className="mt-0"
+                >
                     {flags.map((e) => (
-                        <CheckBox key={e.title} title={e.title} desc="" checked={!!e.checked} onChange={e.onClick} />
+                        <CheckboxInput
+                            value="edit feature flags"
+                            key={e.title}
+                            label={e.title}
+                            checked={!!e.checked}
+                            onChange={e.onClick}
+                        />
                     ))}
-                </div>
+                </CheckboxInputField>
             </Modal>
             <Modal
                 visible={editRoles}
@@ -441,12 +449,20 @@ export default function UserDetail(p: { user: User }) {
                     </button>,
                 ]}
             >
-                <p>Edit user permissions by adding or removing roles for this user.</p>
-                <div className="flex flex-col">
-                    {rop.map((e) => (
-                        <CheckBox key={e.title} title={e.title} desc="" checked={!!e.checked} onChange={e.onClick} />
+                <CheckboxInputField
+                    label="Edit user permissions by adding or removing roles for this user."
+                    className="mt-0"
+                >
+                    {flags.map((e) => (
+                        <CheckboxInput
+                            value="edit user permissions"
+                            key={e.title}
+                            label={e.title}
+                            checked={!!e.checked}
+                            onChange={e.onClick}
+                        />
                     ))}
-                </div>
+                </CheckboxInputField>
             </Modal>
         </>
     );

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -28,8 +28,8 @@ type CheckboxInputProps = {
     value: string;
     checked: boolean;
     disabled?: boolean;
-    label: string;
-    hint?: string;
+    label: string | React.ReactNode;
+    hint?: string | React.ReactNode;
     onChange: (checked: boolean) => void;
 };
 export const CheckboxInput: FC<CheckboxInputProps> = ({
@@ -83,10 +83,10 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
     );
 };
 
-type CheckBoxInputContainerProps = {
+type CheckboxInputContainerProps = {
     className?: string;
 };
 
-export const CheckBoxInputContainer: FC<CheckBoxInputContainerProps> = ({ className, children }) => {
+export const CheckboxInputContainer: FC<CheckboxInputContainerProps> = ({ className, children }) => {
     return <div className={classNames("mt-4 max-w-2xl flex flex-col space-y-4", className)}>{children}</div>;
 };

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from "classnames";
-import { FC, ReactNode, useCallback } from "react";
+import React, { FC, ReactNode, useCallback } from "react";
 import { useId } from "../../hooks/useId";
 import { InputField } from "./InputField";
 import { InputFieldHint } from "./InputFieldHint";
@@ -25,11 +25,11 @@ export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({ label, error, 
 
 type CheckboxInputProps = {
     id?: string;
-    value: string;
+    value?: string;
     checked: boolean;
     disabled?: boolean;
-    label: string | React.ReactNode;
-    hint?: string | React.ReactNode;
+    label: React.ReactNode;
+    hint?: React.ReactNode;
     onChange: (checked: boolean) => void;
 };
 export const CheckboxInput: FC<CheckboxInputProps> = ({
@@ -51,26 +51,33 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
         [onChange],
     );
 
+    const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+        id: elementId,
+        checked: checked,
+        disabled,
+        onChange: handleChange,
+    };
+
+    if (value) {
+        inputProps.value = value;
+    }
+
     return (
         <label className="flex space-x-2 justify-start items-start" htmlFor={elementId}>
             <input
                 type="checkbox"
                 className={classNames(
-                    "h-4 w-4 mt-1 rounded cursor-pointer border-2 dark:filter-invert",
+                    "h-4 w-4 mt-0.5 rounded cursor-pointer border-2 dark:filter-invert",
                     "focus:ring-2 ring-blue-400",
                     "border-gray-600 dark:border-gray-900 bg-transparent",
                     { "bg-gray-600 dark:bg-gray-900": checked },
                 )}
-                value={value}
-                id={elementId}
-                checked={checked}
-                disabled={disabled}
-                onChange={handleChange}
+                {...inputProps}
             />
             <div className="flex flex-col">
                 <span
                     className={classNames(
-                        "text-md font-semibold cursor-pointer",
+                        "text-sm font-semibold cursor-pointer",
                         disabled ? "text-gray-400 dark:text-gray-400" : "text-gray-600 dark:text-gray-100",
                     )}
                 >

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -56,7 +56,7 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
             <input
                 type="checkbox"
                 className={classNames(
-                    "h-4 w-4 mt-0.5 rounded cursor-pointer border-2 dark:filter-invert",
+                    "h-4 w-4 mt-1 rounded cursor-pointer border-2 dark:filter-invert",
                     "focus:ring-2 focus:border-gray-900 ring-blue-400 dark:focus:border-gray-800",
                     "border-gray-600 dark:border-gray-900 bg-transparent",
                     { "bg-gray-600 dark:bg-gray-900": checked },
@@ -70,7 +70,7 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
             <div className="flex flex-col">
                 <span
                     className={classNames(
-                        "text-sm font-semibold cursor-pointer",
+                        "text-md font-semibold cursor-pointer",
                         disabled ? "text-gray-400 dark:text-gray-400" : "text-gray-600 dark:text-gray-100",
                     )}
                 >
@@ -81,4 +81,12 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
             </div>
         </label>
     );
+};
+
+type CheckBoxInputContainerProps = {
+    className?: string;
+};
+
+export const CheckBoxInputContainer: FC<CheckBoxInputContainerProps> = ({ className, children }) => {
+    return <div className={classNames("mt-4 max-w-2xl flex flex-col space-y-4", className)}>{children}</div>;
 };

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -57,7 +57,7 @@ export const CheckboxInput: FC<CheckboxInputProps> = ({
                 type="checkbox"
                 className={classNames(
                     "h-4 w-4 mt-1 rounded cursor-pointer border-2 dark:filter-invert",
-                    "focus:ring-2 focus:border-gray-900 ring-blue-400 dark:focus:border-gray-800",
+                    "focus:ring-2 ring-blue-400",
                     "border-gray-600 dark:border-gray-900 bg-transparent",
                     { "bg-gray-600 dark:bg-gray-900": checked },
                 )}

--- a/components/dashboard/src/components/forms/InputFieldHint.tsx
+++ b/components/dashboard/src/components/forms/InputFieldHint.tsx
@@ -14,7 +14,7 @@ export const InputFieldHint: FC<Props> = ({ disabled = false, children }) => {
     return (
         <span
             className={classNames(
-                "text-sm",
+                "text-md",
                 disabled ? "text-gray-400 dark:text-gray-400" : "text-gray-500 dark:text-gray-400",
             )}
         >

--- a/components/dashboard/src/components/forms/InputFieldHint.tsx
+++ b/components/dashboard/src/components/forms/InputFieldHint.tsx
@@ -14,7 +14,7 @@ export const InputFieldHint: FC<Props> = ({ disabled = false, children }) => {
     return (
         <span
             className={classNames(
-                "text-md",
+                "text-sm",
                 disabled ? "text-gray-400 dark:text-gray-400" : "text-gray-500 dark:text-gray-400",
             )}
         >

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -10,7 +10,7 @@ import { useCallback, useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router";
 import { Link } from "react-router-dom";
 import Alert from "../components/Alert";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInputContainer, CheckboxInput } from "../components/forms/CheckboxInputField";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
@@ -124,51 +124,52 @@ export default function ProjectSettingsView() {
                     </div>
                 </Alert>
             )}
-            <CheckBox
-                title={<span>Enable Incremental Prebuilds </span>}
-                desc={
-                    <span>
-                        When possible, use an earlier successful prebuild as a base to create new prebuilds. This can
-                        make your prebuilds significantly faster, especially if they normally take longer than 10
-                        minutes.{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/changelog/faster-incremental-prebuilds">
-                            Learn more
-                        </a>
-                    </span>
-                }
-                checked={project.settings?.useIncrementalPrebuilds ?? false}
-                onChange={({ target }) => updateProjectSettings({ useIncrementalPrebuilds: target.checked })}
-            />
-            <CheckBox
-                title={<span>Cancel Prebuilds on Outdated Commits </span>}
-                desc={<span>Cancel pending or running prebuilds on the same branch when new commits are pushed.</span>}
-                checked={!project.settings?.keepOutdatedPrebuildsRunning}
-                onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
-            />
-            <CheckBox
-                title={
-                    <span>
-                        Use Last Successful Prebuild{" "}
-                        <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
-                            Alpha
-                        </PillLabel>
-                    </span>
-                }
-                desc={
-                    <span>
-                        Skip waiting for prebuilds in progress and use the last successful prebuild from previous
-                        commits on the same branch.
-                    </span>
-                }
-                checked={!!project.settings?.allowUsingPreviousPrebuilds}
-                onChange={({ target }) =>
-                    updateProjectSettings({
-                        allowUsingPreviousPrebuilds: target.checked,
-                        // we are disabling prebuild cancellation when incremental workspaces are enabled
-                        keepOutdatedPrebuildsRunning: target.checked || project?.settings?.keepOutdatedPrebuildsRunning,
-                    })
-                }
-            />
+            <CheckboxInputContainer>
+                <CheckboxInput
+                    value="Enable Incremental Prebuilds"
+                    label="Enable Incremental Prebuilds"
+                    hint={
+                        <span>
+                            When possible, use an earlier successful prebuild as a base to create new prebuilds. This
+                            can make your prebuilds significantly faster, especially if they normally take longer than
+                            10 minutes.{" "}
+                            <a className="gp-link" href="https://www.gitpod.io/changelog/faster-incremental-prebuilds">
+                                Learn more
+                            </a>
+                        </span>
+                    }
+                    checked={project.settings?.useIncrementalPrebuilds ?? false}
+                    onChange={(checked) => updateProjectSettings({ useIncrementalPrebuilds: checked })}
+                />
+                <CheckboxInput
+                    value="Cancel Prebuilds"
+                    label="Cancel Prebuilds on Outdated Commits"
+                    hint="Cancel pending or running prebuilds on the same branch when new commits are pushed."
+                    checked={!project.settings?.keepOutdatedPrebuildsRunning}
+                    onChange={(checked) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !checked })}
+                />
+                <CheckboxInput
+                    value="Use last successful Prebuild"
+                    label={
+                        <span>
+                            Use Last Successful Prebuild{" "}
+                            <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
+                                Alpha
+                            </PillLabel>
+                        </span>
+                    }
+                    hint="Skip waiting for prebuilds in progress and use the last successful prebuild from previous
+                    commits on the same branch."
+                    checked={!!project.settings?.allowUsingPreviousPrebuilds}
+                    onChange={(checked) =>
+                        updateProjectSettings({
+                            allowUsingPreviousPrebuilds: checked,
+                            // we are disabling prebuild cancellation when incremental workspaces are enabled
+                            keepOutdatedPrebuildsRunning: checked || project?.settings?.keepOutdatedPrebuildsRunning,
+                        })
+                    }
+                />
+            </CheckboxInputContainer>
             <div className="flex mt-4 max-w-2xl">
                 <div className="flex flex-col ml-6">
                     <label

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -8,7 +8,7 @@ import { Project, ProjectEnvVar } from "@gitpod/gitpod-protocol";
 import { useEffect, useState } from "react";
 import { Redirect } from "react-router";
 import Alert from "../components/Alert";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInputContainer, CheckboxInput } from "../components/forms/CheckboxInputField";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
@@ -171,14 +171,15 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
                         onChange={(e) => setValue(e.target.value)}
                     />
                 </div>
-                <div className="mt-4">
-                    <CheckBox
-                        title="Hide Variable in Workspaces"
-                        desc="Unset this environment variable so that it's not accessible from the terminal in workspaces."
+                <CheckboxInputContainer>
+                    <CheckboxInput
+                        value="Hide Variable"
+                        label="Hide Variable in Workspaces"
+                        hint="Unset this environment variable so that it's not accessible from the terminal in workspaces."
                         checked={censored}
                         onChange={() => setCensored(!censored)}
                     />
-                </div>
+                </CheckboxInputContainer>
                 {!censored && (
                     <div className="mt-4">
                         <InfoBox>

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -8,7 +8,7 @@ import { OrganizationSettings } from "@gitpod/gitpod-protocol";
 import React, { useCallback, useState } from "react";
 import Alert from "../components/Alert";
 import { Button } from "../components/Button";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInputContainer, CheckboxInput } from "../components/forms/CheckboxInputField";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { TextInputField } from "../components/forms/TextInputField";
 import { Heading2, Subheading } from "../components/typography/headings";
@@ -146,19 +146,16 @@ export default function TeamSettingsPage() {
                     </Button>
 
                     <Heading2 className="pt-12">Collaboration & Sharing</Heading2>
-                    <CheckBox
-                        title={<span>Workspace Sharing</span>}
-                        desc={
-                            <span>
-                                Allow workspaces creаted within an Organization to share the workspace with any authenticated user.
-                            </span>
-                        }
-                        checked={!settings?.workspaceSharingDisabled}
-                        onChange={({ target }) =>
-                            handleUpdateTeamSettings({ workspaceSharingDisabled: !target.checked })
-                        }
-                        disabled={isLoading}
-                    />
+                    <CheckboxInputContainer>
+                        <CheckboxInput
+                            value="allow workspace sharing"
+                            label="Workspace Sharing"
+                            hint="Allow workspaces created within an Organization to share the workspace with any authenticated user."
+                            checked={!settings?.workspaceSharingDisabled}
+                            onChange={(checked) => handleUpdateTeamSettings({ workspaceSharingDisabled: !checked })}
+                            disabled={isLoading}
+                        />
+                    </CheckboxInputContainer>
                 </form>
 
                 <Heading2 className="pt-12">Delete Organization</Heading2>

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -9,7 +9,7 @@ import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { useQuery } from "@tanstack/react-query";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import Alert from "../components/Alert";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInput, CheckboxInputContainer } from "../components/forms/CheckboxInputField";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import { Delayed } from "../components/Delayed";
@@ -213,13 +213,13 @@ function GitProviders() {
         }
         setEditModal(undefined);
     };
-    const onChangeScopeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const onChangeScopeHandler = (checked: boolean, scope: string) => {
         if (!editModal) {
             return;
         }
-        const scope = e.target.name;
+
         const nextScopes = new Set(editModal.nextScopes);
-        if (e.target.checked) {
+        if (checked) {
             nextScopes.add(scope);
         } else {
             nextScopes.delete(scope);
@@ -303,17 +303,17 @@ function GitProviders() {
                     <ModalBody>
                         <div className="text-gray-500">Configure provider permissions.</div>
                         {(editModal.provider.scopes || []).map((scope) => (
-                            <div key={`scope-${scope}`}>
-                                <CheckBox
-                                    name={scope}
-                                    desc={getDescriptionForScope(scope)}
-                                    title={scope}
+                            <CheckboxInputContainer key={`scope-${scope}`} className="mt-0">
+                                <CheckboxInput
+                                    value={scope}
+                                    label={scope}
+                                    hint={getDescriptionForScope(scope)}
                                     key={`scope-checkbox-${scope}`}
                                     checked={editModal.nextScopes.has(scope)}
                                     disabled={editModal.provider.requirements?.default.includes(scope)}
-                                    onChange={onChangeScopeHandler}
-                                ></CheckBox>
-                            </div>
+                                    onChange={(checked) => onChangeScopeHandler(checked, scope)}
+                                />
+                            </CheckboxInputContainer>
                         ))}
                     </ModalBody>
                     <ModalFooter>

--- a/components/dashboard/src/user-settings/Notifications.tsx
+++ b/components/dashboard/src/user-settings/Notifications.tsx
@@ -7,7 +7,7 @@
 import { useContext, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInputContainer, CheckboxInput } from "../components/forms/CheckboxInputField";
 import { identifyUser } from "../Analytics";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { Heading2 } from "../components/typography/headings";
@@ -83,30 +83,37 @@ export default function Notifications() {
         <div>
             <PageWithSettingsSubMenu>
                 <Heading2>Email Notification Preferences</Heading2>
-                <CheckBox
-                    title="Account Notifications [required]"
-                    desc="Receive essential emails about changes to your account"
-                    checked={true}
-                    disabled={true}
-                />
-                <CheckBox
-                    title="Onboarding guide"
-                    desc="In the first weeks after you sign up, we'll guide you through the product, so you can get the most out of it"
-                    checked={isOnboardingMail}
-                    onChange={toggleOnboardingMail}
-                />
-                <CheckBox
-                    title="Changelog"
-                    desc="Be the first to learn about new features and overall product improvements"
-                    checked={isChangelogMail}
-                    onChange={toggleChangelogMail}
-                />
-                <CheckBox
-                    title="Developer Experience & Product Tips"
-                    desc="Bring back joy and speed to your workflows"
-                    checked={isDevXMail}
-                    onChange={toggleDevXMail}
-                />
+                <CheckboxInputContainer>
+                    <CheckboxInput
+                        value="notify"
+                        label="Account Notifications [required]"
+                        hint="Receive essential emails about changes to your account"
+                        checked={true}
+                        disabled={true}
+                        onChange={(checked) => {}}
+                    />
+                    <CheckboxInput
+                        value="toggle onboarding mails"
+                        label="Onboarding guide"
+                        hint="In the first weeks after you sign up, we'll guide you through the product, so you can get the most out of it"
+                        checked={isOnboardingMail}
+                        onChange={toggleOnboardingMail}
+                    />
+                    <CheckboxInput
+                        value="toggle changelog mails"
+                        label="Changelog"
+                        hint="Be the first to learn about new features and overall product improvements"
+                        checked={isChangelogMail}
+                        onChange={toggleChangelogMail}
+                    />
+                    <CheckboxInput
+                        value="toggle developer experience mails"
+                        label="Developer Experience & Product Tips"
+                        hint="Bring back joy and speed to your workflows"
+                        checked={isDevXMail}
+                        onChange={toggleDevXMail}
+                    />
+                </CheckboxInputContainer>
             </PageWithSettingsSubMenu>
         </div>
     );

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -10,7 +10,7 @@ import { useContext, useEffect, useState } from "react";
 import { Redirect, useHistory, useParams } from "react-router";
 import { Link } from "react-router-dom";
 import Alert from "../components/Alert";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInput, CheckboxInputContainer } from "../components/forms/CheckboxInputField";
 import DateSelector from "../components/DateSelector";
 import { SpinnerOverlayLoader } from "../components/Loader";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
@@ -237,15 +237,15 @@ function PersonalAccessTokenCreateView() {
                             )}
                             <div>
                                 <h4>Permission</h4>
-                                <div className="space-y-2">
+                                <CheckboxInputContainer className="mt-0">
                                     {AllPermissions.map((item) => (
-                                        <CheckBox
-                                            className=""
-                                            title={item.name}
-                                            desc={item.description}
+                                        <CheckboxInput
+                                            value={item.name}
+                                            label={item.name}
+                                            hint={item.description}
                                             checked={item.scopes.every((s) => token.scopes.has(s))}
-                                            onChange={(e) => {
-                                                if (e.target.checked) {
+                                            onChange={(checked) => {
+                                                if (checked) {
                                                     update({}, item.scopes);
                                                 } else {
                                                     update({}, undefined, item.scopes);
@@ -253,7 +253,7 @@ function PersonalAccessTokenCreateView() {
                                             }}
                                         />
                                     ))}
-                                </div>
+                                </CheckboxInputContainer>
                             </div>
                         </div>
                     </div>

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -6,7 +6,7 @@
 
 import { useCallback, useContext, useEffect, useState } from "react";
 import { UserContext } from "../user-context";
-import CheckBox from "../components/CheckBox";
+import { CheckboxInput } from "../components/forms/CheckboxInputField";
 import { User } from "@gitpod/gitpod-protocol";
 import SelectIDEComponent from "../components/SelectIDEComponent";
 import PillLabel from "../components/PillLabel";
@@ -102,10 +102,11 @@ export default function SelectIDE(props: SelectIDEProps) {
                     </a>
                 </p>
             )}
-
-            <CheckBox
-                title="Latest Release (Unstable)"
-                desc={
+            
+            <CheckboxInput
+                value="Enable latest release"
+                label="Latest Release (Unstable)"
+                hint={
                     <span>
                         Use the latest version for each editor.{" "}
                         <a
@@ -129,7 +130,7 @@ export default function SelectIDE(props: SelectIDEProps) {
                     </span>
                 }
                 checked={useLatestVersion}
-                onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}
+                onChange={(checked) => actuallySetUseLatestVersion(checked)}
             />
         </>
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Migrating to the `CheckBoxInput` component instead of `CheckBox` component for consistency.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16768

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Migrate all checkbox inputs to the new CheckBoxInput component for consistency
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
