### PR TITLE
[server] Fix userService.deauthorize to disallow disconnecting the last auth provider

### DIFF
--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -461,7 +461,6 @@ export class UserService {
     }
 
     async deauthorize(user: User, authProviderId: string) {
-        const builtInProviders = ["Public-GitLab", "Public-GitHub", "Public-Bitbucket"];
         const externalIdentities = user.identities.filter(
             (i) => i.authProviderId !== TokenService.GITPOD_AUTH_PROVIDER_ID,
         );
@@ -476,10 +475,8 @@ export class UserService {
             (i) => i !== identity && (!this.config.disableDynamicAuthProviderLogin || isBuiltin(i.authProviderId)),
         );
 
-        if (
-            remainingLoginIdentities.length === 1 &&
-            !builtInProviders.includes(remainingLoginIdentities[0].authProviderId)
-        ) {
+        // Disallow users to deregister the last builtin auth provider's from their user
+        if (remainingLoginIdentities.length === 0) {
             throw new Error(
                 "Cannot remove last authentication provider for logging in to Gitpod. Please delete account if you want to leave.",
             );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
