### PR TITLE
[common-go] Support rate limiting by enum key

### DIFF
--- a/components/common-go/grpc/ratelimit.go
+++ b/components/common-go/grpc/ratelimit.go
@@ -6,6 +6,7 @@ package grpc
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -110,12 +111,16 @@ func getFieldValue(msg protoreflect.Message, path []string) (val string, ok bool
 		return getFieldValue(child, path[1:])
 	}
 
-	if field.Kind() != protoreflect.StringKind {
-		// we only support string fields
+	switch field.Kind() {
+	case protoreflect.StringKind:
+		return msg.Get(field).String(), true
+	case protoreflect.EnumKind:
+		enumNum := msg.Get(field).Enum()
+		return strconv.Itoa(int(enumNum)), true
+	default:
+		// we only support string and enum fields
 		return "", false
 	}
-
-	return msg.Get(field).String(), true
 }
 
 // RatelimitingInterceptor limits how often a gRPC function may be called. If the limit has been

--- a/components/common-go/grpc/ratelimit_test.go
+++ b/components/common-go/grpc/ratelimit_test.go
@@ -5,6 +5,7 @@
 package grpc
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/apipb"
 	"google.golang.org/protobuf/types/known/sourcecontextpb"
+	"google.golang.org/protobuf/types/known/typepb"
 )
 
 func TestGetFieldValue(t *testing.T) {
@@ -32,10 +34,22 @@ func TestGetFieldValue(t *testing.T) {
 			Expectation: Expectation{Found: true, Val: "bar"},
 		},
 		{
-			Name:        "empty field",
+			Name:        "empty string field",
 			Message:     &apipb.Api{},
 			Path:        "name",
 			Expectation: Expectation{Found: true},
+		},
+		{
+			Name:        "enum field",
+			Message:     &apipb.Api{Syntax: typepb.Syntax_SYNTAX_PROTO3},
+			Path:        "syntax",
+			Expectation: Expectation{Found: true, Val: strconv.Itoa(int(typepb.Syntax_SYNTAX_PROTO3))},
+		},
+		{
+			Name:        "empty enum field",
+			Message:     &apipb.Api{},
+			Path:        "syntax",
+			Expectation: Expectation{Found: true, Val: "0"},
 		},
 		{
 			Name:        "non-existent field",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Support gRPC rate limiting on keys that are enums

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Allows us to rate limit by workspace type here https://github.com/gitpod-io/ops/issues/6831

## How to test
<!-- Provide steps to test this PR -->
Tested in a preview env, by configuring a rate limit on ws-manager-mk2's `SetTimeout` endpoint, key-ed on the `type` enum field:
```
"/wsman.WorkspaceManager/SetTimeout": {
  "block": true,
  "bucketSize": 1,
  "refillInterval": "30s",
  "key": "type",
  "keyCacheSize": 10
}
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
