### PR TITLE
[jb] support running tests agaist latest backend version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
       with_werft: ${{ steps.output.outputs.with-werft }}
       with_integration_tests: ${{ steps.output.outputs.with_integration_tests }}
+      latest_ide_version: ${{ contains( steps.pr-details.outputs.pr_body, '[x] latest-ide-version') }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -340,6 +341,9 @@ jobs:
             PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
             PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
             TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
+            TEST_USE_LATEST_VERSION: ${{ needs.configuration.outputs.latest_ide_version }}
+            TEST_BUILD_ID: ${{ github.run_id }}
+            TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
             set -euo pipefail
 

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -1,4 +1,5 @@
 name: JetBrains Test
+run-name: Test ${{ inputs.jb_product }} (latest=${{ inputs.use_latest }}, build_id=${{ inputs.build_id }})
 on:
   workflow_dispatch:
     inputs:
@@ -14,10 +15,32 @@ on:
         type: string
         description: IDE Endpoint
         required: true
+      jb_product:
+        type: string
+        description: JB product
+        required: true
+      use_latest:
+        type: string
+        description: Use latest IDE version
+        required: true
+      build_id:
+        type: string
+        description: Build ID
+        required: true
+      build_url:
+        type: string
+        description: Build URL
+        required: true
 jobs:
   jetbrains-smoke-test-linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Summary
+        if: always()
+        run: |
+          echo "- Build URL: ${{ inputs.build_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- JB Product: ${{ inputs.jb_product }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest Version: ${{ inputs.use_latest }}" >> $GITHUB_STEP_SUMMARY
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -2074,6 +2074,7 @@ type UpdateOwnAuthProviderParams struct {
 
 // CreateWorkspaceOptions is the CreateWorkspaceOptions message type
 type CreateWorkspaceOptions struct {
+	StartWorkspaceOptions
 	ContextURL                         string `json:"contextUrl,omitempty"`
 	IgnoreRunningWorkspaceOnSameCommit bool   `json:"ignoreRunningWorkspaceOnSameCommit,omitemopty"`
 	IgnoreRunningPrebuild              bool   `json:"ignoreRunningPrebuild,omitemopty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] latest-ide-version