### PR TITLE
[ws-manager-mk2] Refactor metrics with EverReady condition

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -152,7 +152,7 @@ func (s *WorkspaceStatus) SetCondition(cond metav1.Condition) {
 	s.Conditions = wsk8s.AddUniqueCondition(s.Conditions, cond)
 }
 
-// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;BackupComplete;BackupFailure
+// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;EverReady;BackupComplete;BackupFailure
 type WorkspaceCondition string
 
 const (
@@ -184,6 +184,10 @@ const (
 
 	// ContentReady is true once the content initialisation is complete
 	WorkspaceConditionContentReady WorkspaceCondition = "ContentReady"
+
+	// EverReady is true if the workspace has ever been ready (content init
+	// succeeded and container is ready)
+	WorkspaceConditionEverReady WorkspaceCondition = "EverReady"
 
 	// BackupComplete is true once the backup has happened
 	WorkspaceConditionBackupComplete WorkspaceCondition = "BackupComplete"
@@ -266,6 +270,14 @@ func NewWorkspaceConditionContentReady(status metav1.ConditionStatus, reason, me
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
+	}
+}
+
+func NewWorkspaceConditionEverReady() metav1.Condition {
+	return metav1.Condition{
+		Type:               string(WorkspaceConditionEverReady),
+		LastTransitionTime: metav1.Now(),
+		Status:             metav1.ConditionTrue,
 	}
 }
 

--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -20,6 +20,7 @@ import (
 const (
 	workspaceStartupSeconds       string = "workspace_startup_seconds"
 	workspaceStartFailuresTotal   string = "workspace_starts_failure_total"
+	workspaceFailuresTotal        string = "workspace_failure_total"
 	workspaceStopsTotal           string = "workspace_stops_total"
 	workspaceBackupsTotal         string = "workspace_backups_total"
 	workspaceBackupFailuresTotal  string = "workspace_backups_failure_total"
@@ -30,6 +31,7 @@ const (
 type controllerMetrics struct {
 	startupTimeHistVec           *prometheus.HistogramVec
 	totalStartsFailureCounterVec *prometheus.CounterVec
+	totalFailuresCounterVec      *prometheus.CounterVec
 	totalStopsCounterVec         *prometheus.CounterVec
 
 	totalBackupCounterVec         *prometheus.CounterVec
@@ -63,6 +65,12 @@ func newControllerMetrics(r *WorkspaceReconciler) (*controllerMetrics, error) {
 			Subsystem: metricsWorkspaceSubsystem,
 			Name:      workspaceStartFailuresTotal,
 			Help:      "total number of workspaces that failed to start",
+		}, []string{"type", "class"}),
+		totalFailuresCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkspaceSubsystem,
+			Name:      workspaceFailuresTotal,
+			Help:      "total number of workspaces that had a failed condition",
 		}, []string{"type", "class"}),
 		totalStopsCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -121,6 +129,18 @@ func (m *controllerMetrics) countWorkspaceStartFailures(log *logr.Logger, ws *wo
 	counter, err := m.totalStartsFailureCounterVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
 		log.Error(err, "could not count workspace startup failure", "type", tpe, "class", class)
+	}
+
+	counter.Inc()
+}
+
+func (m *controllerMetrics) countWorkspaceFailure(log *logr.Logger, ws *workspacev1.Workspace) {
+	class := ws.Spec.Class
+	tpe := string(ws.Spec.Type)
+
+	counter, err := m.totalFailuresCounterVec.GetMetricWithLabelValues(tpe, class)
+	if err != nil {
+		log.Error(err, "could not count workspace failure", "type", tpe, "class", class)
 	}
 
 	counter.Inc()
@@ -210,6 +230,7 @@ type metricState struct {
 	recordedStartTime       bool
 	recordedInitFailure     bool
 	recordedStartFailure    bool
+	recordedFailure         bool
 	recordedContentReady    bool
 	recordedBackupFailed    bool
 	recordedBackupCompleted bool
@@ -223,7 +244,8 @@ func newMetricState(ws *workspacev1.Workspace) metricState {
 		// each workspace.
 		recordedStartTime:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 		recordedInitFailure:     wsk8s.ConditionWithStatusAndReason(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure),
-		recordedStartFailure:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)),
+		recordedStartFailure:    ws.Status.Phase == workspacev1.WorkspacePhaseStopped && !wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionEverReady)),
+		recordedFailure:         wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)),
 		recordedContentReady:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)),
 		recordedBackupFailed:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)),
 		recordedBackupCompleted: wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)),
@@ -245,6 +267,7 @@ func (m *controllerMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.startupTimeHistVec.Describe(ch)
 	m.totalStopsCounterVec.Describe(ch)
 	m.totalStartsFailureCounterVec.Describe(ch)
+	m.totalFailuresCounterVec.Describe(ch)
 
 	m.totalBackupCounterVec.Describe(ch)
 	m.totalBackupFailureCounterVec.Describe(ch)
@@ -260,6 +283,7 @@ func (m *controllerMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.startupTimeHistVec.Collect(ch)
 	m.totalStopsCounterVec.Collect(ch)
 	m.totalStartsFailureCounterVec.Collect(ch)
+	m.totalFailuresCounterVec.Collect(ch)
 
 	m.totalBackupCounterVec.Collect(ch)
 	m.totalBackupFailureCounterVec.Collect(ch)

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -202,13 +202,21 @@ func extractFailure(ws *workspacev1.Workspace, pod *corev1.Pod) (string, *worksp
 	// Check for content init failure.
 	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)); c != nil {
 		if c.Status == metav1.ConditionFalse && c.Reason == workspacev1.ReasonInitializationFailure {
-			return c.Message, nil
+			msg := c.Message
+			if msg == "" {
+				msg = "Content initialization failed for an unknown reason"
+			}
+			return msg, nil
 		}
 	}
 
 	// Check for backup failure.
 	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)); c != nil {
-		return c.Message, nil
+		msg := c.Message
+		if msg == "" {
+			msg = "Backup failed for an unknown reason"
+		}
+		return msg, nil
 	}
 
 	status := pod.Status

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -306,18 +306,11 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 	if !lastState.recordedInitFailure && wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure) {
 		r.metrics.countTotalRestoreFailures(&log, workspace)
 		lastState.recordedInitFailure = true
-
-		if !lastState.recordedStartFailure {
-			r.metrics.countWorkspaceStartFailures(&log, workspace)
-			lastState.recordedStartFailure = true
-		}
 	}
 
-	if !lastState.recordedStartFailure && wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)) {
-		// Only record if there was no other start failure recorded yet, to ensure max one
-		// start failure gets recorded per workspace.
-		r.metrics.countWorkspaceStartFailures(&log, workspace)
-		lastState.recordedStartFailure = true
+	if !lastState.recordedFailure && wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)) {
+		r.metrics.countWorkspaceFailure(&log, workspace)
+		lastState.recordedFailure = true
 	}
 
 	if !lastState.recordedContentReady && wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)) {
@@ -343,6 +336,12 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseStopped {
 		r.metrics.countWorkspaceStop(&log, workspace)
+
+		if !lastState.recordedStartFailure && !wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionEverReady)) {
+			// Workspace never became ready, count as a startup failure.
+			r.metrics.countWorkspaceStartFailures(&log, workspace)
+			lastState.recordedStartFailure = true
+		}
 
 		// Forget about this workspace, no more state updates will be recorded after this.
 		r.metrics.forgetWorkspace(workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -337,10 +337,11 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseStopped {
 		r.metrics.countWorkspaceStop(&log, workspace)
 
-		if !lastState.recordedStartFailure && !wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionEverReady)) {
+		everReady := wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionEverReady))
+		if !lastState.recordedStartFailure && !everReady {
 			// Workspace never became ready, count as a startup failure.
 			r.metrics.countWorkspaceStartFailures(&log, workspace)
-			lastState.recordedStartFailure = true
+			// No need to record in metricState, as we're forgetting the workspace state next anyway.
 		}
 
 		// Forget about this workspace, no more state updates will be recorded after this.


### PR DESCRIPTION
## Description

Introduce an `EverReady` condition:
* Gets set when the workspace container becomes `Ready`, i.e. when content init succeeded and the supervisor readiness check passes.

This condition then allows us to:
* Count startup failure metrics similarly to mk1: a workspace that reaches the `Stopped` phase without ever becoming ready
* Not moving a workspace from `Running` to `Initializing` if its container becomes unready. Once a workspace becomes ready it should not move backwards in phase

To track workspace failures that happen after startup, a new `workspace_failure_total` metric is added which gets incremented whenever a workspaces receives the `Failed` condition. This includes content init and disposal failures, but also all other possible failures.

The `workspace_stops_total` metric is also updated to match MK1 behaviour by including the stop `reason` label.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-29, WKS-23

## How to test
<!-- Provide steps to test this PR -->

Run unit tests

Or in a preview env, check a workspace starts and stops as expected, and the right metrics are incremented.

E.g. the following stop metric reasons are reported for a workspace with an image build:

```
gitpod_ws_manager_mk2_workspace_stops_total{class="default",reason="regular-stop",type="ImageBuild"} 1
gitpod_ws_manager_mk2_workspace_stops_total{class="default",reason="regular-stop",type="Regular"} 1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
