### PR TITLE
[ws-man-bridge] Hard delete workspace clusters on deregistration

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -29,7 +29,10 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
 
     async save(cluster: WorkspaceCluster): Promise<void> {
         const repo = await this.getRepo();
-        await repo.save(cluster);
+        await repo.save({
+            ...cluster,
+            deleted: false,
+        });
     }
 
     async deleteByName(name: string): Promise<void> {

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -31,13 +31,12 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         const repo = await this.getRepo();
         await repo.save({
             ...cluster,
-            deleted: false,
         });
     }
 
     async deleteByName(name: string): Promise<void> {
         const repo = await this.getRepo();
-        await repo.update({ name }, { deleted: true });
+        await repo.delete({ name });
     }
 
     async findByName(name: string): Promise<WorkspaceCluster | undefined> {


### PR DESCRIPTION
context https://gitpod.slack.com/archives/C02EN94AEPL/p1680000631745719

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
