### PR TITLE
[installer] Fix ClusterIssuerKind for mk2

### DIFF
--- a/install/installer/pkg/components/image-builder-mk3-wsman/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3-wsman/deployment.go
@@ -157,17 +157,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: pointer.Int64(30),
 					Volumes:                       volumes,
-					InitContainers: []corev1.Container{
-						{
-							Name:  "setup",
-							Image: ctx.ImageName(ctx.Config.Repository, imagebuildermk3.Component, ctx.VersionManifest.Components.ImageBuilderMk3.Version), ImagePullPolicy: corev1.PullIfNotPresent,
-							Args: []string{
-								"setup",
-							},
-							SecurityContext: &corev1.SecurityContext{RunAsUser: pointer.Int64(0)},
-							Env:             common.ProxyEnv(&ctx.Config),
-						},
-					},
 					Containers: []corev1.Container{{
 						Name:            Component,
 						Image:           ctx.ImageName(ctx.Config.Repository, imagebuildermk3.Component, ctx.VersionManifest.Components.ImageBuilderMk3.Version),

--- a/install/installer/pkg/components/ws-manager-mk2/tlssecret.go
+++ b/install/installer/pkg/components/ws-manager-mk2/tlssecret.go
@@ -52,7 +52,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 				DNSNames:   serverAltNames,
 				IssuerRef: cmmeta.ObjectReference{
 					Name:  issuer,
-					Kind:  certmanagerv1.IssuerKind,
+					Kind:  certmanagerv1.ClusterIssuerKind,
 					Group: "cert-manager.io",
 				},
 			},
@@ -70,7 +70,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 				DNSNames:   clientAltNames,
 				IssuerRef: cmmeta.ObjectReference{
 					Name:  issuer,
-					Kind:  certmanagerv1.IssuerKind,
+					Kind:  certmanagerv1.ClusterIssuerKind,
 					Group: "cert-manager.io",
 				},
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes ws-manager-mk2 certs not becoming ready. https://github.com/gitpod-io/gitpod/pull/16793 refactored all cert issuer kinds to ClusterIssuerKind (except for mk2)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env with mk2 enabled

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
