### PR TITLE
[ws-manager-mk2] Report content init/dispose failures

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -189,9 +189,9 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 
 			if failure != "" {
 				log.Error(initErr, "could not initialize workspace", "name", ws.Name)
-				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionFalse, "InitializationFailure", failure))
+				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionFalse, workspacev1.ReasonInitializationFailure, failure))
 			} else {
-				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionTrue, "InitializationSuccess", ""))
+				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionTrue, workspacev1.ReasonInitializationSuccess, ""))
 			}
 
 			return wsc.Status().Update(ctx, ws)

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -13,6 +13,13 @@ import (
 const (
 	// GitpodFinalizerName is the name of the finalizer we use on workspaces and their pods.
 	GitpodFinalizerName = "gitpod.io/finalizer"
+
+	// ReasonInitializationSuccess is a Reason for the WorkspaceConditionContentReady condition,
+	// incidating content init succeeded.
+	ReasonInitializationSuccess = "InitializationSuccess"
+	// ReasonInitializationFailure is a Reason for the WorkspaceConditionContentReady condition,
+	// indicating that content init failed. The condition's message will contain the failure details.
+	ReasonInitializationFailure = "InitializationFailure"
 )
 
 // WorkspaceSpec defines the desired state of Workspace

--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -218,7 +218,7 @@ func newMetricState(ws *workspacev1.Workspace) metricState {
 		// This is to prevent these from being re-recorded after the controller restarts and clears the metric state for
 		// each workspace.
 		recordedStartTime:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
-		recordedInitFailure:     wsk8s.ConditionWithStatusAndReason(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, "InitializationFailure"),
+		recordedInitFailure:     wsk8s.ConditionWithStatusAndReason(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure),
 		recordedStartFailure:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)),
 		recordedContentReady:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)),
 		recordedBackupFailed:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)),

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -252,7 +252,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 		return r.deleteWorkspacePod(ctx, pod, "timed out")
 
 	// if the content initialization failed, delete the pod
-	case wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, "InitializationFailure") && !isPodBeingDeleted(pod):
+	case wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure) && !isPodBeingDeleted(pod):
 		return r.deleteWorkspacePod(ctx, pod, "init failed")
 
 	case isWorkspaceBeingDeleted(workspace) && !isPodBeingDeleted(pod):
@@ -299,7 +299,7 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 		return
 	}
 
-	if !lastState.recordedInitFailure && wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, "InitializationFailure") {
+	if !lastState.recordedInitFailure && wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure) {
 		r.metrics.countTotalRestoreFailures(&log, workspace)
 		lastState.recordedInitFailure = true
 

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -111,7 +111,7 @@ var _ = Describe("WorkspaceController", func() {
 					Type:               string(workspacev1.WorkspaceConditionContentReady),
 					Status:             metav1.ConditionFalse,
 					Message:            "some failure",
-					Reason:             "InitializationFailure",
+					Reason:             workspacev1.ReasonInitializationFailure,
 					LastTransitionTime: metav1.Now(),
 				})
 			})
@@ -443,7 +443,7 @@ func markContentReady(ws *workspacev1.Workspace) {
 		ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
 			Type:               string(workspacev1.WorkspaceConditionContentReady),
 			Status:             metav1.ConditionTrue,
-			Reason:             "InitializationSuccess",
+			Reason:             workspacev1.ReasonInitializationSuccess,
 			LastTransitionTime: metav1.Now(),
 		})
 	})


### PR DESCRIPTION
## Description

Report content init/dispose failures in the workspace status.

Fixes the `TestMissingBackup` e2e test.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416

## How to test

Tested by modifying ws-daemon to return an init (1) and dispose (2) error:

<img width="459" alt="image" src="https://user-images.githubusercontent.com/9721064/227494379-8311feb4-6b77-4aa5-8b78-714e5b619714.png">

<img width="510" alt="image" src="https://user-images.githubusercontent.com/9721064/227494633-6b092dfd-2223-44cd-9d78-00fa99acce16.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
