### PR TITLE
Improve node-labeler

### DIFF
--- a/components/node-labeler/cmd/podutils.go
+++ b/components/node-labeler/cmd/podutils.go
@@ -7,7 +7,7 @@ package cmd
 import corev1 "k8s.io/api/core/v1"
 
 // IsPodReady returns true if a pod is ready; false otherwise.
-func IsPodReady(pod *corev1.Pod) bool {
+func IsPodReady(pod corev1.Pod) bool {
 	return IsPodReadyConditionTrue(pod.Status)
 }
 


### PR DESCRIPTION
## Description

Configuring timeouts in the HTTP transport does not respect the configured timeouts.
Using `http.NewRequestWithContext` solves the issue.

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
