### PR TITLE
[jb] allow to auto update platform for next EAP

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -9,8 +9,12 @@ on:
                 description: ID of the plugin in lowercase and without spaces.
                 type: string
                 required: true
-            xpath:
-                description: Xpath for the latest platform version in https://www.jetbrains.com/intellij-repository/snapshots
+            productCode:
+                description: JB Product Code
+                type: string
+                required: true
+            productType:
+                description: JB Product Type
                 type: string
                 required: true
             gradlePropertiesPath:
@@ -26,41 +30,29 @@ jobs:
     update-plugin-platform:
         name: Update Platform Version from ${{ inputs.pluginName }}
         runs-on: ubuntu-latest
-        env:
-            SNAPSHOTS_HTML_FILENAME: snapshots.html
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3
-            - name: Save the snapshots page to an HTML file
-              run: curl -sL https://www.jetbrains.com/intellij-repository/snapshots > ${{ env.SNAPSHOTS_HTML_FILENAME }}
             - name: Get Current Platform Version
               id: current-version
               run: |
                   CURRENT_VERSION=$(cat ${{ inputs.gradlePropertiesPath }} | grep platformVersion= | sed 's/platformVersion=//')
+                  echo "Current platform version: $CURRENT_VERSION"
                   echo "::set-output name=result::$CURRENT_VERSION"
-            - name: Extract Major Version from Current Platform Version
-              id: major-version
-              run: |
-                  MAJOR_VERSION=$(cut -c 1-3 <<< ${{ steps.current-version.outputs.result }})
-                  echo "Major Version from Current Platform Version: $MAJOR_VERSION"
-                  echo "::set-output name=result::$MAJOR_VERSION"
-            - name: Replace Major Version Placeholder
-              id: update-xpath
-              run: |
-                  UPDATED_XPATH=$(echo "${{ inputs.xpath }}" | sed 's/MAJOR_VERSION_PLACEHOLDER/${{ steps.major-version.outputs.result }}/')
-                  echo "Updated xpath: $UPDATED_XPATH"
-                  echo "::set-output name=result::$UPDATED_XPATH"
             - name: Get Latest Platform Version
-              uses: QwerMike/xpath-action@v1
               id: latest-version
-              with:
-                  filename: ${{ env.SNAPSHOTS_HTML_FILENAME }}
-                  expression: ${{ steps.update-xpath.outputs.result }}
-            - run: rm ${{ env.SNAPSHOTS_HTML_FILENAME }}
-            - name: Print Result
               run: |
-                  echo "Current platform version: ${{ steps.current-version.outputs.result }}"
-                  echo "Latest platform version:  ${{ steps.latest-version.outputs.result }}"
+                URL="https://data.services.jetbrains.com/products/releases?code=${{ inputs.productCode }}&type=${{ inputs.productType }}&platform=linux"
+                echo "URL: $URL"
+                BUILD=$(curl -s "$URL" |jq -r ".${{ inputs.productCode }}[0].build")
+                echo "BUILD: $BUILD"
+                MAJOR=$(cut -d. -f1 <<< $BUILD)
+                echo "MAJOR: $MAJOR"
+                MINOR=$(cut -d. -f2 <<< $BUILD)
+                echo "MINOR: $MINOR"
+                LATEST_VERSION="$MAJOR.$MINOR-EAP-CANDIDATE-SNAPSHOT"
+                echo "Latest platform version: $LATEST_VERSION"
+                echo "::set-output name=result::$LATEST_VERSION"
             - name: Update ${{ inputs.gradlePropertiesPath }}
               if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               run: |

--- a/.github/workflows/jetbrains-update-plugin-platform.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform.yml
@@ -10,7 +10,8 @@ jobs:
         with:
             pluginName: JetBrains Backend Plugin (EAP)
             pluginId: latest-backend-plugin
-            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.intellij.idea'][1]/tbody/tr/td[contains(text(),'-EAP-CANDIDATE-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER')]/text())[1]"
+            productCode: IIU
+            productType: eap,rc,release
             gradlePropertiesPath: components/ide/jetbrains/backend-plugin/gradle-latest.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
@@ -20,7 +21,8 @@ jobs:
         with:
             pluginName: JetBrains Gateway Plugin (EAP)
             pluginId: latest-gateway-plugin
-            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
+            productCode: GW
+            productType: eap,rc,release
             gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle-latest.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
@@ -30,7 +32,8 @@ jobs:
         with:
             pluginName: JetBrains Gateway Plugin (Stable)
             pluginId: stable-gateway-plugin
-            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
+            productCode: GW
+            productType: release
             gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle-stable.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It removes limiting auto update by major version that we get new PRs whenever there are SDK for new EAP versions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

merge and run on main

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
