### PR TITLE
[ws-manager-mk2] Fix git status

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -28,16 +28,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const (
-	// maxPendingChanges is the limit beyond which we no longer report pending changes.
-	// For example, if a workspace has then 150 untracked files, we'll report the first
-	// 100 followed by "... and 50 more".
-	//
-	// We do this to keep the load on our infrastructure light and because beyond this number
-	// the changes are irrelevant anyways.
-	maxPendingChanges = 100
-)
-
 type WorkspaceOperations interface {
 	// InitWorkspace initializes the workspace content
 	InitWorkspace(ctx context.Context, options InitOptions) (string, error)

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -999,6 +999,7 @@ func extractWorkspaceStatus(ws *workspacev1.Workspace) *wsmanapi.WorkspaceStatus
 			Admission:  admissionLevel,
 			OwnerToken: ws.Status.OwnerToken,
 		},
+		Repo: convertGitStatus(ws.Status.GitStatus),
 	}
 
 	return res
@@ -1011,6 +1012,22 @@ func getConditionMessageIfTrue(conds []metav1.Condition, tpe string) string {
 		}
 	}
 	return ""
+}
+
+func convertGitStatus(gs *workspacev1.GitStatus) *csapi.GitStatus {
+	if gs == nil {
+		return nil
+	}
+	return &csapi.GitStatus{
+		Branch:               gs.Branch,
+		LatestCommit:         gs.LatestCommit,
+		UncommitedFiles:      gs.UncommitedFiles,
+		TotalUncommitedFiles: gs.TotalUncommitedFiles,
+		UntrackedFiles:       gs.UntrackedFiles,
+		TotalUntrackedFiles:  gs.TotalUntrackedFiles,
+		UnpushedCommits:      gs.UnpushedCommits,
+		TotalUnpushedCommits: gs.TotalUnpushedCommits,
+	}
 }
 
 func convertCondition(conds []metav1.Condition, tpe string) wsmanapi.WorkspaceConditionBool {

--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,8 @@ If you want to run an entire test suite, the easiest is to use `./test/run.sh`:
 If you're iterating on a single test, the easiest is to use `go test` directly.
 If your integration tests depends on having having a user token available, then you'll have to set `USER_TOKEN` manually (see `test/run.sh` on how to fetch the credentials that are used during our build)
 
+If you want to run the workspace tests against `ws-manager-mk2`, set the `WS_MANAGER_MK2=true` env var when running the tests.
+
 ```console
 cd test
 go test -v ./... \

--- a/test/tests/components/ws-manager/git_status_test.go
+++ b/test/tests/components/ws-manager/git_status_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsmanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+)
+
+// TestGitStatus tests that the git status is reported after a workspace is stopped.
+func TestGitStatus(t *testing.T) {
+	f := features.New("git-status").
+		WithLabel("component", "ws-manager").
+		Assess("it should report the git status of a workspace when it stops", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			tests := []struct {
+				Name             string
+				ContextURL       string
+				WorkspaceRoot    string
+				CheckoutLocation string
+			}{
+				{
+					Name:             "classic",
+					ContextURL:       "https://github.com/gitpod-io/empty",
+					WorkspaceRoot:    "/workspace/empty",
+					CheckoutLocation: "empty",
+				},
+			}
+			for _, test := range tests {
+				test := test
+				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
+					defer cancel()
+
+					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+					t.Cleanup(func() {
+						api.Done(t)
+					})
+
+					// TODO: change to use server API to launch the workspace, so we could run the integration test as the user code flow
+					//       which is client -> server -> ws-manager rather than client -> ws-manager directly
+					ws1, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+						w.Spec.Initializer = &csapi.WorkspaceInitializer{
+							Spec: &csapi.WorkspaceInitializer_Git{
+								Git: &csapi.GitInitializer{
+									RemoteUri:        test.ContextURL,
+									CheckoutLocation: test.CheckoutLocation,
+									Config:           &csapi.GitConfig{},
+								},
+							},
+						}
+						w.Spec.WorkspaceLocation = test.CheckoutLocation
+						return nil
+					}))
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						if err != nil {
+							sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+							defer scancel()
+
+							sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+							defer sapi.Done(t)
+
+							_, err = stopWs(true, sapi)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+					})
+
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
+						integration.WithInstanceID(ws1.Req.Id),
+						integration.WithContainer("workspace"),
+						integration.WithWorkspacekitLift(true),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					integration.DeferCloser(t, closer)
+
+					var resp agent.WriteFileResponse
+					err = rsa.Call("WorkspaceAgent.WriteFile", &agent.WriteFileRequest{
+						Path:    fmt.Sprintf("%s/foobar.txt", test.WorkspaceRoot),
+						Content: []byte("hello world"),
+						Mode:    0644,
+					}, &resp)
+					rsa.Close()
+					if err != nil {
+						if _, serr := stopWs(true, api); serr != nil {
+							t.Errorf("cannot stop workspace: %q", serr)
+						}
+						t.Fatal(err)
+					}
+
+					lastStatus, err := stopWs(true, api)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					t.Logf("last status: %v", lastStatus)
+					expected := &csapi.GitStatus{
+						Branch:              "main",
+						UntrackedFiles:      []string{"foobar.txt"},
+						TotalUntrackedFiles: 1,
+					}
+					if !proto.Equal(lastStatus.Repo, expected) {
+						t.Fatalf("unexpected git status: expected \"%+q\", got \"%+q\"", expected, lastStatus.Repo)
+					}
+				})
+			}
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes git status not being reported for mk2 workspaces. Also adds an e2e test to check this.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-28

## How to test
<!-- Provide steps to test this PR -->

Run e2e tests, run in preview env and check any workspace file/git changes are shown after the workspace is stopped.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
