### PR TITLE
[common-go] force set configcat log level to error

### DIFF
--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -12,6 +12,7 @@ import (
 
 	configcat "github.com/configcat/go-sdk/v7"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/sirupsen/logrus"
 )
 
 type Client interface {
@@ -65,11 +66,13 @@ func NewClient(opts ...ClientOpt) Client {
 	if opt.sdkKey == "" {
 		return NewAlwaysReturningDefaultValueClient()
 	}
+	logger := log.Log.Dup()
+	logger.Logger.SetLevel(logrus.ErrorLevel)
 	return newConfigCatClient(configcat.Config{
 		SDKKey:       opt.sdkKey,
 		BaseURL:      opt.baseURL,
 		PollInterval: opt.pollInterval,
 		HTTPTimeout:  3 * time.Second,
-		Logger:       &configCatLogger{log.Log},
+		Logger:       &configCatLogger{logger},
 	})
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[common-go] force set configcat log level to error

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [x] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
