### PR TITLE
[jb] bump up major platform version of backend plugin

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=223.8836
-pluginUntilBuild=223.*
+pluginSinceBuild=231.8109
+pluginUntilBuild=231.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2022.3
+pluginVerifierIdeVersions=2023.1
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=223.8836-EAP-CANDIDATE-SNAPSHOT
+platformVersion=231.8109-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodMetricControlProvider.kt
@@ -5,15 +5,16 @@
 package io.gitpod.jetbrains.remote
 
 import com.jetbrains.ide.model.uiautomation.BeControl
+import com.jetbrains.ide.model.uiautomation.DefiniteProgress
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
 import com.jetbrains.rd.ui.bedsl.dsl.*
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rdserver.diagnostics.BackendDiagnosticsService
 import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.MetricControlProvider
 import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressBar
-import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
 
-class GitpodMetricControlProvider : MetricControlProvider {
+abstract class AbstractGitpodMetricControlProvider : MetricControlProvider {
     override val id: String = "gitpodMetricsControl"
     override fun getControl(lifetime: Lifetime): BeControl {
         val backendDiagnosticsService = BackendDiagnosticsService.Companion.getInstance()
@@ -92,7 +93,7 @@ class GitpodMetricControlProvider : MetricControlProvider {
         cpuTotal.valueProperty.change.advise(lifetime) {
             updateLabel()
         }
-        createProgressRow(ctx, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+        createProgressControl(ctx, lifetime, label, cpuPercentage, labelProperty, cpuPercentageProperty, progressBar)
     }
 
     private fun createMemoryControl(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
@@ -115,6 +116,8 @@ class GitpodMetricControlProvider : MetricControlProvider {
             updateLabel()
         }
 
-        createProgressRow(ctx, lifetime, label, memoryPercentage.statusProperty, labelProperty, memoryPercentageProperty, progressBar)
+        createProgressControl(ctx, lifetime, label, memoryPercentage, labelProperty, memoryPercentageProperty, progressBar)
     }
+
+    protected abstract fun createProgressControl(ctx: VerticalGridBuilder, lifetime: Lifetime, label: String, cpuPercentage: Metric, labelProperty: Property<String>, cpuPercentageProperty: Property<String>, progressBar: DefiniteProgress)
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodIgnoredPortsForNotificationServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodIgnoredPortsForNotificationServiceImpl.kt
@@ -2,22 +2,20 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote.internal
+package io.gitpod.jetbrains.remote.latest
 
-import com.intellij.idea.getServerFutureAsync
 import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.jetbrains.ide.BuiltInServerManager
 
 @Suppress("OPT_IN_USAGE")
-class GitpodIgnoredPortsForNotificationServiceImpl : GitpodIgnoredPortsForNotificationService {
+class LatestGitpodIgnoredPortsForNotificationServiceImpl : GitpodIgnoredPortsForNotificationService {
     private val ignoredPortsForNotification = mutableSetOf(5990)
 
     init {
         GlobalScope.launch {
             BuiltInServerManager.getInstance().waitForStart().port.let { ignorePort(it) }
-            getServerFutureAsync().await()?.port?.let { ignorePort(it) }
         }
     }
 

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodMetricControlProvider.kt
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.jetbrains.ide.model.uiautomation.DefiniteProgress
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
+import com.jetbrains.rd.ui.bedsl.dsl.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
+import io.gitpod.jetbrains.remote.AbstractGitpodMetricControlProvider
+
+class LatestGitpodMetricControlProvider: AbstractGitpodMetricControlProvider() {
+
+    override fun createProgressControl(ctx: VerticalGridBuilder, lifetime: Lifetime, label: String, cpuPercentage: Metric, labelProperty: Property<String>, cpuPercentageProperty: Property<String>, progressBar: DefiniteProgress) {
+        createProgressRow(ctx, id, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+    }
+
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/LatestGitpodTerminalService.kt
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rdserver.terminal.BackendTerminalManager
+import io.gitpod.jetbrains.remote.AbstractGitpodTerminalService
+import org.jetbrains.plugins.terminal.ShellTerminalWidget
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class LatestGitpodTerminalService(project: Project): AbstractGitpodTerminalService(project) {
+
+    private val terminalToolWindowManager = TerminalToolWindowManager.getInstance(project)
+    private val backendTerminalManager = BackendTerminalManager.getInstance(project)
+
+    override fun createSharedTerminal(title: String): ShellTerminalWidget {
+        val shellTerminalWidget = terminalToolWindowManager.createLocalShellWidget(null, title, true, false)
+        backendTerminalManager.shareTerminal(shellTerminalWidget.asNewWidget(), UUID.randomUUID().toString())
+        return shellTerminalWidget
+    }
+
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodIgnoredPortsForNotificationServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodIgnoredPortsForNotificationServiceImpl.kt
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.idea.getServerFutureAsync
+import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.jetbrains.ide.BuiltInServerManager
+
+@Suppress("OPT_IN_USAGE")
+class StableGitpodIgnoredPortsForNotificationServiceImpl : GitpodIgnoredPortsForNotificationService {
+    private val ignoredPortsForNotification = mutableSetOf(5990)
+
+    init {
+        GlobalScope.launch {
+            BuiltInServerManager.getInstance().waitForStart().port.let { ignorePort(it) }
+            getServerFutureAsync().await()?.port?.let { ignorePort(it) }
+        }
+    }
+
+    override fun ignorePort(portNumber: Int) {
+        ignoredPortsForNotification.add(portNumber)
+    }
+
+    override fun getIgnoredPorts(): Set<Int> {
+        return ignoredPortsForNotification.toSet()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodMetricControlProvider.kt
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.jetbrains.ide.model.uiautomation.DefiniteProgress
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
+import com.jetbrains.rd.ui.bedsl.dsl.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
+import io.gitpod.jetbrains.remote.AbstractGitpodMetricControlProvider
+
+class StableGitpodMetricControlProvider: AbstractGitpodMetricControlProvider() {
+
+    override fun createProgressControl(ctx: VerticalGridBuilder, lifetime: Lifetime, label: String, cpuPercentage: Metric, labelProperty: Property<String>, cpuPercentageProperty: Property<String>, progressBar: DefiniteProgress) {
+        createProgressRow(ctx, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/StableGitpodTerminalService.kt
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rdserver.terminal.BackendTerminalManager
+import io.gitpod.jetbrains.remote.AbstractGitpodTerminalService
+import org.jetbrains.plugins.terminal.ShellTerminalWidget
+import org.jetbrains.plugins.terminal.TerminalView
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class StableGitpodTerminalService(project: Project): AbstractGitpodTerminalService(project) {
+
+    private val terminalView = TerminalView.getInstance(project)
+    private val backendTerminalManager = BackendTerminalManager.getInstance(project)
+
+    override fun createSharedTerminal(title: String): ShellTerminalWidget {
+        val shellTerminalWidget = terminalView.createLocalShellWidget(null, title, true, false)
+        backendTerminalManager.shareTerminal(shellTerminalWidget, UUID.randomUUID().toString())
+        return shellTerminalWidget
+    }
+
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -6,5 +6,14 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
+                                           implementation="io.gitpod.jetbrains.remote.latest.LatestGitpodMetricControlProvider"/>
+
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.LatestGitpodTerminalService" client="controller"
+                        preload="true"/>
+
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.latest.LatestGitpodIgnoredPortsForNotificationServiceImpl"
+                            preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -6,5 +6,14 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
+                                           implementation="io.gitpod.jetbrains.remote.stable.StableGitpodMetricControlProvider"/>
+
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.StableGitpodTerminalService" client="controller"
+                        preload="true"/>
+
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.stable.StableGitpodIgnoredPortsForNotificationServiceImpl"
+                            preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -26,9 +26,6 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService"
                             preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
-        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
-                            serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodIgnoredPortsForNotificationServiceImpl"
-                            preload="true"/>
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
                             serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodPortForwardingServiceImpl"
                             client="controller" preload="true"/>
@@ -39,13 +36,9 @@
 
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker"
                         client="controller" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" client="controller"
-                        preload="true"/>
 
         <gateway.customization.name
                 implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
-        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
-                                           implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
         <gateway.customization.metrics id="gitpodMetricsProvider"
                                        implementation="io.gitpod.jetbrains.remote.GitpodMetricProvider"/>
 

--- a/components/supervisor-api/java/build.gradle
+++ b/components/supervisor-api/java/build.gradle
@@ -12,15 +12,13 @@ repositories {
 group 'io.gitpod.api'
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-java:3.19.1'
-    implementation 'com.google.protobuf:protobuf-java-util:3.19.1'
-    implementation 'com.google.api.grpc:proto-google-common-protos:2.2.2'
-    implementation 'io.grpc:grpc-core:1.49.0'
-    implementation 'io.grpc:grpc-protobuf:1.49.0'
-    implementation 'io.grpc:grpc-stub:1.49.0'
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
-
-    runtimeOnly 'io.grpc:grpc-netty-shaded:1.41.0'
+    compileOnly 'com.google.protobuf:protobuf-java:3.19.1'
+    compileOnly 'com.google.protobuf:protobuf-java-util:3.19.1'
+    compileOnly 'com.google.api.grpc:proto-google-common-protos:2.2.2'
+    compileOnly 'io.grpc:grpc-core:1.49.0'
+    compileOnly 'io.grpc:grpc-protobuf:1.49.0'
+    compileOnly 'io.grpc:grpc-stub:1.49.0'
+    compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
 }
 
 application {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Update the major version of the backend plugin to unblock auto upgrade of latest images.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- [x] Test stable version in the preview env: 
  - you should see custom metrics in the backend control center, i.e. workspace CPU
  - configured tasks should be attached
  - there should not be notifications about internal IDE ports
- [x] It is not possible to test latest, since images are out dated.
  - Start a Gitpod workspace for this PR with IntelliJ.
  - Run `./launch-dev-server.sh u` from `components/ide/jetbrains/backend-plugin/`
  - Copy Gitpod link from output and open in Browser.
  - Do tests similar for stable.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
