### PR TITLE
[ws-manager-mk2] Refactor maintenance mode to end at a timestamp

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	ozzo "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
@@ -573,5 +574,5 @@ type CpuResourceLimit struct {
 }
 
 type MaintenanceConfig struct {
-	Enabled bool `json:"enabled"`
+	EnabledUntil *time.Time `json:"enabledUntil,omitempty"`
 }

--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -574,5 +574,5 @@ type CpuResourceLimit struct {
 }
 
 type MaintenanceConfig struct {
-	EnabledUntil *time.Time `json:"enabledUntil,omitempty"`
+	EnabledUntil *time.Time `json:"enabledUntil"`
 }

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -79,7 +79,6 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	var cfg config.MaintenanceConfig
 	if err := json.Unmarshal([]byte(configJson), &cfg); err != nil {
-		// TODO: Default to enabled? Invalid timestamp is likely meant to have maintenance mode enabled.
 		log.Error(err, "failed to unmarshal maintenance config, setting maintenance mode as disabled")
 		r.setEnabledUntil(log, nil)
 		return ctrl.Result{}, nil

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -96,7 +96,7 @@ func (r *MaintenanceReconciler) setEnabledUntil(log logr.Logger, enabledUntil *t
 	}
 
 	r.enabledUntil = enabledUntil
-	log.Info("maintenance mode state change", "enabledUntil", enabledUntil)
+	log.Info("maintenance mode state change", "enabled", r.IsEnabled(), "enabledUntil", enabledUntil)
 }
 
 func (r *MaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
 	"github.com/go-logr/logr"
@@ -22,26 +23,30 @@ const (
 	configMapName    = "ws-manager-mk2-maintenance-mode"
 )
 
+var (
+	indefinite = time.Now().Add(999999 * time.Hour)
+)
+
 func NewMaintenanceReconciler(c client.Client) (*MaintenanceReconciler, error) {
 	return &MaintenanceReconciler{
 		Client: c,
-		// Enable by default, until we observe the ConfigMap with the actual value.
+		// Enable maintenance by default, until we observe the ConfigMap with the actual value.
 		// Prevents a race on startup where the workspace reconciler might run before
 		// we observe the maintenance mode ConfigMap. Better be safe and prevent
 		// reconciliation of that workspace until it's certain maintenance mode is
 		// not enabled.
-		enabled: true,
+		enabledUntil: &indefinite,
 	}, nil
 }
 
 type MaintenanceReconciler struct {
 	client.Client
 
-	enabled bool
+	enabledUntil *time.Time
 }
 
 func (r *MaintenanceReconciler) IsEnabled() bool {
-	return r.enabled
+	return r.enabledUntil != nil && time.Now().Before(*r.enabledUntil)
 }
 
 //+kubebuilder:rbac:groups=core,resources=configmap,verbs=get;list;watch
@@ -57,7 +62,7 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := r.Get(ctx, req.NamespacedName, &cm); err != nil {
 		if errors.IsNotFound(err) {
 			// ConfigMap does not exist, disable maintenance mode.
-			r.setEnabled(log, false)
+			r.setEnabledUntil(log, nil)
 			return ctrl.Result{}, nil
 		}
 
@@ -68,29 +73,30 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	configJson, ok := cm.Data["config.json"]
 	if !ok {
 		log.Info("missing config.json, setting maintenance mode as disabled")
-		r.setEnabled(log, false)
+		r.setEnabledUntil(log, nil)
 		return ctrl.Result{}, nil
 	}
 
 	var cfg config.MaintenanceConfig
 	if err := json.Unmarshal([]byte(configJson), &cfg); err != nil {
+		// TODO: Default to enabled? Invalid timestamp is likely meant to have maintenance mode enabled.
 		log.Error(err, "failed to unmarshal maintenance config, setting maintenance mode as disabled")
-		r.setEnabled(log, false)
+		r.setEnabledUntil(log, nil)
 		return ctrl.Result{}, nil
 	}
 
-	r.setEnabled(log, cfg.Enabled)
+	r.setEnabledUntil(log, cfg.EnabledUntil)
 	return ctrl.Result{}, nil
 }
 
-func (r *MaintenanceReconciler) setEnabled(log logr.Logger, enabled bool) {
-	if enabled == r.enabled {
+func (r *MaintenanceReconciler) setEnabledUntil(log logr.Logger, enabledUntil *time.Time) {
+	if enabledUntil == r.enabledUntil {
 		// Nothing to do.
 		return
 	}
 
-	r.enabled = enabled
-	log.Info("maintenance mode state change", "enabled", enabled)
+	r.enabledUntil = enabledUntil
+	log.Info("maintenance mode state change", "enabledUntil", enabledUntil)
 }
 
 func (r *MaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -283,7 +283,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	maintenanceLabels := common.DefaultLabels(Component)
 	maintenanceLabels[LabelMaintenanceConfig] = "true"
 	maintenanceCfg := config.MaintenanceConfig{
-		Enabled: false,
+		EnabledUntil: nil,
 	}
 	mc, err := common.ToJSONString(maintenanceCfg)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Refactor maintenance mode from a boolean `Enabled` to a time `EnabledUntil`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/11416

## How to test
<!-- Provide steps to test this PR -->

Edit `EnabledUntil` in `ws-manager-mk2-maintenance-config` to a future timestamp, observe maintenance mode gets enabled in the logs. Edit to a past timestamp (and/or null) and observe maintenance mode gets disabled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
