### PR TITLE
[server] Expose gRPC API port to public-api & usage

### DIFF
--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -43,6 +43,7 @@ const (
 	SystemNodeCritical              = "system-node-critical"
 	PaymentEndpointComponent        = "payment-endpoint"
 	PublicApiComponent              = "public-api-server"
+	UsageComponent                  = "usage"
 	WSManagerComponent              = "ws-manager"
 	WSManagerMk2Component           = "ws-manager-mk2"
 	WSManagerBridgeComponent        = "ws-manager-bridge"

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -29,4 +29,7 @@ const (
 	AdminCredentialsSecretName      = "admin-credentials"
 	AdminCredentialsSecretMountPath = "/credentials/admin"
 	AdminCredentialsSecretKey       = "admin.json"
+
+	GRPCAPIName = "grpc"
+	GRPCAPIPort = 9877
 )

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -351,6 +351,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							}, {
 								Name:          DebugNodePortName,
 								ContainerPort: common.DebugNodePort,
+							}, {
+								Name:          GRPCAPIName,
+								ContainerPort: GRPCAPIPort,
 							},
 							},
 							// todo(sje): do we need to cater for serverContainer.env from values.yaml?

--- a/install/installer/pkg/components/server/networkpolicy.go
+++ b/install/installer/pkg/components/server/networkpolicy.go
@@ -121,6 +121,32 @@ func Networkpolicy(ctx *common.RenderContext, component string) ([]runtime.Objec
 							},
 						},
 					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: GRPCAPIPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app":       "gitpod",
+										"component": common.PublicApiComponent,
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app":       "gitpod",
+										"component": common.UsageComponent,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/install/installer/pkg/components/server/objects.go
+++ b/install/installer/pkg/components/server/objects.go
@@ -53,6 +53,11 @@ var Objects = common.CompositeRenderFunc(
 			ContainerPort: common.DebugNodePort,
 			ServicePort:   common.DebugNodePort,
 		},
+		{
+			Name:          GRPCAPIName,
+			ContainerPort: GRPCAPIPort,
+			ServicePort:   GRPCAPIPort,
+		},
 	}),
 	common.DefaultServiceAccount(Component),
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/16999
* Part of https://github.com/gitpod-io/ops/issues/8192

## How to test
<!-- Provide steps to test this PR -->
1. `kubectl port-forward service/server 9877:9877`
2.
	```
	curl \
    --header "Content-Type: application/json" \
    --data '{}' \                           
    http://localhost:9877/gitpod.experimental.v1.UserService/BlockUser

	{"code":"unimplemented","message":"unimplemented"}
	```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency