### PR TITLE
[server] Block org-level users from creating/joining new organizations

### DIFF
--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -557,4 +557,13 @@ export class UserService {
 
         throw EmailAddressAlreadyTakenException.create(`Email address is already in use.`, { host });
     }
+
+    /**
+     * Only installation-level users are allowed to create/join other orgs then the one they belong to
+     * @param user
+     * @returns
+     */
+    async mayCreateOrJoinOrganization(user: User): Promise<boolean> {
+        return !user.organizationId;
+    }
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2270,6 +2270,15 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         // Note: this operation is per-user only, hence needs no resource guard
         const user = this.checkAndBlockUser("createTeam");
+
+        const mayCreateOrganization = await this.userService.mayCreateOrJoinOrganization(user);
+        if (!mayCreateOrganization) {
+            throw new ResponseError(
+                ErrorCodes.PERMISSION_DENIED,
+                "Organizational accounts are not allowed to create new organizations",
+            );
+        }
+
         const team = await this.teamDB.createTeam(user.id, name);
         const invite = await this.getGenericInvite(ctx, team.id);
         ctx.span?.setTag("teamId", team.id);
@@ -2290,6 +2299,15 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { inviteId });
 
         const user = this.checkAndBlockUser("joinTeam");
+
+        const mayCreateOrganization = await this.userService.mayCreateOrJoinOrganization(user);
+        if (!mayCreateOrganization) {
+            throw new ResponseError(
+                ErrorCodes.PERMISSION_DENIED,
+                "Organizational accounts are not allowed to join other organizations",
+            );
+        }
+
         // Invites can be used by anyone, as long as they know the invite ID, hence needs no resource guard
         const invite = await this.teamDB.findTeamMembershipInviteById(inviteId);
         if (!invite || invite.invalidationTime !== "") {


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/32448529/226637119-e81c239d-9b5e-405b-baaf-3a93f79dc1fc.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16936

## How to test
 - follow [this link](https://gpl-16936-no-orgs.preview.gitpod-dev.com/iam/oidc/start?id=82792e35-1d01-4d72-8b38-96e4c055e81e) into the preview env
 - try to create a [new org](https://gpl-16936-no-orgs.preview.gitpod-dev.com/orgs/new)
 - see how that fails :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
