### PR TITLE
[billing page] Fix erratic calls to listAvailableUsageAttributionIds

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -22,7 +22,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
     useEffect(() => {
-        if (orgs.isLoading) {
+        if (!orgs?.data) {
             setTeamsAvailableForAttribution([]);
             return;
         }
@@ -49,7 +49,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                 console.error("Could not get list of available billing accounts.", error);
                 setErrorMessage(`Could not get list of available billing accounts. ${error?.message || String(error)}`);
             });
-    }, [orgs]);
+    }, [orgs?.data]);
 
     const setUsageAttributionTeam = async (team?: Team) => {
         if (!user) {


### PR DESCRIPTION
## Description
We've observed a high number of calls to `listAvailableUsageAttributionIds`. This PR is to fix the frontend part causing the many calls to server.

## How to test
1. Navigate to `/user/billing`, make sure you are not redirected 
2. Check the WebSocket comms for `listAvailableUsageAttributionIds`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
