### PR TITLE
[usage] Add server address to config - WEB-94

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -43,6 +43,9 @@ type Config struct {
 
 	// StripePrices configure which Stripe Price IDs should be used
 	StripePrices stripe.StripePrices `json:"stripePrices"`
+
+	// Where to find the gRPC/Connect APIs on the server component
+	ServerAddress string `json:"serverAddress"`
 }
 
 func Start(cfg Config, version string) error {

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -40,6 +40,7 @@ const (
 	ServerComponent                 = "server"
 	ServerIAMSessionPort            = 9876
 	ServerInstallationAdminPort     = 9000
+	ServerGRPCAPIPort               = 9877
 	SystemNodeCritical              = "system-node-critical"
 	PaymentEndpointComponent        = "payment-endpoint"
 	PublicApiComponent              = "public-api-server"

--- a/install/installer/pkg/common/net.go
+++ b/install/installer/pkg/common/net.go
@@ -6,6 +6,8 @@ package common
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 )
@@ -24,4 +26,12 @@ func LocalhostPrometheusAddr() string {
 
 func LocalhostPprofAddr() string {
 	return LocalhostAddressFromPort(baseserver.BuiltinDebugPort)
+}
+
+func ClusterAddress(serviceName string, namespace string, port int) string {
+	return net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace), strconv.Itoa(port))
+}
+
+func ClusterURL(protocol string, serviceName string, namespace string, port int) string {
+	return fmt.Sprintf("%s://%s", protocol, ClusterAddress(serviceName, namespace, port))
 }

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -6,8 +6,6 @@ package public_api_server
 
 import (
 	"fmt"
-	"net"
-	"strconv"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"k8s.io/utils/pointer"
@@ -52,15 +50,15 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	cfg := config.Configuration{
 		PublicURL:                         fmt.Sprintf("https://api.%s", ctx.Config.Domain),
-		GitpodServiceURL:                  fmt.Sprintf("ws://%s.%s.svc.cluster.local:%d", server.Component, ctx.Namespace, server.ContainerPort),
+		GitpodServiceURL:                  common.ClusterURL("ws", server.Component, ctx.Namespace, server.ContainerPort),
 		OIDCClientJWTSigningSecretPath:    oidcClientJWTSigningSecretPath,
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
-		BillingServiceAddress:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
-		SessionServiceAddress:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", common.ServerComponent, ctx.Namespace), strconv.Itoa(common.ServerIAMSessionPort)),
+		BillingServiceAddress:             common.ClusterAddress(usage.Component, ctx.Namespace, usage.GRPCServicePort),
+		SessionServiceAddress:             common.ClusterAddress(common.ServerComponent, ctx.Namespace, common.ServerIAMSessionPort),
 		DatabaseConfigPath:                databaseSecretMountPath,
 		Redis: config.RedisConfiguration{
-			Address: fmt.Sprintf("%s:%d", redis.Component, redis.Port),
+			Address: common.ClusterAddress(redis.Component, ctx.Namespace, redis.Port),
 		},
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -55,7 +55,7 @@ func TestConfigMap(t *testing.T) {
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		DatabaseConfigPath:                "/secrets/database-config",
 		Redis: config.RedisConfiguration{
-			Address: fmt.Sprintf("%s:%d", redis.Component, redis.Port),
+			Address: fmt.Sprintf("%s.%s.svc.cluster.local:%d", redis.Component, ctx.Namespace, redis.Port),
 		},
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -6,9 +6,7 @@ package server
 
 import (
 	"fmt"
-	"net"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -273,9 +271,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"shareSnapshot":    {Group: "inWorkspaceUserAction"},
 			},
 		},
-		ContentServiceAddr:           net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", contentservice.Component, ctx.Namespace), strconv.Itoa(contentservice.RPCPort)),
-		UsageServiceAddr:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
-		IDEServiceAddr:               net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", ideservice.Component, ctx.Namespace), strconv.Itoa(ideservice.GRPCServicePort)),
+		ContentServiceAddr:           common.ClusterAddress(contentservice.Component, ctx.Namespace, contentservice.RPCPort),
+		UsageServiceAddr:             common.ClusterAddress(usage.Component, ctx.Namespace, usage.GRPCServicePort),
+		IDEServiceAddr:               common.ClusterAddress(ideservice.Component, ctx.Namespace, ideservice.GRPCServicePort),
 		MaximumEventLoopLag:          0.35,
 		CodeSync:                     CodeSync{},
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -31,5 +31,5 @@ const (
 	AdminCredentialsSecretKey       = "admin.json"
 
 	GRPCAPIName = "grpc"
-	GRPCAPIPort = 9877
+	GRPCAPIPort = common.ServerGRPCAPIPort
 )

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -37,6 +37,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ForUsers:            1_000_000_000,
 			MinForUsersOnStripe: 0,
 		},
+		ServerAddress: common.ClusterAddress(common.ServerComponent, ctx.Namespace, common.ServerGRPCAPIPort),
 	}
 
 	expWebAppConfig := common.ExperimentalWebappConfig(ctx)

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -41,6 +41,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 		  "usd": ""
 		}
 	   },
+	   "serverAddress": "server.test-namespace.svc.cluster.local:9877",
        "server": {
          "services": {
            "grpc": {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Adds server address to usage config - needed for usage to talk to server
* Refactors ClusterAddress construction to use common

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
