### PR TITLE
Remove references to enterprise licenses

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -29,7 +29,7 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 PREVIEW_NAME="$(previewctl get-name --branch "${INPUT_NAME}")"
 export PREVIEW_NAME
 
-for var in WSMANAGER_MK2 WITH_DEDICATED_EMU WITH_EE_LICENSE ANALYTICS WORKSPACE_FEATURE_FLAGS; do
+for var in WSMANAGER_MK2 WITH_DEDICATED_EMU ANALYTICS WORKSPACE_FEATURE_FLAGS; do
   input_var="INPUT_${var}"
   if [[ -n "${!input_var:-}" ]];then
     export GITPOD_${var}=${!input_var}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,7 +47,6 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 <details>
 <summary>Installer Options</summary>
 
-- [ ] with-ee-license
 - [ ] with-dedicated-emulation
 - [ ] with-ws-manager-mk2
 - [ ] workspace-feature-flags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
       publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-jb-marketplace') }}
       with_ws_manager_mk2: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-ws-manager-mk2') }}
       with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-dedicated-emulation') }}
-      with_ee_license: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-ee-license') }}
       analytics: ${{ contains( steps.pr-details.outputs.pr_body, '[X] analytics') }}
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
@@ -298,7 +297,6 @@ jobs:
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
           wsmanager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
           with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
-          with_ee_license: ${{needs.configuration.outputs.with_ee_license}}
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
 

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -30,7 +30,6 @@ export class Installer {
             PREVIEW_NAME: this.options.previewName,
             GITPOD_ANALYTICS: this.options.analytics,
             GITPOD_WORKSPACE_FEATURE_FLAGS: this.options.workspaceFeatureFlags.join(" "),
-            GITPOD_WITH_EE_LICENSE: this.options.withEELicense,
             GITPOD_WITH_DEDICATED_EMU: this.options.withDedicatedEmulation,
             GITPOD_WSMANAGER_MK2: this.options.useWsManagerMk2,
         };

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -26,7 +26,6 @@ GITPOD_CONTAINER_REGISTRY_URL="eu.gcr.io/gitpod-core-dev/build/";
 GITPOD_IMAGE_PULL_SECRET_NAME="gcp-sa-registry-auth";
 GITPOD_PROXY_SECRET_NAME="proxy-config-certificates";
 GITPOD_ANALYTICS="${GITPOD_ANALYTICS:-}"
-GITPOD_WITH_EE_LICENSE="${GITPOD_WITH_EE_LICENSE:-true}"
 GITPOD_WORKSPACE_FEATURE_FLAGS="${GITPOD_WORKSPACE_FEATURE_FLAGS:-}"
 GITPOD_WITH_DEDICATED_EMU="${GITPOD_WITH_DEDICATED_EMU:-false}"
 GITPOD_WSMANAGER_MK2="${GITPOD_WSMANAGER_MK2:-false}"
@@ -534,16 +533,6 @@ installer --debug-version-file="/tmp/versions.yaml" render \
 # ===============
 
 log_info "Post-processing"
-
-#
-# configureLicense
-#
-if [[ "${GITPOD_WITH_EE_LICENSE}" == "true" ]]
-then
-  readWerftSecret "gpsh-harvester-license" "license" > /tmp/license
-else
-  touch /tmp/license
-fi
 
 #
 # configureWorkspaceFeatureFlags


### PR DESCRIPTION
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
