### PR TITLE
[ws-manager-mk2] Don't dispose image builds

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -221,6 +221,11 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		return ctrl.Result{}, nil
 	}
 
+	if ws.Spec.Type == workspacev1.WorkspaceTypeImageBuild {
+		// No disposal for image builds.
+		return ctrl.Result{}, nil
+	}
+
 	disposeStart := time.Now()
 	var snapshotName string
 	var snapshotUrl string

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -192,7 +192,9 @@ func isDisposalFinished(ws *workspacev1.Workspace) bool {
 		wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)) ||
 		wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionAborted)) ||
 		// Nothing to dispose if content wasn't ready.
-		!wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady))
+		!wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)) ||
+		// Image builds have nothing to dispose.
+		ws.Spec.Type == workspacev1.WorkspaceTypeImageBuild
 }
 
 // extractFailure returns a pod failure reason and possibly a phase. If phase is nil then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Don't dispose image builds

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test
<!-- Provide steps to test this PR -->

Create an image build, and observe it doesn't run disposal once completed, and the image build workspace goes to stopping and then disappears from the cluster. Tested in workspace-preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
