### PR TITLE
[installer] Allow to override the namespace where certmanager is installed

### DIFF
--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -205,19 +205,20 @@ type SpiceDBConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
-	Server                 *ServerConfig          `json:"server,omitempty"`
-	ProxyConfig            *ProxyConfig           `json:"proxy,omitempty"`
-	WorkspaceManagerBridge *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
-	Tracing                *Tracing               `json:"tracing,omitempty"`
-	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
-	DisableMigration       bool                   `json:"disableMigration"`
-	Usage                  *UsageConfig           `json:"usage,omitempty"`
-	ConfigcatKey           string                 `json:"configcatKey"`
-	WorkspaceClasses       []WebAppWorkspaceClass `json:"workspaceClasses"`
-	Stripe                 *StripeConfig          `json:"stripe,omitempty"`
-	IAM                    *IAMConfig             `json:"iam,omitempty"`
-	SpiceDB                *SpiceDBConfig         `json:"spicedb,omitempty"`
+	PublicAPI                    *PublicAPIConfig       `json:"publicApi,omitempty"`
+	Server                       *ServerConfig          `json:"server,omitempty"`
+	ProxyConfig                  *ProxyConfig           `json:"proxy,omitempty"`
+	WorkspaceManagerBridge       *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
+	Tracing                      *Tracing               `json:"tracing,omitempty"`
+	UsePodAntiAffinity           bool                   `json:"usePodAntiAffinity"`
+	DisableMigration             bool                   `json:"disableMigration"`
+	Usage                        *UsageConfig           `json:"usage,omitempty"`
+	ConfigcatKey                 string                 `json:"configcatKey"`
+	WorkspaceClasses             []WebAppWorkspaceClass `json:"workspaceClasses"`
+	Stripe                       *StripeConfig          `json:"stripe,omitempty"`
+	IAM                          *IAMConfig             `json:"iam,omitempty"`
+	SpiceDB                      *SpiceDBConfig         `json:"spicedb,omitempty"`
+	CertmanagerNamespaceOverride string                 `json:"certmanagerNamespaceOverride,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
context: [internal thread](https://gitpod.slack.com/archives/C01KLC56NP7/p1679409826882809?thread_ts=1679404588.580769&cid=C01KLC56NP7)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
