### PR TITLE
[wsman-mk2] Emit event for timed out workspaces

### DIFF
--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 	Expect(wsReconciler.SetupWithManager(k8sManager)).To(Succeed())
 
 	wsActivity = &activity.WorkspaceActivity{}
-	timeoutReconciler, err := NewTimeoutReconciler(k8sManager.GetClient(), conf, wsActivity)
+	timeoutReconciler, err := NewTimeoutReconciler(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("workspace"), conf, wsActivity)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(timeoutReconciler.SetupWithManager(k8sManager)).To(Succeed())
 

--- a/components/ws-manager-mk2/controllers/timeout_controller_test.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -35,7 +36,7 @@ var _ = Describe("TimeoutController", func() {
 			// Use a fake client instead of the envtest's k8s client, such that we can add objects
 			// with custom CreationTimestamps and check timeout logic.
 			fakeClient = fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).Build()
-			r, err = NewTimeoutReconciler(fakeClient, conf, &activity.WorkspaceActivity{})
+			r, err = NewTimeoutReconciler(fakeClient, record.NewFakeRecorder(100), conf, &activity.WorkspaceActivity{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -196,7 +197,7 @@ var _ = Describe("TimeoutController", func() {
 		var r *TimeoutReconciler
 		BeforeEach(func() {
 			var err error
-			r, err = NewTimeoutReconciler(k8sClient, newTestConfig(), &activity.WorkspaceActivity{})
+			r, err = NewTimeoutReconciler(k8sClient, record.NewFakeRecorder(100), newTestConfig(), &activity.WorkspaceActivity{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -148,7 +148,7 @@ func main() {
 	}
 
 	activity := &activity.WorkspaceActivity{}
-	timeoutReconciler, err := controllers.NewTimeoutReconciler(mgr.GetClient(), cfg.Manager, activity)
+	timeoutReconciler, err := controllers.NewTimeoutReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), cfg.Manager, activity)
 	if err != nil {
 		setupLog.Error(err, "unable to create timeout controller", "controller", "Timeout")
 		os.Exit(1)


### PR DESCRIPTION
## Description
 Emit event for timed out workspaces

```
0s          Normal    TimedOut                  workspace/94bd04a6-5692-4f0f-b300-33397fa1e3fc          workspace timed out after period of inactivity (00h01m) took longer than 00h01m
```
## Related Issue(s)
n.a.

## How to test
- Open workspace in [preview environment](https://fo-timedout-events.preview.gitpod-dev.com/workspaces)
- Set timeout of workspace to 1m
- Check events with `kubectl get events` 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
