### PR TITLE
[public-api] Explicit panic handler

### DIFF
--- a/components/public-api-server/pkg/server/logs.go
+++ b/components/public-api-server/pkg/server/logs.go
@@ -59,6 +59,10 @@ func NewLogInterceptor(entry *logrus.Entry) connect.UnaryInterceptorFunc {
 }
 
 func filterHeaders(headers http.Header) http.Header {
+	if headers == nil {
+		return nil
+	}
+
 	cloned := headers.Clone()
 	cloned.Del("Authorization")
 	cloned.Del("Cookie")

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/experiments"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/go-chi/chi/v5"
+	chi_middleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
@@ -176,6 +177,7 @@ func register(srv *baseserver.Server, deps *registerDependencies) error {
 	}
 
 	rootHandler := chi.NewRouter()
+	rootHandler.Use(chi_middleware.Recoverer)
 	rootHandler.Use(middleware.NewLoggingMiddleware())
 
 	handlerOptions := []connect.HandlerOption{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Add a panic recovery middleware to the server, which prints a nicer stack trace should it happen again
* Use context logger for HTTP server, should fix panic observed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
