### PR TITLE
check for repository property on context

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -66,12 +66,20 @@ export function CreateWorkspacePage() {
     );
     const workspaceContext = useWorkspaceContext(contextURL);
     const isLoading = workspaceContext.isLoading || projects.isLoading;
+
+    // see if we have a matching project based on context url and project's repo url
     const project = useMemo(() => {
         if (!workspaceContext.data || !projects.data) {
             return undefined;
         }
-        const cloneUrl = (workspaceContext.data as CommitContext).repository.cloneUrl;
-        return projects.data.projects.find((p) => p.cloneUrl === cloneUrl);
+        if ("repository" in workspaceContext.data) {
+            const cloneUrl = (workspaceContext.data as CommitContext)?.repository?.cloneUrl;
+            if (!cloneUrl) {
+                return;
+            }
+
+            return projects.data.projects.find((p) => p.cloneUrl === cloneUrl);
+        }
     }, [projects.data, workspaceContext.data]);
 
     useEffect(() => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a bug when using a snapshot context url with the new create workspace page. Needed to make the logic that checks for a matching project a bit more resilient to missing properties on the workspace context object.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16926

## How to test
<!-- Provide steps to test this PR -->
* Create a Workspace
* Create a Snapshot from your workspace
* Load the Snapshot URL and ensure it doesn't render an error page like in the issue.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
