### PR TITLE
[server] Cleanup adminBlockUser RPC

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -622,7 +622,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const targetUser = await this.userService.blockUser(req.id, req.blocked);
 
-        const stoppedWorkspaces = await this.workspaceStarter.stopWorkspacesForUser(
+        const stoppedWorkspaces = await this.workspaceStarter.stopRunningWorkspacesForUser(
             ctx,
             req.id,
             "user blocked by admin",

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -630,6 +630,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         );
 
         log.info(`Stopped ${stoppedWorkspaces.length} workspaces in response to admin initiated block.`, {
+            userId: targetUser.id,
             workspaceIds: stoppedWorkspaces.map((w) => w.id),
         });
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -377,7 +377,7 @@ export class UserService {
     async blockUser(targetUserId: string, block: boolean): Promise<User> {
         const target = await this.userDb.findUserById(targetUserId);
         if (!target) {
-            new ResponseError(ErrorCodes.NOT_FOUND, "not found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "not found");
         }
 
         target.blocked = !!block;

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -377,7 +377,7 @@ export class UserService {
     async blockUser(targetUserId: string, block: boolean): Promise<User> {
         const target = await this.userDb.findUserById(targetUserId);
         if (!target) {
-            throw new Error("Not found.");
+            new ResponseError(ErrorCodes.NOT_FOUND, "not found");
         }
 
         target.blocked = !!block;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -420,7 +420,7 @@ export class WorkspaceStarter {
         userID: string,
         reason: string,
         policy?: StopWorkspacePolicy,
-    ): Promise<Workspace> {
+    ): Promise<Workspace[]> {
         const isDefined = <T>(x: T | undefined): x is T => x !== undefined;
 
         const workspaceDb = this.workspaceDb.trace(ctx);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Cleans up blocking users rpc, which makes it easier to introduce it on the gRPC API in `api/user.ts` see https://github.com/gitpod-io/gitpod/pull/16999 for details if needed.

* Moves stopping of workspaces to workspace starter (it already has the stop method there)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
