### PR TITLE
[git-integrations] correct menu entries

### DIFF
--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -83,7 +83,7 @@ function getTeamSettingsMenu(params: {
     }
     if (orgGitAuthProviders) {
         result.push({
-            title: "Git Auth",
+            title: "Git Integrations",
             link: [`/settings/git`],
         });
     }

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -189,11 +189,11 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                 return false;
             }}
         >
-            <ModalHeader>{isNew ? "New Git Auth" : "Git Auth"}</ModalHeader>
+            <ModalHeader>{isNew ? "New Git Integration" : "Git Integration"}</ModalHeader>
             <ModalBody>
                 {isNew && (
                     <Subheading>
-                        Configure Git Auth with a self-managed instance of GitLab, GitHub or Bitbucket Server.
+                        Configure a Git Integration with a self-managed instance of GitLab, GitHub, or Bitbucket Server.
                     </Subheading>
                 )}
 

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -26,14 +26,14 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
         <>
             <div className="flex flex-col space-y-2 md:flex-row md:items-start md:justify-between md:space-y-0">
                 <div>
-                    <Heading2>Git Auth configurations</Heading2>
-                    <Subheading>Configure Git Auth for your organization.</Subheading>
+                    <Heading2>Git Integrations</Heading2>
+                    <Subheading>Configure a Git Integration for your organization.</Subheading>
                 </div>
 
                 {providers.length !== 0 ? (
                     <div className="">
                         <Button className="whitespace-nowrap" onClick={onCreate}>
-                            New Git Auth
+                            New Git Integration
                         </Button>
                     </div>
                 ) : null}
@@ -41,9 +41,9 @@ export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => 
 
             {providers.length === 0 ? (
                 <EmptyMessage
-                    title="No Git Auth configurations"
-                    subtitle="Configure Git Auth with GitHub or GitLab."
-                    buttonText="New Git Auth"
+                    title="No Git Integrations"
+                    subtitle="Configure a Git Integration with GitHub, GitLab, or Bitbucket Server."
+                    buttonText="New Git Integration"
                     onClick={onCreate}
                 />
             ) : (


### PR DESCRIPTION
Replacing "Git Auth" with "Git Integrations". ([Internal discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1679923278367079))


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
