### PR TITLE
Use the same namespace where Gitpod is installed

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -2014,7 +2014,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -652,7 +652,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1657,7 +1657,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1831,7 +1831,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1999,7 +1999,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -652,7 +652,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1725,7 +1725,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -652,7 +652,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1653,7 +1653,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1834,7 +1834,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1843,7 +1843,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -253,7 +253,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -813,7 +813,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -456,7 +456,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1402,7 +1402,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -349,7 +349,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1136,7 +1136,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -358,7 +358,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -995,7 +995,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1834,7 +1834,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1831,7 +1831,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -675,7 +675,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1829,7 +1829,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1838,7 +1838,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1831,7 +1831,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1843,7 +1843,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1834,7 +1834,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -2053,7 +2053,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1834,7 +1834,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -677,7 +677,7 @@ metadata:
     app: gitpod
     component: cluster
   name: gitpod-trust-anchor
-  namespace: cert-manager
+  namespace: default
 spec:
   commonName: root.gitpod.cluster.local
   duration: 8760h0m0s
@@ -1834,7 +1834,7 @@ data:
         app: gitpod
         component: cluster
       name: gitpod-trust-anchor
-      namespace: cert-manager
+      namespace: default
     ---
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -39,7 +39,7 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 			TypeMeta: common.TypeMetaCertificate,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "gitpod-trust-anchor",
-				Namespace: "cert-manager",
+				Namespace: ctx.Namespace,
 				Labels:    common.DefaultLabels(Component),
 			},
 			Spec: v1.CertificateSpec{


### PR DESCRIPTION
## Description

Do not assume cert-manager uses the default namespace `cert-manager` or that such namespace exists.

## Release Notes
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
