### PR TITLE
[installer] Add render-cell support

### DIFF
--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -7,6 +7,7 @@ packages:
       - "**/*.go"
       - "**/testdata/**/*"
       - "cmd/versions.yaml"
+      - "cmd/cellconfig/*.yaml"
       - "pkg/components/**/*.tpl"
       - "pkg/components/**/*.crt"
       - "pkg/components/**/*.key"

--- a/install/installer/cmd/cellconfig/meta.yaml
+++ b/install/installer/cmd/cellconfig/meta.yaml
@@ -1,0 +1,195 @@
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: v1
+kind: Meta
+domain: [[ .DomainName ]]
+metadata:
+  region: [[ .Region ]]
+repository: eu.gcr.io/gitpod-core-dev/build
+
+certificate:
+  kind: secret
+  name: https-certificates
+
+database:
+  inCluster: false
+  external:
+    certificate:
+      name: database
+      kind: secret
+
+objectStorage:
+  blobQuota: 0
+  inCluster: false
+  s3:
+    endpoint: s3.amazonaws.com
+    bucket: [[ .StorageBucket ]]
+
+containerRegistry:
+  inCluster: false
+  external:
+    url: [[ .WorkspaceImageRepo ]]
+    certificate:
+      kind: secret
+      name: aws-ecr-credential
+  privateBaseImageAllowList:
+    - "https://index.docker.io/v1/"
+    - "https://docker.io/"
+
+#observability:
+#  logLevel: info
+#  tracing:
+#    endpoint: http://otel-collector.monitoring-satellite.svc:14268/api/traces
+    # TODO(gpl): enable sampling when available
+    # samplerType: ratelimiting
+    # samplerParam: "5.0"
+
+authProviders: []
+
+disableDefinitelyGp: false
+
+experimental:
+  common:
+    staticMessagebusPassword: [[ .Secrets.MessageBusPassword ]]
+
+    podConfig:
+      proxy:
+        replicas: 2
+        resources:
+          proxy:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+      openvsx-proxy:
+        replicas: 2
+        resources:
+          redis:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          openvsx-proxy:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+      ide-proxy:
+        replicas: 2
+      server:
+        replicas: 2
+        resources:
+          server:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+      public-api-server:
+        replicas: 2
+      dashboard:
+        replicas: 2
+      ide-service:
+        replicas: 2
+
+  workspace:
+    # cmp. here: https://github.com/gitpod-io/gitpod/blob/8ddbf93e003a095f2ea5b5ca2b34ef74b33e8193/components/content-service-api/go/config/config.go#L70
+    stage: "prod"
+    tracing:
+      samplerType: rateLimiting
+      samplerParam: 5.0
+    contentService:
+      usageReportBucketName: [[ .UsageBucket ]]
+
+  ide:
+    ideMetrics:
+      enabledErrorReporting: true
+
+  webapp:
+    disableMigration: false
+    usePodAntiAffinity: true
+    tracing:
+      samplerType: rateLimiting
+      samplerParam: 5.0
+    proxy:
+      configcat:
+        baseUrl: "https://cdn-global.configcat.com"
+        pollInterval: "10m"
+    wsManagerBridge:
+      skipSelf: true
+    server:
+      enableLocalApp: false
+      runDbDeleter: false
+      disableDynamicAuthProviderLogin: false
+      oauthServer:
+        jwtSecret: "[[ .Secrets.JWTSecret ]]"
+      session:
+        secret: "[[ .Secrets.SessionSecret ]]"
+      inactivityPeriodForReposInDays: 14
+
+    publicApi:
+      personalAccessTokenSigningKeySecretName: "personal-access-token-signing-key"
+
+    # TODO: remove. Do not use this in customer cells
+    configcatKey: "WBLaCPtkjkqKHlHedziE9g/TwAe6YyftEGPnGxVRXd0Ig"
+
+    usage:
+      enabled: true
+      schedule: "15m"
+      resetUsageSchedule: "15m"
+      billInstancesAfter: "2022-08-11T08:05:32.499Z"
+      defaultSpendingLimit:
+        forUsers: 500
+        forTeams: 0
+        minForUsersOnStripe: 1000
+
+    workspaceClasses:
+    - id: "g1-standard"
+      category: "GENERAL PURPOSE"
+      displayName: "Standard"
+      description: "4 vCPU, 8GB memory, 30GB disk"
+      powerups: 1
+      isDefault: true
+      credits:
+        perMinute: 0.1666666667
+
+    - id: "g1-large"
+      category: "GENERAL PURPOSE"
+      displayName: "Large"
+      description: "8 vCPU, 16GB memory, 50GB disk"
+      powerups: 2
+      credits:
+        perMinute: 0.3333333333
+      marker:
+        moreResources: true
+
+    - id: "g1-xlarge"
+      category: "GENERAL PURPOSE"
+      displayName: "XLarge"
+      description: "14 vCPU, 30GB memory, 75GB disk"
+      powerups: 2
+      credits:
+        perMinute: 0.3333333333
+      marker:
+        moreResources: true
+
+    - id: "g1-xxlarge"
+      category: "GENERAL PURPOSE"
+      displayName: "XXLarge"
+      description: "30 vCPU, 54GB memory, 100GB disk"
+      powerups: 2
+      credits:
+        perMinute: 0.3333333333
+      marker:
+        moreResources: true
+
+    - id: "gpu-g4dn-8xlarge"
+      category: "ML"
+      displayName: "NVIDIA Tesla 4 16 GiB"
+      description: "30 vCPU, 110GB memory, 500GB disk"
+      powerups: 2
+      credits:
+        perMinute: 0.3333333333
+      marker:
+        moreResources: true
+
+sshGatewayHostKey:
+  kind: secret
+  name: ssh-host-key

--- a/install/installer/cmd/cellconfig/workspace.yaml
+++ b/install/installer/cmd/cellconfig/workspace.yaml
@@ -1,0 +1,282 @@
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: v1
+
+authProviders: []
+
+experimental:
+  workspace:
+    stage: prod
+    #schedulerName: "kumquat"
+    hostURL: "https://[[ .DomainName ]]"
+    wsManagerRateLimits:
+      "/wsman.WorkspaceManager/StartWorkspace":
+        block: true
+        bucketSize: 3
+        refillInterval: "500ms"
+      "/wsman.WorkspaceManager/ControlPort":
+        block: true
+        bucketSize: 6
+        refillInterval: "1s"
+      "/wsman.WorkspaceManager/DeleteVolumeSnapshot":
+        block: true
+        bucketSize: 100
+        refillInterval: "1m"
+    wsProxy:
+      ingressHeader: "Host"
+    #tracing:
+    #  samplerType: const
+    #  samplerParam: 1
+    #cpuLimits:
+    #  enabled: false
+    #  nodeBandwidth: "12"
+    #  limit: "2"
+    #  burstLimit: "6"
+
+    # Configure I/O limits only to avoid starvation
+    ioLimits:
+      writeBandwidthPerSecond: "500Mi"
+      readBandwidthPerSecond: "500Mi"
+    procLimit: 6144
+    oomScores:
+      enabled: true
+      tier1: -1000
+      tier2: -100
+    registryFacade:
+      redisCache:
+        enabled: true
+        singleHostAddr: "[[ .RegistryFacadeCacheHost ]]"
+        passwordSecret: redis-credentials
+        username: default
+        # TODO(aledbf): switch to TLS after switching to cluster
+        useTLS: false
+        insecureSkipVerify: true
+    wsDaemon:
+      runtime:
+        nodeToContainerMapping:
+          - path: "/run/containerd/io.containerd.runtime.v2.task/k8s.io"
+            value: "/mnt/node1"
+          - path: "/var/lib"
+            value: "/mnt/node0"
+
+
+    classes:
+      g1-standard:
+        resources:
+          requests:
+            cpu: "2"
+            memory: 6Gi
+          limits:
+            memory: 8Gi
+            storage: 30Gi
+        templates:
+          default:
+            spec:
+              dnsConfig:
+                nameservers:
+                  - 1.1.1.1
+                  - 8.8.8.8
+              dnsPolicy: None
+              enableServiceLinks: false
+              containers:
+                - env:
+                    - name: GITPOD_PREVENT_METADATA_ACCESS
+                      value: "true"
+                  name: workspace
+
+      g1-large:
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            memory: 16Gi
+            storage: 50Gi
+        templates:
+          default:
+            spec:
+              dnsConfig:
+                nameservers:
+                  - 1.1.1.1
+                  - 8.8.8.8
+              dnsPolicy: None
+              enableServiceLinks: false
+              containers:
+                - env:
+                    - name: GITPOD_PREVENT_METADATA_ACCESS
+                      value: "true"
+                  name: workspace
+
+      g1-xlarge:
+        resources:
+          requests:
+            cpu: "14"
+            memory: 30Gi
+          limits:
+            memory: 30Gi
+            storage: 75Gi
+        templates:
+          default:
+            spec:
+              dnsConfig:
+                nameservers:
+                  - 1.1.1.1
+                  - 8.8.8.8
+              dnsPolicy: None
+              enableServiceLinks: false
+              containers:
+                - env:
+                    - name: GITPOD_PREVENT_METADATA_ACCESS
+                      value: "true"
+                  name: workspace
+
+      g1-xxlarge:
+        resources:
+          requests:
+            cpu: "30"
+            memory: 54Gi
+          limits:
+            memory: 54Gi
+            storage: 100Gi
+        templates:
+          default:
+            spec:
+              dnsConfig:
+                nameservers:
+                  - 1.1.1.1
+                  - 8.8.8.8
+              dnsPolicy: None
+              enableServiceLinks: false
+              containers:
+                - env:
+                    - name: GITPOD_PREVENT_METADATA_ACCESS
+                      value: "true"
+                  name: workspace
+
+      gpu-g4dn-8xlarge:
+        resources:
+          requests:
+            cpu: "30"
+            memory: 110Gi
+          limits:
+            memory: 110Gi
+            storage: 500Gi
+
+        templates:
+          default:
+            spec:
+              tolerations:
+                - key: nvidia.com/gpu
+                  operator: Exists
+                  effect: NoSchedule
+
+              dnsConfig:
+                nameservers:
+                  - 1.1.1.1
+                  - 8.8.8.8
+              dnsPolicy: None
+              enableServiceLinks: false
+              runtimeClassName: nvidia
+              containers:
+                - env:
+                    - name: GITPOD_PREVENT_METADATA_ACCESS
+                      value: "true"
+                  name: workspace
+                  resources:
+                    limits:
+                      cpu: "30"
+                      memory: 110Gi
+                      nvidia.com/gpu: 1
+blockNewUsers:
+  passlist: []
+
+sshGatewayHostKey:
+  kind: secret
+  name: ssh-host-key
+
+certificate:
+  kind: secret
+  name: https-certificates
+
+containerRegistry:
+  inCluster: false
+  external:
+    url: "[[ .WorkspaceImageRepo ]]"
+    certificate:
+      kind: secret
+      name: aws-ecr-credential
+
+domain: "[[ .DomainName ]]"
+
+kind: Workspace
+metadata:
+  region: "[[ .Region ]]"
+
+objectStorage:
+  inCluster: false
+  blobQuota: 0
+  s3:
+    endpoint: s3.amazonaws.com
+    bucket: "[[ .StorageBucket ]]"
+
+#observability:
+#  logLevel: info
+#  tracing:
+#    endpoint: ${JAEGER_ENDPOINT}
+#    secretName: jaeger-authentication
+repository: eu.gcr.io/gitpod-core-dev/build
+workspace:
+  timeoutAfterClose: 5m
+  runtime:
+    containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
+    containerdSocketDir: /run/containerd
+    fsShiftMethod: shiftfs
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+      storage: 30Gi
+    requests:
+      cpu: "4"
+      memory: 8Gi
+
+  templates:
+    default:
+      spec:
+        dnsConfig:
+          nameservers:
+            - 1.1.1.1
+            - 8.8.8.8
+        dnsPolicy: None
+        enableServiceLinks: false
+
+    prebuild:
+      spec:
+        containers:
+          - name: workspace
+            resources:
+              requests:
+                cpu: "4"
+                memory: 6Gi
+              limits:
+                cpu: "6"
+                memory: 8Gi
+
+    regular:
+      spec:
+        enableServiceLinks: false
+
+    imagebuild:
+      spec:
+        containers:
+          - name: workspace
+            resources:
+              requests:
+                cpu: "4"
+                memory: 6Gi
+              limits:
+                cpu: "6"
+                memory: 8Gi
+        enableServiceLinks: false

--- a/install/installer/cmd/render-cell.go
+++ b/install/installer/cmd/render-cell.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io"
+	"os"
+	"text/template"
+
+	_ "embed"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config"
+	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/spf13/cobra"
+)
+
+//go:embed cellconfig/*
+var configTemplates embed.FS
+
+var renderCellOpts struct {
+	Template   string
+	ConfigOnly bool
+}
+
+// renderCmd represents the render command
+var renderCellCmd = &cobra.Command{
+	Use:   "render-cell",
+	Short: "Renders the Kubernetes manifests required to install Gitpod in a Dedicated cell",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		tpl := template.New("installer-config.yaml").Delims("[[", "]]")
+		tpl, err := tpl.ParseFS(configTemplates, "cellconfig/*")
+		if err != nil {
+			return fmt.Errorf("cannot parse installer config template: %w", err)
+		}
+
+		tplCfg, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("cannot load config template parameter from STDIN: %w", err)
+		}
+		rawCfg, cfgVersion, err := config.Load(string(tplCfg), rootOpts.StrictConfigParse)
+		if err != nil {
+			return fmt.Errorf("error loading config: %w", err)
+		}
+		if cfgVersion != "cell/v1" {
+			return fmt.Errorf("unsupported config version: expected cell/v1, got %s", cfgVersion)
+		}
+
+		buf := bytes.NewBuffer(nil)
+		err = tpl.ExecuteTemplate(buf, renderCellOpts.Template+".yaml", rawCfg)
+		if err != nil {
+			return fmt.Errorf("cannot render config template %s: %w", renderCellOpts.Template, err)
+		}
+		if renderCellOpts.ConfigOnly {
+			fmt.Println(buf.String())
+			return nil
+		}
+
+		actualConfig, cfgVersion, err := config.Load(buf.String(), true)
+		if err != nil {
+			return fmt.Errorf("config template produced invalid config: %w", err)
+		}
+		if cfgVersion != config.CurrentVersion {
+			return fmt.Errorf("config template version is mismatch: expected %s, got %s", config.CurrentVersion, cfgVersion)
+		}
+
+		yaml, err := renderKubernetesObjects(cfgVersion, actualConfig.(*configv1.Config))
+		if err != nil {
+			return err
+		}
+
+		err = saveYamlToFiles(".", yaml)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(renderCellCmd)
+
+	renderCellCmd.PersistentFlags().BoolVar(&renderCellOpts.ConfigOnly, "debug-config", false, "only render the config to stdout, not the kubernetes yaml")
+	renderCellCmd.PersistentFlags().StringVar(&renderCellOpts.Template, "template", "", "cell template to use - either workspace or meta")
+	_ = renderCellCmd.MarkFlagRequired("template")
+}

--- a/install/installer/pkg/config/cellv1/config.go
+++ b/install/installer/pkg/config/cellv1/config.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cellv1
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/go-playground/validator/v10"
+)
+
+type Version struct{}
+
+func (v Version) Factory() interface{} {
+	return &InstallerConfigTemplateParameter{}
+}
+
+// Defaults fills in the defaults for this version.
+// obj is expected to be the return value of Factory()
+func (v Version) Defaults(obj interface{}) error { return nil }
+
+// LoadValidationFuncs loads the custom validation functions
+func (v Version) LoadValidationFuncs(*validator.Validate) error { return nil }
+
+// ClusterValidation introduces configuration specific cluster validation checks
+func (v Version) ClusterValidation(cfg interface{}) cluster.ValidationChecks { return nil }
+
+// CheckDeprecated checks for deprecated config params.
+// Returns key/value pair of deprecated params/values and any error messages (used for conflicting params)
+func (v Version) CheckDeprecated(cfg interface{}) (map[string]interface{}, []string) { return nil, nil }
+
+// InstallerConfigTemplateParameter are the parameters handed to the installer config template
+type InstallerConfigTemplateParameter struct {
+	Region      string `json:"region"`
+	ClusterName string `json:"clusterName"`
+	DomainName  string `json:"domainName"`
+
+	Secrets InstallerConfigTemplateParameterSecrets `json:"secrets"`
+
+	WorkspaceImageRepo string `json:"wokspaceImageRepo"`
+
+	StorageBucket string `json:"storageBucket"`
+	UsageBucket   string `json:"usageBucket"`
+
+	RegistryFacadeCacheHost string `json:"registryFacadeCacheHost"`
+}
+
+type InstallerConfigTemplateParameterSecrets struct {
+	MessageBusPassword string
+	JWTSecret          string
+	SessionSecret      string
+}

--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -90,10 +90,6 @@ func Load(overrideConfig string, strict bool) (cfg interface{}, version string, 
 	}
 
 	apiVersion := overrideVS.APIVersion
-	// fall-back to default CurrentVersion if no apiVersion was passed
-	if version == "" {
-		apiVersion = CurrentVersion
-	}
 
 	v, err := LoadConfigVersion(apiVersion)
 	if err != nil {

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -10,6 +10,7 @@ import (
 	agentSmith "github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/config"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/cellv1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/installer/pkg/containerd"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/cpulimit"
@@ -22,6 +23,7 @@ import (
 
 func init() {
 	config.AddVersion("v1", version{})
+	config.AddVersion("cell/v1", cellv1.Version{})
 }
 
 type version struct{}


### PR DESCRIPTION
## Description
This PR adds "config templates" which tie down the configuration we apply to a dedicated cell. We tie this down in the installer to limit our own propensity for introducing variance, and because that configuration is intrinsically tied to the installer/Gitpod version.

## How to test
```bash
cd install/installer
VERSION_MANIFEST=/tmp/versions.yaml VERSION=main-gha.5373 make versionManifest

cat <<EOF > /tmp/parameter.yaml
apiVersion: cell/v1

region: eu-central-1
clusterName: meta
domainName: gitpod.io
storageBucket: "foo"
usageBucket: "foo"
wokspaceImageRepo: "bla"
registryFacadeCacheHost: "localhost"
EOF

cat /tmp/parameter.yaml go run main.go --debug-version-file /tmp/versions.yaml render-cell --template meta
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
