### PR TITLE
[dashboard] give start workspace button focus

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -19,6 +19,9 @@ interface RepositoryFinderProps {
 }
 
 function stripOffProtocol(url: string): string {
+    if (!url.startsWith("http")) {
+        return url;
+    }
     return url.substring(url.indexOf("//") + 2);
 }
 
@@ -105,7 +108,7 @@ function displayContextUrl(contextUrl?: string) {
     if (!contextUrl) {
         return undefined;
     }
-    return contextUrl.substring(contextUrl.indexOf("//") + 2);
+    return stripOffProtocol(contextUrl);
 }
 
 function loadSearchData(): string[] {

--- a/components/dashboard/src/start/start-workspace-options.ts
+++ b/components/dashboard/src/start/start-workspace-options.ts
@@ -49,4 +49,9 @@ export namespace StartWorkspaceOptions {
         }
         return params.toString();
     }
+
+    export function parseContextUrl(locationHash: string): string {
+        let result = locationHash.replace(/^[#/]+/, "").trim();
+        return result;
+    }
 }


### PR DESCRIPTION
## Description
- Allow starting workspaces without using the mouse
- Support all kinds of contextURLs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16754

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
