### PR TITLE
Update docker compose to v2.17.2

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -23,7 +23,7 @@ defaultArgs:
   REPLICATED_API_TOKEN: ""
   REPLICATED_APP: ""
   dockerVersion: 20.10.23
-  dockerComposeVersion: "2.16.0-gitpod.0"
+  dockerComposeVersion: "2.17.2-gitpod.0"
 provenance:
   enabled: true
   slsa: true


### PR DESCRIPTION
## Related Issue(s)
Fixes #16614

## How to test
- Open `https://github.com/Derroylo/sulu-workspace-sample`
- Check the version running `docker compose version` is `Docker Compose version v2.17.2-gitpod.0`
 
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
