### PR TITLE
[common-go] Rate limiting on booleans and composite keys

### DIFF
--- a/components/common-go/grpc/ratelimit.go
+++ b/components/common-go/grpc/ratelimit.go
@@ -33,8 +33,12 @@ type RateLimit struct {
 	// so effectively this is the rate at which requests can be made.
 	RefillInterval util.Duration `json:"refillInterval"`
 
-	KeyCacheSize uint   `json:"keyCacheSize,omitempty"`
-	Key          string `json:"key,omitempty"`
+	// Key is the proto field name to rate limit on. Each unique value of this
+	// field gets its own rate limit bucket. Must be a String, Enum, or Boolean field.
+	// Can be a composite key by separating fields by comma, e.g. `foo.bar,foo.baz`
+	Key string `json:"key,omitempty"`
+	// KeyCacheSize is the max number of buckets kept in a LRU cache.
+	KeyCacheSize uint `json:"keyCacheSize,omitempty"`
 }
 
 func (r RateLimit) Limiter() *rate.Limiter {
@@ -88,11 +92,20 @@ func fieldAccessKey(key string) keyFunc {
 			return "", status.Errorf(codes.Internal, "request was not a protobuf message")
 		}
 
-		val, ok := getFieldValue(msg.ProtoReflect(), strings.Split(key, "."))
-		if !ok {
-			return "", status.Errorf(codes.Internal, "Field %s does not exist in message. This is a rate limiting configuration error.", key)
+		fields := strings.Split(key, ",")
+		var composite string
+		for _, field := range fields {
+			val, ok := getFieldValue(msg.ProtoReflect(), strings.Split(field, "."))
+			if !ok {
+				return "", status.Errorf(codes.Internal, "Field %s does not exist in message. This is a rate limiting configuration error.", field)
+			}
+			// It's technically possible that `|` is part of one of the field values, and therefore could cause collisions
+			// in composite keys, e.g. values (`a|`, `b`), and (`a`, `|b`) would result in the same composite key `a||b`
+			// and share the rate limit. This is currently not possible though given the fields we rate limit on.
+			composite += "|" + val
 		}
-		return val, nil
+
+		return composite, nil
 	}
 }
 
@@ -120,6 +133,13 @@ func getFieldValue(msg protoreflect.Message, path []string) (val string, ok bool
 	case protoreflect.EnumKind:
 		enumNum := msg.Get(field).Enum()
 		return strconv.Itoa(int(enumNum)), true
+	case protoreflect.BoolKind:
+		if msg.Get(field).Bool() {
+			return "t", true
+		} else {
+			return "f", true
+		}
+
 	default:
 		// we only support string and enum fields
 		return "", false

--- a/components/common-go/grpc/ratelimit_test.go
+++ b/components/common-go/grpc/ratelimit_test.go
@@ -52,6 +52,18 @@ func TestGetFieldValue(t *testing.T) {
 			Expectation: Expectation{Found: true, Val: "0"},
 		},
 		{
+			Name:        "bool field",
+			Message:     &apipb.Method{RequestStreaming: true},
+			Path:        "request_streaming",
+			Expectation: Expectation{Found: true, Val: "t"},
+		},
+		{
+			Name:        "empty bool field",
+			Message:     &apipb.Method{},
+			Path:        "request_streaming",
+			Expectation: Expectation{Found: true, Val: "f"},
+		},
+		{
 			Name:        "non-existent field",
 			Message:     &apipb.Api{},
 			Path:        "does-not-exist",
@@ -79,6 +91,41 @@ func TestGetFieldValue(t *testing.T) {
 	}
 }
 
+func TestFieldAccessKey(t *testing.T) {
+	type Expectation struct {
+		Val string
+		Err error
+	}
+	tests := []struct {
+		Name        string
+		Message     proto.Message
+		Key         string
+		Expectation Expectation
+	}{
+		{
+			Name: "composite key",
+			Message: &apipb.Api{
+				SourceContext: &sourcecontextpb.SourceContext{
+					FileName: "bar",
+				},
+				Syntax: typepb.Syntax_SYNTAX_PROTO3,
+			},
+			Key:         "source_context.file_name,syntax",
+			Expectation: Expectation{Val: "|bar|1", Err: nil},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var act Expectation
+			keyFn := fieldAccessKey(test.Key)
+			act.Val, act.Err = keyFn(test.Message)
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected fieldAccessKey (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func BenchmarkGetFieldValue(b *testing.B) {
 	msg := apipb.Api{
 		SourceContext: &sourcecontextpb.SourceContext{
@@ -90,5 +137,58 @@ func BenchmarkGetFieldValue(b *testing.B) {
 	// run the Fib function b.N times
 	for n := 0; n < b.N; n++ {
 		getFieldValue(msgr, path)
+	}
+}
+
+func BenchmarkFieldAccessKey_String(b *testing.B) {
+	msg := &apipb.Api{
+		Name: "bar",
+	}
+	keyFn := fieldAccessKey("name")
+	for n := 0; n < b.N; n++ {
+		if _, err := keyFn(msg); err != nil {
+			b.Logf("failed to access key: %v", err)
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkFieldAccessKey_Enum(b *testing.B) {
+	msg := &apipb.Api{
+		Syntax: typepb.Syntax_SYNTAX_PROTO3,
+	}
+	keyFn := fieldAccessKey("syntax")
+	for n := 0; n < b.N; n++ {
+		if _, err := keyFn(msg); err != nil {
+			b.Logf("failed to access key: %v", err)
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkFieldAccessKey_Bool(b *testing.B) {
+	msg := &apipb.Method{
+		RequestStreaming: true,
+	}
+	keyFn := fieldAccessKey("request_streaming")
+	for n := 0; n < b.N; n++ {
+		if _, err := keyFn(msg); err != nil {
+			b.Logf("failed to access key: %v", err)
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkFieldAccessKey_Composite(b *testing.B) {
+	msg := &apipb.Method{
+		Name:             "bar",
+		RequestStreaming: true,
+	}
+	keyFn := fieldAccessKey("name,request_streaming")
+	for n := 0; n < b.N; n++ {
+		if _, err := keyFn(msg); err != nil {
+			b.Logf("failed to access key: %v", err)
+			b.Fail()
+		}
 	}
 }


### PR DESCRIPTION
## Description

* Support rate limiting keyed on boolean fields
* Support composite rate limit keys
  * Comma separated, e.g. `foo.bar,foo.baz`
* Improve performance of rate limiter by moving string splitting out of the hot path

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Run unit tests and benchmarks. Tested single and composite keys in a preview env


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [x] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
