### PR TITLE
[node-labeler] Skip checks if label already present

### DIFF
--- a/components/node-labeler/cmd/run.go
+++ b/components/node-labeler/cmd/run.go
@@ -206,6 +206,18 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	if !IsPodReady(&pod) {
 		// not ready. Wait until the next update.
+		log.WithField("pod", pod.Name).Info("pod is not yet ready")
+		return reconcile.Result{}, nil
+	}
+
+	var node corev1.Node
+	err = r.Get(ctx, types.NamespacedName{Name: nodeName}, &node)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+
+	if node.Labels[labelToUpdate] == "true" {
+		// Label already exists.
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
## Description

* Return early from reconciliation if the node already has the ready label for that pod.
* Prevents build up of reconcile queue
* Fixes the `ready_seconds` metric being recorded for pod reconciliations where the node was already ready

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Run integration tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
