### PR TITLE
Make sidebars responsive

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -4,6 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import classNames from "classnames";
+import { FC, useEffect, useRef } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import Header, { TabEntry } from "../components/Header";
@@ -20,30 +22,61 @@ export interface PageWithSubMenuProps {
 }
 
 export function PageWithSubMenu(p: PageWithSubMenuProps) {
-    const location = useLocation();
     return (
         <div className="w-full">
             <Header title={p.title} subtitle={p.subtitle} tabs={p.tabs} />
-            <div className="app-container flex pt-9">
+            <div className="app-container flex md:pt-9 flex-col md:flex-row">
+                {/* TODO: extract into SubMenu component and show scrolling indicators */}
                 <div>
-                    <ul className="flex flex-col text tracking-wide text-gray-500 pt-4 lg:pt-0 w-52 space-y-2">
+                    <ul
+                        className={classNames(
+                            // Handle flipping between row and column layout
+                            "flex flex-row md:flex-col items-center",
+                            "w-full md:w-52 overflow-auto md:overflow-visible",
+                            "pt-4 pb-4 md:pb-0",
+                            "space-x-2 md:space-x-0 md:space-y-2",
+                            "tracking-wide text-gray-500",
+                        )}
+                    >
                         {p.subMenu.map((e) => {
-                            let classes = "flex block py-2 px-4 rounded-md";
-                            if (e.link.some((l) => l === location.pathname)) {
-                                classes += " bg-gray-300 text-gray-800 dark:bg-gray-800 dark:text-gray-50";
-                            } else {
-                                classes += " hover:bg-gray-100 dark:hover:bg-gray-800";
-                            }
-                            return (
-                                <Link to={e.link[0]} key={e.title}>
-                                    <li className={classes}>{e.title}</li>
-                                </Link>
-                            );
+                            return <SubmenuItem title={e.title} link={e.link} key={e.title} />;
                         })}
                     </ul>
                 </div>
-                <div className="ml-16 lg:ml-32 w-full pt-1 mb-40">{p.children}</div>
+                <div className="md:ml-16 lg:ml-32 w-full pt-1 mb-40">{p.children}</div>
             </div>
         </div>
     );
 }
+
+type SubmenuItemProps = {
+    title: string;
+    link: string[];
+};
+
+const SubmenuItem: FC<SubmenuItemProps> = ({ title, link }) => {
+    const location = useLocation();
+    const itemRef = useRef<HTMLLIElement>(null);
+
+    // TODO: can remove this once we use sub-routes and don't re-render the whole page for each sub-route
+    useEffect(() => {
+        if (itemRef.current && link.some((l) => l === location.pathname)) {
+            itemRef.current.scrollIntoView({ behavior: "auto", block: "nearest", inline: "start" });
+        }
+    }, [link, location.pathname]);
+
+    let classes = "flex block py-2 px-4 rounded-md whitespace-nowrap max-w-52";
+
+    if (link.some((l) => l === location.pathname)) {
+        classes += " bg-gray-300 text-gray-800 dark:bg-gray-800 dark:text-gray-50";
+    } else {
+        classes += " hover:bg-gray-100 dark:hover:bg-gray-800";
+    }
+    return (
+        <Link to={link[0]} key={title} className="md:w-full">
+            <li ref={itemRef} className={classes}>
+                {title}
+            </li>
+        </Link>
+    );
+};

--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -9,6 +9,7 @@ import { FC, useEffect, useRef } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import Header, { TabEntry } from "../components/Header";
+import { Separator } from "./Separator";
 
 export interface PageWithSubMenuProps {
     title: string;
@@ -43,7 +44,10 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                         })}
                     </ul>
                 </div>
-                <div className="md:ml-16 lg:ml-32 w-full pt-1 mb-40">{p.children}</div>
+                <div className="md:ml-16 lg:ml-32 w-full pt-1 mb-40">
+                    <Separator className="md:hidden" />
+                    <div className="pt-4 md:pt-0">{p.children}</div>
+                </div>
             </div>
         </div>
     );

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -19,7 +19,7 @@ export const Heading1: FC<HeadingProps> = ({ color, tracking, className, childre
             className={classNames(
                 getHeadingColor(color),
                 getTracking(tracking),
-                "font-bold text-5xl leading-64",
+                "font-bold text-4xl md:text-5xl leading-64",
                 className,
             )}
         >


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Step 1 to making sidebars responsive. Shifts the sidebar to a row that scrolls on smaller screens. Also made the `<Heading1/>` slightly smaller on small screens.

| Header | Header |
|--------|--------|
| <img width="407" alt="image" src="https://user-images.githubusercontent.com/367275/227397674-5738b10c-6a3d-4bf6-858e-7f30ca6d6595.png"> | <img width="424" alt="image" src="https://user-images.githubusercontent.com/367275/227397642-b6f2059a-b459-401c-a786-82d2e064c892.png"> | 

**Follow Up Steps**
* Explore using a dropdown for the sidebar navigation items versus scrollable menu.
* Explore adding a scrolling indicator on left/right edge of menu when there's more options off-screen.
* Currently navigation on the submenu results in a full route re-render, which resets the scroll position of the menu. This PR shifts the active item into visibility, but it isn't able to maintain scroll position due to the re-render. We can address this in a followup by using nested routes w/ react-router, and only re-render the portions of the page that change as much as possible.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8133

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-respon4a5450a2ee.preview.gitpod-dev.com/user/account
* Visit some of the pages with sidebar nav (user/org settings) on mobile and desktop.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
