### PR TITLE
wrap ff around connect with linkedin

### DIFF
--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import { FC, RefObject } from "react";
 import SpinnerWhite from "../icons/SpinnerWhite.svg";
 
-type Props = {
+export type ButtonProps = {
     // TODO: determine if we want danger.secondary
     type?: "primary" | "secondary" | "danger" | "danger.secondary";
     // TODO: determine how to handle small/medium (block does w-full atm)
@@ -25,7 +25,7 @@ type Props = {
 // Allow w/ or w/o handling event argument
 type ButtonOnClickHandler = React.DOMAttributes<HTMLButtonElement>["onClick"] | (() => void);
 
-export const Button: FC<Props> = ({
+export const Button: FC<ButtonProps> = ({
     type = "primary",
     className,
     htmlType,

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -31,6 +31,7 @@ const defaultFeatureFlags = {
     userGitAuthProviders: false,
     switchToPAYG: false,
     newSignupFlow: false,
+    linkedinConnectionForOnboarding: false,
 };
 
 const FeatureFlagContext = createContext<FeatureFlagsType>(defaultFeatureFlags);
@@ -51,6 +52,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [userGitAuthProviders, setUserGitAuthProviders] = useState<boolean>(false);
     const [switchToPAYG, setSwitchToPAYG] = useState<boolean>(false);
     const [newSignupFlow, setNewSignupFlow] = useState<boolean>(false);
+    const [linkedinConnectionForOnboarding, setLinkedinConnectionForOnboarding] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -71,6 +73,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 userGitAuthProviders: { defaultValue: false, setter: setUserGitAuthProviders },
                 switchToPAYG: { defaultValue: false, setter: setSwitchToPAYG },
                 newSignupFlow: { defaultValue: false, setter: setNewSignupFlow },
+                linkedinConnectionForOnboarding: { defaultValue: false, setter: setLinkedinConnectionForOnboarding },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -120,10 +123,12 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
             userGitAuthProviders,
             newSignupFlow,
             switchToPAYG,
+            linkedinConnectionForOnboarding,
         };
     }, [
         enablePersonalAccessTokens,
         isUsageBasedBillingEnabled,
+        linkedinConnectionForOnboarding,
         newSignupFlow,
         oidcServiceEnabled,
         orgGitAuthProviders,

--- a/components/dashboard/src/onboarding/OnboardingStep.tsx
+++ b/components/dashboard/src/onboarding/OnboardingStep.tsx
@@ -6,7 +6,7 @@
 
 import { FC, FormEvent, useCallback } from "react";
 import Alert from "../components/Alert";
-import { Button } from "../components/Button";
+import { Button, ButtonProps } from "../components/Button";
 import { Heading2, Subheading } from "../components/typography/headings";
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
     error?: string;
     onSubmit(): void;
     submitButtonText?: string;
-    submitButtonType?: "primary" | "secondary" | "danger" | "danger.secondary";
+    submitButtonType?: ButtonProps["type"];
 };
 export const OnboardingStep: FC<Props> = ({
     title,

--- a/components/dashboard/src/onboarding/StepUserInfo.tsx
+++ b/components/dashboard/src/onboarding/StepUserInfo.tsx
@@ -11,12 +11,14 @@ import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutati
 import { useOnBlurError } from "../hooks/use-onblur-error";
 import { OnboardingStep } from "./OnboardingStep";
 import { LinkedInBanner } from "./LinkedInBanner";
+import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 
 type Props = {
     user: User;
     onComplete(user: User): void;
 };
 export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
+    const { linkedinConnectionForOnboarding } = useFeatureFlags();
     const updateUser = useUpdateCurrentUserMutation();
     // attempt to split provided name for default input values
     const { first, last } = getInitialNameParts(user);
@@ -51,23 +53,30 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
         }
     }, [emailAddress, firstName, lastName, onComplete, updateUser, user.additionalData]);
 
-    const onLinkedInSuccess = async (profile: LinkedInProfile) => {
-        if (!firstName && profile.firstName) {
-            setFirstName(profile.firstName);
-        }
-        if (!lastName && profile.lastName) {
-            setLastName(profile.lastName);
-        }
-        if (!emailAddress && profile.emailAddress) {
-            setEmailAddress(profile.emailAddress);
-        }
-        handleSubmit();
-    };
+    const onLinkedInSuccess = useCallback(
+        async (profile: LinkedInProfile) => {
+            if (!firstName && profile.firstName) {
+                setFirstName(profile.firstName);
+            }
+            if (!lastName && profile.lastName) {
+                setLastName(profile.lastName);
+            }
+            if (!emailAddress && profile.emailAddress) {
+                setEmailAddress(profile.emailAddress);
+            }
+            handleSubmit();
+        },
+        [emailAddress, firstName, handleSubmit, lastName],
+    );
 
     const firstNameError = useOnBlurError("Please enter a value", !!firstName);
     const lastNameError = useOnBlurError("Please enter a value", !!lastName);
+    const emailError = useOnBlurError("Please enter your email address", !!emailAddress);
 
-    const isValid = [firstNameError, lastNameError].every((e) => e.isValid);
+    const isValid =
+        [firstNameError, lastNameError].every((e) => e.isValid) &&
+        // If we're using LinkedIn, we don't need to validate the email input, otherwise we do
+        (linkedinConnectionForOnboarding || (!linkedinConnectionForOnboarding && emailError.isValid));
 
     return (
         <OnboardingStep
@@ -77,8 +86,8 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
             isValid={isValid}
             isSaving={updateUser.isLoading}
             onSubmit={handleSubmit}
-            submitButtonText="Continue with 100 credits per month"
-            submitButtonType="secondary"
+            submitButtonText={linkedinConnectionForOnboarding ? "Continue with 100 credits per month" : undefined}
+            submitButtonType={linkedinConnectionForOnboarding ? "secondary" : undefined}
         >
             {user.avatarUrl && (
                 <div className="my-4 flex justify-center">
@@ -108,7 +117,19 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
                 />
             </div>
 
-            <LinkedInBanner onSuccess={onLinkedInSuccess} />
+            {linkedinConnectionForOnboarding ? (
+                <LinkedInBanner onSuccess={onLinkedInSuccess} />
+            ) : (
+                <TextInputField
+                    value={emailAddress}
+                    label="Work Email"
+                    type="email"
+                    error={emailError.message}
+                    onBlur={emailError.onBlur}
+                    onChange={setEmailAddress}
+                    required
+                />
+            )}
         </OnboardingStep>
     );
 };

--- a/components/dashboard/src/onboarding/StepUserInfo.tsx
+++ b/components/dashboard/src/onboarding/StepUserInfo.tsx
@@ -39,7 +39,8 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
                 ...additionalData,
                 profile: {
                     ...profile,
-                    emailAddress,
+                    // If still no email provided, default to "primary" email
+                    emailAddress: emailAddress || User.getPrimaryEmail(user),
                     lastUpdatedDetailsNudge: new Date().toISOString(),
                 },
             },
@@ -51,7 +52,7 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
         } catch (e) {
             console.error(e);
         }
-    }, [emailAddress, firstName, lastName, onComplete, updateUser, user.additionalData]);
+    }, [emailAddress, firstName, lastName, onComplete, updateUser, user]);
 
     const onLinkedInSuccess = useCallback(
         async (profile: LinkedInProfile) => {

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -5,7 +5,7 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import { FunctionComponent, useCallback, useContext, useEffect, useState } from "react";
+import { FunctionComponent, useCallback, useContext, useState } from "react";
 import gitpodIcon from "../icons/gitpod.svg";
 import { Separator } from "../components/Separator";
 import { useHistory, useLocation } from "react-router";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Wraps the connect with linkedin part of new user onboarding w/ a new feature flag - `linkedinConnectionForOnboarding`. If the flag is off the experience will be like what's on gitpod.io today.

| FF Off | FF On |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/367275/231574846-1e86bcbf-78e8-40d0-bbc2-a25fed36059e.png) | ![image](https://user-images.githubusercontent.com/367275/231575678-6cddd529-de9b-4a29-b976-5f0fcac6c190.png) | 

## How to test
<!-- Provide steps to test this PR -->
* Go through the onboarding flow on the preview environment: https://bmh-ff-conf3e3f052bf.preview.gitpod-dev.com/workspaces?onboarding=force
* With `linkedinConnectionForOnboarding` off, it should be the same experience as what's on gitpod.io today where you must enter in an email address.
* I wasn't able to fully going through with `linkedinConnectionForOnboarding` on and connecting my LinkedIn account as we'd need to add this preview env as a valid redirect_url to the oauth configuration, but nothing should have changed regarding how that works with this PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
