### PR TITLE
[server] gRPC/Connect Unimplemented User Service

### DIFF
--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -18,6 +18,7 @@ packages:
       - components/supervisor-api/typescript-grpcweb:lib
       - components/usage-api/typescript:lib
       - components/ide-service-api/typescript:lib
+      - components/public-api/typescript:lib
     config:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/yarn.lock
@@ -57,6 +58,7 @@ packages:
       - components/supervisor-api/typescript-grpcweb:lib
       - components/usage-api/typescript:lib
       - components/ide-service-api/typescript:lib
+      - components/public-api/typescript:lib
       - :dbtest
     config:
       packaging: library
@@ -83,6 +85,7 @@ packages:
       - components/supervisor-api/typescript-grpcweb:lib
       - components/usage-api/typescript:lib
       - components/ide-service-api/typescript:lib
+      - components/public-api/typescript:lib
     config:
       packaging: library
       yarnLock: ${coreYarnLockBase}/yarn.lock

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -28,6 +28,8 @@
   ],
   "dependencies": {
     "@authzed/authzed-node": "^0.10.0",
+    "@bufbuild/connect": "^0.8.1",
+    "@bufbuild/connect-express": "^0.8.1",
     "@gitbeaker/node": "^35.7.0",
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-db": "0.1.5",
@@ -36,6 +38,7 @@
     "@gitpod/gitpod-protocol": "0.1.5",
     "@gitpod/ide-service-api": "0.1.5",
     "@gitpod/image-builder": "0.1.5",
+    "@gitpod/public-api": "0.1.5",
     "@gitpod/supervisor-api-grpcweb": "0.1.5",
     "@gitpod/usage-api": "0.1.5",
     "@gitpod/ws-manager": "0.1.5",

--- a/components/server/src/api/user.ts
+++ b/components/server/src/api/user.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { injectable } from "inversify";
+import { ServiceImpl, ConnectError, Code } from "@bufbuild/connect";
+import { UserService as UserServiceInterface } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_connectweb";
+import {
+    GetAuthenticatedUserRequest,
+    ListSSHKeysRequest,
+    CreateSSHKeyRequest,
+    GetSSHKeyRequest,
+    DeleteSSHKeyRequest,
+    GetGitTokenRequest,
+    BlockUserRequest,
+    GetAuthenticatedUserResponse,
+    ListSSHKeysResponse,
+    CreateSSHKeyResponse,
+    GetSSHKeyResponse,
+    DeleteSSHKeyResponse,
+    GetGitTokenResponse,
+    BlockUserResponse,
+} from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
+
+@injectable()
+export class APIUserService implements ServiceImpl<typeof UserServiceInterface> {
+    public async getAuthenticatedUser(req: GetAuthenticatedUserRequest): Promise<GetAuthenticatedUserResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async listSSHKeys(req: ListSSHKeysRequest): Promise<ListSSHKeysResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async createSSHKey(req: CreateSSHKeyRequest): Promise<CreateSSHKeyResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async getSSHKey(req: GetSSHKeyRequest): Promise<GetSSHKeyResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async deleteSSHKey(req: DeleteSSHKeyRequest): Promise<DeleteSSHKeyResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async getGitToken(req: GetGitTokenRequest): Promise<GetGitTokenResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    public async blockUser(req: BlockUserRequest): Promise<BlockUserResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -113,6 +113,7 @@ import { IamSessionApp } from "./iam/iam-session-app";
 import { spicedbClientFromEnv, SpiceDBClient } from "./authorization/spicedb";
 import { Authorizer, PermissionChecker } from "./authorization/perms";
 import { EnvVarService } from "./workspace/env-var-service";
+import { APIUserService } from "./api/user";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -313,4 +314,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
         .toDynamicValue(() => spicedbClientFromEnv())
         .inSingletonScope();
     bind(PermissionChecker).to(Authorizer).inSingletonScope();
+
+    // grpc / Connect API
+    bind(APIUserService).toSelf().inSingletonScope();
 });

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -25,6 +25,7 @@
         { "path": "components/ws-proxy" },
         { "path": "components/public-api" },
         { "path": "components/public-api-server" },
+        { "path": "components/public-api/typescript" },
         { "path": "components/gitpod-db" },
         { "path": "test" },
         { "path": "dev/blowtorch" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,10 +1238,32 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bufbuild/connect-express@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@bufbuild/connect-express/-/connect-express-0.8.1.tgz#54eb548896fad2488bc9cd16b968713e0799c955"
+  integrity sha512-DZkPfMYmL1doR8XaeQdwHI0YmKyWz7sG9HaZYEOcBoag+lnlbqXGaakx5gbMnE1OSX7qkSVEqrv7kB/B1tSXOQ==
+  dependencies:
+    "@bufbuild/connect" "0.8.1"
+    "@bufbuild/connect-node" "^0.8.1"
+    "@types/express" "^4.17.17"
+
+"@bufbuild/connect-node@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@bufbuild/connect-node/-/connect-node-0.8.1.tgz#db371506a9c54cac78b0b73b25dd531d86dbe45a"
+  integrity sha512-yIdXWekNaKDBFVWY6S6L0js6Szh2fhunmVxxCd5taOL4KekO5joIfuA9eLuunTDlp1ie0fPPm7Dc5KlxWgOn0Q==
+  dependencies:
+    "@bufbuild/connect" "0.8.1"
+    headers-polyfill "^3.1.2"
+
 "@bufbuild/connect-web@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@bufbuild/connect-web/-/connect-web-0.2.1.tgz#a7ee2914bf1b77d640fc4ee3c3a89d626f3015fa"
   integrity sha512-L580cL9VZCXcjwXMCvIvdFBqdQofVBQcL+jmSis7m8ZxPj5NQ4p7fUhQRTsZMWHkyWINdlZnr7WsHQL0BT7wPQ==
+
+"@bufbuild/connect@0.8.1", "@bufbuild/connect@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@bufbuild/connect/-/connect-0.8.1.tgz#71afa90bf56bb833a7f3e2a492e6f9f83c2bebeb"
+  integrity sha512-cQA0jstYcLknJecTE7KbU4ePNBqiCNviBEcUCbFLve3x+vcSmtoH6jb8z39MeBqFy42ZoWhTGGc3RNCeOx2QUA==
 
 "@bufbuild/protobuf@0.1.1", "@bufbuild/protobuf@^0.1.1":
   version "0.1.1"
@@ -2880,6 +2902,15 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
+"@types/express-serve-static-core@^4.17.33":
+  version "4.17.33"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz#de35d30a9d637dc1450ad18dd583d75d5733d543"
+  integrity sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
 "@types/express-session@*", "@types/express-session@1.17.4":
   version "1.17.4"
   resolved "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.4.tgz"
@@ -2894,6 +2925,16 @@
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.17":
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
+  integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -9354,6 +9395,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-polyfill@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
+  integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
 
 heapdump@^0.3.15:
   version "0.3.15"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds an un-implemented UserService onto server. This service is a gRPC/connect service, which conforms to the same interface as the public-api as per WebApp architectural direction.

Currently unused, but will be used by as part of https://github.com/gitpod-io/ops/issues/8192 to issue a BlockUser call

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17000
* Part of https://github.com/gitpod-io/ops/issues/8192

## How to test
<!-- Provide steps to test this PR -->

1. Preview
2. Port forward `k port-forward deployment/server 9877:9877`
3. 
	```
	curl \
	    --header "Content-Type: application/json" \
	    --data '{}' \                           
	    http://localhost:9877/gitpod.experimental.v1.UserService/BlockUser
	
	{"code":"unimplemented","message":"unimplemented"}
	```
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
