### PR TITLE
Remove usage of applicationCluster column from WorkspaceCluster

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -92,12 +92,6 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
         type: "varchar",
         length: 60,
     })
-    applicationCluster: string;
-
-    @Column({
-        type: "varchar",
-        length: 60,
-    })
     region: WorkspaceRegion;
 
     // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -32,14 +32,14 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         await repo.save(cluster);
     }
 
-    async deleteByName(name: string, applicationCluster: string): Promise<void> {
+    async deleteByName(name: string): Promise<void> {
         const repo = await this.getRepo();
-        await repo.update({ name, applicationCluster }, { deleted: true });
+        await repo.update({ name }, { deleted: true });
     }
 
-    async findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
+    async findByName(name: string): Promise<WorkspaceCluster | undefined> {
         const repo = await this.getRepo();
-        return repo.findOne({ name, applicationCluster, deleted: false });
+        return repo.findOne({ name, deleted: false });
     }
 
     async findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]> {
@@ -52,7 +52,6 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
             state: "available",
             govern: false,
             admissionConstraints: [],
-            applicationCluster: "",
         };
 
         const repo = await this.getRepo();
@@ -62,9 +61,6 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
             .where("wsc.deleted = 0");
         if (predicate.name !== undefined) {
             qb = qb.andWhere("wsc.name = :name", predicate);
-        }
-        if (predicate.applicationCluster !== undefined) {
-            qb = qb.andWhere("wsc.applicationCluster = :applicationCluster", predicate);
         }
         if (predicate.state !== undefined) {
             qb = qb.andWhere("wsc.state = :state", predicate);

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -75,15 +75,6 @@ export class WorkspaceClusterDBSpec {
             maxScore: 100,
             govern: true,
         });
-        const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
-            name: "eu71",
-            region: "north-america",
-            url: "some-url",
-            state: "cordoned",
-            score: 0,
-            maxScore: 0,
-            govern: false,
-        });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             region: "europe",
@@ -95,13 +86,10 @@ export class WorkspaceClusterDBSpec {
         });
 
         await this.db.save(wsc1);
-        await this.db.save(wsc1a);
         await this.db.save(wsc2);
 
-        // Can delete the eu71 cluster as seen by the eu02 application cluster.
         await this.db.deleteByName("eu71");
         expect(await this.db.findByName("eu71")).to.be.undefined;
-        expect(await this.db.findByName("eu71")).not.to.be.undefined;
         expect(await this.db.findByName("us71")).not.to.be.undefined;
     }
 

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -55,12 +55,12 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const result = await this.db.findByName("eu71", "us02");
+        const result = await this.db.findByName("eu71");
         expect(result).not.to.be.undefined;
         expect((result as WorkspaceCluster).name).to.equal("eu71");
 
         // Can find the eu71 cluster as seen by the us02 application cluster.
-        const result2 = await this.db.findByName("eu71", "us02");
+        const result2 = await this.db.findByName("eu71");
         expect(result2).not.to.be.undefined;
         expect((result2 as WorkspaceCluster).name).to.equal("eu71");
     }
@@ -99,10 +99,10 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc2);
 
         // Can delete the eu71 cluster as seen by the eu02 application cluster.
-        await this.db.deleteByName("eu71", "eu02");
-        expect(await this.db.findByName("eu71", "eu02")).to.be.undefined;
-        expect(await this.db.findByName("eu71", "us02")).not.to.be.undefined;
-        expect(await this.db.findByName("us71", "eu02")).not.to.be.undefined;
+        await this.db.deleteByName("eu71");
+        expect(await this.db.findByName("eu71")).to.be.undefined;
+        expect(await this.db.findByName("eu71")).not.to.be.undefined;
+        expect(await this.db.findByName("us71")).not.to.be.undefined;
     }
 
     @test public async testFindFilteredByName() {
@@ -185,7 +185,7 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        await this.db.deleteByName("eu71", "us02");
+        await this.db.deleteByName("eu71");
 
         let wscs = await this.db.findFiltered({});
         expect(wscs.length).to.equal(1);

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -35,7 +35,6 @@ export class WorkspaceClusterDBSpec {
     @test public async findByName() {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "us02",
             region: "europe",
             url: "some-url",
             state: "available",
@@ -45,7 +44,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
-            applicationCluster: "us02",
             region: "europe",
             url: "some-url",
             state: "cordoned",
@@ -60,19 +58,16 @@ export class WorkspaceClusterDBSpec {
         const result = await this.db.findByName("eu71", "us02");
         expect(result).not.to.be.undefined;
         expect((result as WorkspaceCluster).name).to.equal("eu71");
-        expect((result as WorkspaceCluster).applicationCluster).to.equal("us02");
 
         // Can find the eu71 cluster as seen by the us02 application cluster.
         const result2 = await this.db.findByName("eu71", "us02");
         expect(result2).not.to.be.undefined;
         expect((result2 as WorkspaceCluster).name).to.equal("eu71");
-        expect((result2 as WorkspaceCluster).applicationCluster).to.equal("us02");
     }
 
     @test public async deleteByName() {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "eu02",
             region: "europe",
             url: "some-url",
             state: "available",
@@ -82,7 +77,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "us02",
             region: "north-america",
             url: "some-url",
             state: "cordoned",
@@ -92,7 +86,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
-            applicationCluster: "eu02",
             region: "europe",
             url: "some-url",
             state: "cordoned",
@@ -115,7 +108,6 @@ export class WorkspaceClusterDBSpec {
     @test public async testFindFilteredByName() {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "us02",
             region: "north-america",
             url: "some-url",
             state: "cordoned",
@@ -125,7 +117,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
-            applicationCluster: "eu02",
             region: "europe",
             url: "some-url",
             state: "cordoned",
@@ -137,16 +128,14 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const wscs = await this.db.findFiltered({ name: "eu71", applicationCluster: "us02" });
+        const wscs = await this.db.findFiltered({ name: "eu71" });
         expect(wscs.length).to.equal(1);
         expect(wscs[0].name).to.equal("eu71");
-        expect(wscs[0].applicationCluster).to.equal("us02");
     }
 
     @test public async testFindFilteredByApplicationCluster() {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "us02",
             region: "europe",
             url: "some-url",
             state: "available",
@@ -157,7 +146,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
-            applicationCluster: "us02",
             region: "north-america",
             url: "some-url",
             state: "available",
@@ -170,14 +158,13 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const wscs2 = await this.db.findFiltered({ applicationCluster: "us02" });
+        const wscs2 = await this.db.findFiltered({});
         expect(wscs2.length).to.equal(2);
     }
 
     @test public async testFindFilteredExcludesDeletedClusters() {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
-            applicationCluster: "us02",
             region: "europe",
             url: "some-url",
             state: "available",
@@ -187,7 +174,6 @@ export class WorkspaceClusterDBSpec {
         });
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
-            applicationCluster: "us02",
             region: "north-america",
             url: "some-url",
             state: "available",
@@ -201,7 +187,7 @@ export class WorkspaceClusterDBSpec {
 
         await this.db.deleteByName("eu71", "us02");
 
-        let wscs = await this.db.findFiltered({ applicationCluster: "us02" });
+        let wscs = await this.db.findFiltered({});
         expect(wscs.length).to.equal(1);
     }
 
@@ -209,7 +195,6 @@ export class WorkspaceClusterDBSpec {
         const clusters: DBWorkspaceCluster[] = [
             dbWorkspaceCluster({
                 name: "eu71",
-                applicationCluster: "eu02",
                 region: "europe",
                 url: "some-url",
                 state: "available",
@@ -219,7 +204,6 @@ export class WorkspaceClusterDBSpec {
             }),
             dbWorkspaceCluster({
                 name: "eu72",
-                applicationCluster: "eu02",
                 region: "",
                 url: "some-url",
                 state: "cordoned",
@@ -229,7 +213,6 @@ export class WorkspaceClusterDBSpec {
             }),
             dbWorkspaceCluster({
                 name: "us71",
-                applicationCluster: "eu02",
                 region: "",
                 url: "some-url",
                 state: "available",
@@ -243,10 +226,10 @@ export class WorkspaceClusterDBSpec {
             await this.db.save(cluster);
         }
 
-        const withoutRegionFilter = await this.db.findFiltered({ applicationCluster: "eu02" });
+        const withoutRegionFilter = await this.db.findFiltered({});
         expect(withoutRegionFilter.length).to.equal(3);
 
-        const matchingEurope = await this.db.findFiltered({ applicationCluster: "eu02", region: "europe" });
+        const matchingEurope = await this.db.findFiltered({ region: "europe" });
         expect(matchingEurope.length).to.equal(1);
     }
 }

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -22,10 +22,6 @@ export interface WorkspaceCluster {
     // Must be identical to the installationShortname of the cluster it represents!
     name: string;
 
-    // The name of the application cluster to which this cluster should be registered.
-    // The name can be at most 60 characters.
-    applicationCluster: string;
-
     // The name of the region this cluster belongs to. E.g. europe or north-america
     // The name can be at most 60 characters.
     region: WorkspaceRegion;
@@ -116,6 +112,7 @@ export interface WorkspaceClusterDB {
     findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]>;
 }
 
-export type WorkspaceClusterFilter = Pick<WorkspaceCluster, "applicationCluster"> &
-    DeepPartial<Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "region">> &
+export type WorkspaceClusterFilter = DeepPartial<
+    Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "region">
+> &
     Partial<{ minScore: number }>;

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -97,13 +97,13 @@ export interface WorkspaceClusterDB {
      * Deletes the cluster identified by this name, if any.
      * @param name
      */
-    deleteByName(name: string, applicationCluster: string): Promise<void>;
+    deleteByName(name: string): Promise<void>;
 
     /**
      * Finds a WorkspaceCluster with the given name. If there is none, `undefined` is returned.
      * @param name
      */
-    findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined>;
+    findByName(name: string): Promise<WorkspaceCluster | undefined>;
 
     /**
      * Lists all WorkspaceClusterWoTls for which the given predicate is true (does not return TLS for size/speed concerns)

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -32,7 +32,6 @@ export const ImageBuilderClientProvider = Symbol("ImageBuilderClientProvider");
 // ImageBuilderClientProvider caches image builder connections
 export interface ImageBuilderClientProvider {
     getClient(
-        applicationCluster: string,
         user: User,
         workspace: Workspace,
         instance?: WorkspaceInstance,
@@ -97,7 +96,7 @@ export class CachingImageBuilderClientProvider implements ImageBuilderClientProv
         return connection;
     }
 
-    async getClient(applicationCluster: string, user: User, workspace: Workspace, instance?: WorkspaceInstance) {
+    async getClient(user: User, workspace: Workspace, instance?: WorkspaceInstance) {
         return this.getDefault();
     }
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -430,10 +430,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         await this.guardAccess({ kind: "workspaceInstance", subject: runningInstance, workspace: workspace }, "update");
 
-        const client = await this.workspaceManagerClientProvider.get(
-            runningInstance.region,
-            this.config.installationShortname,
-        );
+        const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
 
         const req = new SetTimeoutRequest();
         req.setId(runningInstance.id);
@@ -469,10 +466,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const req = new DescribeWorkspaceRequest();
         req.setId(runningInstance.id);
 
-        const client = await this.workspaceManagerClientProvider.get(
-            runningInstance.region,
-            this.config.installationShortname,
-        );
+        const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
         const desc = await client.describeWorkspace(ctx, req);
         const duration = desc.getStatus()!.getSpec()!.getTimeout();
 
@@ -519,10 +513,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             req.setId(instance.id);
             req.setLevel(lvlmap.get(level)!);
 
-            const client = await this.workspaceManagerClientProvider.get(
-                instance.region,
-                this.config.installationShortname,
-            );
+            const client = await this.workspaceManagerClientProvider.get(instance.region);
             await client.controlAdmission(ctx, req);
         }
 
@@ -548,10 +539,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         await this.guardAccess({ kind: "workspaceInstance", subject: instance, workspace }, "get");
 
-        const client = await this.workspaceManagerClientProvider.get(
-            instance.region,
-            this.config.installationShortname,
-        );
+        const client = await this.workspaceManagerClientProvider.get(instance.region);
         const request = new TakeSnapshotRequest();
         request.setId(instance.id);
         request.setReturnImmediately(true);

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -122,10 +122,7 @@ export class UserDeletionService {
                 req.setPolicy(StopWorkspacePolicy.NORMALLY);
 
                 try {
-                    const manager = await this.workspaceManagerClientProvider.get(
-                        wsi.region,
-                        this.config.installationShortname,
-                    );
+                    const manager = await this.workspaceManagerClientProvider.get(wsi.region);
                     await manager.stopWorkspace({}, req);
                 } catch (err) {
                     log.debug(

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1008,7 +1008,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             req.setId(instanceId);
             req.setClosed(wasClosed);
 
-            const client = await this.workspaceManagerClientProvider.get(wsi.region, this.config.installationShortname);
+            const client = await this.workspaceManagerClientProvider.get(wsi.region);
             await client.markActive(ctx, req);
 
             if (options && options.roundTripTime && Number.isFinite(options.roundTripTime)) {
@@ -1579,10 +1579,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const req = new DescribeWorkspaceRequest();
         req.setId(instance.id);
-        const client = await this.workspaceManagerClientProvider.get(
-            instance.region,
-            this.config.installationShortname,
-        );
+        const client = await this.workspaceManagerClientProvider.get(instance.region);
         const desc = await client.describeWorkspace(ctx, req);
 
         if (!desc.hasStatus()) {
@@ -1635,10 +1632,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         req.setExpose(true);
 
         try {
-            const client = await this.workspaceManagerClientProvider.get(
-                runningInstance.region,
-                this.config.installationShortname,
-            );
+            const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
             await client.controlPort(ctx, req);
         } catch (e) {
             throw this.mapGrpcError(e);
@@ -1690,10 +1684,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         req.setSpec(spec);
         req.setExpose(false);
 
-        const client = await this.workspaceManagerClientProvider.get(
-            instance.region,
-            this.config.installationShortname,
-        );
+        const client = await this.workspaceManagerClientProvider.get(instance.region);
         await client.controlPort(ctx, req);
     }
 
@@ -2085,10 +2076,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 const req = new UpdateSSHKeyRequest();
                 req.setId(instance.id);
                 req.setKeysList(keys);
-                const cli = await this.workspaceManagerClientProvider.get(
-                    instance.region,
-                    this.config.installationShortname,
-                );
+                const cli = await this.workspaceManagerClientProvider.get(instance.region);
                 await cli.updateSSHPublicKey(ctx, req);
             } catch (err) {
                 const logCtx = { userId, instanceId: instance.id };

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3583,7 +3583,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
      * @returns
      */
     protected async getImageBuilderClient(user: User, workspace: Workspace, instance?: WorkspaceInstance) {
-        return this.imagebuilderClientProvider.getClient(this.config.installationShortname, user, workspace, instance);
+        return this.imagebuilderClientProvider.getClient(user, workspace, instance);
     }
 
     async getNotifications(ctx: TraceContext): Promise<AppNotification[]> {

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -32,21 +32,14 @@ export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderC
     protected readonly connectionCache = new Map<string, ImageBuilderClient>();
 
     async getClient(
-        applicationCluster: string,
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
         region?: WorkspaceRegion,
     ): Promise<PromisifiedImageBuilderClient> {
-        const clusters = await this.clientProvider.getStartClusterSets(
-            applicationCluster,
-            user,
-            workspace,
-            instance,
-            region,
-        );
+        const clusters = await this.clientProvider.getStartClusterSets(user, workspace, instance, region);
         for await (let cluster of clusters) {
-            const info = await this.source.getWorkspaceCluster(cluster.installation, applicationCluster);
+            const info = await this.source.getWorkspaceCluster(cluster.installation);
             if (!info) {
                 continue;
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -411,7 +411,7 @@ export class WorkspaceStarter {
         req.setId(instanceId);
         req.setPolicy(policy || StopWorkspacePolicy.NORMALLY);
 
-        const client = await this.clientProvider.get(instanceRegion, this.config.installationShortname);
+        const client = await this.clientProvider.get(instanceRegion);
         await client.stopWorkspace(ctx, req);
     }
 
@@ -640,13 +640,7 @@ export class WorkspaceStarter {
         region?: WorkspaceRegion,
     ): Promise<StartWorkspaceResponse.AsObject | undefined> {
         let lastInstallation = "";
-        const clusters = await this.clientProvider.getStartClusterSets(
-            this.config.installationShortname,
-            user,
-            workspace,
-            instance,
-            region,
-        );
+        const clusters = await this.clientProvider.getStartClusterSets(user, workspace, instance, region);
         for await (let cluster of clusters) {
             try {
                 // getStartManager will throw an exception if there's no cluster available and hence exit the loop
@@ -1835,12 +1829,6 @@ export class WorkspaceStarter {
         instance?: WorkspaceInstance,
         region?: WorkspaceRegion,
     ) {
-        return this.imagebuilderClientProvider.getClient(
-            this.config.installationShortname,
-            user,
-            workspace,
-            instance,
-            region,
-        );
+        return this.imagebuilderClientProvider.getClient(user, workspace, instance, region);
     }
 }

--- a/components/ws-manager-api/typescript/src/client-provider-source.ts
+++ b/components/ws-manager-api/typescript/src/client-provider-source.ts
@@ -15,25 +15,20 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 export const WorkspaceManagerClientProviderSource = Symbol("WorkspaceManagerClientProviderSource");
 
 export interface WorkspaceManagerClientProviderSource {
-    getWorkspaceCluster(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined>;
-    getAllWorkspaceClusters(applicationCluster: string): Promise<WorkspaceClusterWoTLS[]>;
+    getWorkspaceCluster(name: string): Promise<WorkspaceCluster | undefined>;
+    getAllWorkspaceClusters(): Promise<WorkspaceClusterWoTLS[]>;
 }
 
 @injectable()
 export class WorkspaceManagerClientProviderEnvSource implements WorkspaceManagerClientProviderSource {
     protected _clusters: WorkspaceCluster[] | undefined = undefined;
 
-    public async getWorkspaceCluster(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
-        return this.clusters.find((m) => m.name === name && m.applicationCluster === applicationCluster);
+    public async getWorkspaceCluster(name: string): Promise<WorkspaceCluster | undefined> {
+        return this.clusters.find((m) => m.name === name);
     }
 
-    public async getAllWorkspaceClusters(
-        applicationCluster: string,
-        region?: string,
-    ): Promise<WorkspaceClusterWoTLS[]> {
-        return this.clusters.filter(
-            (m) => m.applicationCluster === applicationCluster && (!region || m.region === region),
-        );
+    public async getAllWorkspaceClusters(region?: string): Promise<WorkspaceClusterWoTLS[]> {
+        return this.clusters.filter((m) => !region || m.region === region);
     }
 
     protected get clusters(): WorkspaceCluster[] {
@@ -73,12 +68,12 @@ export class WorkspaceManagerClientProviderDBSource implements WorkspaceManagerC
     @inject(WorkspaceClusterDB)
     protected readonly db: WorkspaceClusterDB;
 
-    public async getWorkspaceCluster(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
-        return this.db.findByName(name, applicationCluster);
+    public async getWorkspaceCluster(name: string): Promise<WorkspaceCluster | undefined> {
+        return this.db.findByName(name);
     }
 
-    public async getAllWorkspaceClusters(applicationCluster: string): Promise<WorkspaceClusterWoTLS[]> {
-        return await this.db.findFiltered({ applicationCluster });
+    public async getAllWorkspaceClusters(): Promise<WorkspaceClusterWoTLS[]> {
+        return await this.db.findFiltered({});
     }
 }
 
@@ -87,9 +82,9 @@ export class WorkspaceManagerClientProviderCompositeSource implements WorkspaceM
     @multiInject(WorkspaceManagerClientProviderSource)
     protected readonly sources: WorkspaceManagerClientProviderSource[];
 
-    async getWorkspaceCluster(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
+    async getWorkspaceCluster(name: string): Promise<WorkspaceCluster | undefined> {
         for (const source of this.sources) {
-            const info = await source.getWorkspaceCluster(name, applicationCluster);
+            const info = await source.getWorkspaceCluster(name);
             if (info !== undefined) {
                 return info;
             }
@@ -97,10 +92,10 @@ export class WorkspaceManagerClientProviderCompositeSource implements WorkspaceM
         return undefined;
     }
 
-    async getAllWorkspaceClusters(applicationCluster: string): Promise<WorkspaceClusterWoTLS[]> {
+    async getAllWorkspaceClusters(): Promise<WorkspaceClusterWoTLS[]> {
         const allClusters: Map<string, WorkspaceClusterWoTLS> = new Map();
         for (const source of this.sources) {
-            const clusters = await source.getAllWorkspaceClusters(applicationCluster);
+            const clusters = await source.getAllWorkspaceClusters();
             for (const cluster of clusters) {
                 if (allClusters.has(cluster.name)) {
                     log.warn(

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -127,11 +127,7 @@ class TestClientProvider {
         this.provider = c.get(WorkspaceManagerClientProvider);
 
         // we don't actually want to try and connect here
-        this.provider.get = async (
-            name: string,
-            applicationCluster: string,
-            grpcOptions?: object,
-        ): Promise<PromisifiedWorkspaceManagerClient> => {
+        this.provider.get = async (name: string, grpcOptions?: object): Promise<PromisifiedWorkspaceManagerClient> => {
             return {} as PromisifiedWorkspaceManagerClient;
         };
     }
@@ -140,13 +136,12 @@ class TestClientProvider {
     public async getStartClusterSets() {
         await this.expectInstallations(
             [["a2", "a3"]],
-            await this.provider.getStartClusterSets("xx01", {} as User, {} as Workspace, {} as WorkspaceInstance),
+            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
             "default case",
         );
         await this.expectInstallations(
             [["con1"], ["a2", "a3", "con1"]],
             await this.provider.getStartClusterSets(
-                "xx01",
                 { rolesOrPermissions: ["new-workspace-cluster"] } as User,
                 {} as Workspace,
                 {} as WorkspaceInstance,
@@ -156,7 +151,6 @@ class TestClientProvider {
         await this.expectInstallations(
             [["a2", "a3", "con2"]],
             await this.provider.getStartClusterSets(
-                "xx01",
                 { rolesOrPermissions: ["monitor"] } as User,
                 {} as Workspace,
                 {} as WorkspaceInstance,
@@ -165,18 +159,12 @@ class TestClientProvider {
         );
         await this.expectInstallations(
             [["a2", "a3"]],
-            await this.provider.getStartClusterSets("xx01", {} as User, {} as Workspace, {} as WorkspaceInstance),
+            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
             "cluster has permission w/o precedence, user NOT",
         );
         await this.expectInstallations(
             [["a3"], ["a2"]],
-            await this.provider.getStartClusterSets(
-                "xx01",
-                {} as User,
-                {} as Workspace,
-                {} as WorkspaceInstance,
-                "europe",
-            ),
+            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance, "europe"),
             "regional cluster set",
         );
     }

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -39,7 +39,6 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "north-america",
                     },
                     {
@@ -50,7 +49,6 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "north-america",
                     },
                     {
@@ -61,7 +59,6 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "north-america",
                     },
                     {
@@ -72,7 +69,6 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "north-america",
                     },
                     {
@@ -83,7 +79,6 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "north-america",
                     },
                     {
@@ -94,7 +89,6 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
-                        applicationCluster: "xx01",
                         region: "europe",
                     },
                     {
@@ -105,7 +99,6 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }],
-                        applicationCluster: "xx01",
                         region: "europe",
                     },
                     {
@@ -118,7 +111,6 @@ class TestClientProvider {
                         admissionConstraints: [
                             { type: "has-permission", permission: "monitor" }, // This is meant to represent a permission that does not take special precedence (cmp. constraints.ts)
                         ],
-                        applicationCluster: "xx01",
                         region: "europe",
                     },
                 ];

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -50,13 +50,12 @@ export class WorkspaceManagerClientProvider implements Disposable {
      * @returns a set of workspace clusters we can start the workspace in
      */
     public async getStartClusterSets(
-        applicationCluster: string,
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
         region?: WorkspaceRegion,
     ): Promise<IWorkspaceClusterStartSet> {
-        const allClusters = await this.source.getAllWorkspaceClusters(applicationCluster);
+        const allClusters = await this.source.getAllWorkspaceClusters();
         const availableClusters = allClusters.filter((c) => c.score > 0 && c.state === "available");
 
         const sets = workspaceClusterSetsAuthorized
@@ -65,7 +64,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
                 if (!r) {
                     return;
                 }
-                return new ClusterSet(this, r, applicationCluster);
+                return new ClusterSet(this, r);
             })
             .filter((s) => s !== undefined) as ClusterSet[];
 
@@ -96,13 +95,9 @@ export class WorkspaceManagerClientProvider implements Disposable {
      * @param name
      * @returns The WorkspaceManagerClient identified by the name. Throws an error if there is none.
      */
-    public async get(
-        name: string,
-        applicationCluster: string,
-        grpcOptions?: object,
-    ): Promise<PromisifiedWorkspaceManagerClient> {
+    public async get(name: string, grpcOptions?: object): Promise<PromisifiedWorkspaceManagerClient> {
         const getConnectionInfo = async () => {
-            const cluster = await this.source.getWorkspaceCluster(name, applicationCluster);
+            const cluster = await this.source.getWorkspaceCluster(name);
             if (!cluster) {
                 throw new Error(`Unknown workspace manager \"${name}\"`);
             }
@@ -140,8 +135,8 @@ export class WorkspaceManagerClientProvider implements Disposable {
     /**
      * @returns All WorkspaceClusters (without TLS config)
      */
-    public async getAllWorkspaceClusters(applicationCluster: string): Promise<WorkspaceClusterWoTLS[]> {
-        return this.source.getAllWorkspaceClusters(applicationCluster);
+    public async getAllWorkspaceClusters(): Promise<WorkspaceClusterWoTLS[]> {
+        return this.source.getAllWorkspaceClusters();
     }
 
     public createConnection<T extends grpc.Client>(
@@ -188,7 +183,6 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
     constructor(
         protected readonly provider: WorkspaceManagerClientProvider,
         protected readonly cluster: WorkspaceClusterWoTLS[],
-        protected readonly applicationCluster: string,
     ) {}
 
     public async next(): Promise<IteratorResult<ClusterClientEntry>> {
@@ -203,7 +197,7 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
         const grpcOptions: grpc.ClientOptions = {
             ...defaultGRPCOptions,
         };
-        const client = await this.provider.get(chosenCluster.name, this.applicationCluster, grpcOptions);
+        const client = await this.provider.get(chosenCluster.name, grpcOptions);
         return {
             done: false,
             value: {

--- a/components/ws-manager-bridge/src/bridge-controller.ts
+++ b/components/ws-manager-bridge/src/bridge-controller.ts
@@ -100,14 +100,14 @@ export class BridgeController {
             ...defaultGRPCOptions,
         };
         const clientProvider = async () => {
-            return this.clientProvider.get(cluster.name, this.config.installation, grpcOptions);
+            return this.clientProvider.get(cluster.name, grpcOptions);
         };
         bridge.start(cluster, clientProvider);
         return bridge;
     }
 
     protected async getAllWorkspaceClusters(): Promise<Map<string, WorkspaceClusterWoTLS>> {
-        const allInfos = await this.clientProvider.getAllWorkspaceClusters(this.config.installation);
+        const allInfos = await this.clientProvider.getAllWorkspaceClusters();
         const result: Map<string, WorkspaceClusterWoTLS> = new Map();
         for (const cluster of allInfos) {
             result.set(cluster.name, cluster);

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -93,7 +93,6 @@ export class ClusterService implements IClusterServiceServer {
                 const clusterByNamePromise = this.clusterDB.findByName(req.name, this.config.installation);
                 const clusterByUrlPromise = this.clusterDB.findFiltered({
                     url: req.url,
-                    applicationCluster: this.config.installation,
                 });
 
                 const [clusterByName, clusterByUrl] = await Promise.all([clusterByNamePromise, clusterByUrlPromise]);
@@ -144,7 +143,6 @@ export class ClusterService implements IClusterServiceServer {
                 const newCluster: WorkspaceCluster = {
                     name: req.name,
                     url: req.url,
-                    applicationCluster: this.config.installation,
                     region: req.region,
                     state,
                     score,
@@ -275,9 +273,7 @@ export class ClusterService implements IClusterServiceServer {
                 const response = new ListResponse();
 
                 const dbClusterIdx = new Map<string, boolean>();
-                const allDBClusters = await this.clusterDB.findFiltered({
-                    applicationCluster: this.config.installation,
-                });
+                const allDBClusters = await this.clusterDB.findFiltered({});
                 for (const cluster of allDBClusters) {
                     const clusterStatus = convertToGRPC(cluster);
                     response.addStatus(clusterStatus);
@@ -319,7 +315,7 @@ function convertToGRPC(ws: WorkspaceClusterWoTLS): ClusterStatus {
     clusterStatus.setScore(ws.score);
     clusterStatus.setMaxScore(ws.maxScore);
     clusterStatus.setGoverned(ws.govern);
-    clusterStatus.setApplicationCluster(ws.applicationCluster);
+    clusterStatus.setApplicationCluster("");
     clusterStatus.setRegion(ws.region);
 
     ws.admissionConstraints?.forEach((c) => {

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -90,7 +90,7 @@ export class ClusterService implements IClusterServiceServer {
                     throw new GRPCError(grpc.status.INVALID_ARGUMENT, `Invalid value for workspace region.`);
                 }
 
-                const clusterByNamePromise = this.clusterDB.findByName(req.name, this.config.installation);
+                const clusterByNamePromise = this.clusterDB.findByName(req.name);
                 const clusterByUrlPromise = this.clusterDB.findFiltered({
                     url: req.url,
                 });
@@ -178,7 +178,7 @@ export class ClusterService implements IClusterServiceServer {
         this.queue.enqueue(async () => {
             try {
                 const req = call.request.toObject();
-                const cluster = await this.clusterDB.findByName(req.name, this.config.installation);
+                const cluster = await this.clusterDB.findByName(req.name);
                 if (!cluster) {
                     throw new GRPCError(
                         grpc.status.NOT_FOUND,
@@ -255,7 +255,7 @@ export class ClusterService implements IClusterServiceServer {
                     );
                 }
 
-                await this.clusterDB.deleteByName(req.name, this.config.installation);
+                await this.clusterDB.deleteByName(req.name);
                 log.info({}, "cluster deregistered", { cluster: req.name });
                 this.triggerReconcile("deregister", req.name);
 

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -55,9 +55,6 @@ export class ClusterService implements IClusterServiceServer {
     // Satisfy the grpc.UntypedServiceImplementation interface.
     [name: string]: any;
 
-    @inject(Configuration)
-    protected readonly config: Configuration;
-
     @inject(WorkspaceClusterDB)
     protected readonly clusterDB: WorkspaceClusterDB;
 
@@ -151,12 +148,7 @@ export class ClusterService implements IClusterServiceServer {
                     tls,
                 };
 
-                let classConstraints = await getSupportedWorkspaceClasses(
-                    this.clientProvider,
-                    newCluster,
-                    this.config.installation,
-                    false,
-                );
+                let classConstraints = await getSupportedWorkspaceClasses(this.clientProvider, newCluster, false);
                 newCluster.admissionConstraints = admissionConstraints.concat(classConstraints);
 
                 await this.clusterDB.save(newCluster);
@@ -280,7 +272,7 @@ export class ClusterService implements IClusterServiceServer {
                     dbClusterIdx.set(cluster.name, true);
                 }
 
-                const allCluster = await this.allClientProvider.getAllWorkspaceClusters(this.config.installation);
+                const allCluster = await this.allClientProvider.getAllWorkspaceClusters();
                 for (const cluster of allCluster) {
                     if (dbClusterIdx.get(cluster.name)) {
                         continue;

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -43,7 +43,7 @@ export class ClusterSyncService {
 
     private async reconcile() {
         log.debug("reconciling workspace classes...");
-        let allClusters = await this.clusterDB.findFiltered({ applicationCluster: this.config.installation });
+        let allClusters = await this.clusterDB.findFiltered({});
         for (const cluster of allClusters) {
             try {
                 let supportedClasses = await getSupportedWorkspaceClasses(

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -46,12 +46,7 @@ export class ClusterSyncService {
         let allClusters = await this.clusterDB.findFiltered({});
         for (const cluster of allClusters) {
             try {
-                let supportedClasses = await getSupportedWorkspaceClasses(
-                    this.clientProvider,
-                    cluster,
-                    this.config.installation,
-                    true,
-                );
+                let supportedClasses = await getSupportedWorkspaceClasses(this.clientProvider, cluster, true);
                 let existingOtherConstraints = cluster.admissionConstraints?.filter((c) => c.type !== "has-class");
                 cluster.admissionConstraints = existingOtherConstraints?.concat(supportedClasses);
                 await this.clusterDB.save(cluster);
@@ -70,7 +65,6 @@ export class ClusterSyncService {
 export async function getSupportedWorkspaceClasses(
     clientProvider: WorkspaceManagerClientProvider,
     cluster: WorkspaceCluster,
-    applicationCluster: string,
     useCache: boolean,
 ) {
     let constraints = await new Promise<AdmissionConstraintHasClass[]>(async (resolve, reject) => {
@@ -79,7 +73,7 @@ export async function getSupportedWorkspaceClasses(
         };
         let client = useCache
             ? await (
-                  await clientProvider.get(cluster.name, applicationCluster, grpcOptions)
+                  await clientProvider.get(cluster.name, grpcOptions)
               ).client
             : clientProvider.createConnection(WorkspaceManagerClient, cluster, grpcOptions);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We are no longer using the applicationCluster property, this removes it from the TypeORM model entirely.

Migration to drop the column will follow once there's no usage.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
