### PR TITLE
[stripe] Re-use constants for event types

### DIFF
--- a/components/public-api-server/pkg/webhooks/stripe.go
+++ b/components/public-api-server/pkg/webhooks/stripe.go
@@ -15,6 +15,12 @@ import (
 
 const maxBodyBytes = int64(65536)
 
+const (
+	InvoiceFinalizedEventType            = "invoice.finalized"
+	CustomerSubscriptionDeletedEventType = "customer.subscription.deleted"
+	ChargeDisputeCreatedEventType        = "charge.dispute.created"
+)
+
 type webhookHandler struct {
 	billingService         billingservice.Interface
 	stripeWebhookSignature string
@@ -58,7 +64,7 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	switch event.Type {
-	case "invoice.finalized":
+	case InvoiceFinalizedEventType:
 		invoiceID, ok := event.Data.Object["id"].(string)
 		if !ok {
 			log.Error("failed to find invoice id in Stripe event payload")
@@ -72,7 +78,7 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-	case "customer.subscription.deleted":
+	case CustomerSubscriptionDeletedEventType:
 		subscriptionID, ok := event.Data.Object["id"].(string)
 		if !ok {
 			log.Error("failed to find subscriptionId id in Stripe event payload")
@@ -85,7 +91,7 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-	case "charge.dispute.created":
+	case ChargeDisputeCreatedEventType:
 		log.Info("Handling charge dispute")
 		disputeID, ok := event.Data.Object["id"].(string)
 		if !ok {

--- a/components/public-api-server/pkg/webhooks/stripe_test.go
+++ b/components/public-api-server/pkg/webhooks/stripe_test.go
@@ -23,11 +23,8 @@ import (
 
 // https://stripe.com/docs/api/events/types
 const (
-	invoiceUpdatedEventType     = "invoice.updated"
-	invoiceFinalizedEventType   = "invoice.finalized"
-	customerCreatedEventType    = "customer.created"
-	customerSubscriptionDeleted = "customer.subscription.deleted"
-	chargeDisputeCreated        = "charge.dispute.created"
+	invoiceUpdatedEventType  = "invoice.updated"
+	customerCreatedEventType = "customer.created"
 )
 
 const (
@@ -55,7 +52,7 @@ func TestWebhookAcceptsPostRequests(t *testing.T) {
 
 	srv := baseServerWithStripeWebhook(t, &billingservice.NoOpClient{})
 
-	payload := payloadForStripeEvent(t, invoiceFinalizedEventType)
+	payload := payloadForStripeEvent(t, InvoiceFinalizedEventType)
 
 	url := fmt.Sprintf("%s%s", srv.HTTPAddress(), "/webhook")
 
@@ -80,11 +77,11 @@ func TestWebhookIgnoresIrrelevantEvents_NoopClient(t *testing.T) {
 		ExpectedStatusCode int
 	}{
 		{
-			EventType:          invoiceFinalizedEventType,
+			EventType:          InvoiceFinalizedEventType,
 			ExpectedStatusCode: http.StatusOK,
 		},
 		{
-			EventType:          customerSubscriptionDeleted,
+			EventType:          CustomerSubscriptionDeletedEventType,
 			ExpectedStatusCode: http.StatusOK,
 		},
 		{
@@ -96,7 +93,7 @@ func TestWebhookIgnoresIrrelevantEvents_NoopClient(t *testing.T) {
 			ExpectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			EventType:          chargeDisputeCreated,
+			EventType:          ChargeDisputeCreatedEventType,
 			ExpectedStatusCode: http.StatusOK,
 		},
 	}
@@ -134,7 +131,7 @@ func TestWebhookInvokesFinalizeInvoiceRPC(t *testing.T) {
 
 	url := fmt.Sprintf("%s%s", srv.HTTPAddress(), "/webhook")
 
-	payload := payloadForStripeEvent(t, invoiceFinalizedEventType)
+	payload := payloadForStripeEvent(t, InvoiceFinalizedEventType)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 	require.NoError(t, err)
 
@@ -154,7 +151,7 @@ func TestWebhookInvokesCancelSubscriptionRPC(t *testing.T) {
 
 	url := fmt.Sprintf("%s%s", srv.HTTPAddress(), "/webhook")
 
-	payload := payloadForStripeEvent(t, customerSubscriptionDeleted)
+	payload := payloadForStripeEvent(t, CustomerSubscriptionDeletedEventType)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
