### PR TITLE
Upgrade node to latest LTS v18.15.0

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: [ self-hosted ]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
@@ -148,7 +148,7 @@ jobs:
         ports:
           - 23306:23306
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: [ self-hosted ]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
@@ -148,7 +148,7 @@ jobs:
         ports:
           - 23306:23306
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
         name: Configuration
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
         outputs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
@@ -89,7 +89,7 @@ jobs:
         needs: [configuration, infrastructure]
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
             volumes:
               - /var/tmp:/var/tmp
               - /tmp:/tmp

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
         name: Configuration
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
         outputs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
@@ -89,7 +89,7 @@ jobs:
         needs: [configuration, infrastructure]
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
             volumes:
               - /var/tmp:/var/tmp
               - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -8,7 +8,7 @@ jobs:
         name: "Find stale preview environments"
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
         outputs:
             names: ${{ steps.set-matrix.outputs.names }}
             count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -8,7 +8,7 @@ jobs:
         name: "Find stale preview environments"
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
         outputs:
             names: ${{ steps.set-matrix.outputs.names }}
             count: ${{ steps.set-matrix.outputs.count }}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5515
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upgrade-node-gha.5599
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/components/ee/payment-endpoint/leeway.Dockerfile
+++ b/components/ee/payment-endpoint/leeway.Dockerfile
@@ -4,13 +4,13 @@
 
 
 
-FROM node:16.13.0-slim as builder
+FROM node:18.15.0-slim as builder
 COPY components-ee-payment-endpoint--app /installer/
 
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:16.13.0-slim
+FROM node:18.15.0-slim
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 

--- a/components/gitpod-db/leeway.Dockerfile
+++ b/components/gitpod-db/leeway.Dockerfile
@@ -2,16 +2,16 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:16.13.0-slim as builder
+FROM node:18.15.0-slim as builder
 COPY components-gitpod-db--migrations /installer/
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:16.13.0 as proxy
+FROM node:18.15.0 as proxy
 RUN wget https://storage.googleapis.com/cloudsql-proxy/v1.23.0/cloud_sql_proxy.linux.amd64 -O /bin/cloud_sql_proxy \
  && chmod +x /bin/cloud_sql_proxy
 
-FROM node:16.13.0-slim
+FROM node:18.15.0-slim
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 COPY migrate.sh /app/migrate.sh
 COPY migrate_gcp.sh /app/migrate_gcp.sh

--- a/components/server/leeway.Dockerfile
+++ b/components/server/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:16.13.0-slim as builder
+FROM node:18.15.0-slim as builder
 
 RUN apt-get update && apt-get install -y build-essential python3
 
@@ -11,7 +11,7 @@ COPY components-server--app /installer/
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:16.13.0-slim
+FROM node:18.15.0-slim
 ENV NODE_OPTIONS="--unhandled-rejections=warn --max_old_space_size=2048"
 # Using ssh-keygen for RSA keypair generation
 RUN apt-get update && apt-get install -yq \

--- a/components/ws-manager-bridge/leeway.Dockerfile
+++ b/components/ws-manager-bridge/leeway.Dockerfile
@@ -2,13 +2,13 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:16.13.0-slim as builder
+FROM node:18.15.0-slim as builder
 COPY components-ws-manager-bridge--app /installer/
 
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:16.13.0-slim
+FROM node:18.15.0-slim
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 # '--no-log-init': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -136,7 +136,7 @@ RUN install-packages netcat
 USER gitpod
 
 # Fix node version we develop against
-ARG GITPOD_NODE_VERSION=16.19.0
+ARG GITPOD_NODE_VERSION=18.15.0
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $GITPOD_NODE_VERSION \
     && npm install -g typescript yarn"

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -141,6 +141,8 @@ RUN bash -c ". .nvm/nvm.sh \
     && nvm install $GITPOD_NODE_VERSION \
     && npm install -g typescript yarn"
 ENV PATH=/home/gitpod/.nvm/versions/node/v${GITPOD_NODE_VERSION}/bin:$PATH
+# TODO: remove after updating webpack https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#openssl-30
+ENV NODE_OPTIONS="--openssl-legacy-provider"
 
 ## Register leeway autocompletion in bashrc
 RUN bash -c "echo . \<\(leeway bash-completion\) >> ~/.bashrc"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
