### PR TITLE
 VS Code Browser release `1.77.1`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: bd6a27e72335bc41b62830483a6e94e4a51a5ceb
-  codeVersion: 1.77.0
+  codeCommit: 35090d043833e8381609109919ec8a47aca5adc7
+  codeVersion: 1.77.1
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.3.3.tar.gz"

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-b740ddb9895e912f0774f36e032ec3fd841b21d3" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-57363b43cd21e4dab4386915ac3ce88c5d9dca92" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
 	CodeWebExtensionVersion     = "commit-3b076b91039c47404d98c4a3198edf2982e24af7" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code


### PR DESCRIPTION
## Description
Update code to `1.77.1`

## Progress

- [x] Update Insiders  (https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml)
- [x] Update Stable (https://github.com/gitpod-io/gitpod/blob/main/install/installer/pkg/components/workspace/ide/constants.go)

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [ ] terminals are preserved and resized properly between window reloads
  - [ ] WebViews are working
  - [ ] extension host process: check language smartness and debugging 
  - [ ] extension management (installing/uninstalling)
  - [ ] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [ ] extensions from `.gitpod.yml` are not installed as sync
     - [ ] extensions installed as sync are actually synced to all new workspaces
  - [ ] settings should not contain any mentions of MS telemetry
  - [ ] WebSockets and workers are properly proxied
     - [ ] diff editor should be operable
     - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [ ] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [ ] that a PR view is preloaded when opening a PR URL
  - [ ] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Release Notes
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-gce-vm