### PR TITLE
[image-builder-mk3] log UserID when build done fails

### DIFF
--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -444,6 +444,9 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 			// build is done
 			o.clearListener(buildID)
 			o.metrics.BuildDone(update.Status == protocol.BuildStatus_done_success)
+			if update.Status != protocol.BuildStatus_done_success {
+				log.WithField("UserID", req.GetTriggeredBy()).Error("image build done failed for user")
+			}
 			break
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Log an error including the userID when build done has failed. This generally indicates pain for users as it pertains to the outer loop experience.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
[Start an image build from here](https://github.com/kylos101/gitpod-custom-image/tree/kylos101/build-fail), it'll fail and log an error with a userID (real data, so, not a fake userID unrelated to the workspace).

[Look for the related error like so.](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-04-04T00:38:32.968560154Z;query=--%20name%20of%20your%20preview%20VM%20host%0AjsonPayload.kubernetes.host%3D%22kylos101-i1bb9ea129b%22%0A%22image%20build%20done%20failed%20for%20user%22%0Atimestamp%3D%222023-04-04T00:38:32.968560154Z%22%0AinsertId%3D%22kjloy4g16clqi3%22?project=gitpod-core-dev). 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
