### PR TITLE
[ws-manager-mk2] Ignore container killed failures

### DIFF
--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -102,6 +102,18 @@ var controllerRules = []rbacv1.PolicyRule{
 	},
 }
 
+var controllerClusterRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"nodes"},
+		Verbs: []string{
+			"get",
+			"list",
+			"watch",
+		},
+	},
+}
+
 // ConfigMap, Leases, and Events access is required for leader-election.
 var leaderElectionRules = []rbacv1.PolicyRule{
 	{
@@ -149,6 +161,15 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    labels,
 			},
 			Rules: controllerRules,
+		},
+
+		&rbacv1.ClusterRole{
+			TypeMeta: common.TypeMetaClusterRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   Component,
+				Labels: labels,
+			},
+			Rules: controllerClusterRules,
 		},
 	}, nil
 }

--- a/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
+++ b/install/installer/pkg/components/ws-manager-mk2/rolebinding.go
@@ -78,5 +78,25 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   Component,
+				Labels: labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     Component,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Component,
+					Namespace: ctx.Namespace,
+				},
+			},
+		},
 	}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ports https://github.com/gitpod-io/gitpod/issues/12021 to mk2. Fixes workspace failure false-positives where the pod's container status ends up in `ContainerStatusUnknown`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-22

## How to test
<!-- Provide steps to test this PR -->

Tested in an ephemeral cluster using loadgen to spin up 100 workspaces and then stopping them. Without this fix, several of them would "fail" with `The container could not be located when the pod was terminated` or `The container could not be located when the pod was deleted.  The container used to be Running`. With this fix none of them do. 

For the workspaces that were failing before the fix, backups were being taken, so nothing was really failing.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
