### PR TITLE
[jb] fix platform version range for stable GW plugin

### DIFF
--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -68,8 +68,14 @@ jobs:
           sudo update-rc.d xvfb defaults
           sudo service xvfb start
       - name: Get leeway cache version
+        env:
+          TEST_USE_LATEST: ${{ inputs.use_latest }}
         run: |
-          leeway collect | grep components/ide/jetbrains/gateway-plugin:publish-latest > gateway.version
+          if [ $TEST_USE_LATEST = "false" ]; then
+            leeway collect | grep components/ide/jetbrains/gateway-plugin:publish-stable > gateway.version
+          else
+            leeway collect | grep components/ide/jetbrains/gateway-plugin:publish-latest > gateway.version
+          fi
       - name: Cache leeway build
         id: cache-npm
         uses: actions/cache@v3

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -56,13 +56,16 @@ jobs:
                 echo "MINOR: $MINOR"
                 LATEST_VERSION="$MAJOR.$MINOR-EAP-CANDIDATE-SNAPSHOT"
                 echo "Latest platform version: $LATEST_VERSION"
-                echo "::set-output name=result::$LATEST_VERSION"
+
+                echo "::set-output name=sinceBuild::$MAJOR.$MINOR"
+                echo "::set-output name=untilBuild::$MAJOR.*"
                 echo "::set-output name=majorVersion::$MAJOR_VERSION"
+                echo "::set-output name=result::$LATEST_VERSION"
             - name: Update ${{ inputs.gradlePropertiesPath }}
               if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               run: |
-                  PLUGIN_SINCE_BUILD=$(echo "${{ steps.latest-version.outputs.result }}" | sed 's/-EAP-CANDIDATE-SNAPSHOT//' | sed 's/-CUSTOM-SNAPSHOT//')
-                  sed -i "s/pluginSinceBuild=.*/pluginSinceBuild=$PLUGIN_SINCE_BUILD/" ${{ inputs.gradlePropertiesPath }}
+                  sed -i "s/pluginSinceBuild=.*/pluginSinceBuild=${{ steps.latest-version.outputs.sinceBuild }}/" ${{ inputs.gradlePropertiesPath }}
+                  sed -i "s/pluginUntilBuild=.*/pluginUntilBuild=${{ steps.latest-version.outputs.untilBuild }}/" ${{ inputs.gradlePropertiesPath }}
                   sed -i "s/pluginVerifierIdeVersions=.*/pluginVerifierIdeVersions=${{ steps.latest-version.outputs.majorVersion }}/" ${{ inputs.gradlePropertiesPath }}
                   sed -i 's/platformVersion=${{ steps.current-version.outputs.result }}/platformVersion=${{ steps.latest-version.outputs.result }}/' ${{ inputs.gradlePropertiesPath }}
                   git diff


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It should fix stable auto upgrade. Before it will set the upper boundary bogusly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Merge and rerun the automation.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
