### PR TITLE
[gha] fix ide integration tests

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -58,29 +58,43 @@ jobs:
                   SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
                   SLACK_MESSAGE: main branch build failed
-    check:
-        name: Check for regressions
-        needs: [configuration]
-        runs-on: [self-hosted]
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+
+    infrastructure:
+        name: Create preview environment infrastructure
+        needs: [ configuration ]
+        runs-on: [ self-hosted ]
+        concurrency:
+            group: ${{ github.head_ref || github.ref_name }}-infrastructure
         steps:
             - uses: actions/checkout@v3
             - name: Create preview environment infrastructure
+              id: create
               uses: ./.github/actions/preview-create
               with:
                   name: ${{ needs.configuration.outputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   infrastructure_provider: harvester
                   large_vm: true
-                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
             - name: Deploy Gitpod to the preview environment
-              if: github.event.inputs.skip_deploy != 'true'
               id: deploy-gitpod
+              if: github.event.inputs.skip_deploy != 'true'
               uses: ./.github/actions/deploy-gitpod
               with:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
+
+    check:
+        name: Check for regressions
+        needs: [configuration, infrastructure]
+        runs-on: [self-hosted]
+        container:
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
+            volumes:
+              - /var/tmp:/var/tmp
+              - /tmp:/tmp
+        steps:
+            - uses: actions/checkout@v3
             - name: Integration Test
               shell: bash
               env:
@@ -153,9 +167,16 @@ jobs:
                   SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
                   SLACK_MESSAGE: ${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed
-            - name: Delete preview environment
-              if: github.event.inputs.skip_delete != 'true' && (success() || failure())
-              uses: ./.github/actions/delete-preview
-              with:
-                  name: ${{ needs.configuration.outputs.name }}
-                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+
+    delete:
+      name: Delete preview environment
+      needs: [ configuration, infrastructure, check ]
+      if: github.event.inputs.skip_delete != 'true' && always()
+      runs-on: [ self-hosted ]
+      steps:
+        - uses: actions/checkout@v3
+        - name: Delete preview environment
+          uses: ./.github/actions/delete-preview
+          with:
+            name: ${{ needs.configuration.outputs.name }}
+            sa_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Moving from https://github.com/gitpod-io/gitpod/pull/16886 so the other one can get merged.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes 
https://github.com/gitpod-io/gitpod/pull/16888#issuecomment-1473371833

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
