### PR TITLE
[dashboard] Ensure we always send an organizationId if we need to!

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -122,10 +122,18 @@ export function CreateWorkspacePage() {
                 return;
             }
 
+            const organizationId = currentOrg?.id;
+            console.log("organizationId: " + JSON.stringify(organizationId));
+            if (!organizationId && !!user?.additionalData?.isMigratedToTeamOnlyAttribution) {
+                // We need an organizationId for this group of users
+                console.warn("Skipping createWorkspace");
+                return;
+            }
+
             try {
                 const result = await createWorkspaceMutation.mutateAsync({
                     contextUrl: contextURL,
-                    organizationId: currentOrg?.id,
+                    organizationId,
                     ...opts,
                 });
                 if (result.workspaceURL) {
@@ -139,7 +147,7 @@ export function CreateWorkspacePage() {
                 console.log(error);
             }
         },
-        [createWorkspaceMutation, history, contextURL, selectedIde, selectedWsClass, currentOrg?.id, useLatestIde],
+        [createWorkspaceMutation, history, contextURL, selectedIde, selectedWsClass, currentOrg?.id, user?.additionalData?.isMigratedToTeamOnlyAttribution, useLatestIde],
     );
 
     // Need a wrapper here so we call createWorkspace w/o any arguments


### PR DESCRIPTION
## Description

Fixes a bug that we noticed yesterday. Probably it was fixed with https://github.com/gitpod-io/gitpod/pull/16976 already, but having the guard + log helps in case this happens again.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
