### PR TITLE
Hide the latest editor warning on stopping/stopped phases of a workspace

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -447,8 +447,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         const withPrebuild = WithPrebuild.is(this.state.workspace?.context);
         let phase: StartPhase | undefined = StartPhase.Preparing;
         let title = undefined;
-        let isTimedOut = false;
-        let isStoppingOrStopped = false;
+        let isStoppingOrStoppedPhase = false;
         let isError = error ? true : false;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
@@ -624,7 +623,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
-                isStoppingOrStopped = true;
+                isStoppingOrStoppedPhase = true;
                 if (isPrebuild) {
                     return (
                         <StartPage title="Prebuild in Progress">
@@ -662,7 +661,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopped means the workspace ended regularly because it was shut down.
             case "stopped":
-                isStoppingOrStopped = true;
+                isStoppingOrStoppedPhase = true;
                 phase = StartPhase.Stopped;
                 if (this.state.hasImageBuildLogs) {
                     const restartWithDefaultImage = (event: React.MouseEvent) => {
@@ -680,7 +679,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 }
                 if (!isPrebuild && this.state.workspaceInstance.status.conditions.timeout) {
                     title = "Timed Out";
-                    isTimedOut = true;
                 }
                 statusMessage = (
                     <div>
@@ -718,7 +716,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 phase={phase}
                 error={error}
                 title={title}
-                showLatestIdeWarning={isError || (!isTimedOut && !isStoppingOrStopped && useLatest)}
+                showLatestIdeWarning={useLatest && (isError || !isStoppingOrStoppedPhase)}
             >
                 {statusMessage}
             </StartPage>

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -448,6 +448,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         let phase: StartPhase | undefined = StartPhase.Preparing;
         let title = undefined;
         let isTimedOut = false;
+        let isStoppingOrStopped = false;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
         const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
@@ -622,6 +623,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
+                isStoppingOrStopped = true;
                 if (isPrebuild) {
                     return (
                         <StartPage title="Prebuild in Progress">
@@ -659,6 +661,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopped means the workspace ended regularly because it was shut down.
             case "stopped":
+                isStoppingOrStopped = true;
                 phase = StartPhase.Stopped;
                 if (this.state.hasImageBuildLogs) {
                     const restartWithDefaultImage = (event: React.MouseEvent) => {
@@ -710,7 +713,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 break;
         }
         return (
-            <StartPage phase={phase} error={error} title={title} showLatestIdeWarning={!isTimedOut && useLatest}>
+            <StartPage
+                phase={phase}
+                error={error}
+                title={title}
+                showLatestIdeWarning={!isTimedOut && !isStoppingOrStopped && useLatest}
+            >
                 {statusMessage}
             </StartPage>
         );

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -449,6 +449,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         let title = undefined;
         let isTimedOut = false;
         let isStoppingOrStopped = false;
+        let isError = error ? true : false;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
         const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
@@ -717,7 +718,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 phase={phase}
                 error={error}
                 title={title}
-                showLatestIdeWarning={!isTimedOut && !isStoppingOrStopped && useLatest}
+                showLatestIdeWarning={isError || (!isTimedOut && !isStoppingOrStopped && useLatest)}
             >
                 {statusMessage}
             </StartPage>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Removes the latest ide alert warning on the workspace stopping and stopped pages and only shows it during workspace (re)start.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11035 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Removes the latest ide alert warning on the workspace stopping and stopped pages
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
