### PR TITLE
Org Settings Page Header updates & cleanup

### DIFF
--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as Exclamation2 } from "../images/exclamation2.svg";
 import { ReactComponent as InfoSvg } from "../images/info.svg";
 import { ReactComponent as XSvg } from "../images/x.svg";
 import { ReactComponent as Check } from "../images/check-circle.svg";
+import classNames from "classnames";
 
 export type AlertType =
     // Green
@@ -20,6 +21,8 @@ export type AlertType =
     | "info"
     // Red
     | "error"
+    // Dark Red
+    | "danger"
     // Blue
     | "message";
 
@@ -32,6 +35,7 @@ export interface AlertProps {
     onClose?: () => void;
     showIcon?: boolean;
     icon?: React.ReactNode;
+    rounded?: boolean;
     children?: React.ReactNode;
 }
 
@@ -73,6 +77,12 @@ const infoMap: Record<AlertType, AlertInfo> = {
         icon: <Exclamation className="w-4 h-4"></Exclamation>,
         iconColor: "text-red-400",
     },
+    danger: {
+        bgCls: "bg-red-600 dark:bg-red-600",
+        txtCls: "text-white",
+        icon: <Exclamation className="w-4 h-4"></Exclamation>,
+        iconColor: "filter-brightness-10",
+    },
 };
 
 export default function Alert(props: AlertProps) {
@@ -84,11 +94,16 @@ export default function Alert(props: AlertProps) {
     const info = infoMap[type];
     const showIcon = props.showIcon ?? true;
     const light = props.light ?? false;
+    const rounded = props.rounded ?? true;
     return (
         <div
-            className={`flex relative whitespace-pre-wrap rounded p-4 ${info.txtCls} ${props.className || ""} ${
-                light ? "" : info.bgCls
-            }`}
+            className={classNames(
+                "flex relative whitespace-pre-wrap p-4",
+                info.txtCls,
+                props.className,
+                light ? "" : info.bgCls,
+                rounded ? "rounded" : "",
+            )}
         >
             {showIcon && <span className={`mt-1 mr-4 h-4 w-4 ${info.iconColor}`}>{props.icon ?? info.icon}</span>}
             <span className="flex-1 text-left">{props.children}</span>

--- a/components/dashboard/src/components/EmptyMessage.tsx
+++ b/components/dashboard/src/components/EmptyMessage.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FC, useCallback } from "react";
+import { Button } from "./Button";
+import { Heading2, Subheading } from "./typography/headings";
+
+type Props = {
+    title: string;
+    subtitle?: string;
+    buttonText?: string;
+    onClick?: () => void;
+    className?: string;
+};
+export const EmptyMessage: FC<Props> = ({ title, subtitle, buttonText, onClick, className }) => {
+    const handleClick = useCallback(() => {
+        onClick && onClick();
+    }, [onClick]);
+    return (
+        <div
+            className={classNames(
+                "w-full flex justify-center mt-2 rounded-xl bg-gray-100 dark:bg-gray-900 px-4 py-14",
+                className,
+            )}
+        >
+            <div className="flex flex-col justify-center items-center text-center space-y-4">
+                <Heading2 color="light">{title}</Heading2>
+                <Subheading className="max-w-md">{subtitle}</Subheading>
+                {buttonText && <Button onClick={handleClick}>{buttonText}</Button>}
+            </div>
+        </div>
+    );
+};

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -4,10 +4,11 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { ReactNode, useEffect } from "react";
+import { FC, ReactNode, useEffect, useMemo } from "react";
 import cn from "classnames";
 import { getGitpodService } from "../service/service";
 import { Heading2 } from "./typography/headings";
+import Alert from "./Alert";
 
 type CloseModalManner = "esc" | "enter" | "x";
 
@@ -125,7 +126,7 @@ type ModalBodyProps = {
 export const ModalBody = ({ children, hideDivider = false, noScroll = false }: ModalBodyProps) => {
     return (
         <div
-            className={cn("border-gray-200 dark:border-gray-800 -mx-6 px-6 ", {
+            className={cn("relative border-gray-200 dark:border-gray-800 -mx-6 px-6 pb-14", {
                 "border-t border-b mt-2 py-4": !hideDivider,
                 "overflow-y-auto": !noScroll,
             })}
@@ -136,8 +137,47 @@ export const ModalBody = ({ children, hideDivider = false, noScroll = false }: M
 };
 
 type ModalFooterProps = {
+    error?: string;
+    warning?: string;
     children: ReactNode;
 };
-export const ModalFooter = ({ children }: ModalFooterProps) => {
-    return <div className="flex justify-end mt-6 space-x-2">{children}</div>;
+export const ModalFooter: FC<ModalFooterProps> = ({ error, warning, children }) => {
+    // Inlining these to ensure error band covers modal left/right borders
+    const alertStyles = useMemo(() => ({ marginLeft: "-25px", marginRight: "-25px" }), []);
+
+    const hasAlert = error || warning;
+
+    return (
+        <div className="relative">
+            {hasAlert && (
+                <div className="absolute -top-12 left-0 right-0" style={alertStyles}>
+                    <ModalFooterAlert error={error} warning={warning} />
+                </div>
+            )}
+            <div className="flex justify-end mt-6 space-x-2">{children}</div>
+        </div>
+    );
+};
+
+type ModalFooterAlertProps = {
+    error?: string;
+    warning?: string;
+};
+const ModalFooterAlert: FC<ModalFooterAlertProps> = ({ error, warning }) => {
+    if (error) {
+        return (
+            <Alert type="danger" rounded={false}>
+                {error}
+            </Alert>
+        );
+    }
+    if (warning) {
+        return (
+            <Alert type="warning" rounded={false}>
+                {warning}
+            </Alert>
+        );
+    }
+
+    return null;
 };

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -29,9 +29,10 @@ type PendingStripeSubscription = { pendingSince: number };
 
 interface Props {
     attributionId?: string;
+    hideSubheading?: boolean;
 }
 
-export default function UsageBasedBillingConfig({ attributionId }: Props) {
+export default function UsageBasedBillingConfig({ attributionId, hideSubheading = false }: Props) {
     const location = useLocation();
     const currentOrg = useCurrentOrg().data;
     const attrId = attributionId ? AttributionId.parse(attributionId) : undefined;
@@ -170,11 +171,13 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
 
     return (
         <div className="mb-16">
-            <Subheading>
-                {attributionId && AttributionId.parse(attributionId)?.kind === "user"
-                    ? "Manage billing for your personal account."
-                    : "Manage billing for your organization."}
-            </Subheading>
+            {!hideSubheading && (
+                <Subheading>
+                    {attributionId && AttributionId.parse(attributionId)?.kind === "user"
+                        ? "Manage billing for your personal account."
+                        : "Manage billing for your organization."}
+                </Subheading>
+            )}
             <div className="max-w-xl flex flex-col">
                 {errorMessage && (
                     <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">

--- a/components/dashboard/src/teams/GitIntegrationsPage.tsx
+++ b/components/dashboard/src/teams/GitIntegrationsPage.tsx
@@ -24,11 +24,14 @@ export default function GitAuth() {
 export const OrgSettingsPageWrapper: FunctionComponent = ({ children }) => {
     const currentOrg = useCurrentOrg();
 
+    const title = "Git Integrations";
+    const subtitle = "Configure Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.";
+
     // Render as much of the page as we can in a loading state to avoid content shift
     if (currentOrg.isLoading) {
         return (
             <div className="w-full">
-                <Header title="Organization Settings" subtitle="Manage your organization's settings." />
+                <Header title={title} subtitle={subtitle} />
                 <div className="w-full">
                     <SpinnerLoader />
                 </div>
@@ -40,5 +43,9 @@ export const OrgSettingsPageWrapper: FunctionComponent = ({ children }) => {
         return <Redirect to={"/"} />;
     }
 
-    return <OrgSettingsPage>{children}</OrgSettingsPage>;
+    return (
+        <OrgSettingsPage title={title} subtitle={subtitle}>
+            {children}
+        </OrgSettingsPage>
+    );
 };

--- a/components/dashboard/src/teams/GitIntegrationsPage.tsx
+++ b/components/dashboard/src/teams/GitIntegrationsPage.tsx
@@ -24,8 +24,8 @@ export default function GitAuth() {
 export const OrgSettingsPageWrapper: FunctionComponent = ({ children }) => {
     const currentOrg = useCurrentOrg();
 
-    const title = "Git Integrations";
-    const subtitle = "Configure Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.";
+    const title = "Git Auth";
+    const subtitle = "Configure Git Auth for GitLab, or Github.";
 
     // Render as much of the page as we can in a loading state to avoid content shift
     if (currentOrg.isLoading) {

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -14,10 +14,12 @@ import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { getTeamSettingsMenu } from "./TeamSettings";
 
 export interface OrgSettingsPageProps {
+    title: string;
+    subtitle: string;
     children: React.ReactNode;
 }
 
-export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
+export function OrgSettingsPage({ title, subtitle, children }: OrgSettingsPageProps) {
     const org = useCurrentOrg();
     const { oidcServiceEnabled, orgGitAuthProviders } = useFeatureFlags();
 
@@ -31,9 +33,6 @@ export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
             }),
         [oidcServiceEnabled, orgGitAuthProviders, org.data],
     );
-
-    const title = "Organization Settings";
-    const subtitle = "Manage your organization's settings.";
 
     // Render as much of the page as we can in a loading state to avoid content shift
     if (org.isLoading) {

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -17,11 +17,16 @@ import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
 import { OrgSettingsPage } from "./OrgSettingsPage";
 import { Heading2, Subheading } from "../components/typography/headings";
+import { EmptyMessage } from "../components/EmptyMessage";
 
 export default function SSO() {
     const currentOrg = useCurrentOrg();
 
-    return <OrgSettingsPage>{currentOrg.data && <OIDCClients organizationId={currentOrg.data?.id} />}</OrgSettingsPage>;
+    return (
+        <OrgSettingsPage title="SSO" subtitle="Configure OpenID Connect single sign-on providers.">
+            {currentOrg.data && <OIDCClients organizationId={currentOrg.data?.id} />}
+        </OrgSettingsPage>
+    );
 }
 
 function OIDCClients(props: { organizationId: string }) {
@@ -85,11 +90,10 @@ function OIDCClients(props: { organizationId: string }) {
             {modal?.mode === "edit" && <></>}
             {modal?.mode === "delete" && <></>}
 
+            <Heading2>OpenID Connect providers</Heading2>
+            <Subheading>Configure single sign-on for your organization.</Subheading>
+
             <div className="flex items-start sm:justify-between mb-2">
-                <div>
-                    <Heading2>Single sign sign-on with OIDC</Heading2>
-                    <Subheading>Setup SSO for your organization.</Subheading>
-                </div>
                 {clientConfigs.length !== 0 ? (
                     <div className="mt-3 flex mt-0">
                         <button onClick={() => setModal({ mode: "new" })} className="ml-2">
@@ -100,18 +104,12 @@ function OIDCClients(props: { organizationId: string }) {
             </div>
 
             {clientConfigs.length === 0 && (
-                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
-                    <div className="m-auto text-center">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No OIDC Clients</h3>
-                        <div className="text-gray-500 mb-6">
-                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
-                            invidunt ut labore et dolore magna aliquyam
-                        </div>
-                        <button className="self-center" onClick={() => setModal({ mode: "new" })}>
-                            New OIDC Client
-                        </button>
-                    </div>
-                </div>
+                <EmptyMessage
+                    title="No OIDC providers"
+                    subtitle="Enter the client ID, client secret, and other information issued by your identity provider, to enable single sign-on for your organization."
+                    buttonText="New OIDC Client"
+                    onClick={() => setModal({ mode: "new" })}
+                />
             )}
 
             <ItemsList className="pt-6">

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -23,7 +23,7 @@ export default function SSO() {
     const currentOrg = useCurrentOrg();
 
     return (
-        <OrgSettingsPage title="SSO" subtitle="Configure OpenID Connect single sign-on providers.">
+        <OrgSettingsPage title="SSO" subtitle="Configure OpenID Connect (OIDC) single sign-on.">
             {currentOrg.data && <OIDCClients organizationId={currentOrg.data?.id} />}
         </OrgSettingsPage>
     );
@@ -90,7 +90,7 @@ function OIDCClients(props: { organizationId: string }) {
             {modal?.mode === "edit" && <></>}
             {modal?.mode === "delete" && <></>}
 
-            <Heading2>OpenID Connect providers</Heading2>
+            <Heading2>OpenID Connect clients</Heading2>
             <Subheading>Configure single sign-on for your organization.</Subheading>
 
             <div className="flex items-start sm:justify-between mb-2">
@@ -106,7 +106,7 @@ function OIDCClients(props: { organizationId: string }) {
             {clientConfigs.length === 0 && (
                 <EmptyMessage
                     title="No OIDC providers"
-                    subtitle="Enter the client ID, client secret, and other information issued by your identity provider, to enable single sign-on for your organization."
+                    subtitle="Enable single sign-on for your organization using an external identity provider (IdP) service that supports the OpenID Connect (OIDC) standard, such as Google."
                     buttonText="New OIDC Client"
                     onClick={() => setModal({ mode: "new" })}
                 />

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -27,7 +27,7 @@ type PendingPlan = Plan & { pendingSince: number };
 
 export default function TeamBillingPage() {
     return (
-        <OrgSettingsPage>
+        <OrgSettingsPage title={"Organization Billing"} subtitle="Manage billing for your organization.">
             <TeamBilling />
         </OrgSettingsPage>
     );

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -37,7 +37,7 @@ export function getTeamSettingsMenu(params: {
     }
     if (orgGitAuthProviders) {
         result.push({
-            title: "Git Integrations",
+            title: "Git Auth",
             link: [`/settings/git`],
         });
     }

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -109,7 +109,7 @@ export default function TeamSettings() {
 
     return (
         <>
-            <OrgSettingsPage>
+            <OrgSettingsPage title="Organization Settings" subtitle="Manage your organization's settings.">
                 <Heading2>Organization Name</Heading2>
                 <Subheading className="max-w-2xl">
                     This is your organization's visible name within Gitpod. For example, the name of your company.

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -5,7 +5,6 @@
  */
 
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { Heading2 } from "../components/typography/headings";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
@@ -19,8 +18,10 @@ export default function TeamUsageBasedBilling() {
 
     return (
         <>
-            <Heading2>Organization Billing</Heading2>
-            <UsageBasedBillingConfig attributionId={org && AttributionId.render({ kind: "team", teamId: org.id })} />
+            <UsageBasedBillingConfig
+                hideSubheading
+                attributionId={org && AttributionId.render({ kind: "team", teamId: org.id })}
+            />
         </>
     );
 }

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -47,7 +47,7 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     return (
         <>
             <Item className="h-16">
-                <ItemFieldIcon>
+                <ItemFieldIcon className="w-1/12">
                     <div
                         className={
                             "rounded-full w-3 h-3 text-sm align-middle m-auto " +
@@ -57,13 +57,13 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
                         &nbsp;
                     </div>
                 </ItemFieldIcon>
-                <ItemField className="w-3/12 flex flex-col my-auto">
+                <ItemField className="w-5/12 flex items-center">
                     <span className="font-medium truncate overflow-ellipsis">{provider.type}</span>
                 </ItemField>
-                <ItemField className="w-7/12 flex flex-col my-auto">
+                <ItemField className="w-5/12 flex items-center">
                     <span className="my-auto truncate text-gray-500 overflow-ellipsis">{provider.host}</span>
                 </ItemField>
-                <ItemFieldContextMenu menuEntries={menuEntries} />
+                <ItemFieldContextMenu className="w-1/12" menuEntries={menuEntries} />
             </Item>
             {showDeleteConfirmation && (
                 <ConfirmationModal

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -6,7 +6,7 @@
 
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
-import Alert from "../../components/Alert";
+import { Button } from "../../components/Button";
 import { InputField } from "../../components/forms/InputField";
 import { SelectInputField } from "../../components/forms/SelectInputField";
 import { TextInputField } from "../../components/forms/TextInputField";
@@ -16,7 +16,6 @@ import { useInvalidateOrgAuthProvidersQuery } from "../../data/auth-providers/or
 import { useUpsertOrgAuthProviderMutation } from "../../data/auth-providers/upsert-org-auth-provider-mutation";
 import { useCurrentOrg } from "../../data/organizations/orgs-query";
 import { useOnBlurError } from "../../hooks/use-onblur-error";
-import exclamation from "../../images/exclamation.svg";
 import { openAuthorizeWindow } from "../../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../../service/service";
 
@@ -104,6 +103,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
             console.error("no current team selected");
             return;
         }
+
         // Set a saving state and clear any error message
         setSavingProvider(true);
         setErrorMessage(undefined);
@@ -193,9 +193,6 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
         >
             <ModalHeader>{isNew ? "New Git Integration" : "Git Integration"}</ModalHeader>
             <ModalBody>
-                {!isNew && savedProvider?.status !== "verified" && (
-                    <Alert type="warning">You need to activate this integration.</Alert>
-                )}
                 <div className="flex flex-col text-gray-500">
                     Configure an integration with a self-managed instance of GitLab, GitHub, or Bitbucket.
                 </div>
@@ -239,22 +236,14 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                         onBlur={clientSecretOnBlur}
                     />
                 </div>
-
-                {errorMessage && (
-                    <div className="flex rounded-md bg-red-600 p-3">
-                        <img
-                            className="w-4 h-4 mx-2 my-auto filter-brightness-10"
-                            src={exclamation}
-                            alt="exclamation mark"
-                        />
-                        <span className="text-white">{errorMessage}</span>
-                    </div>
-                )}
             </ModalBody>
-            <ModalFooter>
-                <button onClick={activate} disabled={!isValid || savingProvider}>
+            <ModalFooter
+                error={errorMessage}
+                warning={!isNew && savedProvider?.status !== "verified" ? "You need to activate this integration." : ""}
+            >
+                <Button onClick={activate} disabled={!isValid || savingProvider} loading={savingProvider}>
                     Activate Integration
-                </button>
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
@@ -18,6 +18,7 @@ export const GitIntegrations: FunctionComponent = () => {
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
                     <Heading2>Git Integrations</Heading2>
+
                     <Subheading>
                         Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.
                     </Subheading>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
@@ -6,26 +6,11 @@
 
 import { FunctionComponent } from "react";
 import { SpinnerLoader } from "../../components/Loader";
-import { Heading2, Subheading } from "../../components/typography/headings";
 import { useOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
 import { GitIntegrationsList } from "./GitIntegrationsList";
 
 export const GitIntegrations: FunctionComponent = () => {
     const { data, isLoading } = useOrgAuthProvidersQuery();
 
-    return (
-        <div>
-            <div className="flex items-start sm:justify-between mb-2">
-                <div>
-                    <Heading2>Git Integrations</Heading2>
-
-                    <Subheading>
-                        Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.
-                    </Subheading>
-                </div>
-            </div>
-
-            {isLoading ? <SpinnerLoader /> : <GitIntegrationsList providers={data || []} />}
-        </div>
-    );
+    return <div>{isLoading ? <SpinnerLoader /> : <GitIntegrationsList providers={data || []} />}</div>;
 };

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -6,8 +6,9 @@
 
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useState } from "react";
-import { ItemsList } from "../../components/ItemsList";
-import { Heading2 } from "../../components/typography/headings";
+import { Button } from "../../components/Button";
+import { EmptyMessage } from "../../components/EmptyMessage";
+import { Item, ItemField, ItemsList } from "../../components/ItemsList";
 import { GitIntegrationListItem } from "./GitIntegrationListItem";
 import { GitIntegrationModal } from "./GitIntegrationModal";
 
@@ -23,27 +24,24 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
     return (
         <>
             {providers.length === 0 ? (
-                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
-                    <div className="m-auto text-center px-8">
-                        <Heading2 color="light" className="self-center mb-4">
-                            No Git Integrations
-                        </Heading2>
-                        <div className="text-gray-500 mb-6 max-w-md">
-                            In addition to the default Git Providers you can authorize with a self-hosted instance of a
-                            provider.
-                        </div>
-                        <button className="self-center" onClick={onCreate}>
-                            New Integration
-                        </button>
-                    </div>
-                </div>
+                <EmptyMessage
+                    title="No Git Integrations"
+                    subtitle="In addition to the default Git Providers you can authorize with a self-hosted instance of a provider."
+                    buttonText="New Integration"
+                    onClick={onCreate}
+                />
             ) : (
                 <>
                     <div className="mt-3">
-                        <button onClick={onCreate}>New Integration</button>
+                        <Button onClick={onCreate}>New Integration</Button>
                     </div>
 
                     <ItemsList className="pt-6">
+                        <Item header={true}>
+                            <ItemField className="w-1/12"> </ItemField>
+                            <ItemField className="w-5/12">Provider Type</ItemField>
+                            <ItemField className="w-6/12">Host Name</ItemField>
+                        </Item>
                         {providers.map((p) => (
                             <GitIntegrationListItem key={p.id} provider={p} />
                         ))}

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -25,8 +25,8 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
         <>
             {providers.length === 0 ? (
                 <EmptyMessage
-                    title="No Git Integrations"
-                    subtitle="In addition to the default Git Providers you can authorize with a self-hosted instance of a provider."
+                    title="No Git Auth configurations"
+                    subtitle="Configure Git Auth with GitHub or GitLab."
                     buttonText="New Integration"
                     onClick={onCreate}
                 />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some cleanup around the Org Settings pages.

### Updates the Header/Subheader for the Org Settings pages
Each page now updates the main head accordingly

| Settings | SSO | Git Integrations | Billing |
| -- | -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/367275/225173162-68068cc8-5c0f-45e1-9bdf-fe5fb6692c8d.png) | ![image](https://user-images.githubusercontent.com/367275/225173232-894f0e76-8a25-485e-aa63-b593d05ab461.png) | ![image](https://user-images.githubusercontent.com/367275/225173325-b5b84040-4d61-4916-a5eb-0819f06aa0be.png) | ![image](https://user-images.githubusercontent.com/367275/225173461-d671a585-bca7-4a10-8da2-91b15b766541.png) |

### Cleans up displaying errors/warnings in a Modal in the Git Integrations flow
* `<ModalFooter error="error message" warning="warning message" />`
* only 1 shows at a time. `error` takes precedence.
* Pinned above the footer (would like to have it animate/slide up in a future iteration
* Ended up adding an `<Alert type="danger"/>` to get the darker alert style. Open to alternatives here, cc @gtsiolis 

| Warning | Error |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/367275/225172965-709b0c50-2054-4d26-8b5d-d2736d9fae0a.png) | ![image](https://user-images.githubusercontent.com/367275/225173001-96bb7da3-7b74-4818-bc37-c7d8545a8152.png) |



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15995

## How to test
<!-- Provide steps to test this PR -->
* **Preview Env:** https://bmh-git-auth-cleanup.preview.gitpod-dev.com/workspaces
* Create an Org and visit the Settings page for it.
* Ensure each page has an updated Header/Subheading like in the screenshots.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
