### PR TITLE
Update delete account button spacing

### DIFF
--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -91,7 +91,9 @@ export default function Account() {
                     </ProfileInformation>
                 </form>
                 <Heading2 className="mt-12">Delete Account</Heading2>
-                <Subheading>This action will remove all the data associated with your account in Gitpod.</Subheading>
+                <Subheading className="mb-3">
+                    This action will remove all the data associated with your account in Gitpod.
+                </Subheading>
                 <Button type="danger.secondary" onClick={() => setModal(true)}>
                     Delete Account
                 </Button>


### PR DESCRIPTION
## Description

Minor spacing change to the delete account button under `/account`. Seems like a small side effect from the typography components added in https://github.com/gitpod-io/gitpod/pull/16673.

This will add a ~spacing-scale-3 (`1rem`/`16px`) between the heading and the button.

| BEFORE | AFTER |
|-|-|
| <img width="697" alt="button-before" src="https://user-images.githubusercontent.com/120486/229582741-88d0ca04-079e-40f8-8680-b8485f499ce6.png"> | <img width="697" alt="button-after" src="https://user-images.githubusercontent.com/120486/229582745-db936e96-71e4-4531-a38f-88100b35bfc1.png"> |

Posting for visibility below a screenshot from **Foundations / Spacing** in the component library in our Figma team, to justify the change.

| Spacing Guidelines |
|-|
| ![Spacing](https://user-images.githubusercontent.com/120486/205070541-e116ccfe-83d5-41c2-bbbf-f91726934e31.png) |

https://github.com/gitpod-io/gitpod/blob/2d4f94634ce3178b224e62ac582dc005fc636f5a/components/dashboard/src/user-settings/Account.tsx#L93-L97

Cc @easyCZ because [relevant discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1680514715896819) (internal)

Cc @selfcontained because https://github.com/gitpod-io/gitpod/pull/16673

## How to test
Go to user account settings and notice the button spacing in the delete account section.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
