### PR TITLE
[ws-manager-mk2] Garbage collect workspaces

### DIFF
--- a/components/ws-daemon/pkg/controller/housekeeping.go
+++ b/components/ws-daemon/pkg/controller/housekeeping.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/opentracing/opentracing-go"
+)
+
+const minContentGCAge = 1 * time.Hour
+
+type Housekeeping struct {
+	Location string
+	Interval time.Duration
+}
+
+func NewHousekeeping(location string, interval time.Duration) *Housekeeping {
+	return &Housekeeping{
+		Location: location,
+		Interval: interval,
+	}
+}
+
+func (h *Housekeeping) Start(ctx context.Context) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Housekeeping.Start")
+	defer tracing.FinishSpan(span, nil)
+	log.WithField("interval", h.Interval.String()).Debug("started workspace housekeeping")
+
+	ticker := time.NewTicker(h.Interval)
+	defer ticker.Stop()
+
+	run := true
+	for run {
+		var errs []error
+		select {
+		case <-ticker.C:
+			errs = h.doHousekeeping(ctx)
+		case <-ctx.Done():
+			run = false
+		}
+
+		for _, err := range errs {
+			log.WithError(err).Error("error during housekeeping")
+		}
+	}
+
+	span.Finish()
+	log.Debug("stopping workspace housekeeping")
+}
+
+func (h *Housekeeping) doHousekeeping(ctx context.Context) (errs []error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "doHousekeeping")
+	defer func() {
+		msgs := make([]string, len(errs))
+		for i, err := range errs {
+			msgs[i] = err.Error()
+		}
+
+		var err error
+		if len(msgs) > 0 {
+			err = fmt.Errorf(strings.Join(msgs, ". "))
+		}
+		tracing.FinishSpan(span, &err)
+	}()
+
+	errs = make([]error, 0)
+
+	// Find workspace directories which are left over.
+	files, err := os.ReadDir(h.Location)
+	if err != nil {
+		return []error{fmt.Errorf("cannot list existing workspaces content directory: %w", err)}
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			continue
+		}
+
+		// If this is the -daemon directory, make sure we assume the correct state file name
+		name := f.Name()
+		name = strings.TrimSuffix(name, string(filepath.Separator))
+		name = strings.TrimSuffix(name, "-daemon")
+
+		if _, err := os.Stat(filepath.Join(h.Location, fmt.Sprintf("%s.workspace.json", name))); !errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
+		// We have found a workspace content directory without a workspace state file, which means we don't manage this folder.
+		// Within the working area/location of a session store we must be the only one who creates directories, because we want to
+		// make sure we don't leak files over time.
+
+		// For good measure we wait a while before deleting that directory.
+		nfo, err := f.Info()
+		if err != nil {
+			log.WithError(err).Warn("Found workspace content directory without a corresponding state file, but could not retrieve its info")
+			errs = append(errs, err)
+			continue
+		}
+		if time.Since(nfo.ModTime()) < minContentGCAge {
+			continue
+		}
+
+		err = os.RemoveAll(filepath.Join(h.Location, f.Name()))
+		if err != nil {
+			log.WithError(err).Warn("Found workspace content directory without a corresponding state file, but could not delete the content directory")
+			errs = append(errs, err)
+			continue
+		}
+
+		log.WithField("directory", f.Name()).Info("deleted workspace content directory without corresponding state file")
+	}
+
+	return errs
+}

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -221,6 +221,9 @@ func NewDaemon(config Config) (*Daemon, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		housekeeping := controller.NewHousekeeping(contentCfg.WorkingArea, 5*time.Minute)
+		go housekeeping.Start(context.Background())
 	}
 
 	dsptch, err := dispatch.NewDispatch(containerRuntime, clientset, config.Runtime.KubernetesNamespace, nodename, listener...)


### PR DESCRIPTION
## Description
Old workspaces (identified by having no workspace state file) will be garbage collected after 1 hour. This takes care of situations where we fail to remove the workspace content after backup e.g. because ws-daemon has been restarted.

## Related Issue(s)
n.a.

## How to test
- Open workspace in [preview environment](https://gc71da2917f.workspace-preview.gitpod-io-dev.com/workspaces)
- SSH into node and delete the workspace state file from disk
- The garbage collection age has been modified in the preview environment so the workspace should be garbage collected after 2 minutes. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
