### PR TITLE
[dashboard] Use proxy endpoint to fetch feature flags

### DIFF
--- a/components/dashboard/src/experiments/client.ts
+++ b/components/dashboard/src/experiments/client.ts
@@ -22,12 +22,12 @@ export function getExperimentsClient(): Client {
 }
 
 function newProxyConfigCatClient(): Client {
-    const clientKey = "unimportant"; // the client key is populated by the proxy
+    const clientKey = "gitpod"; // the client key is populated by the proxy
     const client = configcat.createClientWithLazyLoad(clientKey, {
         logger: configcat.createConsoleLogger(LogLevel.Error),
         cacheTimeToLiveSeconds: 60 * 3, // 3 minutes
         requestTimeoutMs: 1500,
-        proxy: "/configcat",
+        proxy: `${window.location.origin}/configcat`,
     });
 
     return new ConfigCatClient(client);

--- a/components/dashboard/src/experiments/client.ts
+++ b/components/dashboard/src/experiments/client.ts
@@ -27,7 +27,7 @@ function newProxyConfigCatClient(): Client {
         logger: configcat.createConsoleLogger(LogLevel.Error),
         cacheTimeToLiveSeconds: 60 * 3, // 3 minutes
         requestTimeoutMs: 1500,
-        proxy: `${window.location.origin}/configcat`,
+        baseUrl: `${window.location.origin}/configcat`,
     });
 
     return new ConfigCatClient(client);

--- a/components/dashboard/src/experiments/client.ts
+++ b/components/dashboard/src/experiments/client.ts
@@ -4,7 +4,6 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { newAlwaysReturningDefaultValueClient } from "@gitpod/gitpod-protocol/lib/experiments/always-default";
 import * as configcat from "configcat-js";
 import { ConfigCatClient } from "@gitpod/gitpod-protocol/lib/experiments/configcat";
 import { Client } from "@gitpod/gitpod-protocol/lib/experiments/types";
@@ -18,40 +17,17 @@ export function getExperimentsClient(): Client {
         return client;
     }
 
-    const host = window.location.hostname;
-    if (host === "gitpod.io") {
-        client = newProductionConfigCatClient();
-    } else if (host === "gitpod-staging.com" || host.endsWith("gitpod-dev.com") || host.endsWith("gitpod-io-dev.com")) {
-        client = newNonProductionConfigCatClient();
-    } else {
-        // We're gonna use a client which always returns the default value.
-        client = newAlwaysReturningDefaultValueClient();
-    }
-
+    client = newProxyConfigCatClient();
     return client;
 }
 
-// newProductionConfigCatClient constructs a new ConfigCat client with production configuration.
-function newProductionConfigCatClient(): Client {
-    // clientKey is an identifier of our ConfigCat application. It is not a secret.
-    const clientKey = "WBLaCPtkjkqKHlHedziE9g/TwAe6YyftEGPnGxVRXd0Ig";
+function newProxyConfigCatClient(): Client {
+    const clientKey = ""; // the client key is populated by the proxy
     const client = configcat.createClientWithLazyLoad(clientKey, {
         logger: configcat.createConsoleLogger(LogLevel.Error),
         cacheTimeToLiveSeconds: 60 * 3, // 3 minutes
         requestTimeoutMs: 1500,
-    });
-
-    return new ConfigCatClient(client);
-}
-
-// newNonProductionConfigCatClient constructs a new ConfigCat client with non-production configuration.
-function newNonProductionConfigCatClient(): Client {
-    // clientKey is an identifier of our ConfigCat application. It is not a secret.
-    const clientKey = "WBLaCPtkjkqKHlHedziE9g/LEAOCNkbuUKiqUZAcVg7dw";
-    const client = configcat.createClientWithLazyLoad(clientKey, {
-        logger: configcat.createConsoleLogger(LogLevel.Error),
-        cacheTimeToLiveSeconds: 60 * 3, // 3 minutes
-        requestTimeoutMs: 1500,
+        proxy: "/configcat",
     });
 
     return new ConfigCatClient(client);

--- a/components/dashboard/src/experiments/client.ts
+++ b/components/dashboard/src/experiments/client.ts
@@ -22,7 +22,7 @@ export function getExperimentsClient(): Client {
 }
 
 function newProxyConfigCatClient(): Client {
-    const clientKey = ""; // the client key is populated by the proxy
+    const clientKey = "unimportant"; // the client key is populated by the proxy
     const client = configcat.createClientWithLazyLoad(clientKey, {
         logger: configcat.createConsoleLogger(LogLevel.Error),
         cacheTimeToLiveSeconds: 60 * 3, // 3 minutes


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16821

## How to test
<!-- Provide steps to test this PR -->
1. Feature flags load in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
