### PR TITLE
[jb] support testing of stable GW

### DIFF
--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           DISPLAY: ':10'
           LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: '8388608'
+          TEST_USE_LATEST: ${{ inputs.use_latest }}
         run: |
           export GATEWAY_LINK=$(jq -r '.inputs.secret_gateway_link' $GITHUB_EVENT_PATH)
           export GITPOD_TEST_ACCESSTOKEN=$(jq -r '.inputs.secret_access_token' $GITHUB_EVENT_PATH)
@@ -89,11 +90,17 @@ jobs:
 
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
 
-          sudo mkdir -p /workspace/.gradle-latest
-          sudo chown -R $(whoami) /workspace
-
-          mkdir -p $HOME/.cache/pluginVerifier-latest
-          leeway run dev/jetbrains-test:test -Dversion=integration-test -DpublishToJBMarketplace=false
+          if [ $TEST_USE_LATEST = "false" ]; then
+            sudo mkdir -p /workspace/.gradle-stable
+            sudo chown -R $(whoami) /workspace
+            mkdir -p $HOME/.cache/pluginVerifier-stable
+            leeway run dev/jetbrains-test:test-stable -Dversion=integration-test -DpublishToJBMarketplace=false
+          else
+            sudo mkdir -p /workspace/.gradle-latest
+            sudo chown -R $(whoami) /workspace
+            mkdir -p $HOME/.cache/pluginVerifier-latest
+            leeway run dev/jetbrains-test:test-latest -Dversion=integration-test -DpublishToJBMarketplace=false
+          fi
       - name: Move video
         if: always()
         run: |

--- a/dev/jetbrains-test/BUILD.yaml
+++ b/dev/jetbrains-test/BUILD.yaml
@@ -1,13 +1,19 @@
 scripts:
-  - name: test
+  - name: test-stable
+    srcs:
+      - "test.sh"
+    deps:
+      - components/ide/jetbrains/gateway-plugin:publish-stable
+    workdir: origin
+    script: |
+        cp $COMPONENTS_IDE_JETBRAINS_GATEWAY_PLUGIN__PUBLISH_STABLE/build/distributions/gitpod-gateway.zip gitpod-gateway.zip
+        ./test.sh
+  - name: test-latest
+    srcs:
+      - "test.sh"
     deps:
       - components/ide/jetbrains/gateway-plugin:publish-latest
     workdir: origin
     script: |
         cp $COMPONENTS_IDE_JETBRAINS_GATEWAY_PLUGIN__PUBLISH_LATEST/build/distributions/gitpod-gateway.zip gitpod-gateway.zip
-        export GATEWAY_PLUGIN_PATH=$(pwd)/gitpod-gateway.zip
-        mkdir -p ~/.local/share/JetBrains/consentOptions/
-        echo -n "rsch.send.usage.stat:1.1:0:1644945193441" > ~/.local/share/JetBrains/consentOptions/accepted
-        mkdir -p ~/.config/JetBrains/JetBrainsClient/options
-        touch ~/.config/JetBrains/JetBrainsClient/options/ide.general.xml
-        ./gradlew test
+        ./test.sh

--- a/dev/jetbrains-test/src/main/kotlin/io/gitpod/jetbrains/launcher/IdeDownloader.kt
+++ b/dev/jetbrains-test/src/main/kotlin/io/gitpod/jetbrains/launcher/IdeDownloader.kt
@@ -23,8 +23,8 @@ class IdeDownloader @JvmOverloads constructor(private val httpClient: OkHttpClie
         }
     }
 
-    fun downloadAndExtractLatestEap(ide: Ide, toDir: Path): Path {
-        val idePackage = downloadIde(ide, toDir)
+    fun downloadAndExtract(ide: Ide, toDir: Path, type: String): Path {
+        val idePackage = downloadIde(ide, toDir, type)
         return extractIde(idePackage, toDir)
     }
 
@@ -43,8 +43,8 @@ class IdeDownloader @JvmOverloads constructor(private val httpClient: OkHttpClie
         }
     }
 
-    private fun downloadIde(ide: Ide, toDir: Path): Path {
-        val ideDownloadLink = getIdeDownloadUrl(ide, httpClient)
+    private fun downloadIde(ide: Ide, toDir: Path, type: String): Path {
+        val ideDownloadLink = getIdeDownloadUrl(ide, httpClient, type)
         val idePackageName = ideDownloadLink.substringAfterLast("/").removeSuffix("/")
         val targetFile = toDir.resolve(idePackageName)
         return downloadFile(ideDownloadLink, targetFile)
@@ -60,13 +60,13 @@ class IdeDownloader @JvmOverloads constructor(private val httpClient: OkHttpClie
         }
     }
 
-    private fun getIdeDownloadUrl(ide: Ide, httpClient: OkHttpClient): String {
+    private fun getIdeDownloadUrl(ide: Ide, httpClient: OkHttpClient, type: String): String {
         return httpClient.newCall(
             Request.Builder().url(
                 "https://data.services.jetbrains.com/products/releases".toHttpUrl()
                     .newBuilder()
                     .addQueryParameter("code", ide.feedsCode)
-                    .addQueryParameter("type", "eap,rc,release")
+                    .addQueryParameter("type", type)
                     .addQueryParameter("platform", getFeedsOsPropertyName())
                     .build()
             ).build()

--- a/dev/jetbrains-test/src/test/kotlin/io/gitpod/jetbrains/launcher/GatewayLauncherTest.kt
+++ b/dev/jetbrains-test/src/test/kotlin/io/gitpod/jetbrains/launcher/GatewayLauncherTest.kt
@@ -78,8 +78,11 @@ class GatewayLauncherTest {
         val client = OkHttpClient()
         remoteRobot = RemoteRobot("http://localhost:8082", client)
         val ideDownloader = IdeDownloader(client)
+
+        val useLatest = System.getenv("TEST_USE_LATEST")?.toBoolean() ?: false
+        val type = if (useLatest) "eap,rc,release" else "release"
         gatewayProcess = IdeLauncher.launchIde(
-            ideDownloader.downloadAndExtractLatestEap(Ide.GATEWAY, tmpDir),
+            ideDownloader.downloadAndExtract(Ide.GATEWAY, tmpDir, type),
             mapOf("robot-server.port" to 8082),
             emptyList(),
             listOf(

--- a/dev/jetbrains-test/test.sh
+++ b/dev/jetbrains-test/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+GATEWAY_PLUGIN_PATH=$(pwd)/gitpod-gateway.zip
+export GATEWAY_PLUGIN_PATH
+
+mkdir -p ~/.local/share/JetBrains/consentOptions/
+echo -n "rsch.send.usage.stat:1.1:0:1644945193441" > ~/.local/share/JetBrains/consentOptions/accepted
+mkdir -p ~/.config/JetBrains/JetBrainsClient/options
+touch ~/.config/JetBrains/JetBrainsClient/options/ide.general.xml
+./gradlew test


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It allows to run test against platform changes to stable GW plugin.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check out https://github.com/gitpod-io/gitpod/actions/runs/4552408927/jobs/8028172989 and corresponding GW tests actions https://github.com/gitpod-io/gitpod/actions/workflows/jetbrains-integration-test.yml

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
