### PR TITLE
[ws-manager-mk2] Maintenance continue reconciles

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -168,7 +168,10 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		}
 
 	case workspace.IsHeadless() && (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed):
-		workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
+		// Don't start disposal if maintenance mode is enabled.
+		if !r.maintenance.IsEnabled() {
+			workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
+		}
 
 		if isDisposalFinished(workspace) {
 			workspace.Status.Phase = workspacev1.WorkspacePhaseStopped

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -105,13 +105,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	conf := newTestConfig()
-	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("workspace"), &conf, metrics.Registry, &fakeMaintenance{enabled: false})
+	maintenance := &fakeMaintenance{enabled: false}
+	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("workspace"), &conf, metrics.Registry, maintenance)
 	wsMetrics = wsReconciler.metrics
 	Expect(err).ToNot(HaveOccurred())
 	Expect(wsReconciler.SetupWithManager(k8sManager)).To(Succeed())
 
 	wsActivity = &activity.WorkspaceActivity{}
-	timeoutReconciler, err := NewTimeoutReconciler(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("workspace"), conf, wsActivity)
+	timeoutReconciler, err := NewTimeoutReconciler(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("workspace"), conf, wsActivity, maintenance)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(timeoutReconciler.SetupWithManager(k8sManager)).To(Succeed())
 

--- a/components/ws-manager-mk2/controllers/timeout_controller_test.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller_test.go
@@ -36,7 +36,7 @@ var _ = Describe("TimeoutController", func() {
 			// Use a fake client instead of the envtest's k8s client, such that we can add objects
 			// with custom CreationTimestamps and check timeout logic.
 			fakeClient = fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).Build()
-			r, err = NewTimeoutReconciler(fakeClient, record.NewFakeRecorder(100), conf, &activity.WorkspaceActivity{})
+			r, err = NewTimeoutReconciler(fakeClient, record.NewFakeRecorder(100), conf, &activity.WorkspaceActivity{}, &fakeMaintenance{enabled: false})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -197,7 +197,7 @@ var _ = Describe("TimeoutController", func() {
 		var r *TimeoutReconciler
 		BeforeEach(func() {
 			var err error
-			r, err = NewTimeoutReconciler(k8sClient, record.NewFakeRecorder(100), newTestConfig(), &activity.WorkspaceActivity{})
+			r, err = NewTimeoutReconciler(k8sClient, record.NewFakeRecorder(100), newTestConfig(), &activity.WorkspaceActivity{}, &fakeMaintenance{enabled: false})
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -103,12 +103,6 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Info("reconciling workspace", "ws", req.NamespacedName)
-	if r.maintenance.IsEnabled() {
-		// Don't reconcile workspaces in maintenance mode, to prevent Pod creation and deletion.
-		// Requeue after some time to ensure we do still reconcile this workspace when
-		// maintenance mode ends.
-		return ctrl.Result{RequeueAfter: maintenanceRequeue}, nil
-	}
 
 	var workspacePods corev1.PodList
 	err := r.List(ctx, &workspacePods, client.InNamespace(req.Namespace), client.MatchingFields{wsOwnerKey: req.Name})

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -148,7 +148,7 @@ func main() {
 	}
 
 	activity := &activity.WorkspaceActivity{}
-	timeoutReconciler, err := controllers.NewTimeoutReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), cfg.Manager, activity)
+	timeoutReconciler, err := controllers.NewTimeoutReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), cfg.Manager, activity, maintenanceReconciler)
 	if err != nil {
 		setupLog.Error(err, "unable to create timeout controller", "controller", "Timeout")
 		os.Exit(1)


### PR DESCRIPTION
## Description

Continue reconciling workspaces in maintenance mode, to e.g. finish disposal and advance the workspace phase to stopped. Instead, don't move a workspace to Stopping (which starts disposal in daemon) for timeouts and when a headless workspace exits.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-48

## How to test
<!-- Provide steps to test this PR -->

Enable maintenance mode, and observe starting/stopping workspaces is still not possible, but the workspaces should get reconciled and advance phase if they were e.g. stopping at the time of maintenance mode. 

Workspaces should not timeout when maintenance mode is enabled, but should once it gets disabled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
