### PR TITLE
[observability] add supervisor dashboard

### DIFF
--- a/operations/observability/mixins/IDE/dashboards.libsonnet
+++ b/operations/observability/mixins/IDE/dashboards.libsonnet
@@ -13,6 +13,7 @@
     'gitpod-component-openvsx-proxy.json': (import 'dashboards/components/openvsx-proxy.json'),
     'gitpod-component-openvsx-mirror.json': (import 'dashboards/components/openvsx-mirror.json'),
     'gitpod-component-ssh-gateway.json': (import 'dashboards/components/ssh-gateway.json'),
+    'gitpod-component-supervisor.json': (import 'dashboards/components/supervisor.json'),
     'gitpod-component-jb.json': (import 'dashboards/components/jb.json'),
     'gitpod-component-browser-overview.json': (import 'dashboards/components/browser-overview.json'),
     'gitpod-component-code-browser.json': (import 'dashboards/components/code-browser.json'),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add missing dashboard setting

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
