### PR TITLE
[server] Implement blockUser

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -18,9 +18,9 @@
     "clean:node": "rimraf node_modules",
     "purge": "yarn clean && yarn clean:node && yarn run rimraf yarn.lock",
     "lint": "yarn tslint -p .",
-    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
+    "test": "mocha --opts mocha.opts --exclude './node_modules/**'",
     "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
-    "db-test-run": "mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",
+    "db-test-run": "mocha --opts mocha.opts **/*.spec.db.ts **/*.spec.ts --exclude './node_modules/**'",
     "telepresence": "leeway run .:telepresence"
   },
   "files": [

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -18,9 +18,9 @@
     "clean:node": "rimraf node_modules",
     "purge": "yarn clean && yarn clean:node && yarn run rimraf yarn.lock",
     "lint": "yarn tslint -p .",
-    "test": "mocha --opts mocha.opts --exclude './node_modules/**'",
+    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
-    "db-test-run": "mocha --opts mocha.opts **/*.spec.db.ts **/*.spec.ts --exclude './node_modules/**'",
+    "db-test-run": "mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",
     "telepresence": "leeway run .:telepresence"
   },
   "files": [

--- a/components/server/src/api/user.spec.ts
+++ b/components/server/src/api/user.spec.ts
@@ -13,7 +13,7 @@ import { UserService } from "../user/user-service";
 import { BlockUserRequest, BlockUserResponse } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
 import { User } from "@gitpod/gitpod-protocol";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
-import { Workspace } from "@gitpod/gitpod-protocol/src/protocol";
+import { Workspace } from "@gitpod/gitpod-protocol/lib/protocol";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { v4 as uuidv4 } from "uuid";
 import { ConnectError, Code } from "@bufbuild/connect";

--- a/components/server/src/api/user.spec.ts
+++ b/components/server/src/api/user.spec.ts
@@ -1,0 +1,48 @@
+import { suite, test } from "mocha-typescript";
+import { APIUserService } from "./user";
+import { Container } from "inversify";
+import { testContainer } from "@gitpod/gitpod-db/lib";
+import { WorkspaceStarter } from "../workspace/workspace-starter";
+import { UserService } from "../user/user-service";
+import { BlockUserRequest } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
+import { User } from "@gitpod/gitpod-protocol";
+import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
+import { Workspace } from "@gitpod/gitpod-protocol/src/protocol";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+
+@suite()
+export class APIUserServiceSpec {
+    private container: Container;
+    private workspaceStarter: WorkspaceStarter;
+    private userService: UserService;
+
+    private sut: APIUserService;
+
+    async before() {
+        this.workspaceStarter = {} as WorkspaceStarter;
+        this.userService = {} as UserService;
+        this.container = testContainer.createChild();
+
+        this.container.bind(WorkspaceStarter).toDynamicValue((ctx) => this.workspaceStarter);
+        this.container.bind(UserService).toDynamicValue((ctx) => this.userService);
+        this.container.bind(APIUserService).toSelf().inSingletonScope();
+    }
+
+    @test async blockUser_rejectsInvalidArguments() {
+        this.userService.blockUser = async (targetUserId: string, block: boolean): Promise<User> => {
+            return {
+                id: targetUserId,
+            } as User;
+        };
+        this.workspaceStarter.stopRunningWorkspacesForUser = async (
+            ctx: TraceContext,
+            userID: string,
+            reason: string,
+            policy?: StopWorkspacePolicy,
+        ): Promise<Workspace[]> => {
+            return [];
+        };
+
+        await this.sut.blockUser(new BlockUserRequest({ userId: "foo", reason: "naughty" }));
+    }
+}

--- a/components/server/src/api/user.spec.ts
+++ b/components/server/src/api/user.spec.ts
@@ -10,45 +10,72 @@ import { Container } from "inversify";
 import { testContainer } from "@gitpod/gitpod-db/lib";
 import { WorkspaceStarter } from "../workspace/workspace-starter";
 import { UserService } from "../user/user-service";
-import { BlockUserRequest } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
+import { BlockUserRequest, BlockUserResponse } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
 import { User } from "@gitpod/gitpod-protocol";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { Workspace } from "@gitpod/gitpod-protocol/src/protocol";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { v4 as uuidv4 } from "uuid";
+import { ConnectError, Code } from "@bufbuild/connect";
+import * as chai from "chai";
+
+const expect = chai.expect;
 
 @suite()
 export class APIUserServiceSpec {
     private container: Container;
-    private workspaceStarter: WorkspaceStarter;
-    private userService: UserService;
-
-    private sut: APIUserService;
-
-    async before() {
-        this.workspaceStarter = {} as WorkspaceStarter;
-        this.userService = {} as UserService;
-        this.container = testContainer.createChild();
-
-        this.container.bind(WorkspaceStarter).toDynamicValue((ctx) => this.workspaceStarter);
-        this.container.bind(UserService).toDynamicValue((ctx) => this.userService);
-        this.container.bind(APIUserService).toSelf().inSingletonScope();
-    }
-
-    @test async blockUser_rejectsInvalidArguments() {
-        this.userService.blockUser = async (targetUserId: string, block: boolean): Promise<User> => {
-            return {
-                id: targetUserId,
-            } as User;
-        };
-        this.workspaceStarter.stopRunningWorkspacesForUser = async (
+    private workspaceStarterMock: WorkspaceStarter = {
+        stopRunningWorkspacesForUser: async (
             ctx: TraceContext,
             userID: string,
             reason: string,
             policy?: StopWorkspacePolicy,
         ): Promise<Workspace[]> => {
             return [];
-        };
+        },
+    } as WorkspaceStarter;
+    private userServiceMock: UserService = {
+        blockUser: async (targetUserId: string, block: boolean): Promise<User> => {
+            return {
+                id: targetUserId,
+            } as User;
+        },
+    } as UserService;
 
-        await this.sut.blockUser(new BlockUserRequest({ userId: "foo", reason: "naughty" }));
+    async before() {
+        this.container = testContainer.createChild();
+
+        this.container.bind(WorkspaceStarter).toConstantValue(this.workspaceStarterMock);
+        this.container.bind(UserService).toConstantValue(this.userServiceMock);
+        this.container.bind(APIUserService).toSelf().inSingletonScope();
+    }
+
+    @test async blockUser_rejectsInvalidArguments() {
+        const scenarios: BlockUserRequest[] = [
+            new BlockUserRequest({ userId: "", reason: "naughty" }), // no user id
+            new BlockUserRequest({ userId: "foo", reason: "naughty" }), // user id is not a uuid
+            new BlockUserRequest({ userId: uuidv4(), reason: "" }), // no reason value
+        ];
+
+        const sut = this.container.get<APIUserService>(APIUserService);
+
+        for (let scenario of scenarios) {
+            try {
+                console.log("blockUser", scenario);
+                console.log("sut", sut);
+                await sut.blockUser(scenario);
+                expect.fail("blockUser did not throw an exception");
+            } catch (err) {
+                expect(err).to.be.an.instanceof(ConnectError);
+                expect(err.code).to.equal(Code.InvalidArgument);
+            }
+        }
+    }
+
+    @test async blockUser_delegatesToUserServiceAndWorkspaceStarter() {
+        const sut = this.container.get<APIUserService>(APIUserService);
+
+        const response = await sut.blockUser(new BlockUserRequest({ userId: uuidv4(), reason: "naughty" }));
+        expect(response).to.deep.equal(new BlockUserResponse());
     }
 }

--- a/components/server/src/api/user.spec.ts
+++ b/components/server/src/api/user.spec.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
 import { suite, test } from "mocha-typescript";
 import { APIUserService } from "./user";
 import { Container } from "inversify";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements blockUser on the gRPC/Connect server side.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Sign in
2. Get your user ID
1. `kubectl port-forward service/server 9877:9877`
3. 
	```
	curl \
	--header "Content-Type: application/json" \
	--data '{"userId": "your-user-id", "reason": "foo"}' \                           
	http://localhost:9877/gitpod.experimental.v1.UserService/BlockUser

	{}
	```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
