### PR TITLE
support integration-test for gha

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,5 +61,5 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 - [ ] /werft with-large-vm
 - [ ] /werft with-gce-vm
       If enabled this will create the environment on GCE infra
-- [ ] /werft with-integration-tests=all
+- [ ] with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
       with_werft: ${{ steps.output.outputs.with-werft }}
+      with_integration_tests: ${{ steps.output.outputs.with_integration_tests }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -66,6 +67,7 @@ jobs:
         run: |
           {
             echo "workspace_feature_flags=$(echo "$PR_DESC" | grep -oP '(?<=\[X\] workspace-feature-flags).*')"
+            echo "with_integration_tests=$(echo "$PR_DESC" | grep -oiP '(?<=\[x\] with-integration-tests=).*')"
           } >> $GITHUB_OUTPUT
 
   build-previewctl:
@@ -315,3 +317,47 @@ jobs:
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
+
+  integration-test:
+    name: "Run integration test"
+    needs: [ configuration, build-previewctl, build-gitpod, infrastructure, install ]
+    runs-on: [ self-hosted ]
+    container:
+        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-jam-dev-image.2
+        volumes:
+          - /var/tmp:/var/tmp
+          - /tmp:/tmp
+    if: needs.configuration.outputs.with_integration_tests != ''
+    concurrency:
+      group: ${{ github.head_ref || github.ref_name }}-integration-test
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run integration test
+        shell: bash
+        env:
+            ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            INTEGRATION_TEST_USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
+            INTEGRATION_TEST_USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
+            PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+            PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
+            TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
+        run: |
+            set -euo pipefail
+
+            export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+            export HOME="/home/gitpod"
+            export PREVIEW_ENV_DEV_SA_KEY_PATH="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
+
+            echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+            gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+            leeway run dev/preview/previewctl:install
+
+            echo "Setting up access to core-dev and harvester"
+            previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+            previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+            $GITHUB_WORKSPACE/test/run.sh -s ${TEST_SUITS}
+


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
support run integration-test for gha

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

see this job https://github.com/gitpod-io/gitpod/actions/runs/4502498386/jobs/7925282541

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=vscode
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
