### PR TITLE
[server/db] resume periodic deleter on quorum re-election

### DIFF
--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -334,13 +334,13 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         if (!this.config.runDbDeleter) {
             return;
         }
-        const areWeLeader = await this.qorum.areWeLeader();
-        if (areWeLeader) {
-            log.info("[PeriodicDbDeleter] Current instance is leader, starting periodic deleter.");
-            this.periodicDbDeleter.start();
-        } else {
-            log.info("[PeriodicDbDeleter] Current instance is not the leader, periodic deleter will not run.");
-        }
+        this.periodicDbDeleter.start(async () => {
+            const areWeLeader = await this.qorum.areWeLeader();
+            log.info(
+                "[PeriodicDbDeleter]" + areWeLeader ? "Deleter should run." : "Current instance is not the leader",
+            );
+            return areWeLeader;
+        });
     }
 
     protected async registerRoutes(app: express.Application) {


### PR DESCRIPTION
Quorum leader is re-elected whenever the leader got unresponsive, but the periodic deleter is only considering this once on server init. This can lead to a state where no deleter is active.



## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
