### PR TITLE
[common-go] Composable log fields

### DIFF
--- a/components/common-go/log/fields.go
+++ b/components/common-go/log/fields.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package log
+
+import log "github.com/sirupsen/logrus"
+
+const (
+	UserIDField = "userId"
+	// OwnerIDField is the log field name of a workspace owner
+	OwnerIDField = UserIDField
+	// WorkspaceIDField is the log field name of a workspace ID (not instance ID)
+	WorkspaceIDField = "workspaceId"
+	// WorkspaceInstanceIDField is the log field name of a workspace instance ID
+	WorkspaceInstanceIDField = "instanceId"
+	// ProjectIDField is the log field name of the project
+	ProjectIDField = "projectId"
+	// TeamIDField is the log field name of the team
+	TeamIDField = "teamId"
+
+	OrganizationIDField = "orgId"
+
+	ServiceContextField = "serviceContext"
+)
+
+// OWI builds a structure meant for logrus which contains the owner, workspace and instance.
+// Beware that this refers to the terminology outside of wsman which maps like:
+//
+//	owner = owner, workspace = metaID, instance = workspaceID
+func OWI(owner, workspace, instance string) log.Fields {
+	return log.Fields{
+		OwnerIDField:             owner,
+		WorkspaceIDField:         workspace,
+		WorkspaceInstanceIDField: instance,
+	}
+}
+
+// LogContext builds a structure meant for logrus which contains the owner, workspace and instance.
+// Beware that this refers to the terminology outside of wsman which maps like:
+//
+//	owner = owner, workspace = metaID, instance = workspaceID
+func LogContext(ownerID, workspaceID, instanceID, projectID, orgID string) log.Fields {
+	return Compose(
+		WorkspaceOwner(ownerID),
+		WorkspaceID(workspaceID),
+		WorkspaceInstanceID(instanceID),
+		ProjectID(projectID),
+		OrganizationID(orgID),
+	)
+}
+
+func WorkspaceOwner(owner string) log.Fields {
+	return String(OwnerIDField, owner)
+}
+
+func WorkspaceID(workspaceID string) log.Fields {
+	return String(WorkspaceIDField, workspaceID)
+}
+
+func WorkspaceInstanceID(instanceID string) log.Fields {
+	return String(WorkspaceInstanceIDField, instanceID)
+}
+
+func ProjectID(projectID string) log.Fields {
+	return String(ProjectIDField, projectID)
+}
+
+func OrganizationID(orgID string) log.Fields {
+	return Compose(
+		// We continue to log TeamID in place of Organization for compatibility.
+		String(TeamIDField, orgID),
+		String(OrganizationIDField, orgID),
+	)
+
+}
+
+// Compose composes multiple sets of log.Fields into a single
+func Compose(fields ...log.Fields) log.Fields {
+	res := log.Fields{}
+	for _, f := range fields {
+		for key, val := range f {
+			res[key] = val
+		}
+	}
+	return res
+}
+
+// ServiceContext is the shape required for proper error logging in the GCP context.
+// See https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext
+// Note that we musn't set resourceType for reporting errors.
+type serviceContext struct {
+	Service string `json:"service"`
+	Version string `json:"version"`
+}
+
+func ServiceContext(service, version string) log.Fields {
+	return log.Fields{
+		ServiceContextField: serviceContext{service, version},
+	}
+}
+
+func String(key, value string) log.Fields {
+	return log.Fields{key: value}
+}

--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -19,69 +19,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// OwnerField is the log field name of a workspace owner
-	OwnerField = "userId"
-	// WorkspaceField is the log field name of a workspace ID (not instance ID)
-	WorkspaceField = "workspaceId"
-	// InstanceField is the log field name of a workspace instance ID
-	InstanceField = "instanceId"
-	// ProjectField is the log field name of the project
-	ProjectField = "projectId"
-	// TeamField is the log field name of the team
-	TeamField = "teamId"
-)
-
-// OWI builds a structure meant for logrus which contains the owner, workspace and instance.
-// Beware that this refers to the terminology outside of wsman which maps like:
-//
-//	owner = owner, workspace = metaID, instance = workspaceID
-func OWI(owner, workspace, instance string) log.Fields {
-	return log.Fields{
-		OwnerField:     owner,
-		WorkspaceField: workspace,
-		InstanceField:  instance,
-	}
-}
-
-// LogContext builds a structure meant for logrus which contains the owner, workspace and instance.
-// Beware that this refers to the terminology outside of wsman which maps like:
-//
-//	owner = owner, workspace = metaID, instance = workspaceID
-func LogContext(owner, workspace, instance, project, team string) log.Fields {
-	logFields := log.Fields{}
-
-	if owner != "" {
-		logFields[OwnerField] = owner
-	}
-
-	if workspace != "" {
-		logFields[WorkspaceField] = workspace
-	}
-
-	if instance != "" {
-		logFields[InstanceField] = instance
-	}
-
-	if project != "" {
-		logFields[ProjectField] = project
-	}
-
-	if team != "" {
-		logFields[TeamField] = team
-	}
-
-	return logFields
-}
-
-// ServiceContext is the shape required for proper error logging in the GCP context.
-// See https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext
-// Note that we musn't set resourceType for reporting errors.
-type ServiceContext struct {
-	Service string `json:"service"`
-	Version string `json:"version"`
-}
-
 // Log is the application wide console logger
 var Log = log.WithFields(log.Fields{})
 
@@ -111,9 +48,7 @@ func logLevelFromEnv() {
 
 // Init initializes/configures the application-wide logger
 func Init(service, version string, json, verbose bool) {
-	Log = log.WithFields(log.Fields{
-		"serviceContext": ServiceContext{service, version},
-	})
+	Log = log.WithFields(ServiceContext(service, version))
 	log.SetReportCaller(true)
 
 	if json {

--- a/components/common-go/tracing/tracing.go
+++ b/components/common-go/tracing/tracing.go
@@ -100,7 +100,7 @@ func FromContext(ctx context.Context, name string) (opentracing.Span, context.Co
 
 // ApplyOWI sets the owner, workspace and instance tags on a span
 func ApplyOWI(span opentracing.Span, owi logrus.Fields) {
-	for _, k := range []string{log.OwnerField, log.WorkspaceField, log.InstanceField, log.ProjectField, log.TeamField} {
+	for _, k := range []string{log.OwnerIDField, log.WorkspaceIDField, log.WorkspaceInstanceIDField, log.ProjectIDField, log.TeamIDField} {
 		val, ok := owi[k]
 		if !ok {
 			continue


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Adds helper methods to construct structured fields for logs.
* Keeps the existing OWI helper the same, but re-uses the composition
* Adds an alias for Team/Org on log fields

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
