### PR TITLE
[ws-manager-mk2] Implement DescribeCluster

### DIFF
--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -684,6 +684,26 @@ func (wsm *WorkspaceManagerServer) UpdateSSHKey(ctx context.Context, req *wsmana
 	return &wsmanapi.UpdateSSHKeyResponse{}, err
 }
 
+func (wsm *WorkspaceManagerServer) DescribeCluster(ctx context.Context, req *wsmanapi.DescribeClusterRequest) (*wsmanapi.DescribeClusterResponse, error) {
+	span, _ := tracing.FromContext(ctx, "DescribeCluster")
+	defer tracing.FinishSpan(span, nil)
+
+	classes := make([]*wsmanapi.WorkspaceClass, len(wsm.Config.WorkspaceClasses))
+
+	i := 0
+	for id, class := range wsm.Config.WorkspaceClasses {
+		classes[i] = &wsmanapi.WorkspaceClass{
+			Id:          id,
+			DisplayName: class.Name,
+		}
+		i += 1
+	}
+
+	return &wsmanapi.DescribeClusterResponse{
+		WorkspaceClasses: classes,
+	}, nil
+}
+
 // modifyWorkspace modifies a workspace object using the mod function. If the mod function returns a gRPC status error, that error
 // is returned directly. If mod returns a non-gRPC error it is turned into one.
 func (wsm *WorkspaceManagerServer) modifyWorkspace(ctx context.Context, id string, updateStatus bool, mod func(ws *workspacev1.Workspace) error) error {


### PR DESCRIPTION
## Description

Same implementation as mk1

Context: https://gitpod.slack.com/archives/C02EN94AEPL/p1680006550822509?thread_ts=1680000631.745719&cid=C02EN94AEPL

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
