### PR TITLE
[preview] Fix deploy of resources in multiple ns

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -590,7 +590,7 @@ export -f diff-apply
 mkdir temp-installer || true
 pushd temp-installer
 # this will split the big yaml produced by the installer, so we can diff individual parts of it and run them in parallel
-yq4 -s '.kind + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
+yq4 -s '.kind + "_" + .metadata.namespace + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
 rm .yml || true # this one is a leftover from the split
 # shellcheck disable=SC2038
 find . | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -590,7 +590,7 @@ export -f diff-apply
 mkdir temp-installer || true
 pushd temp-installer
 # this will split the big yaml produced by the installer, so we can diff individual parts of it and run them in parallel
-yq4 -s '.kind + "_" + .metadata.namespace + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
+yq4 -s '.kind + "_" + (.metadata.namespace // "") + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
 rm .yml || true # this one is a leftover from the split
 # shellcheck disable=SC2038
 find . | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"


### PR DESCRIPTION
## Description
Fixes resources that exist in multiple namespaces under the same name (e.g. `ws-manager-mk2`'s role) only getting deployed in one namespace

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Create preview env

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
