### PR TITLE
User Pref Editor change cleanup

### DIFF
--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -76,7 +76,7 @@ export default function Preferences() {
                         Learn more
                     </a>
                 </Subheading>
-                <SelectIDE updateUserContext={false} location="preferences" />
+                <SelectIDE location="preferences" />
 
                 <ThemeSelector className="mt-12" />
 

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -37,7 +37,6 @@ export default function SelectIDE(props: SelectIDEProps) {
             const additionalData = user?.additionalData || {};
             const ideSettings = additionalData.ideSettings || {};
 
-            // Avoid mutating user object in state for updates
             const updates = {
                 additionalData: {
                     ...additionalData,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some small cleanup to the code in user prefs around updating the editor options.

* Adjusted user update logic to avoid mutating user object in react state directly.
* Also cleaned up a few places that needed a `useCallback()` wrapper.

Fixes WEB-39

## How to test
<!-- Provide steps to test this PR -->
* Go to user preferences
* Change Editor
* Click Account in side, then click Preferences
* Ensure your Editor change is reflected
* Reload page and ensure it's still reflected.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
