### PR TITLE
Update VS Code Browser to `1.76.2`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: eedb6867a25066a77416d154c60d2d73869326c2
-  codeVersion: 1.76.1
+  codeCommit: 2543ade4b0d8226ae4573c64d0efba8c6820e8ca
+  codeVersion: 1.76.2
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.3.2.tar.gz"

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3912,14 +3912,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3915,11 +3915,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3353,14 +3353,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3356,11 +3356,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3729,14 +3729,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4304,11 +4304,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4301,14 +4301,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3566,11 +3566,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3563,14 +3563,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3390,14 +3390,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3393,11 +3393,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3732,14 +3732,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3748,11 +3748,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3745,14 +3745,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1290,11 +1290,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1287,14 +1287,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2678,11 +2678,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2675,14 +2675,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3732,14 +3732,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3729,14 +3729,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3727,14 +3727,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3730,11 +3730,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3739,11 +3739,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3736,14 +3736,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3729,14 +3729,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3732,11 +3732,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3741,14 +3741,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3744,11 +3744,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3732,14 +3732,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4062,14 +4062,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4065,11 +4065,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3732,14 +3732,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3735,11 +3735,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3732,14 +3732,14 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-09c60f2a32f8f33a583d41b9878741730fb756cb",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-37273e54bbbaa4e83882b56a355706b7b903fec9",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,10 +6,10 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-09c60f2a32f8f33a583d41b9878741730fb756cb" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-37273e54bbbaa4e83882b56a355706b7b903fec9" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-37273e54bbbaa4e83882b56a355706b7b903fec9" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-09c60f2a32f8f33a583d41b9878741730fb756cb" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-9bca96df9401ae4a74ab4632548cb3c20136fa4e" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-37273e54bbbaa4e83882b56a355706b7b903fec9" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Update code to https://github.com/microsoft/vscode/releases/tag/1.76.2

A part of https://github.com/gitpod-io/gitpod/issues/16587

## Progress

- [x] Update Insiders  (https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml)
- [x] Update Stable (https://github.com/gitpod-io/gitpod/blob/main/install/installer/pkg/components/workspace/ide/constants.go)

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [ ] settings should not contain any mentions of MS telemetry
  - [ ] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type <kbd>Gitpod</kbd> prefix
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-gce-vm