### PR TITLE
Revert "Remove workspace_classes_backend feature flag (#16825)"

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -44,6 +44,8 @@ import { getSupportedWorkspaceClasses } from "./cluster-sync-service";
 import { Configuration } from "./config";
 import { GRPCError } from "./rpc";
 import { isWorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { GetWorkspacesRequest, WorkspaceManagerClient } from "@gitpod/ws-manager/lib";
 
 export interface ClusterServiceServerOptions {
     port: number;
@@ -148,8 +150,32 @@ export class ClusterService implements IClusterServiceServer {
                     tls,
                 };
 
-                let classConstraints = await getSupportedWorkspaceClasses(this.clientProvider, newCluster, false);
-                newCluster.admissionConstraints = admissionConstraints.concat(classConstraints);
+                const enabled = await getExperimentsClientForBackend().getValueAsync(
+                    "workspace_classes_backend",
+                    false,
+                    {},
+                );
+                if (enabled) {
+                    let classConstraints = await getSupportedWorkspaceClasses(this.clientProvider, newCluster, false);
+                    newCluster.admissionConstraints = admissionConstraints.concat(classConstraints);
+                } else {
+                    // try to connect to validate the config. Throws an exception if it fails.
+                    await new Promise<void>((resolve, reject) => {
+                        const c = this.clientProvider.createConnection(WorkspaceManagerClient, newCluster);
+                        c.getWorkspaces(new GetWorkspacesRequest(), (err: any) => {
+                            if (err) {
+                                reject(
+                                    new GRPCError(
+                                        grpc.status.FAILED_PRECONDITION,
+                                        `cannot reach ${req.url}: ${err.message}`,
+                                    ),
+                                );
+                            } else {
+                                resolve();
+                            }
+                        });
+                    });
+                }
 
                 await this.clusterDB.save(newCluster);
                 log.info({}, "cluster registered", { cluster: req.name });

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -42,6 +42,11 @@ export class ClusterSyncService {
     }
 
     private async reconcile() {
+        const enabled = await this.featureClient.getValueAsync("workspace_classes_backend", false, {});
+        if (!enabled) {
+            return;
+        }
+
         log.debug("reconciling workspace classes...");
         let allClusters = await this.clusterDB.findFiltered({});
         for (const cluster of allClusters) {


### PR DESCRIPTION
This reverts commit afb724660182fcd480dc2e7fc06c45291b0023ad.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
