### PR TITLE
Proper focus rings

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -94,23 +94,17 @@ function ContextMenu(props: ContextMenuProps) {
 
     return (
         <div className="relative">
-            <div
-                className="cursor-pointer"
+            <button
+                title="Expand actions menu"
+                className="cursor-pointer reset"
                 onClick={() => {
                     toggleExpanded();
                     // Don't use `e.stopPropagation();` because that prevents that clicks on other context menus closes this one.
                     setSkipClickHandler(true);
                 }}
-                onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                        toggleExpanded();
-                        setSkipClickHandler(true);
-                    }
-                }}
-                tabIndex={0}
             >
                 {children}
-            </div>
+            </button>
             {expanded ? (
                 <div
                     className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${

--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -150,9 +150,9 @@ function ContextMenu(props: ContextMenuProps) {
                                 );
                             } else {
                                 return (
-                                    <div key={key} onClick={e.onClick}>
+                                    <button key={key} onClick={e.onClick} className="reset">
                                         {entry}
-                                    </div>
+                                    </button>
                                 );
                             }
                         })

--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -96,11 +96,18 @@ function ContextMenu(props: ContextMenuProps) {
         <div className="relative">
             <div
                 className="cursor-pointer"
-                onClick={(e) => {
+                onClick={() => {
                     toggleExpanded();
                     // Don't use `e.stopPropagation();` because that prevents that clicks on other context menus closes this one.
                     setSkipClickHandler(true);
                 }}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        toggleExpanded();
+                        setSkipClickHandler(true);
+                    }
+                }}
+                tabIndex={0}
             >
                 {children}
             </div>

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -58,6 +58,7 @@
     button.reset {
         @apply bg-transparent hover:bg-transparent font-normal rounded-none;
         padding: unset;
+        text-align: start;
     }
     button.secondary {
         @apply bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-500 dark:text-gray-100 hover:text-gray-600;

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -55,6 +55,10 @@
     button {
         @apply cursor-pointer px-4 py-2 my-auto bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600 text-gray-100 dark:text-green-100 text-sm font-medium rounded-md focus:outline-none focus:ring transition ease-in-out;
     }
+    button.reset {
+        @apply bg-transparent hover:bg-transparent font-normal rounded-none;
+        padding: unset;
+    }
     button.secondary {
         @apply bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-500 dark:text-gray-100 hover:text-gray-600;
     }


### PR DESCRIPTION
## Description

Fixes focus and focus rings for the following components:
- https://github.com/gitpod-io/gitpod/blob/main/components/dashboard/src/components/SelectableCardSolid.tsx
- https://github.com/gitpod-io/gitpod/blob/main/components/dashboard/src/components/CheckBox.tsx?rgh-link-date=2023-03-07T22%3A36%3A12Z
- [`<ContextMenu>`](https://github.com/gitpod-io/gitpod/blob/main/components/dashboard/src/components/ContextMenu.tsx)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
