### PR TITLE
[Create Workspace] small fixes/improvements

### DIFF
--- a/components/dashboard/src/data/workspaces/resolve-context-query.ts
+++ b/components/dashboard/src/data/workspaces/resolve-context-query.ts
@@ -9,17 +9,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 
 export function useWorkspaceContext(contextUrl?: string) {
-    const query = useQuery<WorkspaceContext, Error>(
-        ["workspace-context", contextUrl],
-        () => {
-            if (!contextUrl) {
-                throw new Error("no contextURL. Query should be disabled.");
-            }
-            return getGitpodService().server.resolveContext(contextUrl);
-        },
-        {
-            enabled: !!contextUrl,
-        },
-    );
+    const query = useQuery<WorkspaceContext | null, Error>(["workspace-context", contextUrl], () => {
+        if (!contextUrl) {
+            return null;
+        }
+        return getGitpodService().server.resolveContext(contextUrl);
+    });
     return query;
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3669,6 +3669,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getIDToken(): Promise<void> {}
     public async resolveContext(ctx: TraceContextWithSpan, contextUrl: string): Promise<WorkspaceContext> {
         const user = this.checkAndBlockUser("resolveContext");
-        return this.contextParser.handle(ctx, user, contextUrl);
+        const normalizedCtxURL = this.contextParser.normalizeContextURL(contextUrl);
+        return this.contextParser.handle(ctx, user, normalizedCtxURL);
     }
 }


### PR DESCRIPTION
## Description
Several smaller improvements to the create workspace page
- apply the same preprocessing of the given contextURL for resolving a workspace context that is applied when creating a workspace.
- handle `referrer` prefix URLs, so that the workspace starts immediately
- ensure createWorkspace is not called multiple times

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/WEB-68/startworkspacewithoptions-invalid-url-error-on-missing-scheme
Fixes https://linear.app/gitpod/issue/WEB-81/context-urls-with-referrer-dont-show-modal
Fixes https://linear.app/gitpod/issue/WEB-73/[new-workspace-page]-dont-start-more-than-one-workspace-with-enter

## How to test
<!-- Provide steps to test this PR -->
- Try starting a workspace with a contextURL that lacks the https:// part
- start a workspace using referrer prefix : https://se-create-workspace.preview.gitpod-dev.com/new/#referrer:jetbrains-gateway:phpstorm/https://github.com/gitpod-samples/template-php-laravel-mysql
- try starting multiple workspace by hitting enter

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
