### PR TITLE
[db] Leadership election through MySQL

### DIFF
--- a/components/gitpod-db/src/election-db.ts
+++ b/components/gitpod-db/src/election-db.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export const ElectionDB = Symbol("ElectionDB");
+
+export interface ElectionDB {
+    store(id: string, key: string): Promise<void>;
+    get(): Promise<string | undefined>;
+}

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -42,3 +42,4 @@ export * from "./webhook-event-db";
 export * from "./typeorm/metrics";
 export * from "./personal-access-token-db";
 export * from "./typeorm/entity/db-personal-access-token";
+export * from "./election-db";

--- a/components/gitpod-db/src/typeorm/entity/db-election.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-election.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Transformer } from "../transformer";
+
+@Entity("d_b_election")
+export class DBElection {
+    @PrimaryColumn()
+    electionName: string;
+
+    @PrimaryColumn()
+    leaderName: string;
+
+    @Column({
+        type: "timestamp",
+        precision: 6,
+        transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
+    })
+    updatedAt?: string;
+}

--- a/components/gitpod-db/src/typeorm/migration/1680623153984-AddDBElection.ts
+++ b/components/gitpod-db/src/typeorm/migration/1680623153984-AddDBElection.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDBElection1680623153984 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_election (
+                electionName varchar(255) NOT NULL
+                leaderName varchar(255) NOT NULL,
+                updatedAt timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+                PRIMARY KEY (election_id, leaderName)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP TABLE IF EXISTS d_b_election;");
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
