### PR TITLE
[dashboard] Avoid re-rendering the whole App on Org load

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -52,17 +52,17 @@ const App: FunctionComponent = () => {
         return <Login />;
     }
 
-    // At this point we want to make sure that we never render AppRoutes prematurely, e.g. without an Org.
+    // At this point we want to make sure that we never render AppRoutes prematurely, e.g. without finishing loading the orgs
     // This would cause us to re-render the whole App again soon after, creating havoc with all our "onMount" hooks.
-    if (currentOrgQuery.isLoading || !currentOrgQuery.data) {
+    if (currentOrgQuery.isLoading) {
         return <AppLoading />;
     }
 
     // If we made it here, we have a logged in user w/ their teams. Yay.
     return (
         <Suspense fallback={<AppLoading />}>
-            {/* Use org id as key to force re-render on org change */}
-            <AppRoutes key={currentOrgQuery.data.id} />
+            {/* Use org id, or user id (for personal account) as key to force re-render on org change */}
+            <AppRoutes key={currentOrgQuery?.data?.id ?? user.id} />
         </Suspense>
     );
 };

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -51,17 +51,18 @@ const App: FunctionComponent = () => {
     if (!user) {
         return <Login />;
     }
-    // TODO(gpl) "isLoading" is "true" even if there are errors in this "useCurrentOrg" call.
-    // Why don't understand as to why .isLoading is not resolved at some point, though. Maybe we're missing proper error handling for useOrganizations
-    // if (currentOrgQuery.isLoading) {
-    //     return <AppLoading />;
-    // }
+
+    // At this point we want to make sure that we never render AppRoutes prematurely, e.g. without an Org.
+    // This would cause us to re-render the whole App again soon after, creating havoc with all our "onMount" hooks.
+    if (currentOrgQuery.isLoading || !currentOrgQuery.data) {
+        return <AppLoading />;
+    }
 
     // If we made it here, we have a logged in user w/ their teams. Yay.
     return (
         <Suspense fallback={<AppLoading />}>
             {/* Use org id as key to force re-render on org change */}
-            <AppRoutes key={currentOrgQuery.data?.id ?? "no-org"} />
+            <AppRoutes key={currentOrgQuery.data.id} />
         </Suspense>
     );
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - inject the frontend into staging
 - manipulate https://github.com/gitpod-io/gitpod/blob/8496ae0c36d868fbb0681f950c1da84cad24a432/components/dashboard/src/hooks/use-user-and-teams-loader.ts#L24-L26 to set `user` to `undefined`
 - see how you end up with the loading screen :+1:
 - on removing that code, you should end up with the rendered App again :+1:
 - (this tests that [the fix from yesterday](https://github.com/gitpod-io/gitpod/pull/16941/files) is still in effect)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
