### PR TITLE
[preview] diff-apply server side force conflicts

### DIFF
--- a/dev/preview/workflow/lib/k8s-util.sh
+++ b/dev/preview/workflow/lib/k8s-util.sh
@@ -96,6 +96,6 @@ function diff-apply {
   if kubectl --context "${context}" diff -f "${yaml}" > /dev/null; then
     echo "Skipping ${yaml}, as it produced no diff"
   else
-    kubectl --context "${context}" apply --server-side -f "${yaml}"
+    kubectl --context "${context}" apply --server-side --force-conflicts -f "${yaml}"
   fi
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes 
```bash
Apply failed with 4 conflicts: conflicts with "kubectl-client-side-apply" using apps/v1:
- .spec.template.spec.containers[name="agent-smith"].env
- .spec.template.spec.containers[name="agent-smith"].env[name="KUBE_NAMESPACE"].valueFrom.fieldRef
- .spec.template.spec.containers[name="agent-smith"].env[name="NODENAME"].valueFrom.fieldRef
- .spec.template.spec.containers[name="kube-rbac-proxy"].env[name="IP"].valueFrom.fieldRef
```

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
