### PR TITLE
[gha] fix skipped jobs to pass required checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,8 @@ jobs:
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true')
     runs-on: [ self-hosted ]
+    outputs:
+      success: ${{ job.status }}
     concurrency:
       group: ${{ github.head_ref || github.ref_name }}-build-gitpod
       # For the main branch we always want the build job to run to completion
@@ -280,6 +282,25 @@ jobs:
           if-no-files-found: ignore
           path: |
             test-coverage-report
+
+  # A skipped check counts as passed in gh actions - so there can be a case where
+  # build-gitpod never ran, and a PR got merged regardless
+  # this should provide a workaround to that and provide a check we can always use as a required
+  ci-check:
+    runs-on: [ self-hosted ]
+    if: always() # always run, so we never skip the check
+    needs: [ build-gitpod ]
+    steps:
+      # pass step only when the output of build-gitpod job is set
+      - run: |
+          passed="${{ needs.build-gitpod.outputs.success }}"
+          if [[ $passed == "success" ]]; then
+            echo "build-gitpod passed"
+            exit 0
+          else
+            echo "build-gitpod failed"
+            exit 1
+          fi
 
   install:
     name: "Install Gitpod"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
   # this should provide a workaround to that and provide a check we can always use as a required
   ci-check:
     runs-on: [ self-hosted ]
-    if: always() # always run, so we never skip the check
+    if: always() && github.event_name == 'push' # always run, so we never skip the check
     needs: [ build-gitpod ]
     steps:
       # pass step only when the output of build-gitpod job is set

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,6 @@ jobs:
   build-gitpod:
     name: Build Gitpod
     needs: [ configuration ]
-    if: |
-      (needs.configuration.outputs.pr_no_diff_skip != 'true')
     runs-on: [ self-hosted ]
     outputs:
       success: ${{ job.status }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Job that got skipped, and the check failed: https://github.com/gitpod-io/gitpod/actions/runs/4407130749/jobs/7720371677

Job with successful build and passed check: https://github.com/gitpod-io/gitpod/actions/runs/4407123233/jobs/7720393924

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
