### PR TITLE
[jb] nudge to improve integration tests

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -44,7 +44,11 @@ jobs:
               run: |
                 URL="https://data.services.jetbrains.com/products/releases?code=${{ inputs.productCode }}&type=${{ inputs.productType }}&platform=linux"
                 echo "URL: $URL"
-                BUILD=$(curl -s "$URL" |jq -r ".${{ inputs.productCode }}[0].build")
+                RELEASE=$(curl -s "$URL" |jq ".${{ inputs.productCode }}[0]")
+                MAJOR_VERSION=$(echo $RELEASE |jq -r ".majorVersion")
+                echo "MAJOR_VERSION: $MAJOR_VERSION"
+
+                BUILD=$(echo $RELEASE |jq -r ".build")
                 echo "BUILD: $BUILD"
                 MAJOR=$(cut -d. -f1 <<< $BUILD)
                 echo "MAJOR: $MAJOR"
@@ -53,11 +57,13 @@ jobs:
                 LATEST_VERSION="$MAJOR.$MINOR-EAP-CANDIDATE-SNAPSHOT"
                 echo "Latest platform version: $LATEST_VERSION"
                 echo "::set-output name=result::$LATEST_VERSION"
+                echo "::set-output name=majorVersion::$MAJOR_VERSION"
             - name: Update ${{ inputs.gradlePropertiesPath }}
               if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               run: |
                   PLUGIN_SINCE_BUILD=$(echo "${{ steps.latest-version.outputs.result }}" | sed 's/-EAP-CANDIDATE-SNAPSHOT//' | sed 's/-CUSTOM-SNAPSHOT//')
                   sed -i "s/pluginSinceBuild=.*/pluginSinceBuild=$PLUGIN_SINCE_BUILD/" ${{ inputs.gradlePropertiesPath }}
+                  sed -i "s/pluginVerifierIdeVersions=.*/pluginVerifierIdeVersions=${{ steps.latest-version.outputs.majorVersion }}/" ${{ inputs.gradlePropertiesPath }}
                   sed -i 's/platformVersion=${{ steps.current-version.outputs.result }}/platformVersion=${{ steps.latest-version.outputs.result }}/' ${{ inputs.gradlePropertiesPath }}
                   git diff
             - name: Create Pull Request for Gateway Plugin
@@ -71,12 +77,19 @@ jobs:
                       This PR updates the Platform Version from ${{ inputs.pluginName }} to the latest version.
 
                       ## How to test
+
+                      Merge if tests are green, if something breaks then add tests for regressions.
+
+                      <details>
+                      <summary>if you want to test manually for some reasons</summary>
+
                       1. Ensure you have the Gateway installed from [JetBrains Toolbox App](https://www.jetbrains.com/toolbox-app/) and have it up-to-date.
                         - You should use Gateway version corresponding to plugin qualifier, i.e. for stable plugin test with released, for latest test with EAP.
                         - It could be that a new Gateway is not published for the given SDK yet then wait for it to be published. You can check the build version in the About dialog.
                       2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
                         - You can also uninstall current Gitpod plugin, configure dev channel using https://plugins.jetbrains.com/plugins/list?channel=dev&pluginId=18438-gitpod-gateway and restart GW to test that the proper version is detected and installed.
                       3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
+                      </details>
 
                       ## Release Notes
                       ```release-note
@@ -114,11 +127,17 @@ jobs:
                       This PR updates the Platform Version from ${{ inputs.pluginName }} to the latest version.
 
                       ## How to test
+
+                      Merge if tests are green, if something breaks then add tests for regressions.
+
+                      <details>
+                      <summary>if you want to test manually for some reasons</summary>
                       1. Open the preview environment generated for this branch
                       2. Choose the _Latest Release (Unstable)_ version of IntelliJ IDEA as your preferred editor
                       3. Start a workspace using this repository: https://github.com/gitpod-samples/spring-petclinic
                       4. Verify that the workspace starts successfully
                       5. Verify that the IDE opens successfully
+                      </details>
 
                       ## Release Notes
                       ```release-note

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -32,18 +32,25 @@ jobs:
                       This PR updates the JetBrains IDE images to the most recent `stable` version.
 
                       ## How to test
+
+                      Merge if tests are green, if something breaks then add tests for regressions.
+
+                      <details>
+                      <summary>if you want to test manually for some reasons</summary>
+
                       1. For each IDE changed on this PR, follow these steps:
-                      1. Open the preview environment generated for this branch
-                      1. Choose the stable version of the IDE that you're testing as your default editor
-                      1. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
-                      1. Verify that the workspace starts successfully
-                      1. Verify that the IDE opens successfully
-                      1. Verify that the version of the IDE corresponds to the one being updated in this PR
+                      2. Open the preview environment generated for this branch
+                      3. Choose the stable version of the IDE that you're testing as your default editor
+                      4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
+                      5. Verify that the workspace starts successfully
+                      6. Verify that the IDE opens successfully
+                      7. Verify that the version of the IDE corresponds to the one being updated in this PR
 
                       The following resources should help, in case something goes wrong (e.g. workspaces don't start):
 
                       - https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
                       - https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
+                      </details>
 
                       ## Release Notes
                       ```release-note


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Fixes generation of plugin verifier version.
- Nudge to rely and improves tests instead of doing manual testing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
