### PR TITLE
[dashboard] handle context resolution errors

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -24,6 +24,7 @@ import { getURLHash } from "./utils";
 import ErrorMessage from "./components/ErrorMessage";
 import { Heading1, Heading2, Subheading } from "./components/typography/headings";
 import { SSOLoginForm } from "./login/SSOLoginForm";
+import { useAuthProviders } from "./data/auth-providers/auth-provider-query";
 
 function Item(props: { icon: string; iconSize?: string; text: string }) {
     const iconSize = props.iconSize || 28;
@@ -52,9 +53,8 @@ export function Login() {
 
     const urlHash = useMemo(() => getURLHash(), []);
 
-    const [authProviders, setAuthProviders] = useState<AuthProviderInfo[]>([]);
+    const authProviders = useAuthProviders();
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
-    const [providerFromContext, setProviderFromContext] = useState<AuthProviderInfo>();
     const [hostFromContext, setHostFromContext] = useState<string | undefined>();
     const [repoPathname, setRepoPathname] = useState<string | undefined>();
 
@@ -70,18 +70,10 @@ export function Login() {
         }
     }, [urlHash]);
 
-    useEffect(() => {
-        (async () => {
-            setAuthProviders(await getGitpodService().server.getAuthProviders());
-        })();
-    }, []);
-
-    useEffect(() => {
-        if (hostFromContext && authProviders) {
-            const providerFromContext = authProviders.find((provider) => provider.host === hostFromContext);
-            setProviderFromContext(providerFromContext);
-        }
-    }, [hostFromContext, authProviders]);
+    let providerFromContext: AuthProviderInfo | undefined;
+    if (hostFromContext && authProviders.data) {
+        providerFromContext = authProviders.data.find((provider) => provider.host === hostFromContext);
+    }
 
     const showWelcome = !hasLoggedInBefore() && !hasVisitedMarketingWebsiteBefore() && !urlHash.startsWith("https://");
 
@@ -209,7 +201,7 @@ export function Login() {
                                     <button
                                         key={"button" + providerFromContext.host}
                                         className="btn-login flex-none w-56 h-10 p-0 inline-flex"
-                                        onClick={() => openLogin(providerFromContext.host)}
+                                        onClick={() => openLogin(providerFromContext!.host)}
                                     >
                                         {iconForAuthProvider(providerFromContext.authProviderType)}
                                         <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">
@@ -217,7 +209,7 @@ export function Login() {
                                         </span>
                                     </button>
                                 ) : (
-                                    authProviders.map((ap) => (
+                                    authProviders.data?.map((ap) => (
                                         <button
                                             key={"button" + ap.host}
                                             className="btn-login flex-none w-56 h-10 p-0 inline-flex"

--- a/components/dashboard/src/data/auth-providers/auth-provider-query.ts
+++ b/components/dashboard/src/data/auth-providers/auth-provider-query.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+export const useAuthProviders = () => {
+    return useQuery<AuthProviderInfo[]>({
+        queryKey: ["auth-providers"],
+        queryFn: async () => {
+            return await getGitpodService().server.getAuthProviders();
+        },
+    });
+};

--- a/components/dashboard/src/data/workspaces/resolve-context-query.ts
+++ b/components/dashboard/src/data/workspaces/resolve-context-query.ts
@@ -9,11 +9,17 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 
 export function useWorkspaceContext(contextUrl?: string) {
-    const query = useQuery<WorkspaceContext | null, Error>(["workspace-context", contextUrl], () => {
-        if (!contextUrl) {
-            return null;
-        }
-        return getGitpodService().server.resolveContext(contextUrl);
-    });
+    const query = useQuery<WorkspaceContext | null, Error>(
+        ["workspace-context", contextUrl],
+        () => {
+            if (!contextUrl) {
+                return null;
+            }
+            return getGitpodService().server.resolveContext(contextUrl);
+        },
+        {
+            retry: false,
+        },
+    );
     return query;
 }

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -30,6 +30,7 @@ import { UsageLimitReachedModal } from "../components/UsageLimitReachedModal";
 import { StartWorkspaceOptions } from "./start-workspace-options";
 import { useLocation } from "react-router";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
+import { useAuthProviders } from "../data/auth-providers/auth-provider-query";
 
 export interface CreateWorkspaceProps {
     contextUrl: string;
@@ -382,6 +383,7 @@ export function LimitReachedOutOfHours() {
 
 export function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
     const [statusMessage, setStatusMessage] = useState<React.ReactNode>();
+    const authProviders = useAuthProviders();
     const { host, owner, repoName, userIsOwner, userScopes, lastUpdate } = p.error.data;
     const repoFullName = owner && repoName ? `${owner}/${repoName}` : "";
 
@@ -394,7 +396,7 @@ export function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
             console.log("userScopes", userScopes);
             console.log("lastUpdate", lastUpdate);
 
-            const authProvider = (await getGitpodService().server.getAuthProviders()).find((p) => p.host === host);
+            const authProvider = authProviders.data?.find((p) => p.host === host);
             if (!authProvider) {
                 return;
             }

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -29,6 +29,7 @@ import { AuthEntryItem } from "./AuthEntryItem";
 import { IntegrationEntryItem } from "./IntegrationItemEntry";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { SelectAccountModal } from "./SelectAccountModal";
+import { useAuthProviders } from "../data/auth-providers/auth-provider-query";
 
 export default function Integrations() {
     return (
@@ -45,7 +46,7 @@ export default function Integrations() {
 function GitProviders() {
     const { user, setUser } = useContext(UserContext);
 
-    const [authProviders, setAuthProviders] = useState<AuthProviderInfo[]>([]);
+    const authProviders = useAuthProviders();
     const [allScopes, setAllScopes] = useState<Map<string, string[]>>(new Map());
     const [disconnectModal, setDisconnectModal] = useState<{ provider: AuthProviderInfo } | undefined>(undefined);
     const [editModal, setEditModal] = useState<
@@ -54,20 +55,11 @@ function GitProviders() {
     const [selectAccountModal, setSelectAccountModal] = useState<SelectAccountPayload | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
-    useEffect(() => {
-        updateAuthProviders();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    const updateAuthProviders = useCallback(async () => {
-        setAuthProviders(await getGitpodService().server.getAuthProviders());
-    }, []);
-
     const updateCurrentScopes = useCallback(async () => {
         if (user) {
             const scopesByProvider = new Map<string, string[]>();
             const connectedProviders = user.identities.map((i) =>
-                authProviders.find((ap) => ap.authProviderId === i.authProviderId),
+                authProviders.data?.find((ap) => ap.authProviderId === i.authProviderId),
             );
             for (let provider of connectedProviders) {
                 if (!provider) {
@@ -106,7 +98,7 @@ function GitProviders() {
                     separator: true,
                 });
             }
-            const connectedWithSecondProvider = authProviders.some(
+            const connectedWithSecondProvider = authProviders.data?.some(
                 (p) => p.authProviderId !== provider.authProviderId && isConnected(p.authProviderId),
             );
             if (connectedWithSecondProvider) {
@@ -340,8 +332,8 @@ function GitProviders() {
                 </a>
             </Subheading>
             <ItemsList className="pt-6">
-                {authProviders &&
-                    authProviders.map((ap) => (
+                {authProviders.data &&
+                    authProviders.data.map((ap) => (
                         <AuthEntryItem
                             key={ap.authProviderId}
                             isConnected={isConnected}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1300,27 +1300,43 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 createdWorkspaceId: workspace.id,
             };
         } catch (error) {
-            if (NotFoundError.is(error)) {
-                throw new ResponseError(ErrorCodes.NOT_FOUND, "Repository not found.", error.data);
-            }
-            if (UnauthorizedError.is(error)) {
-                throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "Unauthorized", error.data);
-            }
-            if (InvalidGitpodYMLError.is(error)) {
-                throw new ResponseError(ErrorCodes.INVALID_GITPOD_YML, error.message);
-            }
-
-            const errorCode = this.parseErrorCode(error);
-            if (errorCode) {
-                // specific errors will be handled in create-workspace.tsx
-                throw error;
-            }
-            log.debug(logContext, error);
-            throw new ResponseError(
-                ErrorCodes.CONTEXT_PARSE_ERROR,
-                error && error.message ? error.message : `Cannot create workspace for URL: ${normalizedContextUrl}`,
-            );
+            this.handleError(error, logContext, normalizedContextUrl);
+            throw error;
         }
+    }
+
+    public async resolveContext(ctx: TraceContextWithSpan, contextUrl: string): Promise<WorkspaceContext> {
+        const user = this.checkAndBlockUser("resolveContext");
+        const normalizedCtxURL = this.contextParser.normalizeContextURL(contextUrl);
+        try {
+            return await this.contextParser.handle(ctx, user, normalizedCtxURL);
+        } catch (error) {
+            this.handleError(error, { userId: user.id }, normalizedCtxURL);
+            throw error;
+        }
+    }
+
+    private handleError(error: any, logContext: LogContext, normalizedContextUrl: string) {
+        if (NotFoundError.is(error)) {
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "Repository not found.", error.data);
+        }
+        if (UnauthorizedError.is(error)) {
+            throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "Unauthorized", error.data);
+        }
+        if (InvalidGitpodYMLError.is(error)) {
+            throw new ResponseError(ErrorCodes.INVALID_GITPOD_YML, error.message);
+        }
+
+        const errorCode = this.parseErrorCode(error);
+        if (errorCode) {
+            // specific errors will be handled in create-workspace.tsx
+            throw error;
+        }
+        log.debug(logContext, error);
+        throw new ResponseError(
+            ErrorCodes.CONTEXT_PARSE_ERROR,
+            error && error.message ? error.message : `Cannot create workspace for URL: ${normalizedContextUrl}`,
+        );
     }
 
     /**
@@ -3668,9 +3684,4 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async getIDToken(): Promise<void> {}
-    public async resolveContext(ctx: TraceContextWithSpan, contextUrl: string): Promise<WorkspaceContext> {
-        const user = this.checkAndBlockUser("resolveContext");
-        const normalizedCtxURL = this.contextParser.normalizeContextURL(contextUrl);
-        return this.contextParser.handle(ctx, user, normalizedCtxURL);
-    }
 }


### PR DESCRIPTION
## Description
This pull request improves the handling of context resolution errors by refactoring the code and introducing new error messages. It adds a new method resolveContext to the GitpodServer interface and handles errors separately using the handleError method. Additionally, it updates the usage of authProviders and includes the useAuthProviders hook to manage auth provider data within the components. Overall, this improves the user experience by providing more informative error messages and streamlining the code.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16977
Fixes WEB-67

## How to test
<!-- Provide steps to test this PR -->
Login to the preview environment and try starting a workspace on a private repository.
E.g: https://svenefftin78d9e41e4b.preview.gitpod-dev.com/#github.com/gitpod-io/gitpod-dedicated

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
