### PR TITLE
[ws-manager-mk2] Emit events for workspaces and snapshots

### DIFF
--- a/components/ws-daemon/pkg/controller/snapshot_controller.go
+++ b/components/ws-daemon/pkg/controller/snapshot_controller.go
@@ -110,6 +110,10 @@ func (ssc *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	snapshotErr = ssc.operations.TakeSnapshot(ctx, snapshot.Spec.WorkspaceID, snapshotName)
+	if snapshotErr != nil {
+		log.Error(snapshotErr, "could not take snapshot", "workspace", snapshot.Spec.WorkspaceID)
+	}
+
 	err = retry.RetryOnConflict(retryParams, func() error {
 		err := ssc.Client.Get(ctx, req.NamespacedName, &snapshot)
 		if err != nil {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -210,7 +210,7 @@ func NewDaemon(config Config) (*Daemon, error) {
 		}
 
 		wsctrl, err := controller.NewWorkspaceController(
-			mgr.GetClient(), nodename, config.Runtime.SecretsNamespace, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps, wrappedReg)
+			mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), nodename, config.Runtime.SecretsNamespace, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps, wrappedReg)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +219,8 @@ func NewDaemon(config Config) (*Daemon, error) {
 			return nil, err
 		}
 
-		ssctrl := controller.NewSnapshotController(mgr.GetClient(), nodename, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps)
+		ssctrl := controller.NewSnapshotController(
+			mgr.GetClient(), mgr.GetEventRecorderFor("snapshot"), nodename, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps)
 		err = ssctrl.SetupWithManager(mgr)
 		if err != nil {
 			return nil, err

--- a/components/ws-manager-api/go/crd/v1/snapshot_types.go
+++ b/components/ws-manager-api/go/crd/v1/snapshot_types.go
@@ -30,7 +30,7 @@ type SnapshotStatus struct {
 	// +kubebuilder:validation:Optional
 	URL string `json:"url,omitempty"`
 
-	// Completed indicates if the snapshot operation has completed either by taking the snapshot or through failure
+	// Completed indicates if the snapshot operation has completed either by taking the snapshot or due to failure
 	// +kubebuilder:validation:Required
 	Completed bool `json:"completed"`
 }

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_snapshots.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_snapshots.yaml
@@ -65,7 +65,7 @@ spec:
             properties:
               completed:
                 description: Completed indicates if the snapshot operation has completed
-                  either by taking the snapshot or through failure
+                  either by taking the snapshot or due to failure
                 type: boolean
               error:
                 description: Erorr is the error observed during snapshot creation

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -31,7 +31,7 @@ const (
 	containerUnknownExitCode = 255
 )
 
-func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace, pods corev1.PodList, cfg *config.Configuration) error {
+func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace, pods corev1.PodList, cfg *config.Configuration) error {
 	log := log.FromContext(ctx)
 
 	switch len(pods.Items) {
@@ -104,6 +104,8 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 			LastTransitionTime: metav1.Now(),
 			Message:            failure,
 		})
+
+		r.Recorder.Event(workspace, corev1.EventTypeWarning, "Failed", failure)
 	}
 
 	switch {

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	conf := newTestConfig()
-	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), &conf, metrics.Registry, &fakeMaintenance{enabled: false})
+	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("workspace"), &conf, metrics.Registry, &fakeMaintenance{enabled: false})
 	wsMetrics = wsReconciler.metrics
 	Expect(err).ToNot(HaveOccurred())
 	Expect(wsReconciler.SetupWithManager(k8sManager)).To(Succeed())

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -117,7 +117,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	oldStatus := workspace.Status
+	oldStatus := workspace.Status.DeepCopy()
 	err = r.updateWorkspaceStatus(ctx, &workspace, workspacePods, r.Config)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -348,7 +348,7 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 	r.metrics.rememberWorkspace(workspace, &lastState)
 }
 
-func (r *WorkspaceReconciler) emitPhaseEvents(ctx context.Context, ws *workspacev1.Workspace, old workspacev1.WorkspaceStatus) {
+func (r *WorkspaceReconciler) emitPhaseEvents(ctx context.Context, ws *workspacev1.Workspace, old *workspacev1.WorkspaceStatus) {
 	if ws.Status.Phase == workspacev1.WorkspacePhaseInitializing && old.Phase != workspacev1.WorkspacePhaseInitializing {
 		r.Recorder.Event(ws, corev1.EventTypeNormal, "Initializing", "")
 	}

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -6261,6 +6261,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -5572,6 +5572,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -6078,6 +6078,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -6715,6 +6715,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5839,6 +5839,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -5589,6 +5589,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -6081,6 +6081,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -6094,6 +6094,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -2317,6 +2317,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -6081,6 +6081,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -6078,6 +6078,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -6076,6 +6076,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -6085,6 +6085,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -6078,6 +6078,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -6090,6 +6090,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -6081,6 +6081,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -6494,6 +6494,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -6081,6 +6081,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -6081,6 +6081,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole node-labeler
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/pkg/components/ws-daemon/clusterrole.go
+++ b/install/installer/pkg/components/ws-daemon/clusterrole.go
@@ -93,6 +93,14 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 						"update",
 					},
 				},
+				rbacv1.PolicyRule{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"patch",
+					},
+				},
 			),
 		},
 	}, nil


### PR DESCRIPTION
## Description
Emit events for workspaces and snapshots. Depends on https://github.com/gitpod-io/gitpod/pull/16896

```
kubectl get events | rg workspace/
108s        Normal    Creating            workspace/064b1210-53d1-42df-9ac5-a00dbc60a22f                      
107s        Normal    Initializing        workspace/064b1210-53d1-42df-9ac5-a00dbc60a22f                      
104s        Normal    Running             workspace/064b1210-53d1-42df-9ac5-a00dbc60a22f                      
0s          Normal    Stopping            workspace/064b1210-53d1-42df-9ac5-a00dbc60a22f                      
0s          Normal    Deleting            workspace/064b1210-53d1-42df-9ac5-a00dbc60a22f
```

```
20m         Warning   Failed         workspace/32739418-0e1e-43a0-ba82-090050686b64    Content init failed: cannot initialize workspace: no backup found
10m         Warning   Failed         workspace/2921aee7-726a-48dd-a826-6372d3446a15    Backup failed: BOOM
```

`
## Related Issue(s)
n.a.

## How to test
Using https://g8a099d879e.workspace-preview.gitpod-io-dev.com/workspaces
- `kubectl get events`
- Start workspace
- Take snapshot
- Stop workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
