### PR TITLE
Configure registry-facade secrets without using external dependencies

### DIFF
--- a/install/installer/pkg/components/registry-facade/configmap.go
+++ b/install/installer/pkg/components/registry-facade/configmap.go
@@ -20,14 +20,6 @@ import (
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var tls regfac.TLS
-	if ctx.Config.Certificate.Name != "" {
-		tls = regfac.TLS{
-			Certificate: "/mnt/certificates/tls.crt",
-			PrivateKey:  "/mnt/certificates/tls.key",
-		}
-	}
-
 	var (
 		ipfsCache  *regfac.IPFSCacheConfig
 		redisCache *regfac.RedisCacheConfig
@@ -86,9 +78,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Registry: regfac.Config{
 			Port:               ServicePort,
 			RemoteSpecProvider: remoteSpecProviders,
-			TLS:                &tls,
-			Store:              "/mnt/cache/registry",
-			RequireAuth:        false,
+			TLS: &regfac.TLS{
+				Certificate: "/mnt/certificates/tls.crt",
+				PrivateKey:  "/mnt/certificates/tls.key",
+			},
+			Store:       "/mnt/cache/registry",
+			RequireAuth: false,
 			StaticLayer: []regfac.StaticLayerCfg{
 				{
 					Ref:  ctx.ImageName(ctx.Config.Repository, SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -36,26 +36,23 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	var (
-		volumes      []corev1.Volume
-		volumeMounts []corev1.VolumeMount
-	)
-
-	if ctx.Config.Certificate.Name != "" {
-		name := "config-certificates"
-		volumes = append(volumes, corev1.Volume{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: ctx.Config.Certificate.Name,
+		volumes = []corev1.Volume{
+			{
+				Name: "config-certificates",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "builtin-registry-facade-cert",
+					},
 				},
 			},
-		})
-
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      name,
-			MountPath: "/mnt/certificates",
-		})
-	}
+		}
+		volumeMounts = []corev1.VolumeMount{
+			{
+				Name:      "config-certificates",
+				MountPath: "/mnt/certificates",
+			},
+		}
+	)
 
 	if objs, err := common.DockerRegistryHash(ctx); err != nil {
 		return nil, err

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -28,23 +28,23 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	var volumes []corev1.Volume
-	var volumeMounts []corev1.VolumeMount
-	if ctx.Config.Certificate.Name != "" {
-		volumes = append(volumes, corev1.Volume{
+	volumes := []corev1.Volume{
+		{
 			Name: "config-certificates",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: ctx.Config.Certificate.Name,
 				},
 			},
-		})
-
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "config-certificates",
-			MountPath: "/mnt/certificates",
-		})
+		},
 	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "config-certificates",
+			MountPath: "/mnt/certificates"},
+	}
+
 	if ctx.Config.SSHGatewayHostKey != nil {
 		volumes = append(volumes, corev1.Volume{
 			Name: "host-key",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Finish the revert of [this change](https://github.com//gitpod-io/gitpod/commit/3c3530e6da4e29758ef3b986b78d7a76d382c5c1)
We should not use the secret for `proxy` in registry-facade but the one created for the component

## How to test
- Workspaces should open without issues

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
