### PR TITLE
[ws-manager-mk2] Introduce experimental mode

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -131,6 +131,8 @@ type Configuration struct {
 	// TimeoutMaxConcurrentReconciles configures the max amount of concurrent workspace reconciliations on
 	// the timeout controller.
 	TimeoutMaxConcurrentReconciles int `json:"timeoutMaxConcurrentReconciles,omitempty"`
+	// ExperimentalMode controls if experimental features are enabled
+	ExperimentalMode bool `json:"experimentalMode"`
 }
 
 type WorkspaceClass struct {

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -317,29 +317,34 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 		workloadType = "headless"
 	}
 
+	matchExpressions := []corev1.NodeSelectorRequirement{
+		{
+			Key:      "gitpod.io/workload_workspace_" + workloadType,
+			Operator: corev1.NodeSelectorOpExists,
+		},
+		{
+			Key:      "gitpod.io/ws-daemon_ready_ns_" + sctx.Config.Namespace,
+			Operator: corev1.NodeSelectorOpExists,
+		},
+		{
+			Key:      "gitpod.io/registry-facade_ready_ns_" + sctx.Config.Namespace,
+			Operator: corev1.NodeSelectorOpExists,
+		},
+	}
+
+	if sctx.Config.ExperimentalMode {
+		matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
+			Key:      "gitpod.io/experimental",
+			Operator: corev1.NodeSelectorOpExists,
+		})
+	}
+
 	affinity := &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{
-								Key:      "gitpod.io/workload_workspace_" + workloadType,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							{
-								Key:      "gitpod.io/ws-daemon_ready_ns_" + sctx.Config.Namespace,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							{
-								Key:      "gitpod.io/registry-facade_ready_ns_" + sctx.Config.Namespace,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							{
-								Key:      "gitpod.io/experimental",
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
+						MatchExpressions: matchExpressions,
 					},
 				},
 			},

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -82,6 +82,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	var schedulerName string
+	var experimentalMode bool
 	gitpodHostURL := "https://" + ctx.Config.Domain
 	workspaceClusterHost := fmt.Sprintf("ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
 	workspaceURLTemplate := fmt.Sprintf("https://{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
@@ -149,6 +150,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 		if ucfg.Workspace.UseWsmanagerMk2 {
 			hostWorkingArea = wsdaemon.HostWorkingAreaMk2
+			experimentalMode = ucfg.Workspace.UseMk2ExperimentalMode
 		}
 
 		return nil
@@ -221,6 +223,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			RegistryFacadeHost:               fmt.Sprintf("reg.%s:%d", ctx.Config.Domain, common.RegistryFacadeServicePort),
 			WorkspaceMaxConcurrentReconciles: 25,
 			TimeoutMaxConcurrentReconciles:   15,
+			ExperimentalMode:                 experimentalMode,
 		},
 		Content: struct {
 			Storage storageconfig.StorageConfig `json:"storage"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -134,6 +134,7 @@ type WorkspaceConfig struct {
 
 	EnableProtectedSecrets *bool `json:"enableProtectedSecrets"`
 	UseWsmanagerMk2        bool  `json:"useWsmanagerMk2,omitempty"`
+	UseMk2ExperimentalMode bool  `json:"useMk2ExperimentalMode,omitempty"`
 }
 
 type PersistentVolumeClaim struct {


### PR DESCRIPTION
## Description
Introduce experimental mode which allows us to control whether workspaces are scheduled on experimental nodes.

## Related Issue(s)
n.a.

## How to test
Run installer and check output of `installer render --config configFile --use-experimental-config`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
