### PR TITLE
Add new feature for custom workspace network CIDR

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -284,7 +284,7 @@ func main() {
 					}
 
 					vethIpNet := net.IPNet{
-						IP:   net.ParseIP(vethIp.String()),
+						IP:   vethIp,
 						Mask: mask.Mask,
 					}
 
@@ -429,7 +429,7 @@ func main() {
 					}
 
 					cethIpNet := net.IPNet{
-						IP:   net.ParseIP(cethIp.String()),
+						IP:   cethIp,
 						Mask: mask.Mask,
 					}
 

--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -23,10 +23,10 @@ import (
 )
 
 // WorkspaceLifecycleHooks configures the lifecycle hooks for all workspaces
-func WorkspaceLifecycleHooks(cfg Config, workspaceExistenceCheck WorkspaceExistenceCheck, uidmapper *iws.Uidmapper, xfs *quota.XFS, cgroupMountPoint string) map[session.WorkspaceState][]session.WorkspaceLivecycleHook {
+func WorkspaceLifecycleHooks(cfg Config, workspaceCIDR string, workspaceExistenceCheck WorkspaceExistenceCheck, uidmapper *iws.Uidmapper, xfs *quota.XFS, cgroupMountPoint string) map[session.WorkspaceState][]session.WorkspaceLivecycleHook {
 	// startIWS starts the in-workspace service for a workspace. This lifecycle hook is idempotent, hence can - and must -
 	// be called on initialization and ready. The on-ready hook exists only to support ws-daemon restarts.
-	startIWS := iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift), cgroupMountPoint)
+	startIWS := iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift), cgroupMountPoint, workspaceCIDR)
 
 	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
 		session.WorkspaceInitializing: {

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -69,7 +69,7 @@ type WorkspaceService struct {
 type WorkspaceExistenceCheck func(instanceID string) bool
 
 // NewWorkspaceService creates a new workspce initialization service, starts housekeeping and the Prometheus integration
-func NewWorkspaceService(ctx context.Context, cfg Config, runtime container.Runtime, wec WorkspaceExistenceCheck, uidmapper *iws.Uidmapper, cgroupMountPoint string, reg prometheus.Registerer) (res *WorkspaceService, err error) {
+func NewWorkspaceService(ctx context.Context, cfg Config, runtime container.Runtime, wec WorkspaceExistenceCheck, uidmapper *iws.Uidmapper, cgroupMountPoint string, reg prometheus.Registerer, workspaceCIDR string) (res *WorkspaceService, err error) {
 	//nolint:ineffassign
 	span, ctx := opentracing.StartSpanFromContext(ctx, "NewWorkspaceService")
 	defer tracing.FinishSpan(span, &err)
@@ -86,7 +86,9 @@ func NewWorkspaceService(ctx context.Context, cfg Config, runtime container.Runt
 	}
 
 	// read all session json files
-	store, err := session.NewStore(ctx, cfg.WorkingArea, WorkspaceLifecycleHooks(cfg, wec, uidmapper, xfs, cgroupMountPoint))
+	store, err := session.NewStore(ctx, cfg.WorkingArea,
+		WorkspaceLifecycleHooks(cfg, workspaceCIDR, wec, uidmapper, xfs, cgroupMountPoint),
+	)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create session store: %w", err)
 	}

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -43,6 +43,8 @@ type RuntimeConfig struct {
 	Kubeconfig          string            `json:"kubeconfig"`
 	KubernetesNamespace string            `json:"namespace"`
 	SecretsNamespace    string            `json:"secretsNamespace"`
+
+	WorkspaceCIDR string `json:"workspaceCIDR,omitempty"`
 }
 
 type IOLimitConfig struct {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -194,6 +194,7 @@ func NewDaemon(config Config) (*Daemon, error) {
 
 		hooks := content.WorkspaceLifecycleHooks(
 			contentCfg,
+			config.Runtime.WorkspaceCIDR,
 			func(instanceID string) bool { return true },
 			&iws.Uidmapper{Config: config.Uidmapper, Runtime: containerRuntime},
 			xfs,
@@ -239,6 +240,7 @@ func NewDaemon(config Config) (*Daemon, error) {
 		&iws.Uidmapper{Config: config.Uidmapper, Runtime: containerRuntime},
 		config.CPULimit.CGroupBasePath,
 		wrappedReg,
+		config.Runtime.WorkspaceCIDR,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create content service: %w", err)

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -67,6 +67,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	var wscontroller daemon.WorkspaceControllerConfig
 
+	// default workspace network CIDR (and fallback)
+	workspaceCIDR := "10.0.5.0/30"
+
 	ctx.WithExperimental(func(ucfg *experimental.Config) error {
 		if ucfg.Workspace == nil {
 			return nil
@@ -105,6 +108,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		wscontroller.WorkingAreaSuffix = "-mk2"
 		wscontroller.MaxConcurrentReconciles = 15
 
+		if ucfg.Workspace.WorkspaceCIDR != "" {
+			workspaceCIDR = ucfg.Workspace.WorkspaceCIDR
+		}
+
 		return nil
 	})
 
@@ -123,6 +130,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						SocketPath: "/mnt/containerd/containerd.sock",
 					},
 				},
+				WorkspaceCIDR: workspaceCIDR,
 			},
 			Content: content.Config{
 				WorkingArea:     "/mnt/workingarea",

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -68,6 +68,8 @@ type WorkspaceConfig struct {
 	WorkspaceURLTemplate     string   `json:"workspaceURLTemplate,omitempty"`
 	WorkspacePortURLTemplate string   `json:"workspacePortURLTemplate,omitempty"`
 
+	WorkspaceCIDR string `json:"workspaceCIDR,omitempty"`
+
 	CPULimits struct {
 		Enabled          bool              `json:"enabled"`
 		NodeCPUBandwidth resource.Quantity `json:"nodeBandwidth"`

--- a/install/installer/pkg/config/v1/experimental/validation.go
+++ b/install/installer/pkg/config/v1/experimental/validation.go
@@ -46,6 +46,10 @@ func ClusterValidation(cfg *Config) cluster.ValidationChecks {
 		if scr := cfg.Workspace.RegistryFacade.RedisCache.PasswordSecret; scr != "" {
 			res = append(res, cluster.CheckSecret(scr, cluster.CheckSecretRequiredData("password")))
 		}
+
+		if cfg.Workspace.WorkspaceCIDR != "" {
+			res = append(res, cluster.CheckWorkspaceCIDR(cfg.Workspace.WorkspaceCIDR))
+		}
 	}
 
 	return res


### PR DESCRIPTION
## Description

The default workspace network cell uses a private range that can conflict with some pre-existing network in the VPC that creates a network routing error (`no route to host`) when we try to reach any IP address of the such subnet.
For this scenario, we introduce a new ws-daemon parameter that allows us to set a different subnet. If the parameter is not present, we use the default value we use.

fixes WKS-50

## How to test
- Use the default configuration
  - Verify workspaces run
  - Check the IP addresses in the workspace. The value should be `10.0.5.2/30`
- Change the installer configuration to set a different subnet
  - Verify workspaces run
  - Check the IP addresses in the workspace. The value should match the subnet, and the workspace should have the second IP address in the range.

## Release Notes
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
