### PR TITLE
[dashboard] Redirect `/switch-to-payg` to docs

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -170,6 +170,12 @@ export const AppRoutes = () => {
         return <Redirect to={"/new/" + search + hash} />;
     }
 
+    // TODO(gpl): Hack to maintain email links after subscriptions are cancelled
+    if (location.pathname.startsWith(switchToPAYGPathMain)) {
+        window.location.href = `https://www.gitpod.io/docs/configure/billing`;
+        return <div></div>;
+    }
+
     return (
         <Route>
             <div className="container">


### PR DESCRIPTION
## Description
As discussed [here](https://gitpod.slack.com/archives/C02EN94AEPL/p1680253858918529?thread_ts=1680246650.399619&cid=C02EN94AEPL).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- try visit https://gpl-switch-redirect.preview.gitpod-dev.com/switch-to-payg?personalSubscription=asd

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
