### PR TITLE
[e2e] Support and fixes for mk2 e2e tests

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -29,7 +29,7 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 PREVIEW_NAME="$(previewctl get-name --branch "${INPUT_NAME}")"
 export PREVIEW_NAME
 
-for var in WITH_WS_MANAGER_MK2 WITH_DEDICATED_EMU WITH_EE_LICENSE ANALYTICS WORKSPACE_FEATURE_FLAGS; do
+for var in WSMANAGER_MK2 WITH_DEDICATED_EMU WITH_EE_LICENSE ANALYTICS WORKSPACE_FEATURE_FLAGS; do
   input_var="INPUT_${var}"
   if [[ -n "${!input_var:-}" ]];then
     export GITPOD_${var}=${!input_var}

--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -13,7 +13,7 @@ inputs:
     previewctl_hash:
         description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
         required: false
-    with_ws_manager_mk2:
+    wsmanager_mk2:
         description: "Use WS Manager MK2"
         required: false
     with_dedicated_emu:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          with_ws_manager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
+          wsmanager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
           with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
           with_ee_license: ${{needs.configuration.outputs.with_ee_license}}
           analytics: ${{needs.configuration.outputs.analytics}}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -130,6 +130,7 @@ jobs:
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             version: ${{ needs.configuration.outputs.version}}
             previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}
+            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 }}
 
     check:
         name: Check for regressions
@@ -204,7 +205,7 @@ jobs:
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
 
-                  WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 }}"
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -16,6 +16,10 @@ on:
                 required: false
                 type: boolean
                 description: "Skip delete preview environment (debug only)"
+            wsman_mk2:
+                required: false
+                type: boolean
+                description: "Run tests against ws-manager-mk2"
     schedule:
         - cron: "0 3,12 * * *"
 jobs:
@@ -99,7 +103,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: Workspace Integration Tests failed
+                  SLACK_MESSAGE: "Workspace Integration Tests failed (used mk2: ${{ github.event.inputs.wsman_mk2 }})"
 
     infrastructure:
       needs: [ configuration ]
@@ -199,6 +203,8 @@ jobs:
                   WS_DAEMON_TESTS="$BASE_TESTS_DIR/components/ws-daemon"
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
+
+                  WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -103,7 +103,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "Workspace Integration Tests failed (used mk2: ${{ github.event.inputs.wsman_mk2 }})"
+                  SLACK_MESSAGE: "Workspace Integration Tests failed"
 
     infrastructure:
       needs: [ configuration ]
@@ -250,7 +250,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: ${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 }})"
 
     delete:
       name: Delete preview environment

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -366,7 +366,8 @@ func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsman
 		ws.Status.SetCondition(workspacev1.NewWorkspaceConditionStoppedByRequest(gracePeriod.String()))
 		return nil
 	})
-	if err != nil {
+	// Ignore NotFound errors, workspace has already been stopped.
+	if err != nil && status.Code(err) != codes.NotFound {
 		return nil, err
 	}
 	return &wsmanapi.StopWorkspaceResponse{}, nil

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -634,4 +634,8 @@ leeway run components:add-smith-token \
   -DPREVIEW_K3S_KUBE_CONTEXT="${PREVIEW_K3S_KUBE_CONTEXT}" \
   -DPREVIEW_NAMESPACE="${PREVIEW_NAMESPACE}"
 
+# Add experimental node label if ws-manager-mk2 is enabled.
+# Remove once mk2 workspaces no longer run on experimental nodes.
+kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" --namespace="${PREVIEW_NAMESPACE}" label nodes "${PREVIEW_K3S_KUBE_CONTEXT}" gitpod.io/experimental="true" --overwrite
+
 log_success "Installation is happy: https://${DOMAIN}/workspaces"

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -636,6 +636,8 @@ leeway run components:add-smith-token \
 
 # Add experimental node label if ws-manager-mk2 is enabled.
 # Remove once mk2 workspaces no longer run on experimental nodes.
-kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" --namespace="${PREVIEW_NAMESPACE}" label nodes "${PREVIEW_K3S_KUBE_CONTEXT}" gitpod.io/experimental="true" --overwrite
+if [[ "${GITPOD_WSMANAGER_MK2}" == "true" ]]; then
+  kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" --namespace="${PREVIEW_NAMESPACE}" label nodes "${PREVIEW_K3S_KUBE_CONTEXT}" gitpod.io/experimental="true" --overwrite
+fi
 
 log_success "Installation is happy: https://${DOMAIN}/workspaces"

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -586,12 +586,16 @@ const (
 	ComponentWorkspaceDaemon ComponentType = "ws-daemon"
 	// ComponentWorkspaceManager points to the workspace manager
 	ComponentWorkspaceManager ComponentType = "ws-manager"
+	// ComponentWorkspaceManagerMK2 points to the MK2 workspace manager
+	ComponentWorkspaceManagerMK2 ComponentType = "ws-manager-mk2"
 	// ComponentContentService points to the content service
 	ComponentContentService ComponentType = "content-service"
 	// ComponentWorkspace points to a workspace
 	ComponentWorkspace ComponentType = "workspace"
 	// ComponentImageBuilderMK3 points to the image-builder-mk3
 	ComponentImageBuilderMK3 ComponentType = "image-builder-mk3"
+	// ComponentImageBuilderMK3Wsman points to ws-manager-mk2's image-builder-mk3
+	ComponentImageBuilderMK3Wsman ComponentType = "image-builder-mk3-wsman"
 )
 
 func waitForPodRunningReady(c kubernetes.Interface, podName string, namespace string, timeout time.Duration) error {

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -142,17 +142,24 @@ func waitOnGitpodRunning(namespace string, waitTimeout time.Duration) env.Func {
 	klog.V(2).Info("Checking status of Gitpod components...")
 
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		imgBuilder := "image-builder-mk3"
+		wsman := "ws-manager"
+		if UseWsmanMk2() {
+			imgBuilder = "image-builder-mk3-wsman"
+			wsman = "ws-manager-mk2"
+		}
+
 		components := []string{
 			"agent-smith",
 			"blobserve",
 			"content-service",
 			"dashboard",
-			"image-builder-mk3",
+			imgBuilder,
 			"proxy",
 			"registry-facade",
 			"server",
 			"ws-daemon",
-			"ws-manager",
+			wsman,
 			"ws-manager-bridge",
 			"ws-proxy",
 		}
@@ -220,4 +227,8 @@ func getNamespace(path string) (string, error) {
 	}
 
 	return namespace, nil
+}
+
+func UseWsmanMk2() bool {
+	return os.Getenv("WS_MANAGER_MK2") == "true"
 }

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -120,8 +120,13 @@ func assertEnvSuppliedBySecret(t *testing.T, wsPod *corev1.Pod, secretEnv string
 					t.Fatalf("environment variable value is not supplied by secret")
 				}
 
-				if env.ValueFrom.SecretKeyRef.Name != wsPod.Name {
-					t.Fatalf("expected environment variable values are not supplied by secret %s", wsPod.Name)
+				expectedName := wsPod.Name
+				if integration.UseWsmanMk2() {
+					expectedName = fmt.Sprintf("%s-env", strings.TrimPrefix(wsPod.Name, "ws-"))
+				}
+
+				if env.ValueFrom.SecretKeyRef.Name != expectedName {
+					t.Fatalf("expected environment variable values are not supplied by secret %s", expectedName)
 				}
 			}
 		}


### PR DESCRIPTION
## Description

* Support running e2e tests against ws-manager-mk2 by setting the `WS_MANAGER_MK2=true` env var
* Fixes for mk2 to pass failing tests
* Add boolean to Github Actions workflow to run tests against mk2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

* Run e2e tests with(out) `WS_MANAGER_MK2=true`
* Trigger GHA from this branch with the mk2 boolean enabled/disabled

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
