### PR TITLE
[gitpod-cli] change `gp rebuild` to `gp validate`

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -778,8 +778,8 @@ function ImageBuildView(props: ImageBuildViewProps) {
                 <>
                     <div className="mt-6 w-11/12 lg:w-3/5">
                         <p className="text-center text-gray-400 dark:text-gray-500">
-                            💡 You can use the <code>gp rebuild</code> command to rebuild the workspace from the editor
-                            terminal. &nbsp;
+                            💡 You can use the <code>gp validate</code> command to validate the workspace configuration
+                            from the editor terminal. &nbsp;
                             <a
                                 href="https://www.gitpod.io/docs/configure/workspaces/workspace-image#trying-out-changes-to-your-dockerfile"
                                 target="_blank"

--- a/components/gitpod-cli/cmd/ports-await.go
+++ b/components/gitpod-cli/cmd/ports-await.go
@@ -75,7 +75,7 @@ var awaitPortCmdAlias = &cobra.Command{
 	Short:      awaitPortCmd.Short,
 	Long:       awaitPortCmd.Long,
 	Args:       awaitPortCmd.Args,
-	Run:        awaitPortCmd.Run,
+	RunE:       awaitPortCmd.RunE,
 }
 
 func init() {

--- a/components/gitpod-cli/cmd/ports-expose.go
+++ b/components/gitpod-cli/cmd/ports-expose.go
@@ -95,7 +95,7 @@ var portExposeCmdAlias = &cobra.Command{
 	Short:      portExposeCmd.Short,
 	Long:       portExposeCmd.Long,
 	Args:       portExposeCmd.Args,
-	Run:        portExposeCmd.Run,
+	RunE:       portExposeCmd.RunE,
 }
 
 func init() {

--- a/components/supervisor/validate.sh
+++ b/components/supervisor/validate.sh
@@ -27,4 +27,4 @@ sudo rm -rf /.supervisor/frontend && true
 sudo ln -s "$DIR/frontend/dist" /.supervisor/frontend
 echo "$DIR/frontend/dist linked in /.supervisor/frontend"
 
-gp rebuild --workspace-folder="$ROOT_DIR/dev/ide/example/workspace" --gitpod-env "GITPOD_ANALYTICS_SEGMENT_KEY=YErmvd89wPsrCuGcVnF2XAl846W9WIGl" --gitpod-env "GP_OPEN_EDITOR=" --gitpod-env "GP_PREVIEW_BROWSER=" --gitpod-env "GP_EXTERNAL_BROWSER=" "$@"
+gp validate --workspace-folder="$ROOT_DIR/dev/ide/example/workspace" --gitpod-env "GITPOD_ANALYTICS_SEGMENT_KEY=YErmvd89wPsrCuGcVnF2XAl846W9WIGl" --gitpod-env "GP_OPEN_EDITOR=" --gitpod-env "GP_PREVIEW_BROWSER=" --gitpod-env "GP_EXTERNAL_BROWSER=" "$@"

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3915,11 +3915,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3356,11 +3356,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4304,11 +4304,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3566,11 +3566,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3393,11 +3393,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3748,11 +3748,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1290,11 +1290,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2678,11 +2678,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3730,11 +3730,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3739,11 +3739,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3744,11 +3744,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4065,11 +4065,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-3b076b91039c47404d98c4a3198edf2982e24af7",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-09c60f2a32f8f33a583d41b9878741730fb756cb" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-3b076b91039c47404d98c4a3198edf2982e24af7" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[gitpod-cli] change `gp rebuild` to `gp validate`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16389

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in this preview env
2. try `gp rebuild --help` it will only show `--prebuild` and `--log` flag, and a deprecated tips
3. try `gp validate` it should work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gitpod-cli] change `gp rebuild` to `gp validate`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
