### PR TITLE
[dashboard] Still render in face of failing listTeams

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -51,9 +51,11 @@ const App: FunctionComponent = () => {
     if (!user) {
         return <Login />;
     }
-    if (currentOrgQuery.isLoading) {
-        return <AppLoading />;
-    }
+    // TODO(gpl) "isLoading" is "true" even if there are errors in this "useCurrentOrg" call.
+    // Why don't understand as to why .isLoading is not resolved at some point, though. Maybe we're missing proper error handling for useOrganizations
+    // if (currentOrgQuery.isLoading) {
+    //     return <AppLoading />;
+    // }
 
     // If we made it here, we have a logged in user w/ their teams. Yay.
     return (

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -39,6 +39,11 @@ export function useOrganizations() {
         getQueryKey(user),
         async () => {
             console.log("Fetching orgs... " + JSON.stringify(getQueryKey(user)));
+            if (!user) {
+                console.log("useOrganizations with empty user");
+                return [];
+            }
+
             const response = await teamsService.listTeams({});
             const result: OrganizationInfo[] = [];
             for (const org of response.teams) {
@@ -63,6 +68,9 @@ export function useOrganizations() {
                 // refresh user billing mode to update the billing mode in the user context as it depends on the orgs
                 refreshUserBillingMode();
                 queryClient.invalidateQueries(getUserBillingModeQueryKey(user.id));
+            },
+            onError: (err) => {
+                console.error("useOrganizations", err);
             },
             enabled: !!user,
             cacheTime: 1000 * 60 * 60 * 1, // 1 hour


### PR DESCRIPTION
## Description
For some reason App() is stuck on `orgs.isLoading`, although other components can load orgs just fine.
Also, the linear dependency of mounting `AppRoutes` later then necessary slows down loading times.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16916

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixes https://github.com/gitpod-io/gitpod/issues/16916
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
