### PR TITLE
[org] Disallow logins with organizational Git Auth

### DIFF
--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -59,6 +59,7 @@ export class AuthProviderService {
             host: oap.host.toLowerCase(),
             verified: oap.status === "verified",
             builtin: false,
+            disallowLogin: !!oap.organizationId,
             // hiddenOnDashboard: true, // i.e. show only if it's used
             loginContextMatcher: `https://${oap.host}/`,
             oauth: {

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -110,6 +110,15 @@ export class Authenticator {
             res.redirect(this.getSorryUrl(`Bad request: missing parameters.`));
             return;
         }
+        // Logins with organizational Git Auth is not permitted
+        if (authProvider.info.organizationId) {
+            log.info({ sessionId: req.sessionID }, `Login with "${host}" is not permitted.`, {
+                "authorize-flow": true,
+                ap: authProvider.info,
+            });
+            res.redirect(this.getSorryUrl(`Login with "${host}" is not permitted.`));
+            return;
+        }
         if (this.config.disableDynamicAuthProviderLogin && !authProvider.params.builtin) {
             log.info({ sessionId: req.sessionID }, `Auth Provider is not allowed.`, { ap: authProvider.info });
             res.redirect(this.getSorryUrl(`Login with ${authProvider.params.host} is not allowed.`));


### PR DESCRIPTION
## Description
We need to make sure that login with organizational Git Auth is not permitted. Those organizational Git Auth providers are limited to be used for Git operations and API calls only.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16873

## How to test
1. Create an org
2. Create Git Auth for that org (doesn't need to be a valid Git provider, a random but reachable GitLab would work)
3. Try to login by navigating to `/api/login?host=some-gitlab.com`
4. See no redirect attempt to the Git provider happens.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
