### PR TITLE
default orgGitAuthProviders to true for dedicated

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -28,6 +28,7 @@ const defaultFeatureFlags = {
     oidcServiceEnabled: false,
     // Default to true to enable on gitpod dedicated until ff support is added for dedicated
     orgGitAuthProviders: true,
+    userGitAuthProviders: false,
     switchToPAYG: false,
     newSignupFlow: false,
 };
@@ -47,6 +48,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
     const [oidcServiceEnabled, setOidcServiceEnabled] = useState<boolean>(false);
     const [orgGitAuthProviders, setOrgGitAuthProviders] = useState<boolean>(false);
+    const [userGitAuthProviders, setUserGitAuthProviders] = useState<boolean>(false);
     const [switchToPAYG, setSwitchToPAYG] = useState<boolean>(false);
     const [newSignupFlow, setNewSignupFlow] = useState<boolean>(false);
 
@@ -66,6 +68,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 oidcServiceEnabled: { defaultValue: false, setter: setOidcServiceEnabled },
                 // Default to true to enable on gitpod dedicated until ff support is added for dedicated
                 orgGitAuthProviders: { defaultValue: true, setter: setOrgGitAuthProviders },
+                userGitAuthProviders: { defaultValue: false, setter: setUserGitAuthProviders },
                 switchToPAYG: { defaultValue: false, setter: setSwitchToPAYG },
                 newSignupFlow: { defaultValue: false, setter: setNewSignupFlow },
             };
@@ -114,6 +117,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
             usePublicApiWorkspacesService,
             oidcServiceEnabled,
             orgGitAuthProviders,
+            userGitAuthProviders,
             newSignupFlow,
             switchToPAYG,
         };
@@ -128,6 +132,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         startWithOptions,
         switchToPAYG,
         usePublicApiWorkspacesService,
+        userGitAuthProviders,
     ]);
 
     return <FeatureFlagContext.Provider value={flags}>{children}</FeatureFlagContext.Provider>;

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -26,7 +26,8 @@ const defaultFeatureFlags = {
     usePublicApiWorkspacesService: false,
     enablePersonalAccessTokens: false,
     oidcServiceEnabled: false,
-    orgGitAuthProviders: false,
+    // Default to true to enable on gitpod dedicated until ff support is added for dedicated
+    orgGitAuthProviders: true,
     switchToPAYG: false,
     newSignupFlow: false,
 };
@@ -63,7 +64,8 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                     setter: setUsePublicApiWorkspacesService,
                 },
                 oidcServiceEnabled: { defaultValue: false, setter: setOidcServiceEnabled },
-                orgGitAuthProviders: { defaultValue: false, setter: setOrgGitAuthProviders },
+                // Default to true to enable on gitpod dedicated until ff support is added for dedicated
+                orgGitAuthProviders: { defaultValue: true, setter: setOrgGitAuthProviders },
                 switchToPAYG: { defaultValue: false, setter: setSwitchToPAYG },
                 newSignupFlow: { defaultValue: false, setter: setNewSignupFlow },
             };

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -110,6 +110,7 @@
     select.error {
         @apply border-gitpod-red dark:border-gitpod-red focus:border-gitpod-red dark:focus:border-gitpod-red;
     }
+    select[disabled],
     textarea[disabled],
     input[disabled] {
         @apply bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -23,7 +23,7 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     const menuEntries = useMemo(() => {
         const result: ContextMenuEntry[] = [];
         result.push({
-            title: provider.status === "verified" ? "Edit Configuration" : "Activate Integration",
+            title: provider.status === "verified" ? "Edit" : "Activate",
             onClick: () => setShowEditModal(true),
             separator: true,
         });

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -33,7 +33,7 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
                 {providers.length !== 0 ? (
                     <div className="">
                         <Button className="whitespace-nowrap" onClick={onCreate}>
-                            New Integration
+                            New Git Auth
                         </Button>
                     </div>
                 ) : null}
@@ -43,7 +43,7 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
                 <EmptyMessage
                     title="No Git Auth configurations"
                     subtitle="Configure Git Auth with GitHub or GitLab."
-                    buttonText="New Integration"
+                    buttonText="New Git Auth"
                     onClick={onCreate}
                 />
             ) : (

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -123,8 +123,8 @@ export class AuthProviderService {
     }
 
     async createOrgAuthProvider(entry: AuthProviderEntry.NewOrgEntry): Promise<AuthProviderEntry> {
-        // TODO: only restrict existing provider w/ same host if it's the same organization
-        const existing = await this.authProviderDB.findByHost(entry.host);
+        const orgProviders = await this.authProviderDB.findByOrgId(entry.organizationId);
+        const existing = orgProviders.find((p) => p.host === entry.host);
         if (existing) {
             throw new Error("Provider for this host already exists.");
         }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3104,12 +3104,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 throw new Error("Host could not be reached.");
             }
 
-            // const hostContext = this.hostContextProvider.get(host);
-            // if (hostContext) {
-            //     const builtInExists = hostContext.authProvider.params.ownerId === undefined;
-            //     log.debug(`Attempt to override existing auth provider.`, { entry, newProvider, builtInExists });
-            //     throw new Error("Provider for this host already exists.");
-            // }
+            const hostContext = this.hostContextProvider.get(host);
+            if (hostContext) {
+                const builtInExists = hostContext.authProvider.params.ownerId === undefined;
+                log.debug(`Attempt to override existing auth provider.`, { entry, newProvider, builtInExists });
+                throw new Error("Provider for this host already exists.");
+            }
 
             const result = await this.authProviderService.createOrgAuthProvider(newProvider);
             return AuthProviderEntry.redact(result);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3104,12 +3104,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 throw new Error("Host could not be reached.");
             }
 
-            const hostContext = this.hostContextProvider.get(host);
-            if (hostContext) {
-                const builtInExists = hostContext.authProvider.params.ownerId === undefined;
-                log.debug(`Attempt to override existing auth provider.`, { entry, newProvider, builtInExists });
-                throw new Error("Provider for this host already exists.");
-            }
+            // const hostContext = this.hostContextProvider.get(host);
+            // if (hostContext) {
+            //     const builtInExists = hostContext.authProvider.params.ownerId === undefined;
+            //     log.debug(`Attempt to override existing auth provider.`, { entry, newProvider, builtInExists });
+            //     throw new Error("Provider for this host already exists.");
+            // }
 
             const result = await this.authProviderService.createOrgAuthProvider(newProvider);
             return AuthProviderEntry.redact(result);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Next steps in preparing Git Auth for use in orgs and in dedicated.

* Default `orgGitAuthProviders` flag to `true` in dashboard so it's on for dedicated. Still off for production though. We can revisit this once we have more robust ff support in dedicated.
* Several small Git Auth config UI updates/fixes I noticed when testing
* Adjusting org git auth providers and how we check for duplicate host names.
* Adding `userGitAuthProviders` feature flag that guards ability to create user-based git auth providers. Default is `false` so it's disabled on dedicated, but flag is `true` in non-prod and prod to keep existing behavior.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16934, https://github.com/gitpod-io/gitpod/issues/17018

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-git-auth-updates.preview.gitpod-dev.com/user/account
Should be able to create providers both under orgs and users.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
