### PR TITLE
Org Settings and Modal alert updates

### DIFF
--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -4,11 +4,13 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, ReactNode, useEffect, useMemo } from "react";
+import { FC, ReactNode, useEffect } from "react";
 import cn from "classnames";
 import { getGitpodService } from "../service/service";
 import { Heading2 } from "./typography/headings";
 import Alert, { AlertProps } from "./Alert";
+import "./modal.css";
+import classNames from "classnames";
 
 type CloseModalManner = "esc" | "enter" | "x";
 
@@ -114,7 +116,11 @@ type ModalHeaderProps = {
 };
 
 export const ModalHeader = ({ children }: ModalHeaderProps) => {
-    return <Heading2 className="pb-2">{children}</Heading2>;
+    return (
+        <div className="pb-2">
+            <Heading2>{children}</Heading2>
+        </div>
+    );
 };
 
 type ModalBodyProps = {
@@ -126,7 +132,7 @@ type ModalBodyProps = {
 export const ModalBody = ({ children, hideDivider = false, noScroll = false }: ModalBodyProps) => {
     return (
         <div
-            className={cn("relative border-gray-200 dark:border-gray-800 -mx-6 px-6 pb-14", {
+            className={cn("relative border-gray-200 dark:border-gray-800 -mx-6 px-6 pb-6", {
                 "border-t border-b mt-2 py-4": !hideDivider,
                 "overflow-y-auto": !noScroll,
             })}
@@ -141,26 +147,32 @@ type ModalFooterProps = {
     children: ReactNode;
 };
 export const ModalFooter: FC<ModalFooterProps> = ({ alert, children }) => {
-    // Inlining these to ensure error band covers modal left/right borders
-    const alertStyles = useMemo(() => ({ marginLeft: "-25px", marginRight: "-25px" }), []);
-
     return (
-        <div className="relative">
-            {alert && (
-                <div className="absolute bottom-12 left-0 right-0" style={alertStyles}>
-                    {alert}
-                </div>
-            )}
-            <div className="flex justify-end mt-6 space-x-2">{children}</div>
-        </div>
+        <>
+            {alert}
+            <div
+                className={classNames(
+                    // causes footer to show up on top of alert
+                    "relative",
+                    // make as wide as the modal so it covers the alert
+                    "-mx-6 -mb-6 p-6",
+                    // apply the same bg and rounded corners as the modal
+                    "bg-white dark:bg-gray-900 rounded-b-xl",
+                )}
+            >
+                <div className="flex justify-end space-x-2">{children}</div>
+            </div>
+        </>
     );
 };
 
 // Wrapper around Alert to ensure it's used correctly in a Modal
 export const ModalFooterAlert: FC<AlertProps> = ({ closable = true, children, ...alertProps }) => {
     return (
-        <Alert rounded={false} closable={closable} {...alertProps}>
-            {children}
-        </Alert>
+        <div className="gp-modal-footer-alert gp-modal-footer-alert_animate absolute">
+            <Alert rounded={false} closable={closable} {...alertProps}>
+                {children}
+            </Alert>
+        </div>
     );
 };

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -169,7 +169,12 @@ export const ModalFooter: FC<ModalFooterProps> = ({ alert, children }) => {
 // Wrapper around Alert to ensure it's used correctly in a Modal
 export const ModalFooterAlert: FC<AlertProps> = ({ closable = true, children, ...alertProps }) => {
     return (
-        <div className="gp-modal-footer-alert gp-modal-footer-alert_animate absolute">
+        <div
+            className={classNames({
+                "gp-modal-footer-alert border-b": !closable,
+                "gp-modal-footer-alert_animate absolute": closable,
+            })}
+        >
             <Alert rounded={false} closable={closable} {...alertProps}>
                 {children}
             </Alert>

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -116,11 +116,7 @@ type ModalHeaderProps = {
 };
 
 export const ModalHeader = ({ children }: ModalHeaderProps) => {
-    return (
-        <div className="pb-2">
-            <Heading2>{children}</Heading2>
-        </div>
-    );
+    return <Heading2 className="pb-2">{children}</Heading2>;
 };
 
 type ModalBodyProps = {

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -8,7 +8,7 @@ import { FC, ReactNode, useEffect, useMemo } from "react";
 import cn from "classnames";
 import { getGitpodService } from "../service/service";
 import { Heading2 } from "./typography/headings";
-import Alert from "./Alert";
+import Alert, { AlertProps } from "./Alert";
 
 type CloseModalManner = "esc" | "enter" | "x";
 
@@ -137,21 +137,18 @@ export const ModalBody = ({ children, hideDivider = false, noScroll = false }: M
 };
 
 type ModalFooterProps = {
-    error?: string;
-    warning?: string;
+    alert?: ReactNode;
     children: ReactNode;
 };
-export const ModalFooter: FC<ModalFooterProps> = ({ error, warning, children }) => {
+export const ModalFooter: FC<ModalFooterProps> = ({ alert, children }) => {
     // Inlining these to ensure error band covers modal left/right borders
     const alertStyles = useMemo(() => ({ marginLeft: "-25px", marginRight: "-25px" }), []);
 
-    const hasAlert = error || warning;
-
     return (
         <div className="relative">
-            {hasAlert && (
+            {alert && (
                 <div className="absolute bottom-12 left-0 right-0" style={alertStyles}>
-                    <ModalFooterAlert error={error} warning={warning} />
+                    {alert}
                 </div>
             )}
             <div className="flex justify-end mt-6 space-x-2">{children}</div>
@@ -159,25 +156,11 @@ export const ModalFooter: FC<ModalFooterProps> = ({ error, warning, children }) 
     );
 };
 
-type ModalFooterAlertProps = {
-    error?: string;
-    warning?: string;
-};
-const ModalFooterAlert: FC<ModalFooterAlertProps> = ({ error, warning }) => {
-    if (error) {
-        return (
-            <Alert type="danger" rounded={false}>
-                {error}
-            </Alert>
-        );
-    }
-    if (warning) {
-        return (
-            <Alert type="warning" rounded={false}>
-                {warning}
-            </Alert>
-        );
-    }
-
-    return null;
+// Wrapper around Alert to ensure it's used correctly in a Modal
+export const ModalFooterAlert: FC<AlertProps> = ({ closable = true, children, ...alertProps }) => {
+    return (
+        <Alert rounded={false} closable={closable} {...alertProps}>
+            {children}
+        </Alert>
+    );
 };

--- a/components/dashboard/src/components/modal.css
+++ b/components/dashboard/src/components/modal.css
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+@layer components {
+    .gp-modal-footer-alert {
+        @apply bottom-2;
+        left: -1px;
+        right: -1px;
+        /* Start w/ a fixed height to keep it smaller than the footer */
+        max-height: 70px;
+        overflow: hidden;
+    }
+    .gp-modal-footer-alert_animate {
+        animation: showModalFooterAlert 0.5s ease-out forwards;
+    }
+
+    /* Animates alert from behind footer */
+    @keyframes showModalFooterAlert {
+        0% {
+            @apply bottom-2;
+        }
+
+        /* Swaps max-height and overflow so it's not fixed height anymore */
+        50% {
+            max-height: inherit;
+            overflow: visible;
+        }
+
+        100% {
+            bottom: 85px;
+            max-height: inherit;
+            overflow: visible;
+        }
+    }
+}

--- a/components/dashboard/src/components/modal.css
+++ b/components/dashboard/src/components/modal.css
@@ -6,14 +6,19 @@
 
 @layer components {
     .gp-modal-footer-alert {
+        margin-top: -1px;
+        margin-left: -25px;
+        margin-right: -25px;
+    }
+    .gp-modal-footer-alert_animate {
         @apply bottom-2;
+        margin-left: 0px;
+        margin-right: 0px;
         left: -1px;
         right: -1px;
         /* Start w/ a fixed height to keep it smaller than the footer */
         max-height: 70px;
         overflow: hidden;
-    }
-    .gp-modal-footer-alert_animate {
         animation: showModalFooterAlert 0.5s ease-out forwards;
     }
 

--- a/components/dashboard/src/teams/GitIntegrationsPage.tsx
+++ b/components/dashboard/src/teams/GitIntegrationsPage.tsx
@@ -9,7 +9,7 @@ import { OrgSettingsPage } from "./OrgSettingsPage";
 
 export default function GitAuthPage() {
     return (
-        <OrgSettingsPage title="Git Auth" subtitle="Configure Git Auth for GitLab or Github.">
+        <OrgSettingsPage>
             <GitIntegrations />
         </OrgSettingsPage>
     );

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -14,12 +14,10 @@ import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { getTeamSettingsMenu } from "./TeamSettings";
 
 export interface OrgSettingsPageProps {
-    title: string;
-    subtitle: string;
     children: React.ReactNode;
 }
 
-export function OrgSettingsPage({ title, subtitle, children }: OrgSettingsPageProps) {
+export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
     const org = useCurrentOrg();
     const { oidcServiceEnabled, orgGitAuthProviders } = useFeatureFlags();
 
@@ -33,6 +31,9 @@ export function OrgSettingsPage({ title, subtitle, children }: OrgSettingsPagePr
             }),
         [oidcServiceEnabled, orgGitAuthProviders, org.data],
     );
+
+    const title = "Organization Settings";
+    const subtitle = "Manage your organization's settings.";
 
     // Render as much of the page as we can in a loading state to avoid content shift
     if (org.isLoading) {

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -9,7 +9,7 @@ import { OIDCClients } from "./sso/OIDCClients";
 
 export default function SSO() {
     return (
-        <OrgSettingsPage title="SSO" subtitle="Configure OpenID Connect (OIDC) single sign-on.">
+        <OrgSettingsPage>
             <OIDCClients />
         </OrgSettingsPage>
     );

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -27,7 +27,7 @@ type PendingPlan = Plan & { pendingSince: number };
 
 export default function TeamBillingPage() {
     return (
-        <OrgSettingsPage title={"Organization Billing"} subtitle="Manage billing for your organization.">
+        <OrgSettingsPage>
             <TeamBilling />
         </OrgSettingsPage>
     );

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -109,7 +109,7 @@ export default function TeamSettings() {
 
     return (
         <>
-            <OrgSettingsPage title="Organization Settings" subtitle="Manage your organization's settings.">
+            <OrgSettingsPage>
                 <Heading2>Organization Name</Heading2>
                 <Subheading className="max-w-2xl">
                     This is your organization's visible name within Gitpod. For example, the name of your company.

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -47,7 +47,7 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     return (
         <>
             <Item className="h-16">
-                <ItemFieldIcon className="">
+                <ItemFieldIcon>
                     <div
                         className={
                             "rounded-full w-3 h-3 text-sm align-middle m-auto " +

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -51,7 +51,7 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
                     <div
                         className={
                             "rounded-full w-3 h-3 text-sm align-middle m-auto " +
-                            (provider.status !== "verified" ? "bg-green-500" : "bg-gray-400")
+                            (provider.status === "verified" ? "bg-green-500" : "bg-gray-400")
                         }
                     >
                         &nbsp;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -47,11 +47,11 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     return (
         <>
             <Item className="h-16">
-                <ItemFieldIcon className="w-1/12">
+                <ItemFieldIcon className="">
                     <div
                         className={
                             "rounded-full w-3 h-3 text-sm align-middle m-auto " +
-                            (provider.status === "verified" ? "bg-green-500" : "bg-gray-400")
+                            (provider.status !== "verified" ? "bg-green-500" : "bg-gray-400")
                         }
                     >
                         &nbsp;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -246,7 +246,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                         ) : (
                             !isNew &&
                             savedProvider?.status !== "verified" && (
-                                <ModalFooterAlert type="warning" closable>
+                                <ModalFooterAlert type="warning" closable={false}>
                                     You need to activate this integration.
                                 </ModalFooterAlert>
                             )

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -6,6 +6,7 @@
 
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import Alert from "../../components/Alert";
 import { Button } from "../../components/Button";
 import { InputField } from "../../components/forms/InputField";
 import { SelectInputField } from "../../components/forms/SelectInputField";
@@ -245,7 +246,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                         ) : (
                             !isNew &&
                             savedProvider?.status !== "verified" && (
-                                <ModalFooterAlert type="warning" closable={false}>
+                                <ModalFooterAlert type="warning" closable>
                                     You need to activate this integration.
                                 </ModalFooterAlert>
                             )

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -11,7 +11,7 @@ import { InputField } from "../../components/forms/InputField";
 import { SelectInputField } from "../../components/forms/SelectInputField";
 import { TextInputField } from "../../components/forms/TextInputField";
 import { InputWithCopy } from "../../components/InputWithCopy";
-import Modal, { ModalBody, ModalFooter, ModalHeader } from "../../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
 import { useInvalidateOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
 import { useUpsertOrgAuthProviderMutation } from "../../data/auth-providers/upsert-org-auth-provider-mutation";
 import { useCurrentOrg } from "../../data/organizations/orgs-query";
@@ -238,8 +238,20 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                 </div>
             </ModalBody>
             <ModalFooter
-                error={errorMessage}
-                warning={!isNew && savedProvider?.status !== "verified" ? "You need to activate this integration." : ""}
+                alert={
+                    <>
+                        {errorMessage ? (
+                            <ModalFooterAlert type="danger">{errorMessage}</ModalFooterAlert>
+                        ) : (
+                            !isNew &&
+                            savedProvider?.status !== "verified" && (
+                                <ModalFooterAlert type="warning" closable={false}>
+                                    You need to activate this integration.
+                                </ModalFooterAlert>
+                            )
+                        )}
+                    </>
+                }
             >
                 <Button type="secondary" onClick={props.onClose}>
                     Cancel

--- a/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
@@ -6,7 +6,6 @@
 
 import { FunctionComponent } from "react";
 import { SpinnerLoader } from "../../components/Loader";
-import { Heading2, Subheading } from "../../components/typography/headings";
 import { useOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
 import { GitIntegrationsList } from "./GitIntegrationsList";
 
@@ -17,11 +16,5 @@ export const GitIntegrations: FunctionComponent = () => {
         return <SpinnerLoader />;
     }
 
-    return (
-        <div>
-            <Heading2>Git Auth configurations</Heading2>
-            <Subheading>Configure Git Auth for your organization.</Subheading>
-            <GitIntegrationsList providers={data || []} />
-        </div>
-    );
+    return <GitIntegrationsList providers={data || []} />;
 };

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -9,6 +9,7 @@ import { FunctionComponent, useCallback, useState } from "react";
 import { Button } from "../../components/Button";
 import { EmptyMessage } from "../../components/EmptyMessage";
 import { Item, ItemField, ItemsList } from "../../components/ItemsList";
+import { Heading2, Subheading } from "../../components/typography/headings";
 import { GitIntegrationListItem } from "./GitIntegrationListItem";
 import { GitIntegrationModal } from "./GitIntegrationModal";
 
@@ -23,6 +24,21 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
 
     return (
         <>
+            <div className="flex flex-col space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0">
+                <div>
+                    <Heading2>Git Auth configurations</Heading2>
+                    <Subheading>Configure Git Auth for your organization.</Subheading>
+                </div>
+
+                {providers.length !== 0 ? (
+                    <div className="">
+                        <Button className="whitespace-nowrap" onClick={onCreate}>
+                            New Integration
+                        </Button>
+                    </div>
+                ) : null}
+            </div>
+
             {providers.length === 0 ? (
                 <EmptyMessage
                     title="No Git Auth configurations"
@@ -31,22 +47,16 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
                     onClick={onCreate}
                 />
             ) : (
-                <>
-                    <div className="mt-3">
-                        <Button onClick={onCreate}>New Integration</Button>
-                    </div>
-
-                    <ItemsList className="pt-6">
-                        <Item header={true}>
-                            <ItemField className="w-1/12"> </ItemField>
-                            <ItemField className="w-5/12">Provider Type</ItemField>
-                            <ItemField className="w-6/12">Host Name</ItemField>
-                        </Item>
-                        {providers.map((p) => (
-                            <GitIntegrationListItem key={p.id} provider={p} />
-                        ))}
-                    </ItemsList>
-                </>
+                <ItemsList className="pt-6">
+                    <Item header={true}>
+                        <ItemField className="w-1/12"> </ItemField>
+                        <ItemField className="w-5/12">Provider Type</ItemField>
+                        <ItemField className="w-6/12">Host Name</ItemField>
+                    </Item>
+                    {providers.map((p) => (
+                        <GitIntegrationListItem key={p.id} provider={p} />
+                    ))}
+                </ItemsList>
             )}
             {showCreateModal && <GitIntegrationModal onClose={hideModal} />}
         </>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -8,7 +8,7 @@ import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useState } from "react";
 import { Button } from "../../components/Button";
 import { EmptyMessage } from "../../components/EmptyMessage";
-import { Item, ItemField, ItemsList } from "../../components/ItemsList";
+import { Item, ItemField, ItemFieldIcon, ItemsList } from "../../components/ItemsList";
 import { Heading2, Subheading } from "../../components/typography/headings";
 import { GitIntegrationListItem } from "./GitIntegrationListItem";
 import { GitIntegrationModal } from "./GitIntegrationModal";
@@ -49,7 +49,7 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
             ) : (
                 <ItemsList className="pt-6">
                     <Item header={true}>
-                        <ItemField className="w-1/12"> </ItemField>
+                        <ItemFieldIcon />
                         <ItemField className="w-5/12">Provider Type</ItemField>
                         <ItemField className="w-6/12">Host Name</ItemField>
                     </Item>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -24,7 +24,7 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
 
     return (
         <>
-            <div className="flex flex-col space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0">
+            <div className="flex flex-col space-y-2 md:flex-row md:items-start md:justify-between md:space-y-0">
                 <div>
                     <Heading2>Git Auth configurations</Heading2>
                     <Subheading>Configure Git Auth for your organization.</Subheading>

--- a/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
@@ -11,7 +11,7 @@ import { Button } from "../../components/Button";
 import { InputField } from "../../components/forms/InputField";
 import { TextInputField } from "../../components/forms/TextInputField";
 import { InputWithCopy } from "../../components/InputWithCopy";
-import Modal, { ModalBody, ModalFooter, ModalHeader } from "../../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
 import { useUpsertOIDCClientMutation } from "../../data/oidc-clients/upsert-oidc-client-mutation";
 import { useCurrentOrg } from "../../data/organizations/orgs-query";
 import { useOnBlurError } from "../../hooks/use-onblur-error";
@@ -89,8 +89,6 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
         }
     }, [clientConfig?.id, clientId, clientSecret, isNew, isValid, issuer, onClose, org, upsertClientConfig]);
 
-    const errorMessage = upsertClientConfig.isError ? "There was a problem saving your configuration." : "";
-
     return (
         <Modal
             visible
@@ -136,7 +134,9 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
                     onChange={setClientSecret}
                 />
             </ModalBody>
-            <ModalFooter error={errorMessage}>
+            <ModalFooter
+                alert={upsertClientConfig.isError ? <SaveErrorAlert error={upsertClientConfig.error as Error} /> : null}
+            >
                 <Button type="secondary" onClick={onClose}>
                     Cancel
                 </Button>
@@ -145,5 +145,23 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
                 </Button>
             </ModalFooter>
         </Modal>
+    );
+};
+
+type SaveErrorMessageProps = {
+    error?: Error;
+};
+const SaveErrorAlert: FC<SaveErrorMessageProps> = ({ error }) => {
+    const message = error?.message || "";
+
+    return (
+        <ModalFooterAlert type="danger">
+            <span>There was a problem saving your configuration.</span>
+            {message && (
+                <div>
+                    <span className="text-xs font-mono">{message}</span>
+                </div>
+            )}
+        </ModalFooterAlert>
     );
 };

--- a/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
@@ -157,11 +157,7 @@ const SaveErrorAlert: FC<SaveErrorMessageProps> = ({ error }) => {
     return (
         <ModalFooterAlert type="danger">
             <span>There was a problem saving your configuration.</span>
-            {message && (
-                <div>
-                    <span className="text-xs font-mono">{message}</span>
-                </div>
-            )}
+            {message && <div className="leading-4 text-xs font-mono">{message}</div>}
         </ModalFooterAlert>
     );
 };

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -8,7 +8,7 @@ import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/
 import { FC, useCallback, useMemo, useState } from "react";
 import ConfirmationModal from "../../components/ConfirmationModal";
 import { ContextMenuEntry } from "../../components/ContextMenu";
-import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon } from "../../components/ItemsList";
+import { Item, ItemField, ItemFieldContextMenu } from "../../components/ItemsList";
 import { useDeleteOIDCClientMutation } from "../../data/oidc-clients/delete-oidc-client-mutation";
 import { gitpodHostUrl } from "../../service/service";
 import { OIDCClientConfigModal } from "./OIDCClientConfigModal";
@@ -24,17 +24,17 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
     const menuEntries = useMemo(() => {
         const result: ContextMenuEntry[] = [
             {
+                title: "Edit",
+                onClick: () => setShowEditModal(true),
+                separator: true,
+            },
+            {
                 title: "Login",
                 onClick: () => {
                     window.location.href = gitpodHostUrl
                         .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })
                         .toString();
                 },
-                separator: true,
-            },
-            {
-                title: "Edit",
-                onClick: () => setShowEditModal(true),
                 separator: true,
             },
             {
@@ -57,17 +57,12 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
 
     return (
         <>
-            <Item key={clientConfig.id} className="h-16">
-                <ItemFieldIcon className="w-1/12 flex items-center">
-                    <div className={"rounded-full w-3 h-3 text-sm align-middle m-auto bg-gray-400"}>&nbsp;</div>
-                </ItemFieldIcon>
-                <ItemField className="w-5/12 flex flex-grow items-center">
-                    <span className="text-sm font-medium truncate overflow-ellipsis">{clientConfig.id}</span>
+            <Item key={clientConfig.id}>
+                <ItemField className="flex flex-col flex-grow">
+                    <span className="font-medium truncate overflow-ellipsis">{clientConfig.oidcConfig?.issuer}</span>
+                    <span className="text-sm text-gray-500 truncate overflow-ellipsis">{clientConfig.id}</span>
                 </ItemField>
-                <ItemField className="w-5/12 flex flex-grow items-center">
-                    <span className="text-gray-500 truncate overflow-ellipsis">{clientConfig.oidcConfig?.issuer}</span>
-                </ItemField>
-                <ItemFieldContextMenu className="w-1/12" menuEntries={menuEntries} />
+                <ItemFieldContextMenu menuEntries={menuEntries} />
             </Item>
             {showDeleteConfirmation && (
                 <ConfirmationModal

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -19,11 +19,7 @@ export const OIDCClients: FC = () => {
     const { data, isLoading } = useOIDCClientsQuery();
 
     if (isLoading) {
-        return (
-            <div>
-                <SpinnerLoader />
-            </div>
-        );
+        return <SpinnerLoader />;
     }
 
     return <OIDCClientsList clientConfigs={data || []} />;

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -38,7 +38,7 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
         <>
             {showCreateModal && <OIDCClientConfigModal onClose={hideModal} />}
 
-            <div className="flex flex-col space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0">
+            <div className="flex flex-col space-y-2 md:flex-row md:items-start md:justify-between md:space-y-0">
                 <div>
                     <Heading2>OpenID Connect clients</Heading2>
                     <Subheading>Configure single sign-on for your organization.</Subheading>
@@ -62,12 +62,6 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
                 />
             ) : (
                 <ItemsList className="pt-6">
-                    <Item header={true}>
-                        <ItemField className="flex flex-col">
-                            <span>Issuer URL</span>
-                            <span>ID</span>
-                        </ItemField>
-                    </Item>
                     {clientConfigs.map((cc) => (
                         <OIDCClientListItem key={cc.id} clientConfig={cc} />
                     ))}

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -62,6 +62,11 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
                 />
             ) : (
                 <ItemsList className="pt-6">
+                    <Item header={true}>
+                        <ItemField className="flex flex-col">
+                            <span>Issuer URL</span>
+                        </ItemField>
+                    </Item>
                     {clientConfigs.map((cc) => (
                         <OIDCClientListItem key={cc.id} clientConfig={cc} />
                     ))}

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -42,13 +42,17 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
         <>
             {showCreateModal && <OIDCClientConfigModal onClose={hideModal} />}
 
-            <Heading2>OpenID Connect clients</Heading2>
-            <Subheading>Configure single sign-on for your organization.</Subheading>
+            <div className="flex flex-col space-y-2 md:flex-row md:items-center md:justify-between md:space-y-0">
+                <div>
+                    <Heading2>OpenID Connect clients</Heading2>
+                    <Subheading>Configure single sign-on for your organization.</Subheading>
+                </div>
 
-            <div className="flex items-start sm:justify-between mb-2">
                 {clientConfigs.length !== 0 ? (
-                    <div className="mt-3 flex mt-0">
-                        <Button onClick={onCreate}>New OIDC Client</Button>
+                    <div className="">
+                        <Button className="whitespace-nowrap" onClick={onCreate}>
+                            New OIDC Client
+                        </Button>
                     </div>
                 ) : null}
             </div>
@@ -63,9 +67,10 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
             ) : (
                 <ItemsList className="pt-6">
                     <Item header={true}>
-                        <ItemField className="w-1/12"> </ItemField>
-                        <ItemField className="w-5/12">ID</ItemField>
-                        <ItemField className="w-6/12">Issuer URL</ItemField>
+                        <ItemField className="flex flex-col">
+                            <span>Issuer URL</span>
+                            <span>ID</span>
+                        </ItemField>
                     </Item>
                     {clientConfigs.map((cc) => (
                         <OIDCClientListItem key={cc.id} clientConfig={cc} />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Swap org settings page heading back so it's the same for all pages ([discussed here](https://github.com/gitpod-io/gitpod/pull/16868#discussion_r1138564211))

* Updated SSO & Git Auth page headings for consistency
<img width="775" alt="image" src="https://user-images.githubusercontent.com/367275/226069128-ddc1c151-3614-4ea6-bbfa-264b7d4a6710.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/367275/226069355-578b14b2-fa72-4d44-a253-6faa9b5e8b1f.png">


* SSO client api error message details included in Modal alerts
<img width="543" alt="image" src="https://user-images.githubusercontent.com/367275/226069185-217921b1-9150-4231-a192-d8886fba07d3.png">

SSO clients list items updated so issuer URL is more prominent than ID.
<img width="535" alt="image" src="https://user-images.githubusercontent.com/367275/226069213-fdca2813-1f0b-4ee2-acb3-065d1991f3bd.png">

## Modal Footer Alert improvements
Made some updates so modal alerts can be closeable, and animate in if so. If they're not closeable they render statically between the modal body and footer.

| Non-Closeable | Closeable |
|--------|--------|
| <img width="537" alt="image" src="https://user-images.githubusercontent.com/367275/226069501-f49a6fae-d968-4423-8c02-6f714c381839.png"> | ![Screen Recording 2023-03-17 at 5 33 39 PM](https://user-images.githubusercontent.com/367275/226070423-6dd31de3-0a5b-4144-b9a1-6e0f9b61ec76.gif) (it's much smoother/quicker live) |

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-org-sef32ac21e40.preview.gitpod-dev.com/workspaces
* Create an Org
* Visit Org Settings - verify main heading is Org Settings for each page
* Create an SSO client with something like `test.com` for the issuer url.
* Verify the error alert includes api response details
* Create a Git Auth configuration.
* Verify the Activation warning shows up in the modal if you go back in to edit it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
