### PR TITLE
[node-labeler] Do not return an error if the node does not exist

### DIFF
--- a/components/node-labeler/cmd/run.go
+++ b/components/node-labeler/cmd/run.go
@@ -188,6 +188,12 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		time.Sleep(1 * time.Second)
 		err := updateLabel(labelToUpdate, false, nodeName, r)
 		if err != nil {
+			// this is a edge case when cluster-autoscaler removes a node
+			// (all the running pods will be removed after that)
+			if errors.IsNotFound(err) {
+				return reconcile.Result{}, nil
+			}
+
 			log.WithError(err).Error("unexpected error removing node label")
 			return reconcile.Result{RequeueAfter: time.Second * 10}, err
 		}

--- a/components/node-labeler/cmd/run.go
+++ b/components/node-labeler/cmd/run.go
@@ -72,7 +72,10 @@ var runCmd = &cobra.Command{
 			client,
 		}
 
-		c, err := controller.New("pod-watcher", mgr, controller.Options{Reconciler: r})
+		c, err := controller.New("pod-watcher", mgr, controller.Options{
+			Reconciler:              r,
+			MaxConcurrentReconciles: 20,
+		})
 		if err != nil {
 			log.WithError(err).Fatal("unable to bind controller watch event handler")
 		}


### PR DESCRIPTION
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
