### PR TITLE
[server] Tone down unnecessary logging around websocket verifyClient

### DIFF
--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -23,8 +23,7 @@ export const query = (...tuples: [string, string][]) => {
 // Non-Strict: "rely" on subdomain parsing (do we still need this?)
 export const isAllowedWebsocketDomain = (originHeader: string, gitpodHostName: string, strict: boolean): boolean => {
     if (!originHeader) {
-        // TODO(gpl) Can we get rid of this dependency alltogether?
-        log.debug("Origin header check not applied because of empty Origin header!");
+        // Origin header check not applied because of empty Origin header
         return true;
     }
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -175,7 +175,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 if (info.req.url === "/v1") {
                     // Connection attempt with Bearer-Token: be less strict for now
                     if (!verifyOrigin(info.origin, false)) {
-                        log.warn("Websocket connection attempt with non-matching Origin header.", {
+                        log.debug("Websocket connection attempt with non-matching Origin header.", {
                             origin: info.origin,
                         });
                         return callback(false, 403);
@@ -197,7 +197,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 if (!authenticatedUsingBearerToken) {
                     // Connection attempt with cookie/session based authentication: be strict about where we accept connections from!
                     if (!verifyOrigin(info.origin, true)) {
-                        log.warn("Websocket connection attempt with non-matching Origin header: " + info.origin);
+                        log.debug("Websocket connection attempt with non-matching Origin header: " + info.origin);
                         return callback(false, 403);
                     }
                 }


### PR DESCRIPTION
## Description
 Removes unnecessary lines that spill the logs: [link](https://cloudlogging.app.goo.gl/6fdRCFzVj1hrfvvg7)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
