### PR TITLE
Fixing remaining dashboard lint errors

### DIFF
--- a/components/dashboard/src/components/LinkButton.tsx
+++ b/components/dashboard/src/components/LinkButton.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FC, MouseEvent, useCallback } from "react";
+
+type Props = {
+    className?: string;
+    onClick: () => void;
+};
+
+// A button that looks like a link
+export const LinkButton: FC<Props> = ({ className, children, onClick }) => {
+    const handleClick = useCallback(
+        (e: MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            onClick();
+        },
+        [onClick],
+    );
+
+    return (
+        <button
+            className={classNames(
+                "text-sm font-normal",
+                "bg-transparent hover:bg-transparent p-0 rounded-none",
+                "text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500",
+                className,
+            )}
+            onClick={handleClick}
+        >
+            {children}
+        </button>
+    );
+};

--- a/components/dashboard/src/user-settings/Plans.tsx
+++ b/components/dashboard/src/user-settings/Plans.tsx
@@ -27,6 +27,7 @@ import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
+import { LinkButton } from "../components/LinkButton";
 
 type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
@@ -394,14 +395,7 @@ export default function PlansPage() {
                 <p className="text-green-600">
                     Downgrade scheduled
                     <br />
-                    {/* TODO: change these <a> to use a LinkButton component once we have it */}
-                    <a
-                        className="text-blue-light leading-6"
-                        href="javascript:void(0)"
-                        onClick={() => confirmCancelDowngrade()}
-                    >
-                        Cancel
-                    </a>
+                    <LinkButton onClick={() => confirmCancelDowngrade()}>Cancel</LinkButton>
                 </p>
             );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
@@ -457,13 +451,7 @@ export default function PlansPage() {
                 <p className="text-green-600">
                     Downgrade scheduled
                     <br />
-                    <a
-                        className="text-blue-light leading-6"
-                        href="javascript:void(0)"
-                        onClick={() => confirmCancelDowngrade()}
-                    >
-                        Cancel
-                    </a>
+                    <LinkButton onClick={() => confirmCancelDowngrade()}>Cancel</LinkButton>
                 </p>
             );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
@@ -528,13 +516,7 @@ export default function PlansPage() {
                 <p className="text-green-600">
                     Downgrade scheduled
                     <br />
-                    <a
-                        className="text-blue-light leading-6"
-                        href="javascript:void(0)"
-                        onClick={() => confirmCancelDowngrade()}
-                    >
-                        Cancel
-                    </a>
+                    <LinkButton onClick={() => confirmCancelDowngrade()}>Cancel</LinkButton>
                 </p>
             );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
@@ -671,38 +653,23 @@ export default function PlansPage() {
                         <progress value="0" max="100" />
                     )}
                     <p className="text-sm">
-                        <a
-                            className={`gp-link ${isChargebeeCustomer ? "" : "invisible"}`}
-                            href="javascript:void(0)"
+                        <LinkButton
+                            className={isChargebeeCustomer ? "" : "invisible"}
                             onClick={() => {
                                 ChargebeeClient.getOrCreate().then((chargebeeClient) => chargebeeClient.openPortal());
                             }}
                         >
                             Billing
-                        </a>
+                        </LinkButton>
                         {!!accountStatement && Plans.isFreePlan(currentPlan.chargebeeId) && (
                             <span className="pl-6">
                                 {currency === "EUR" ? (
                                     <>
-                                        € /{" "}
-                                        <a
-                                            className="text-blue-light hover:underline"
-                                            href="javascript:void(0)"
-                                            onClick={() => setCurrency("USD")}
-                                        >
-                                            $
-                                        </a>
+                                        € / <LinkButton onClick={() => setCurrency("USD")}>$</LinkButton>
                                     </>
                                 ) : (
                                     <>
-                                        <a
-                                            className="text-blue-light hover:underline"
-                                            href="javascript:void(0)"
-                                            onClick={() => setCurrency("EUR")}
-                                        >
-                                            €
-                                        </a>{" "}
-                                        / $
+                                        <LinkButton onClick={() => setCurrency("EUR")}>€</LinkButton> / $
                                     </>
                                 )}
                             </span>

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -30,6 +30,7 @@ export const poll = async <T>(
             }
             return;
         }
+        // eslint-disable-next-line no-loop-func
         await new Promise((resolve) => setTimeout(resolve, delayInSeconds * 1000));
         if (opts.token?.cancelled) {
             return;

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -13,7 +13,6 @@ import Tooltip from "../components/Tooltip";
 import dayjs from "dayjs";
 import { WorkspaceEntryOverflowMenu } from "./WorkspaceOverflowMenu";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
-import { projectsPathInstallGitHubApp } from "../projects/projects.routes";
 
 type Props = {
     info: WorkspaceInfo;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes the last remaining lint errors in dashboard.

* Swaps some uses of `<a>` tags w/ onClick handlers to use a new `<LinkButton/>` component, which is a `<button>` styled to look like a link. This is the preferred way to handle this type of UX for a11y reasons. Here's a screenshot of it applied to to old Plans page, which was the only place atm that had these lint errors, but we should be able to use this component for any future areas as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-112

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-link-button.preview.gitpod-dev.com/user/plans

* Can run `yarn lint` from dashboard component manually to verify there are no lint errors. I ran it and verified it myself though too.
* To verify the `<LinkButton/>` changes, can navigate to the old Plans page, and you should be able to see them used in the currency toggle to test clicking them.
  * https://bmh-link-button.preview.gitpod-dev.com/user/plans
<img width="387" alt="image" src="https://user-images.githubusercontent.com/367275/231295307-32437979-a6b4-452b-a144-1de4228c7e4c.png">

## Risk
Low risk. The only visible changes are on the Plans page, and it should behave as it used to.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
