### PR TITLE
[server] Fix file provider accept header

### DIFF
--- a/components/server/src/github/file-provider.ts
+++ b/components/server/src/github/file-provider.ts
@@ -60,7 +60,7 @@ export class GithubFileProvider implements FileProvider {
             path,
             ref: commit.revision,
             headers: {
-                accept: "application/vnd.github.VERSION.raw",
+                accept: "application/vnd.github.raw",
             },
         };
 
@@ -70,7 +70,7 @@ export class GithubFileProvider implements FileProvider {
                 if (typeof response.data === "string") {
                     return response.data;
                 }
-                log.warn("GithubFileProvider.getFileContent – unexpected response type.", {
+                log.warn("GithubFileProvider.getFileContent – unexpected response type.", {
                     request: params,
                     response: {
                         headers: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The old accept header is not listed in [Github's media types](https://docs.github.com/en/rest/overview/media-types?apiVersion=2022-11-28), the new one is

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
