### PR TITLE
Remove GITPOD_MEMORY from ws-manager

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1006,7 +1006,7 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 	memory := cgroups.NewMemoryController("/sys/fs/cgroup")
 	if limit, err := memory.Max(); err == nil {
 		memTotal := int64(limit * 1024 * 1024)
-		envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -Xmx%sm", memTotal)
+		envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -Xmx%vm", memTotal)
 	}
 
 	var env, envn []string

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -570,17 +570,6 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 	heartbeatInterval := time.Duration(sctx.Config.HeartbeatInterval)
 	result = append(result, corev1.EnvVar{Name: "GITPOD_INTERVAL", Value: fmt.Sprintf("%d", int64(heartbeatInterval/time.Millisecond))})
 
-	res, err := class.Container.Requests.ResourceList()
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create environment: %w", err)
-	}
-	memoryInMegabyte := res.Memory().Value() / (1000 * 1000)
-	result = append(result, corev1.EnvVar{Name: "GITPOD_MEMORY", Value: strconv.FormatInt(memoryInMegabyte, 10)})
-
-	if sctx.Headless {
-		result = append(result, corev1.EnvVar{Name: "GITPOD_HEADLESS", Value: "true"})
-	}
-
 	// remove empty env vars
 	cleanResult := make([]corev1.EnvVar, 0)
 	for _, v := range result {

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -482,11 +482,6 @@ func createWorkspaceContainer(sctx *startWorkspaceContext) (*corev1.Container, e
 }
 
 func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, error) {
-	class, ok := sctx.Config.WorkspaceClasses[sctx.Workspace.Spec.Class]
-	if !ok {
-		return nil, xerrors.Errorf("unknown workspace class: %s", sctx.Workspace.Spec.Class)
-	}
-
 	getWorkspaceRelativePath := func(segment string) string {
 		// ensure we do not produce nested paths for the default workspace location
 		return filepath.Join("/workspace", strings.TrimPrefix(segment, "/workspace"))

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -828,13 +828,6 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	heartbeatInterval := time.Duration(m.Config.HeartbeatInterval)
 	result = append(result, corev1.EnvVar{Name: "GITPOD_INTERVAL", Value: fmt.Sprintf("%d", int64(heartbeatInterval/time.Millisecond))})
 
-	res, err := startContext.ContainerConfiguration().Requests.ResourceList()
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create environment: %w", err)
-	}
-	memoryInMegabyte := res.Memory().Value() / (1000 * 1000)
-	result = append(result, corev1.EnvVar{Name: "GITPOD_MEMORY", Value: strconv.FormatInt(memoryInMegabyte, 10)})
-
 	if startContext.Headless {
 		result = append(result, corev1.EnvVar{Name: "GITPOD_HEADLESS", Value: "true"})
 	}

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -100,14 +100,6 @@ type startWorkspaceContext struct {
 	VolumeSnapshot *workspaceVolumeSnapshotStatus `json:"volumeSnapshot"`
 }
 
-func (swctx *startWorkspaceContext) ContainerConfiguration() config.ContainerConfiguration {
-	var res config.ContainerConfiguration
-	if swctx.Class != nil {
-		res = swctx.Class.Container
-	}
-	return res
-}
-
 const (
 	// workspaceVolume is the name of the workspace volume
 	workspaceVolumeName = "vol-this-workspace"

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -146,10 +146,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -133,10 +133,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -148,10 +148,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "0"
-                        },
-                        {
                             "name": "some-envvar",
                             "value": "foofoo"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
@@ -137,10 +137,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
@@ -134,10 +134,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "0"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -179,10 +179,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -136,10 +136,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "0"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
@@ -151,10 +151,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
@@ -143,10 +143,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
@@ -183,10 +183,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -146,10 +146,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -147,10 +147,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "0"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -142,10 +142,6 @@
                         {
                             "name": "GITPOD_INTERVAL",
                             "value": "30000"
-                        },
-                        {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
                         }
                     ],
                     "resources": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -144,10 +144,6 @@
                             "value": "30000"
                         },
                         {
-                            "name": "GITPOD_MEMORY",
-                            "value": "999"
-                        },
-                        {
                             "name": "GITPOD_HEADLESS",
                             "value": "true"
                         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
