### PR TITLE
[github action] use roboquat to create PR

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -110,16 +110,11 @@ jobs:
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
-                  labels: "team: IDE,editor: jetbrains,do-not-merge/hold"
+                  labels: "team: IDE,editor: jetbrains"
                   team-reviewers: "engineering-ide"
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
-            - name: Approve Pull Request for Gateway Plugin (EAP)
-              if: ${{ inputs.pluginId == 'latest-gateway-plugin' && steps.create-gateway-pr.outputs.pull-request-number }}
-              uses: hmarr/auto-approve-action@v3
-              with:
-                  pull-request-number: ${{ steps.create-gateway-pr.outputs.pull-request-number }}
             - name: Create Pull Request for Backend Plugin
               id: create-backend-pr
               if: ${{ contains(inputs.pluginId, 'backend-plugin') && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
@@ -158,16 +153,11 @@ jobs:
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
-                  labels: "team: IDE,editor: jetbrains,do-not-merge/hold"
+                  labels: "team: IDE,editor: jetbrains"
                   team-reviewers: "engineering-ide"
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
-            - name: Approve Pull Request for Backend Plugin
-              if: ${{ steps.create-backend-pr.outputs.pull-request-number }}
-              uses: hmarr/auto-approve-action@v3
-              with:
-                  pull-request-number: ${{ steps.create-backend-pr.outputs.pull-request-number }}
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -72,6 +72,9 @@ jobs:
                   commit-message: "[JetBrains] Update IDE images to new build version"
                   branch: "jetbrains/update-stable-ides"
                   labels: "team: IDE,editor: jetbrains"
+                  token: ${{ secrets.ROBOQUAT_REPO_PAT }}
+                  committer: Robo Quat <roboquat@gitpod.io>
+                  author: Robo Quat <roboquat@gitpod.io>
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[github action] use roboquat to create PR
This PR also remove auto approve, because it's doesn't work

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
See this PR https://github.com/gitpod-io/gitpod/pull/17185 it created by `roboquat` and github action is running.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
