### PR TITLE
[ws-manager-mk2] Extract headless task failure (WKS-18)

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -148,10 +148,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	case pod.Status.Phase == corev1.PodRunning:
 		var ready bool
 		for _, cs := range pod.Status.ContainerStatuses {
-			if cs.Ready || cs.State.Terminated != nil {
-				// If container is terminated, it's been ready, we don't want to move back to initializing.
-				// We will reconcile the termination state once the pod phase is updated to reflect the
-				// terminated container.
+			if cs.Ready {
 				ready = true
 				break
 			}

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -126,7 +126,11 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.updateMetrics(ctx, &workspace)
 	r.emitPhaseEvents(ctx, &workspace, oldStatus)
 
-	log.V(1).Info("updating workspace status", "status", workspace.Status)
+	var podStatus *corev1.PodStatus
+	if len(workspacePods.Items) > 0 {
+		podStatus = &workspacePods.Items[0].Status
+	}
+	log.Info("updating workspace status", "status", workspace.Status, "podStatus", podStatus)
 	err = r.Status().Update(ctx, &workspace)
 	if err != nil {
 		// log.WithValues("status", workspace).Error(err, "unable to update workspace status")


### PR DESCRIPTION
## Description
* If a headless task container exits with a non-empty `Message`, consider it a failure (as we do with mk1).
* Always log workspace status in reconciliations. We can disable at a later point, but without it it becomes almost impossible to debug workspace/pod state changes.
  * In addition, also log the pod status

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

In a preview env, create an image build, restart ws-daemon during the build (which currently causes the build to fail), and observe the workspace exits with a `Failed` condition and doesn't transition through `Initializing` after `Running`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
