### PR TITLE
Improve app and org loading states

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -10,7 +10,7 @@ import { AppLoading } from "./app/AppLoading";
 import { AppRoutes } from "./app/AppRoutes";
 import { useCurrentOrg } from "./data/organizations/orgs-query";
 import { useAnalyticsTracking } from "./hooks/use-analytics-tracking";
-import { useUserAndTeamsLoader } from "./hooks/use-user-and-teams-loader";
+import { useUserLoader } from "./hooks/use-user-loader";
 import { Login } from "./Login";
 import { isGitpodIo } from "./utils";
 
@@ -18,7 +18,7 @@ const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 
 // Top level Dashboard App component
 const App: FunctionComponent = () => {
-    const { user, isSetupRequired, loading } = useUserAndTeamsLoader();
+    const { user, isSetupRequired, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
 
     // Setup analytics/tracking

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -5,9 +5,10 @@
  */
 
 import * as GitpodCookie from "@gitpod/gitpod-protocol/lib/util/gitpod-cookie";
-import React, { FunctionComponent, Suspense } from "react";
+import React, { FC, Suspense } from "react";
 import { AppLoading } from "./app/AppLoading";
 import { AppRoutes } from "./app/AppRoutes";
+import { GitpodErrorBoundary } from "./components/ErrorBoundary";
 import { useCurrentOrg } from "./data/organizations/orgs-query";
 import { useAnalyticsTracking } from "./hooks/use-analytics-tracking";
 import { useUserLoader } from "./hooks/use-user-loader";
@@ -16,8 +17,18 @@ import { isGitpodIo } from "./utils";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 
+// Wrap the App in an ErrorBoundary to catch User/Org loading errors
+// This will also catch any errors that happen to bubble all the way up to the top
+const AppWithErrorBoundary: FC = () => {
+    return (
+        <GitpodErrorBoundary>
+            <App />
+        </GitpodErrorBoundary>
+    );
+};
+
 // Top level Dashboard App component
-const App: FunctionComponent = () => {
+const App: FC = () => {
     const { user, isSetupRequired, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
 
@@ -67,4 +78,4 @@ const App: FunctionComponent = () => {
     );
 };
 
-export default App;
+export default AppWithErrorBoundary;

--- a/components/dashboard/src/app/AppLoading.tsx
+++ b/components/dashboard/src/app/AppLoading.tsx
@@ -5,8 +5,19 @@
  */
 
 import { FunctionComponent } from "react";
+import { Delayed } from "../components/Delayed";
+import { Heading3, Subheading } from "../components/typography/headings";
+import gitpodIcon from "../icons/gitpod.svg";
 
-// TODO: Would be great to show a loading UI if it's been loading for awhile
 export const AppLoading: FunctionComponent = () => {
-    return <></>;
+    return (
+        // Wait 3 seconds before showing the loading screen to avoid flashing it too quickly
+        <Delayed wait={3000}>
+            <div className="flex flex-col justify-center items-center w-full h-screen space-y-4">
+                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0 animate-bounce"} />
+                <Heading3>Just getting a few more things ready</Heading3>
+                <Subheading>hang in there...</Subheading>
+            </div>
+        </Delayed>
+    );
 };

--- a/components/dashboard/src/app/AppLoading.tsx
+++ b/components/dashboard/src/app/AppLoading.tsx
@@ -11,10 +11,10 @@ import gitpodIcon from "../icons/gitpod.svg";
 
 export const AppLoading: FunctionComponent = () => {
     return (
-        // Wait 3 seconds before showing the loading screen to avoid flashing it too quickly
-        <Delayed wait={3000}>
+        // Wait 2 seconds before showing the loading screen to avoid flashing it too quickly
+        <Delayed wait={2000}>
             <div className="flex flex-col justify-center items-center w-full h-screen space-y-4">
-                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0 animate-bounce"} />
+                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0"} />
                 <Heading3>Just getting a few more things ready</Heading3>
                 <Subheading>hang in there...</Subheading>
             </div>

--- a/components/dashboard/src/components/Delayed.tsx
+++ b/components/dashboard/src/components/Delayed.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useEffect, useState } from "react";
+
+type Props = {
+    wait?: number;
+};
+export const Delayed: FC<Props> = ({ wait = 1000, children }) => {
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => setShow(true), wait);
+        return () => clearTimeout(timeout);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    if (!show) {
+        return null;
+    }
+
+    return <>{children}</>;
+};

--- a/components/dashboard/src/components/EmptyMessage.tsx
+++ b/components/dashboard/src/components/EmptyMessage.tsx
@@ -5,13 +5,13 @@
  */
 
 import classNames from "classnames";
-import { FC, useCallback } from "react";
+import { FC, ReactNode, useCallback } from "react";
 import { Button } from "./Button";
 import { Heading2, Subheading } from "./typography/headings";
 
 type Props = {
-    title: string;
-    subtitle?: string;
+    title: ReactNode;
+    subtitle?: ReactNode;
     buttonText?: string;
     onClick?: () => void;
     className?: string;

--- a/components/dashboard/src/components/ErrorBoundary.tsx
+++ b/components/dashboard/src/components/ErrorBoundary.tsx
@@ -18,9 +18,18 @@ export const GitpodErrorBoundary: FC = ({ children }) => {
     );
 };
 
+type CaughtError = Error & { code?: number };
+
 export const DefaultErrorFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+    // adjust typing, as we may have caught an api error here w/ a code property
+    const caughtError = error as CaughtError;
+
     const emailSubject = encodeURIComponent("Gitpod Dashboard Error");
-    const emailBody = encodeURIComponent(`\n\nError: ${error.message}`);
+    let emailBodyStr = `\n\nError: ${caughtError.message}`;
+    if (caughtError.code) {
+        emailBodyStr += `\nCode: ${caughtError.code}`;
+    }
+    const emailBody = encodeURIComponent(emailBodyStr);
 
     return (
         <div role="alert" className="app-container mt-14 flex flex-col items-center justify-center space-y-6">
@@ -36,7 +45,14 @@ export const DefaultErrorFallback: FC<FallbackProps> = ({ error, resetErrorBound
             <div>
                 <button onClick={resetErrorBoundary}>Reload</button>
             </div>
-            {error.message && <pre>{error.message}</pre>}
+            <div>
+                {caughtError.code && (
+                    <span>
+                        <strong>Code:</strong> {caughtError.code}
+                    </span>
+                )}
+                {caughtError.message && <pre>{caughtError.message}</pre>}
+            </div>
         </div>
     );
 };

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -6,10 +6,10 @@
 
 import { Organization, OrgMemberInfo, User } from "@gitpod/gitpod-protocol";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import { useLocation } from "react-router";
 import { publicApiTeamMembersToProtocol, publicApiTeamToProtocol, teamsService } from "../../service/public-api";
-import { useCurrentUser, UserContext } from "../../user-context";
+import { useCurrentUser } from "../../user-context";
 import { getUserBillingModeQueryKey } from "../billing-mode/user-billing-mode-query";
 import { noPersistence } from "../setup";
 
@@ -31,7 +31,6 @@ export function useOrganizationsInvalidator() {
 export function useOrganizations() {
     const user = useCurrentUser();
     const queryClient = useQueryClient();
-    const { refreshUserBillingMode } = useContext(UserContext);
     const query = useQuery<OrganizationInfo[], Error>(
         getQueryKey(user),
         async () => {
@@ -60,8 +59,8 @@ export function useOrganizations() {
                 if (!user) {
                     return;
                 }
+
                 // refresh user billing mode to update the billing mode in the user context as it depends on the orgs
-                refreshUserBillingMode();
                 queryClient.invalidateQueries(getUserBillingModeQueryKey(user.id));
             },
             onError: (err) => {

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -5,19 +5,16 @@
  */
 
 import { Organization, OrgMemberInfo, User } from "@gitpod/gitpod-protocol";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useContext } from "react";
 import { useLocation } from "react-router";
 import { publicApiTeamMembersToProtocol, publicApiTeamToProtocol, teamsService } from "../../service/public-api";
-import { getGitpodService } from "../../service/service";
 import { useCurrentUser, UserContext } from "../../user-context";
 import { getUserBillingModeQueryKey } from "../billing-mode/user-billing-mode-query";
 import { noPersistence } from "../setup";
 
 export interface OrganizationInfo extends Organization {
     members: OrgMemberInfo[];
-    billingMode?: BillingMode;
     isOwner: boolean;
     invitationId?: string;
 }
@@ -47,13 +44,11 @@ export function useOrganizations() {
             const response = await teamsService.listTeams({});
             const result: OrganizationInfo[] = [];
             for (const org of response.teams) {
-                const billingMode = await getGitpodService().server.getBillingModeForTeam(org.id);
                 const members = publicApiTeamMembersToProtocol(org.members || []);
                 const isOwner = members.some((m) => m.role === "owner" && m.userId === user?.id);
                 result.push({
                     ...publicApiTeamToProtocol(org),
                     members,
-                    billingMode,
                     isOwner,
                     invitationId: org.teamInvitation?.id,
                 });

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -63,12 +63,10 @@ export function useOrganizations() {
                 // refresh user billing mode to update the billing mode in the user context as it depends on the orgs
                 queryClient.invalidateQueries(getUserBillingModeQueryKey(user.id));
             },
-            onError: (err) => {
-                console.error("useOrganizations", err);
-            },
             enabled: !!user,
             cacheTime: 1000 * 60 * 60 * 1, // 1 hour
             staleTime: 1000 * 60 * 60 * 1, // 1 hour
+            useErrorBoundary: true,
         },
     );
     return query;

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -66,6 +66,7 @@ export function useOrganizations() {
             enabled: !!user,
             cacheTime: 1000 * 60 * 60 * 1, // 1 hour
             staleTime: 1000 * 60 * 60 * 1, // 1 hour
+            // We'll let an ErrorBoundary catch the error
             useErrorBoundary: true,
         },
     );

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -11,7 +11,7 @@ import {
     PersistQueryClientProvider,
     PersistQueryClientProviderProps,
 } from "@tanstack/react-query-persist-client";
-import { QueryClient, QueryKey } from "@tanstack/react-query";
+import { QueryCache, QueryClient, QueryKey } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { FunctionComponent } from "react";
 
@@ -28,7 +28,14 @@ export function isNoPersistence(queryKey: QueryKey): boolean {
 }
 
 export const setupQueryClientProvider = () => {
-    const client = new QueryClient();
+    const client = new QueryClient({
+        queryCache: new QueryCache({
+            // log any errors our queries throw
+            onError: (error) => {
+                console.error(error);
+            },
+        }),
+    });
     const queryClientPersister = createIDBPersister();
 
     const persistOptions: PersistQueryClientProviderProps["persistOptions"] = {

--- a/components/dashboard/src/hooks/use-analytics-tracking.ts
+++ b/components/dashboard/src/hooks/use-analytics-tracking.ts
@@ -13,6 +13,11 @@ export const useAnalyticsTracking = () => {
 
     // listen and notify Segment of client-side path updates
     useEffect(() => {
+        //store current path to have access to previous when path changes
+        const w = window as any;
+        const _gp = w._gp || (w._gp = {});
+        _gp.path = window.location.pathname;
+
         return history.listen((location: any) => {
             const path = window.location.pathname;
             trackPathChange({

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -12,7 +12,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { trackLocation } from "../Analytics";
 import { refreshSearchData } from "../components/RepositoryFinder";
 
-export const useUserAndTeamsLoader = () => {
+export const useUserLoader = () => {
     const [loading, setLoading] = useState<boolean>(true);
     const { user, setUser } = useContext(UserContext);
     const [isSetupRequired, setSetupRequired] = useState(false);

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -34,10 +34,14 @@ export const useUserLoader = () => {
                         setSetupRequired(true);
                         return;
                     }
-                }
 
-                // If it wasn't a setup required error, re-throw it
-                throw error;
+                    // If it was a server error, throw it so we can catch it with an ErrorBoundary
+                    if (error.code >= 500) {
+                        throw error;
+                    }
+
+                    // Other errors will treat user as needing to log in
+                }
             } finally {
                 trackLocation(!!user);
             }

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -4,42 +4,51 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext } from "react";
 import { User } from "@gitpod/gitpod-protocol";
 import { UserContext } from "../user-context";
 import { getGitpodService } from "../service/service";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { trackLocation } from "../Analytics";
 import { refreshSearchData } from "../components/RepositoryFinder";
+import { useQuery } from "@tanstack/react-query";
+import { noPersistence } from "../data/setup";
 
 export const useUserLoader = () => {
-    const [loading, setLoading] = useState<boolean>(true);
-    const { user, setUser } = useContext(UserContext);
+    const { setUser } = useContext(UserContext);
     const [isSetupRequired, setSetupRequired] = useState(false);
 
-    useEffect(() => {
-        (async () => {
-            let loggedInUser: User | undefined;
+    // For now, we're using the user context to store the user, but letting react-query handle the loading
+    // In the future, we should remove the user context and use react-query to access the user
+    const { data, isLoading } = useQuery({
+        queryKey: noPersistence(["current-user"]),
+        queryFn: async () => {
+            let user: User | undefined;
             try {
-                loggedInUser = await getGitpodService().server.getLoggedInUser();
-                setUser(loggedInUser);
+                user = await getGitpodService().server.getLoggedInUser();
+                setUser(user);
                 refreshSearchData();
             } catch (error) {
-                console.error(error);
                 if (error && "code" in error) {
                     if (error.code === ErrorCodes.SETUP_REQUIRED) {
                         setSetupRequired(true);
+                        return;
                     }
                 }
-            } finally {
-                trackLocation(!!loggedInUser);
-            }
-            setLoading(false);
-            (window as any)._gp.path = window.location.pathname; //store current path to have access to previous when path changes
-        })();
-        // Ensure this only ever runs once
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
-    return { user, loading, isSetupRequired };
+                // If it wasn't a setup required error, re-throw it
+                throw error;
+            } finally {
+                trackLocation(!!user);
+            }
+
+            return user;
+        },
+        // We'll let an ErrorBoundary catch the error
+        useErrorBoundary: true,
+        cacheTime: 1000 * 60 * 60 * 1, // 1 hour
+        staleTime: 1000 * 60 * 60 * 1, // 1 hour
+    });
+
+    return { user: data, loading: isLoading, isSetupRequired };
 };

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -15,12 +15,12 @@ import { useQuery } from "@tanstack/react-query";
 import { noPersistence } from "../data/setup";
 
 export const useUserLoader = () => {
-    const { setUser } = useContext(UserContext);
+    const { user, setUser } = useContext(UserContext);
     const [isSetupRequired, setSetupRequired] = useState(false);
 
     // For now, we're using the user context to store the user, but letting react-query handle the loading
     // In the future, we should remove the user context and use react-query to access the user
-    const { data, isLoading } = useQuery({
+    const { isLoading } = useQuery({
         queryKey: noPersistence(["current-user"]),
         queryFn: async () => {
             let user: User | undefined;
@@ -54,5 +54,5 @@ export const useUserLoader = () => {
         staleTime: 1000 * 60 * 60 * 1, // 1 hour
     });
 
-    return { user: data, loading: isLoading, isSetupRequired };
+    return { user, loading: isLoading, isSetupRequired };
 };

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -46,7 +46,7 @@ export const useUserLoader = () => {
                 trackLocation(!!user);
             }
 
-            return user;
+            return user || null;
         },
         // We'll let an ErrorBoundary catch the error
         useErrorBoundary: true,

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -12,6 +12,7 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
 import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 
 export interface OrganizationSelectorProps {}
 
@@ -20,6 +21,7 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
     const orgs = useOrganizations();
     const currentOrg = useCurrentOrg();
     const { data: userBillingMode } = useUserBillingMode();
+    const { data: orgBillingMode } = useOrgBillingMode();
     const { showUsageView } = useFeatureFlags();
 
     const userFullName = user?.fullName || user?.name || "...";
@@ -70,10 +72,7 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
         BillingMode.showUsageBasedBilling(userBillingMode) &&
         !user?.additionalData?.isMigratedToTeamOnlyAttribution;
 
-    const showUsageForOrg =
-        currentOrg.data &&
-        currentOrg.data.isOwner &&
-        (currentOrg.data.billingMode?.mode === "usage-based" || showUsageView);
+    const showUsageForOrg = currentOrg.data?.isOwner && (orgBillingMode?.mode === "usage-based" || showUsageView);
 
     if (showUsageForPersonalAccount || showUsageForOrg) {
         linkEntries.push({

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -62,7 +62,7 @@ export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
     );
 }
 
-export function getTeamSettingsMenu(params: {
+function getTeamSettingsMenu(params: {
     team?: Team;
     billingMode?: BillingMode;
     ssoEnabled?: boolean;

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -14,6 +14,7 @@ import DropDown from "../components/DropDown";
 import PillLabel from "../components/PillLabel";
 import SolidCard from "../components/SolidCard";
 import { Heading2, Subheading } from "../components/typography/headings";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { ReactComponent as CheckSvg } from "../images/check.svg";
@@ -36,6 +37,7 @@ export default function TeamBillingPage() {
 const TeamBilling: FunctionComponent = () => {
     const user = useCurrentUser();
     const currentOrg = useCurrentOrg();
+    const orgBillingMode = useOrgBillingMode();
     const [teamSubscription, setTeamSubscription] = useState<TeamSubscription2 | undefined>();
     const { currency, setCurrency } = useContext(PaymentContext);
     const [pendingTeamPlan, setPendingTeamPlan] = useState<PendingPlan | undefined>();
@@ -125,7 +127,7 @@ const TeamBilling: FunctionComponent = () => {
         window.localStorage.setItem(`pendingPlanForTeam${orgId}`, JSON.stringify(pending));
     };
 
-    const isLoading = currentOrg.isLoading;
+    const isLoading = currentOrg.isLoading || orgBillingMode.isLoading;
     const teamPlan = pendingTeamPlan || Plans.getById(teamSubscription?.planId);
 
     const featuresByPlanType: { [type in PlanType]?: Array<React.ReactNode> } = {
@@ -301,7 +303,7 @@ const TeamBilling: FunctionComponent = () => {
         );
     }
 
-    const showUBP = BillingMode.showUsageBasedBilling(currentOrg.data?.billingMode);
+    const showUBP = BillingMode.showUsageBasedBilling(orgBillingMode.data);
 
     return showUBP ? <TeamUsageBasedBilling /> : renderTeamBilling();
 };

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -4,8 +4,6 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Team } from "@gitpod/gitpod-protocol";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import React, { useCallback, useState } from "react";
 import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -15,41 +13,6 @@ import { teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
 import { OrgSettingsPage } from "./OrgSettingsPage";
-
-export function getTeamSettingsMenu(params: {
-    team?: Team;
-    billingMode?: BillingMode;
-    ssoEnabled?: boolean;
-    orgGitAuthProviders: boolean;
-}) {
-    const { billingMode, ssoEnabled, orgGitAuthProviders } = params;
-    const result = [
-        {
-            title: "General",
-            link: [`/settings`],
-        },
-    ];
-    if (ssoEnabled) {
-        result.push({
-            title: "SSO",
-            link: [`/sso`],
-        });
-    }
-    if (orgGitAuthProviders) {
-        result.push({
-            title: "Git Auth",
-            link: [`/settings/git`],
-        });
-    }
-    if (billingMode?.mode !== "none") {
-        // The Billing page contains both chargebee and usage-based components, so: always show them!
-        result.push({
-            title: "Billing",
-            link: ["/billing"],
-        });
-    }
-    return result;
-}
 
 export default function TeamSettings() {
     const user = useCurrentUser();

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -7,12 +7,14 @@
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
 
 export default function TeamUsageBasedBilling() {
     const org = useCurrentOrg().data;
+    const orgBillingMode = useOrgBillingMode();
 
-    if (!BillingMode.showUsageBasedBilling(org?.billingMode)) {
+    if (!BillingMode.showUsageBasedBilling(orgBillingMode.data)) {
         return <></>;
     }
 

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -5,33 +5,22 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import React, { createContext, useState, useCallback, useContext } from "react";
-import { getGitpodService } from "./service/service";
+import React, { createContext, useState, useContext, useMemo } from "react";
 
 const UserContext = createContext<{
     user?: User;
     setUser: React.Dispatch<User>;
-    userBillingMode?: BillingMode;
-    refreshUserBillingMode: () => void;
 }>({
     setUser: () => null,
-    refreshUserBillingMode: () => null,
 });
 
 const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
-    const [billingMode, setBillingMode] = useState<BillingMode>();
 
-    const refreshUserBillingMode = useCallback(() => {
-        return getGitpodService().server.getBillingModeForUser().then(setBillingMode);
-    }, []);
+    // Wrap value in useMemo to avoid unnecessary re-renders
+    const ctxValue = useMemo(() => ({ user, setUser }), [user, setUser]);
 
-    return (
-        <UserContext.Provider value={{ user, setUser, userBillingMode: billingMode, refreshUserBillingMode }}>
-            {children}
-        </UserContext.Provider>
-    );
+    return <UserContext.Provider value={ctxValue}>{children}</UserContext.Provider>;
 };
 
 export { UserContext, UserContextProvider };

--- a/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
@@ -9,7 +9,8 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useContext, useMemo } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
-import { UserContext } from "../user-context";
+import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
+import { useCurrentUser } from "../user-context";
 import {
     settingsPathAccount,
     settingsPathBilling,
@@ -30,11 +31,12 @@ export interface PageWithAdminSubMenuProps {
 }
 
 export function PageWithSettingsSubMenu({ children }: PageWithAdminSubMenuProps) {
-    const { userBillingMode, user } = useContext(UserContext);
+    const user = useCurrentUser();
+    const userBillingMode = useUserBillingMode();
     const { enablePersonalAccessTokens } = useContext(FeatureFlagContext);
 
     const settingsMenu = useMemo(() => {
-        return getSettingsMenu(user, userBillingMode, enablePersonalAccessTokens);
+        return getSettingsMenu(user, userBillingMode.data, enablePersonalAccessTokens);
     }, [user, userBillingMode, enablePersonalAccessTokens]);
 
     return (

--- a/components/dashboard/src/user-settings/Plans.tsx
+++ b/components/dashboard/src/user-settings/Plans.tsx
@@ -21,11 +21,12 @@ import InfoBox from "../components/InfoBox";
 import Modal from "../components/Modal";
 import SelectableCard from "../components/SelectableCard";
 import { getGitpodService } from "../service/service";
-import { UserContext } from "../user-context";
+import { useCurrentUser } from "../user-context";
 import Tooltip from "../components/Tooltip";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
 
 type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
@@ -44,7 +45,8 @@ type TeamClaimModal =
       };
 
 export default function PlansPage() {
-    const { user, userBillingMode } = useContext(UserContext);
+    const user = useCurrentUser();
+    const userBillingMode = useUserBillingMode();
     const { currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
     const { isUsageBasedBillingEnabled } = useContext(FeatureFlagContext);
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
@@ -708,10 +710,10 @@ export default function PlansPage() {
                     </p>
                 </div>
                 <div className="mt-4 flex justify-center space-x-3 2xl:space-x-7">{planCards}</div>
-                {assignedTs && userBillingMode?.mode === "chargebee" && !!userBillingMode.teamNames && (
+                {assignedTs && userBillingMode.data?.mode === "chargebee" && !!userBillingMode.data?.teamNames && (
                     <Alert type="info" className="mt-10 mx-auto">
                         <p>Assigned Organization Seats</p>
-                        <ul>{userBillingMode.teamNames.join(", ")}</ul>
+                        <ul>{userBillingMode.data.teamNames.join(", ")}</ul>
                     </Alert>
                 )}
                 {!!confirmUpgradeToPlan && (

--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -14,6 +14,7 @@ import { getGitpodService } from "../service/service";
 import dayjs from "dayjs";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { Heading2, Subheading } from "../components/typography/headings";
+import { EmptyMessage } from "../components/EmptyMessage";
 
 interface AddModalProps {
     value: SSHPublicKeyValue;
@@ -210,18 +211,17 @@ export default function SSHKeys() {
                 ) : null}
             </div>
             {dataList.length === 0 ? (
-                <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full h-96">
-                    <div className="pt-28 flex flex-col items-center w-112 m-auto">
-                        <Heading2 color="light" className="text-center pb-3 text-gray-500 dark:text-gray-400">
-                            No SSH Keys
-                        </Heading2>
-                        <Subheading className="pb-6">
+                <EmptyMessage
+                    title="No SSH Keys"
+                    subtitle={
+                        <span>
                             SSH keys allow you to establish a <b>secure connection</b> between your <b>computer</b> and{" "}
                             <b>workspaces</b>.
-                        </Subheading>
-                        <button onClick={addOne}>New SSH Key</button>
-                    </div>
-                </div>
+                        </span>
+                    }
+                    buttonText="New SSH Key"
+                    onClick={addOne}
+                />
             ) : (
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
                     {dataList.map((key) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Addresses a few things that deal with app loading state, and org loading.

* Adds top level ErrorBoundary to catch errors if user or org loading throw errors
  * Swapped user loading to a useQuery so errors can get caught in ErrorBoundary. Left UserContext for state management for now, but we can migrate to an exposed useQuery later to get the user.
* Extract org billing mode from `useOrganizations()` query and swap to `useOrgBillingMode()` query where it was used. This removes having to load every orgs billing mode as a blocking path for the app rendering.
* Removed `UserContext.billingMode` in favor of `userUserBillingMode()` query
* Add a view for `<AppLoading/>` that shows up if app takes longer than 3 seconds to load.

![app-loading](https://user-images.githubusercontent.com/367275/227043439-fee61d83-d9af-4878-8efd-1af78466d6e9.gif)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16803

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
