### PR TITLE
Improve node-labeler 

### DIFF
--- a/components/node-labeler/cmd/run.go
+++ b/components/node-labeler/cmd/run.go
@@ -6,8 +6,10 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -164,7 +166,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		component     string
 		labelToUpdate string
 
-		waitTimeout time.Duration = 1 * time.Second
+		waitTimeout time.Duration = 5 * time.Second
 	)
 
 	switch {
@@ -173,8 +175,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		labelToUpdate = fmt.Sprintf(registryFacadeLabel, namespace)
 		ipAddress = pod.Status.HostIP
 		port = strconv.Itoa(registryFacadePort)
-		// wait for kube-proxy sync to avoid connection refused due to missing nodeport rules
-		waitTimeout = 15 * time.Second
 	case strings.HasPrefix(pod.Name, wsDaemon):
 		component = wsDaemon
 		labelToUpdate = fmt.Sprintf(wsdaemonLabel, namespace)
@@ -206,14 +206,13 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	if !IsPodReady(&pod) {
 		// not ready. Wait until the next update.
-		log.WithField("pod", pod.Name).Info("pod is not yet ready")
 		return reconcile.Result{}, nil
 	}
 
 	var node corev1.Node
 	err = r.Get(ctx, types.NamespacedName{Name: nodeName}, &node)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		return reconcile.Result{}, fmt.Errorf("obtaining node %s: %w", nodeName, err)
 	}
 
 	if node.Labels[labelToUpdate] == "true" {
@@ -223,7 +222,14 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	err = waitForTCPPortToBeReachable(ipAddress, port, 30*time.Second)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("Unexpected error waiting for probe URL: %v", err)
+		return reconcile.Result{}, fmt.Errorf("waiting for TCP port: %v", err)
+	}
+
+	if component == registryFacade {
+		err = waitForRegistryFacade(ipAddress, port, 30*time.Second)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("waiting for registry-facade: %v", err)
+		}
 	}
 
 	time.Sleep(waitTimeout)
@@ -297,5 +303,64 @@ func waitForTCPPortToBeReachable(host string, port string, timeout time.Duration
 
 			continue
 		}
+	}
+}
+
+func waitForRegistryFacade(host, port string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	transport := newDefaultTransport()
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	dummyURL := fmt.Sprintf("https://%v:%v/v2/remote/not-a-valid-image/manifests/latest", host, port)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("port %v on host %v never reachable", port, host)
+		case <-ticker.C:
+			req, err := http.NewRequest(http.MethodGet, dummyURL, nil)
+			if err != nil {
+				log.WithError(err).Error("unexpected error building HTTP request")
+				continue
+			}
+
+			req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json")
+			resp, err := client.Do(req)
+			if err != nil {
+				log.WithError(err).Error("unexpected error during HTTP request")
+				continue
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode == http.StatusNotFound {
+				return nil
+			}
+		}
+	}
+}
+
+func newDefaultTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   1 * time.Second,
+			KeepAlive: 1 * time.Second,
+			DualStack: false,
+		}).DialContext,
+		MaxIdleConns:          0,
+		MaxIdleConnsPerHost:   1,
+		IdleConnTimeout:       5 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
+		DisableKeepAlives:     true,
 	}
 }


### PR DESCRIPTION
## Description

Ensure registry-facade can reach `ws-manager` by trying to get details from a workspace.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
NONE
```

## Build Options:

- [x] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
