### PR TITLE
[Create WS] Various fixes

### DIFF
--- a/components/dashboard/src/data/workspaces/resolve-context-query.ts
+++ b/components/dashboard/src/data/workspaces/resolve-context-query.ts
@@ -9,17 +9,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 
 export function useWorkspaceContext(contextUrl?: string) {
-    const query = useQuery<WorkspaceContext, Error>(
-        ["workspace-context", contextUrl],
-        () => {
-            if (!contextUrl) {
-                throw new Error("no contextURL. Query should be disabled.");
-            }
-            return getGitpodService().server.resolveContext(contextUrl);
-        },
-        {
-            enabled: !!contextUrl,
-        },
-    );
+    const query = useQuery<WorkspaceContext | null, Error>(["workspace-context", contextUrl], () => {
+        if (!contextUrl) {
+            return null;
+        }
+        return getGitpodService().server.resolveContext(contextUrl);
+    });
     return query;
 }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -521,6 +521,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                         <div className="flex flex-col text-center m-auto text-sm w-72 text-gray-400">
                             {client.installationSteps.map((step) => (
                                 <div
+                                    key={step}
                                     dangerouslySetInnerHTML={{
                                         // eslint-disable-next-line no-template-curly-in-string
                                         __html: step.replaceAll("${OPEN_LINK_LABEL}", openLinkLabel),

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -13,12 +13,14 @@ import Tooltip from "../components/Tooltip";
 import dayjs from "dayjs";
 import { WorkspaceEntryOverflowMenu } from "./WorkspaceOverflowMenu";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
+import { projectsPathInstallGitHubApp } from "../projects/projects.routes";
 
 type Props = {
     info: WorkspaceInfo;
+    shortVersion?: boolean;
 };
 
-export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
+export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion }) => {
     const [menuActive, setMenuActive] = useState(false);
 
     const workspace = info.workspace;
@@ -63,32 +65,36 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
                     </a>
                 </Tooltip>
             </ItemField>
-            <ItemField className="w-4/12 flex flex-col my-auto">
-                <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
-                    {workspace.description}
-                </div>
-                <a href={normalizedContextUrl}>
-                    <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">
-                        {normalizedContextUrlDescription}
-                    </div>
-                </a>
-            </ItemField>
-            <ItemField className="w-2/12 flex flex-col my-auto">
-                <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
-                    <Tooltip content={currentBranch}>{currentBranch}</Tooltip>
-                </div>
-                <div className="mr-auto">
-                    <PendingChangesDropdown workspaceInstance={info.latestInstance} />
-                </div>
-            </ItemField>
-            <ItemField className="w-2/12 flex my-auto">
-                <Tooltip content={`Created ${dayjs(info.workspace.creationTime).fromNow()}`}>
-                    <div className="text-sm w-full text-gray-400 overflow-ellipsis truncate">
-                        {dayjs(WorkspaceInfo.lastActiveISODate(info)).fromNow()}
-                    </div>
-                </Tooltip>
-            </ItemField>
-            <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
+            {!shortVersion && (
+                <>
+                    <ItemField className="w-4/12 flex flex-col my-auto">
+                        <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
+                            {workspace.description}
+                        </div>
+                        <a href={normalizedContextUrl}>
+                            <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">
+                                {normalizedContextUrlDescription}
+                            </div>
+                        </a>
+                    </ItemField>
+                    <ItemField className="w-2/12 flex flex-col my-auto">
+                        <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
+                            <Tooltip content={currentBranch}>{currentBranch}</Tooltip>
+                        </div>
+                        <div className="mr-auto">
+                            <PendingChangesDropdown workspaceInstance={info.latestInstance} />
+                        </div>
+                    </ItemField>
+                    <ItemField className="w-2/12 flex my-auto">
+                        <Tooltip content={`Created ${dayjs(info.workspace.creationTime).fromNow()}`}>
+                            <div className="text-sm w-full text-gray-400 overflow-ellipsis truncate">
+                                {dayjs(WorkspaceInfo.lastActiveISODate(info)).fromNow()}
+                            </div>
+                        </Tooltip>
+                    </ItemField>
+                    <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
+                </>
+            )}
         </Item>
     );
 };

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -482,6 +482,7 @@ export namespace GitpodServer {
         organizationId?: string;
 
         // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
+        //TODO(se) remove this option and let clients do that check if they like. The new create workspace page does it already
         ignoreRunningWorkspaceOnSameCommit?: boolean;
         ignoreRunningPrebuild?: boolean;
         allowUsingPreviousPrebuilds?: boolean;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3669,6 +3669,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getIDToken(): Promise<void> {}
     public async resolveContext(ctx: TraceContextWithSpan, contextUrl: string): Promise<WorkspaceContext> {
         const user = this.checkAndBlockUser("resolveContext");
-        return this.contextParser.handle(ctx, user, contextUrl);
+        const normalizedCtxURL = this.contextParser.normalizeContextURL(contextUrl);
+        return this.contextParser.handle(ctx, user, normalizedCtxURL);
     }
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1136,6 +1136,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
             logContext = { userId: user.id };
 
+            //TODO(se) remove this implicit check and let instead clients do the checking.
             // Credit check runs in parallel with the other operations up until we start consuming resources.
             // Make sure to await for the creditCheck promise in the right places.
             const runningInstancesPromise = this.workspaceDb.trace(ctx).findRegularRunningInstances(user.id);


### PR DESCRIPTION
## Description
Several smaller improvements to the create workspace page
- apply the same preprocessing of the given contextURL for resolving a workspace context that is applied when creating a workspace.
- handle `referrer` prefix URLs, so that the workspace starts immediately
- ensure createWorkspace is not called multiple times
- checks and displays directly if a workspace on the same revision is already running

<img width="643" alt="Screenshot 2023-04-06 at 11 55 43" src="https://user-images.githubusercontent.com/372735/230345917-6fccda26-0f22-4e02-82dd-53148671cf6b.png">
cc @gtsiolis 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/WEB-68/startworkspacewithoptions-invalid-url-error-on-missing-scheme
Fixes https://linear.app/gitpod/issue/WEB-81/context-urls-with-referrer-dont-show-modal
Fixes https://linear.app/gitpod/issue/WEB-73/[new-workspace-page]-dont-start-more-than-one-workspace-with-enter

## How to test
<!-- Provide steps to test this PR -->
- Try starting a workspace with a contextURL that lacks the https:// part: https://se-create-ws-page.preview.gitpod-dev.com/#github.com/gitpod-io/website
- start a workspace using referrer prefix : https://se-create-ws-page.preview.gitpod-dev.com/#referrer:jetbrains-gateway:phpstorm/https://github.com/gitpod-samples/template-php-laravel-mysql
- try starting multiple workspace by hitting enter
- try start multiple workspaces on the same revision and see how the create workspace page displays those workspaces

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
