### PR TITLE
 VS Code Browser release `1.77.2`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: dc8f6057dd198072b7e7e85dd8fa5b3e62cec97f
+  codeCommit: 91b6169b4d3d2fad270fed608b41ba208f5e9069
   codeVersion: 1.77.2
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -8,7 +8,7 @@ defaultArgs:
   publishToJBMarketplace: true
   localAppVersion: unknown
   codeCommit: dc8f6057dd198072b7e7e85dd8fa5b3e62cec97f
-  codeVersion: 1.77.0
+  codeVersion: 1.77.2
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.3.3.tar.gz"

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 91b6169b4d3d2fad270fed608b41ba208f5e9069
+  codeCommit: 0a605ca73f92b085f1668416e78851b14cfd25ca
   codeVersion: 1.77.2
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: bd6a27e72335bc41b62830483a6e94e4a51a5ceb
+  codeCommit: dc8f6057dd198072b7e7e85dd8fa5b3e62cec97f
   codeVersion: 1.77.0
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-b740ddb9895e912f0774f36e032ec3fd841b21d3" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-a72832e1c9c64728f4052f4d783854be7464d4d0" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
 	CodeWebExtensionVersion     = "commit-3b076b91039c47404d98c4a3198edf2982e24af7" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code


### PR DESCRIPTION
## Description
Update code to `1.77.2`
Implements https://github.com/microsoft/vscode/releases/tag/1.77.2

## Progress

- [x] Update Insiders  (https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml)
- [x] Update Stable (https://github.com/gitpod-io/gitpod/blob/main/install/installer/pkg/components/workspace/ide/constants.go)

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [ ] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [ ] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Release Notes
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-gce-vm