### PR TITLE
[ws-manager-mk2] [WKS-14] Refactor workspace operations

### DIFF
--- a/components/ws-daemon/pkg/controller/snapshot_controller.go
+++ b/components/ws-daemon/pkg/controller/snapshot_controller.go
@@ -26,11 +26,11 @@ type SnapshotReconciler struct {
 	client.Client
 	maxConcurrentReconciles int
 	nodeName                string
-	operations              *WorkspaceOperations
+	operations              WorkspaceOperations
 	recorder                record.EventRecorder
 }
 
-func NewSnapshotController(c client.Client, recorder record.EventRecorder, nodeName string, maxConcurrentReconciles int, wso *WorkspaceOperations) *SnapshotReconciler {
+func NewSnapshotController(c client.Client, recorder record.EventRecorder, nodeName string, maxConcurrentReconciles int, wso WorkspaceOperations) *SnapshotReconciler {
 	return &SnapshotReconciler{
 		Client:                  c,
 		maxConcurrentReconciles: maxConcurrentReconciles,
@@ -109,7 +109,7 @@ func (ssc *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	snapshotErr = ssc.operations.TakeSnapshot(ctx, snapshot.Spec.WorkspaceID, snapshotName)
+	snapshotErr = ssc.operations.Snapshot(ctx, snapshot.Spec.WorkspaceID, snapshotName)
 	if snapshotErr != nil {
 		log.Error(snapshotErr, "could not take snapshot", "workspace", snapshot.Spec.WorkspaceID)
 	}

--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -57,13 +57,13 @@ type WorkspaceController struct {
 	client.Client
 	NodeName                string
 	maxConcurrentReconciles int
-	operations              *WorkspaceOperations
+	operations              WorkspaceOperations
 	metrics                 *workspaceMetrics
 	secretNamespace         string
 	recorder                record.EventRecorder
 }
 
-func NewWorkspaceController(c client.Client, recorder record.EventRecorder, nodeName, secretNamespace string, maxConcurrentReconciles int, ops *WorkspaceOperations, reg prometheus.Registerer) (*WorkspaceController, error) {
+func NewWorkspaceController(c client.Client, recorder record.EventRecorder, nodeName, secretNamespace string, maxConcurrentReconciles int, ops WorkspaceOperations, reg prometheus.Registerer) (*WorkspaceController, error) {
 	metrics := newWorkspaceMetrics()
 	reg.Register(metrics)
 
@@ -172,11 +172,11 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 		}
 
 		initStart := time.Now()
-		failure, initErr := wsc.operations.InitWorkspaceContent(ctx, InitContentOptions{
+		failure, initErr := wsc.operations.InitWorkspace(ctx, InitOptions{
 			Meta: WorkspaceMeta{
 				Owner:       ws.Spec.Ownership.Owner,
-				WorkspaceId: ws.Spec.Ownership.WorkspaceID,
-				InstanceId:  ws.Name,
+				WorkspaceID: ws.Spec.Ownership.WorkspaceID,
+				InstanceID:  ws.Name,
 			},
 			Initializer: init,
 			Headless:    ws.IsHeadless(),
@@ -269,11 +269,11 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		}
 	}
 
-	gitStatus, disposeErr := wsc.operations.BackupWorkspace(ctx, DisposeOptions{
+	gitStatus, disposeErr := wsc.operations.BackupWorkspace(ctx, BackupOptions{
 		Meta: WorkspaceMeta{
 			Owner:       ws.Spec.Ownership.Owner,
-			WorkspaceId: ws.Spec.Ownership.WorkspaceID,
-			InstanceId:  ws.Name,
+			WorkspaceID: ws.Spec.Ownership.WorkspaceID,
+			InstanceID:  ws.Name,
 		},
 		WorkspaceLocation: ws.Spec.WorkspaceLocation,
 		SnapshotName:      snapshotName,


### PR DESCRIPTION
## Description
- Harmonize names
- Introduce interface for workspace operations so that we can mock it in tests

## Related Issue(s)
Fixes WKS-14

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
