### PR TITLE
[preview] Fix preview env, remove /tmp/license refs

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -3,7 +3,7 @@
 # to test this script, follow these steps
 # 1. generate a config like so: ./installer init > config.yaml
 # 2. generate a k8s manifest like so: ./installer render -n $(kubens -c) -c config.yaml > k8s.yaml
-# 3. fake a license and feature file like so: echo "foo" > /tmp/license && echo '"bar"' > /tmp/defaultFeatureFlags
+# 3. fake a feature file like so: echo '"bar"' > /tmp/defaultFeatureFlags
 # 4. call this script like so: ./.werft/jobs/build/installer/post-process.sh 1234 5678 2 your-branch-just-dashes
 
 set -euo pipefail
@@ -28,8 +28,6 @@ fi
 echo "Use node pool index $NODE_POOL_INDEX"
 
 # Optional params
-# default yes, we add a license
-LICENSE=$(cat /tmp/license)
 # default, no, we do not add feature flags, file is empty
 DEFAULT_FEATURE_FLAGS=$(cat /tmp/defaultFeatureFlags)
 # if payment is configured: Append the YAML objects
@@ -124,13 +122,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       STAGE="devstaging"
       STAGE_EXPR="s/\"stage\": \"production\"/\"stage\": \"$STAGE\"/"
       sed -i "$STAGE_EXPR" /tmp/"$NAME"overrides.yaml
-      # Install EE license, if it exists
-      # This is a temporary solution until #6868 is resolved
-      if [ "${#LICENSE}" -gt 0 ]; then
-         echo "Installing EE License..."
-         LICENSE_EXPR="s/\"license\": \"\"/\"license\": \"$LICENSE\"/"
-         sed -i "$LICENSE_EXPR" /tmp/"$NAME"overrides.yaml
-      fi
       # DEFAULT_FEATURE_FLAGS
       # default none, this is CSV list like: ws-feature-flags=registry_facade,full_workspace_backup
       if [ "${#DEFAULT_FEATURE_FLAGS}" -gt 0 ]; then

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -582,7 +582,6 @@ WITH_VM=true "$ROOT/.werft/jobs/build/installer/post-process.sh" "${PREVIEW_NAME
 #
 rm -f /tmp/payment
 rm -f /tmp/defaultFeatureFlags
-rm -f /tmp/license
 rm -f /tmp/public-api
 
 # ===============


### PR DESCRIPTION
## Description

Fixes preview env failing to come up with `cat /tmp/license file not found`, https://github.com/gitpod-io/gitpod/pull/17008/ removed the file and license references.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Create a preview env successfully from this branch

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
