### PR TITLE
[public-api] Fix panic due to incorrect err ref

### DIFF
--- a/components/public-api-server/pkg/apiv1/team.go
+++ b/components/public-api-server/pkg/apiv1/team.go
@@ -125,7 +125,7 @@ func (s *TeamService) ListTeams(ctx context.Context, req *connect.Request[v1.Lis
 	for res := range resultsChan {
 		if res.err != nil {
 			log.Extract(ctx).WithError(err).Error("Failed to populate team with details.")
-			return nil, err
+			return nil, res.err
 		}
 
 		resultMap[res.team.GetId()] = res.team


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I'll be adding a regression test in a follow-up PR, just want to get this fix in quick

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Sign in
3. Repeatedly reload /workspaces page until you exhaust the rate limit imposed by `server`
4. Eventually, you should get a "rate limited" response, but not a 500 from the ListTeams endpoint

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
