### PR TITLE
[ws-manager-mk2] Check empty ns, delete secrets before finalizer

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -228,7 +228,7 @@ type WorkspaceRuntimeStatus struct {
 // Columns with priority > 0 will only show up with `-o wide`.
 //+kubebuilder:printcolumn:name="Workspace",type="string",JSONPath=".spec.ownership.workspaceID",priority=10
 //+kubebuilder:printcolumn:name="Class",type="string",JSONPath=".spec.class"
-//+kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",priority=10
+//+kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 //+kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.runtime.nodeName"
 //+kubebuilder:printcolumn:name="Owner",type="string",JSONPath=".spec.ownership.owner"
 //+kubebuilder:printcolumn:name="Team",type="string",JSONPath=".spec.ownership.team"

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
@@ -31,7 +31,6 @@ spec:
       type: string
     - jsonPath: .spec.type
       name: Type
-      priority: 10
       type: string
     - jsonPath: .status.runtime.nodeName
       name: Node

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -99,6 +99,17 @@ func main() {
 		go pprof.Serve(cfg.PProf.Addr)
 	}
 
+	// Check that namespace config values are set. Empty namespaces default to a cluster-scoped cache,
+	// which the controller doesn't have the right RBAC for.
+	if cfg.Manager.Namespace == "" {
+		setupLog.Error(nil, "namespace cannot be empty")
+		os.Exit(1)
+	}
+	if cfg.Manager.SecretsNamespace == "" {
+		setupLog.Error(nil, "secretsNamespace cannot be empty")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     cfg.Prometheus.Addr,


### PR DESCRIPTION
## Description

Small fixes/improvements:
* Show workspace type by default in `kubectl get ws`
* Only remove finalizer once secrets deletion succeeded
* Check for empty namespaces in config on startup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
