### PR TITLE
Allow vscode desktop error report

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5206,7 +5206,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9559,7 +9560,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4647,7 +4647,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -8580,7 +8581,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5023,7 +5023,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9376,7 +9377,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5600,7 +5600,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -10175,7 +10176,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: d22764951cee6db56ea9a1426f5107d2e4fd0fff420361529795e55e16f1d999
+        gitpod.io/checksum_config: 52a87b96221d3429888d832fd96677ffa206e9645f4141a671080bec151bfdb3
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4857,7 +4857,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9096,7 +9097,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4684,7 +4684,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -8702,7 +8703,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5026,7 +5026,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9940,7 +9941,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -5039,7 +5039,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9396,7 +9397,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -2581,7 +2581,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -3460,7 +3461,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -3969,7 +3969,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -6580,7 +6581,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5026,7 +5026,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9379,7 +9380,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5023,7 +5023,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9376,7 +9377,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5021,7 +5021,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9386,7 +9387,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5030,7 +5030,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9383,7 +9384,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5023,7 +5023,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9376,7 +9377,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5035,7 +5035,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9388,7 +9389,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5026,7 +5026,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9379,7 +9380,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5356,7 +5356,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9820,7 +9821,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5026,7 +5026,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9367,7 +9368,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5026,7 +5026,8 @@ data:
             "vscode-workbench",
             "vscode-server",
             "vscode-web",
-            "gitpod-cli"
+            "gitpod-cli",
+            "vscode-desktop-extension"
           ]
         }
       },
@@ -9379,7 +9380,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82bbddda1db42c99ce600d77026a61a8bae98a12a8d8c345c7d599a9d1158ea1
+        gitpod.io/checksum_config: ef5919405425791f25bbe4820597a9d9c487e25b132708cdfbf02f9c75c75981
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -374,6 +374,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			"vscode-server",
 			"vscode-web",
 			"gitpod-cli",
+			"vscode-desktop-extension",
 		},
 	}
 


### PR DESCRIPTION
## Description
Allow vscode desktop error report

Related https://github.com/gitpod-io/gitpod-vscode-desktop/pull/39


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
