### PR TITLE
[Switch to PAYG] Deduplicate calls to server.subscribeToStripe

### DIFF
--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -335,9 +335,13 @@ function SwitchToPAYG() {
             }
 
             case "done":
-                // Hooray and confetti!
-                resetAllNotifications();
-                dropConfetti();
+                if (!confettiDropped) {
+                    confettiDropped = true;
+
+                    // Hooray and confetti!
+                    resetAllNotifications();
+                    dropConfetti();
+                }
                 return;
         }
     }, [
@@ -643,6 +647,8 @@ function parseSearchParams(search: string): PageParams | undefined {
         }
     }
 }
+
+let confettiDropped = false;
 
 let subscribeToStripe_called = false;
 async function subscribeToStripe(

--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -427,8 +427,15 @@ function SwitchToPAYG() {
 
         const attributionId = pageState.attributionId || "";
         const parsed = AttributionId.parse(attributionId);
+        let billingLink = "/billing";
         const orgId = parsed?.kind === "team" ? parsed.teamId : undefined;
-        const billingLink = orgId ? `/billing?org=${orgId}` : "/user/billing";
+        if (orgId) {
+            billingLink = `/billing?org=${orgId}`;
+        } else {
+            if (!user.additionalData?.isMigratedToTeamOnlyAttribution) {
+                billingLink = "/user/billing";
+            }
+        }
 
         return (
             <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full mt-24">

--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -27,6 +27,9 @@ import { Heading2, Subheading } from "./components/typography/headings";
 import { useCurrentOrg, useOrganizations } from "./data/organizations/orgs-query";
 import { PaymentContext } from "./payment-context";
 
+// DEFAULTS
+const DEFAULT_USAGE_LIMIT = 1000;
+
 /**
  * Keys of known page params
  */
@@ -45,7 +48,7 @@ type PageParams = {
     setupIntentId?: string;
 };
 type PageState = {
-    phase: "call-to-action" | "trigger-signup" | "wait-for-signup" | "cleanup" | "done";
+    phase: "call-to-action" | "trigger-signup" | "cleanup" | "done";
     attributionId?: string;
     setupIntentId?: string;
     old?: {
@@ -68,11 +71,10 @@ function SwitchToPAYG() {
 
     const currentOrg = useCurrentOrg().data;
     const orgs = useOrganizations().data;
-    const [errorMessage, setErrorMessage] = useState<string | undefined>();
+    const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
     const [selectedOrganization, setSelectedOrganization] = useState<Team | undefined>(undefined);
     const [showBillingSetupModal, setShowBillingSetupModal] = useState<boolean>(false);
     const [pendingStripeSubscription, setPendingStripeSubscription] = useState<boolean>(false);
-    const [droppedConfetti, setDroppedConfetti] = useState<boolean>(false);
     const { dropConfetti } = useConfetti();
 
     useEffect(() => {
@@ -80,11 +82,12 @@ function SwitchToPAYG() {
     }, [currentOrg, setSelectedOrganization]);
 
     useEffect(() => {
-        const { phase, attributionId, setupIntentId } = pageState;
+        const phase = pageState.phase;
+        const attributionId = pageState.attributionId;
+        const setupIntentId = pageState.setupIntentId;
         if (phase !== "trigger-signup") {
             return;
         }
-        console.log("phase: " + phase);
 
         // We're back from the Stripe modal: (safely) trigger the signup
         if (!attributionId) {
@@ -97,53 +100,34 @@ function SwitchToPAYG() {
             return;
         }
 
-        let cancelled = false;
-        (async () => {
-            // At this point we're coming back from the Stripe modal, and have the intent to setup a new subscription.
-            // Technically, we have to guard against:
-            //  - reloads
-            //  - unmounts (for whatever reason)
+        console.log(`trigger-signup: ${JSON.stringify({ phase, attributionId, setupIntentId })}`);
 
-            // Do we already have a subscription (co-owner, me in another tab, reload, etc.)?
-            let subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
-            if (subscriptionId) {
-                console.log(`${attributionId} already has a subscription! Moving to cleanup`);
-                // We're happy!
-                if (!cancelled) {
-                    setPageState((s) => ({ ...s, phase: "cleanup" }));
-                }
-                return;
-            }
-
-            // Now we want to signup for sure
-            setPendingStripeSubscription(true);
-            try {
-                if (cancelled) return;
-
-                const limit = 1000;
-                console.log("SUBSCRIBE TO STRIPE");
-                await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
-                // Here we go off the effect handler due to the await
-                if (!cancelled) {
-                    setPageState((s) => ({ ...s, phase: "wait-for-signup" }));
-                }
-            } catch (error) {
-                if (cancelled) return;
-
-                setErrorMessage(`Could not subscribe to Stripe. ${error?.message || String(error)}`);
+        // do not await here, it might get called several times during rendering, but only first call has any effect.
+        setPendingStripeSubscription(true);
+        subscribeToStripe(
+            setupIntentId,
+            attributionId,
+            (update) => {
+                setPageState((prev) => ({ ...prev, ...update }));
                 setPendingStripeSubscription(false);
-                return;
-            }
-        })().catch(console.error);
-
-        return () => {
-            cancelled = true;
-        };
-    }, [pageState, setPageState]);
+            },
+            (errorMessage) => {
+                setErrorMessage(errorMessage);
+                setPendingStripeSubscription(false);
+            },
+        ).catch(console.error);
+    }, [pageState.attributionId, pageState.phase, pageState.setupIntentId, setPageState]);
 
     useEffect(() => {
-        const { phase, attributionId, old } = pageState;
-        const { setupIntentId, type, oldSubscriptionOrTeamId } = pageParams || {};
+        if (!pageParams?.type) {
+            return;
+        }
+        const phase = pageState.phase;
+        const attributionId = pageState.attributionId;
+        const old = pageState.old;
+        const type = pageParams.type;
+        const oldSubscriptionOrTeamId = pageParams.oldSubscriptionOrTeamId;
+
         if (phase === "trigger-signup") {
             // Handled in separate effect
             return;
@@ -158,12 +142,28 @@ function SwitchToPAYG() {
             return;
         }
 
-        console.log("phase: " + phase);
+        console.log(
+            `context: ${JSON.stringify({
+                state: { phase, attributionId, old },
+                params: { type, oldSubscriptionOrTeamId },
+                oldSubscriptionOrTeamId,
+                type,
+            })}`,
+        );
+
         switch (phase) {
             case "call-to-action": {
                 // Check: Can we progress?
-                if (setupIntentId) {
-                    setPageState((s) => ({ ...s, setupIntentId, phase: "trigger-signup" }));
+                if (pageParams.setupIntentId) {
+                    if (pageState.setupIntentId === pageParams.setupIntentId) {
+                        // we've been here already
+                        return;
+                    }
+                    setPageState((prev) => ({
+                        ...prev,
+                        setupIntentId: pageParams.setupIntentId,
+                        phase: "trigger-signup",
+                    }));
                     return;
                 }
 
@@ -190,7 +190,7 @@ function SwitchToPAYG() {
                             if (Subscription.isCancelled(sub, now) || !Subscription.isActive(sub, now)) {
                                 // We're happy!
                                 if (!cancelled) {
-                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                    setPageState((prev) => ({ ...prev, phase: "done" }));
                                 }
                                 return;
                             }
@@ -215,7 +215,7 @@ function SwitchToPAYG() {
                             if (TeamSubscription.isCancelled(ts, now) || !TeamSubscription.isActive(ts, now)) {
                                 // We're happy!
                                 if (!cancelled) {
-                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                    setPageState((prev) => ({ ...prev, phase: "done" }));
                                 }
                                 return;
                             }
@@ -245,7 +245,7 @@ function SwitchToPAYG() {
                             if (TeamSubscription2.isCancelled(ts2, now) || !TeamSubscription2.isActive(ts2, now)) {
                                 // We're happy!
                                 if (!cancelled) {
-                                    setPageState((s) => ({ ...s, phase: "done" }));
+                                    setPageState((prev) => ({ ...prev, phase: "done" }));
                                 }
                                 return;
                             }
@@ -259,55 +259,8 @@ function SwitchToPAYG() {
                         }
                     }
                     if (!cancelled && !attributionId) {
-                        setPageState((s) => {
-                            const attributionId = s.attributionId || derivedAttributionId;
-                            return { ...s, attributionId, old };
-                        });
+                        setPageState((prev) => ({ ...prev, old, attributionId: derivedAttributionId }));
                     }
-                })().catch(console.error);
-
-                return () => {
-                    cancelled = true;
-                };
-            }
-
-            case "wait-for-signup": {
-                // Wait for the singup to be completed
-                if (!attributionId) {
-                    console.error("Signup, but attributionId not set!");
-                    return;
-                }
-                setPendingStripeSubscription(true);
-
-                let cancelled = false;
-                (async () => {
-                    // We need to poll for the subscription to appear
-                    let subscriptionId: string | undefined;
-                    for (let i = 1; i <= 10; i++) {
-                        if (cancelled) {
-                            break;
-                        }
-
-                        try {
-                            subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
-                            if (subscriptionId) {
-                                break;
-                            }
-                        } catch (error) {
-                            console.error("Search for subscription failed.", error);
-                        }
-                        await new Promise((resolve) => setTimeout(resolve, 1000));
-                    }
-                    if (cancelled) {
-                        return;
-                    }
-
-                    setPendingStripeSubscription(false);
-                    if (!subscriptionId) {
-                        setErrorMessage(`Could not find the subscription.`);
-                        return;
-                    }
-                    setPageState((s) => ({ ...s, phase: "cleanup" }));
                 })().catch(console.error);
 
                 return () => {
@@ -377,29 +330,27 @@ function SwitchToPAYG() {
                         break;
                     }
                 }
-                setPageState((s) => ({ ...s, phase: "done" }));
+                setPageState((prev) => ({ ...prev, phase: "done" }));
                 return;
             }
 
             case "done":
                 // Hooray and confetti!
                 resetAllNotifications();
-                if (!droppedConfetti) {
-                    setDroppedConfetti(true);
-                    dropConfetti();
-                }
+                dropConfetti();
                 return;
         }
     }, [
-        location.search,
-        pageParams,
-        pageState,
-        setPageState,
-        pendingStripeSubscription,
-        setPendingStripeSubscription,
         selectedOrganization,
         dropConfetti,
-        droppedConfetti,
+        setPageState,
+        pageParams?.type,
+        pageParams?.oldSubscriptionOrTeamId,
+        pageParams?.setupIntentId,
+        pageState.phase,
+        pageState.attributionId,
+        pageState.old,
+        pageState.setupIntentId,
     ]);
 
     const onUpgradePlan = useCallback(async () => {
@@ -638,7 +589,7 @@ function renderCard(props: {
                 >
                     {props.headline}
                 </p>
-                <input className="opacity-0" type="radio" checked={props.selected} />
+                <input className="opacity-0" type="radio" checked={props.selected} readOnly={true} />
             </div>
             <div className="pl-1 grid auto-rows-auto">
                 <div
@@ -690,6 +641,57 @@ function parseSearchParams(search: string): PageParams | undefined {
                 setupIntentId,
             };
         }
+    }
+}
+
+let subscribeToStripe_called = false;
+async function subscribeToStripe(
+    setupIntentId: string,
+    attributionId: string,
+    updateState: (u: Partial<PageState>) => void,
+    onError: (e: string) => void,
+) {
+    if (subscribeToStripe_called) {
+        return;
+    }
+    subscribeToStripe_called = true;
+
+    // Do we already have a subscription (co-owner, me in another tab, reload, etc.)?
+    let subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
+    if (subscriptionId) {
+        console.log(`${attributionId} already has a subscription! Moving to cleanup`);
+        // We're happy!
+        updateState({ phase: "cleanup" });
+        return;
+    }
+
+    // Now we want to signup for sure
+    try {
+        await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, DEFAULT_USAGE_LIMIT);
+
+        // We need to poll for the subscription to appear
+        let subscriptionId: string | undefined;
+        for (let i = 1; i <= 10; i++) {
+            try {
+                subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
+                if (subscriptionId) {
+                    break;
+                }
+            } catch (error) {
+                console.error("Search for subscription failed.", error);
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+
+        if (!subscriptionId) {
+            onError(`Could not find the subscription.`);
+            return;
+        }
+
+        updateState({ phase: "cleanup" });
+    } catch (error) {
+        onError(`Could not subscribe to Stripe. ${error?.message || String(error)}`);
+        return;
     }
 }
 

--- a/components/dashboard/src/hooks/use-local-storage.ts
+++ b/components/dashboard/src/hooks/use-local-storage.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 type SetValue<T> = Dispatch<SetStateAction<T>>;
 
@@ -20,16 +20,16 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T
         }
         return initialValue;
     });
-    const setValue: SetValue<T> = (value) => {
+
+    useEffect(() => {
         try {
-            const valueToStore = value instanceof Function ? value(storedValue) : value;
-            setStoredValue(valueToStore);
             if (typeof window !== "undefined") {
-                window.localStorage.setItem(key, JSON.stringify(valueToStore));
+                window.localStorage.setItem(key, JSON.stringify(storedValue));
             }
         } catch (error) {
             console.log(error);
         }
-    };
-    return [storedValue, setValue];
+    }, [key, storedValue]);
+
+    return [storedValue, setStoredValue];
 }


### PR DESCRIPTION
## Description
This PR fixes superfluous and expensive calls to server (e.g. `getAccountStatement` 7 -> 2), but also ensures `server.subscribeToStripe` is called just a single time.

<img width="510" alt="Screenshot 2023-03-14 at 12 00 56" src="https://user-images.githubusercontent.com/914497/224985465-c46e2e17-2711-4519-98e8-ead5104df09a.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
