### PR TITLE
Update switch to PAYG success page layout

### DIFF
--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -393,10 +393,11 @@ function SwitchToPAYG() {
         }
 
         return (
-            <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full mt-24">
+            <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full mt-24 text-center">
                 <Heading2>You're now on pay-as-you-go! 🎊</Heading2>
                 <Subheading>
                     New subscriptions are limited to 1000 credits ({Currency.getSymbol(currency)}9 / month) by default.
+                    <br />
                     Change your monthly limit on the billing page if you need more.
                 </Subheading>
 


### PR DESCRIPTION
## Description

Minor layout update for the switch to PAYG success page.

See [relevant discussion](https://gitpod.slack.com/archives/C01LDA2B0FJ/p1678965083746239) (internal).

| BEFORE | AFTER |
|-|-|
| <img width="1512" alt="Screenshot 2023-03-16 at 13 29 13" src="https://user-images.githubusercontent.com/120486/225605203-f39b6fd9-bd8a-4dc3-9384-7308ec6f5c66.png"> | <img width="1512" alt="Screenshot 2023-03-16 at 13 37 27" src="https://user-images.githubusercontent.com/120486/225605454-9aac3fda-7f6a-4764-a2f3-80dbded2aa59.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
