### PR TITLE
[server] Unimplemented workspaces service

### DIFF
--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -14,12 +14,15 @@ import { ConnectRouter } from "@bufbuild/connect";
 import { expressConnectMiddleware } from "@bufbuild/connect-express";
 import { UserService as UserServiceDefinition } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_connectweb";
 import { TeamsService as TeamsServiceDefinition } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
+import { WorkspacesService as WorkspacesServiceDefinition } from "@gitpod/public-api/lib/gitpod/experimental/v1/workspaces_connectweb";
 import { AddressInfo } from "net";
+import { APIWorkspacesService } from "./workspaces";
 
 @injectable()
 export class API {
     @inject(APIUserService) protected readonly apiUserService: APIUserService;
     @inject(APITeamsService) protected readonly apiTeamService: APITeamsService;
+    @inject(APIWorkspacesService) protected readonly apiWorkspacesService: APIWorkspacesService;
 
     public listen(port: number): http.Server {
         const app = express();
@@ -38,6 +41,7 @@ export class API {
                 routes: (router: ConnectRouter) => {
                     router.service(UserServiceDefinition, this.apiUserService);
                     router.service(TeamsServiceDefinition, this.apiTeamService);
+                    router.service(WorkspacesServiceDefinition, this.apiWorkspacesService);
                 },
             }),
         );

--- a/components/server/src/api/workspaces.ts
+++ b/components/server/src/api/workspaces.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Code, ConnectError, ServiceImpl } from "@bufbuild/connect";
+import { injectable } from "inversify";
+import { WorkspacesService as WorkspacesServiceInterface } from "@gitpod/public-api/lib/gitpod/experimental/v1/workspaces_connectweb";
+import {
+    CreateAndStartWorkspaceRequest,
+    CreateAndStartWorkspaceResponse,
+    DeleteWorkspaceRequest,
+    DeleteWorkspaceResponse,
+    GetOwnerTokenRequest,
+    GetOwnerTokenResponse,
+    GetWorkspaceRequest,
+    GetWorkspaceResponse,
+    ListWorkspacesRequest,
+    ListWorkspacesResponse,
+    StopWorkspaceRequest,
+    StopWorkspaceResponse,
+    StreamWorkspaceStatusRequest,
+    UpdatePortRequest,
+    UpdatePortResponse,
+} from "@gitpod/public-api/lib/gitpod/experimental/v1";
+
+@injectable()
+export class APIWorkspacesService implements ServiceImpl<typeof WorkspacesServiceInterface> {
+    async listWorkspaces(req: ListWorkspacesRequest): Promise<ListWorkspacesResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async getWorkspace(req: GetWorkspaceRequest): Promise<GetWorkspaceResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async *streamWorkspaceStatus(req: StreamWorkspaceStatusRequest) {
+        // yield { sentence: `How are you feeling today?` };
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async getOwnerToken(req: GetOwnerTokenRequest): Promise<GetOwnerTokenResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async createAndStartWorkspace(req: CreateAndStartWorkspaceRequest): Promise<CreateAndStartWorkspaceResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async stopWorkspace(req: StopWorkspaceRequest): Promise<StopWorkspaceResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async deleteWorkspace(req: DeleteWorkspaceRequest): Promise<DeleteWorkspaceResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+
+    async updatePort(req: UpdatePortRequest): Promise<UpdatePortResponse> {
+        throw new ConnectError("unimplemented", Code.Unimplemented);
+    }
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -112,6 +112,7 @@ import { API } from "./api/server";
 import { LinkedInService } from "./linkedin-service";
 import { AuthJWT } from "./auth/jwt";
 import { SnapshotService } from "./workspace/snapshot-service";
+import { APIWorkspacesService } from "./api/workspaces";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -313,6 +314,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     // grpc / Connect API
     bind(APIUserService).toSelf().inSingletonScope();
     bind(APITeamsService).toSelf().inSingletonScope();
+    bind(APIWorkspacesService).toSelf().inSingletonScope();
     bind(API).toSelf().inSingletonScope();
 
     bind(AuthJWT).toSelf().inSingletonScope();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds an unimplmeneted workspaces service. Currently unused. Mostly to have the setup in place and reduce required steps when we approach implementing it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
