### PR TITLE
[test] Fix loop closures

### DIFF
--- a/test/tests/components/ws-manager/additional_repositories_test.go
+++ b/test/tests/components/ws-manager/additional_repositories_test.go
@@ -42,6 +42,7 @@ func TestAdditionalRepositories(t *testing.T) {
 			}
 
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -57,6 +57,7 @@ func TestBackup(t *testing.T) {
 				*/
 			}
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 
@@ -406,6 +407,7 @@ func TestMissingBackup(t *testing.T) {
 				// {Name: "pvc", FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}},
 			}
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name+"_backup_init", func(t *testing.T) {
 					t.Parallel()
 

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -65,6 +65,7 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 				*/
 			}
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 
@@ -540,6 +541,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 			}
 
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -59,6 +59,7 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 		WithLabel("type", "tasks").
 		Assess("it can run workspace tasks", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -145,6 +145,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 
 			for _, ff := range ffs {
 				for _, test := range tests {
+					test := test
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
 						report.SetupReport(t, report.FeatureContentInit, fmt.Sprintf("Test to open %v", test.ContextURL))
 						if test.Skip {

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -38,6 +38,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 		WithLabel("component", "server").
 		Assess("it can instrument a workspace", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			for _, test := range tests {
+				test := test
 				t.Run(test.ContextURL, func(t *testing.T) {
 					report.SetupReport(t, report.FeatureExample, "this is the example test for instrumenting a workspace")
 

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -73,6 +73,7 @@ func TestGitHooks(t *testing.T) {
 
 			for _, ff := range ffs {
 				for _, test := range tests {
+					test := test
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
 						t.Parallel()
 

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -141,6 +141,7 @@ func TestGitActions(t *testing.T) {
 
 			for _, ff := range ffs {
 				for _, test := range tests {
+					test := test
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
 						t.Parallel()
 						if test.Skip {


### PR DESCRIPTION
## Description

Fix loop closures, some parallel tests were accessing the loop variable which would most likely have changed value at the time it gets accessed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Potentially might fix some flakiness with the tests?

## How to test
<!-- Provide steps to test this PR -->

This should no longer pick up any loopclosure lint errors:
```
cd test
golangci-lint run | grep closure
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
