### PR TITLE
:sparkles: [workflow] PR comment with Preview env URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - name: Create comment
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
         id: build-status-comment
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,9 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
+              ...context.repo,
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
               body: `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`
             });
   configuration:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{github.event.number}}
+          issue-number: ${{github.event.issue.number}}
           body: |
             🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
             * 🏷️ **Name** - ${{github.head_ref}}\n

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{github.event.number}}
           body: |
             🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
             * 🏷️ **Name** - ${{github.head_ref}}\n

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,34 +19,33 @@ jobs:
       group: ${{ github.head_ref || github.ref_name }}-configuration
     steps:
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{github.event.issue.number}}
-          body: |
-            🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
-            * 🏷️ **Name** - ${{github.head_ref}}\n
-            * 🔖 **Latest commit** - ${{github.sha}}\n
-            * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
-            * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n
-          reactions: rocket
-
-        # uses: actions/github-script@v6
-        # # if: github.event_name == 'pull_request' && github.event.action == 'opened'
-        # id: build-status-comment
+        # uses: peter-evans/create-or-update-comment@v3
         # with:
-        #   github-token: ${{secrets.GITHUB_TOKEN}}
-        #   script: |
-        #     const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-        #     `* 🏷️ **Name** - ${{github.head_ref}}\`
-        #     `* 🔖 **Latest commit** - ${{github.sha}}\`
-        #     `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-        #     `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
-        #     github.issues.createComment({
-        #     issue_number: context.issue.number,
-        #     owner: context.repo.owner,
-        #     repo: context.repo.repo,
-        #     body: output
-        #     });
+        #   issue-number: ${{github.event.issue.number}}
+        #   body: |
+        #     🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
+        #     * 🏷️ **Name** - ${{github.head_ref}}\n
+        #     * 🔖 **Latest commit** - ${{github.sha}}\n
+        #     * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
+        #     * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n
+        #   reactions: rocket
+        uses: actions/github-script@v6
+        # if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        id: build-status-comment
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+            `* 🏷️ **Name** - ${{github.head_ref}}\`
+            `* 🔖 **Latest commit** - ${{github.sha}}\`
+            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+            github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+            });
   configuration:
     name: Configure job parameters
     runs-on: [ self-hosted ]
@@ -386,35 +385,35 @@ jobs:
     runs-on: [ self-hosted ]
     steps:
     - name: Update comment
-      uses: peter-evans/create-or-update-comment@v3
-      with:
-        comment-id: ${{ steps.build-status-comment.outputs.comment-id }}
-        body: |
-          🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
-          * 🏷️ **Name** - ${{github.head_ref}}\n
-          * 🔖 **Latest commit** - ${{github.sha}}\n
-          * 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\n
-          * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
-          * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})
-        reactions: hooray
-
-      # uses: actions/github-script@v6
+      # uses: peter-evans/create-or-update-comment@v3
       # with:
-      #   github-token: ${{secrets.GITHUB_TOKEN}}
-      #   script: |
-      #     const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-      #       `* 🏷️ **Name** - ${{github.head_ref}}\`
-      #       `* 🔖 **Latest commit** - ${{github.sha}}\`
-      #       `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
-      #       `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-      #       `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
-      #     github.rest.issues.updateComment({
-      #       issue_number: ${{ github.event.issue.number }},
-      #       owner: context.repo.owner,
-      #       repo: context.repo.repo,
-      #       comment_id: ${{steps.build-status-comment.outputs.comment-id}},
-      #       body: commentBody
-      #     })
+      #   comment-id: ${{ steps.build-status-comment.outputs.comment-id }}
+      #   body: |
+      #     🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
+      #     * 🏷️ **Name** - ${{github.head_ref}}\n
+      #     * 🔖 **Latest commit** - ${{github.sha}}\n
+      #     * 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\n
+      #     * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
+      #     * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})
+      #   reactions: hooray
+
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+            `* 🏷️ **Name** - ${{github.head_ref}}\`
+            `* 🔖 **Latest commit** - ${{github.sha}}\`
+            `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
+            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+          github.rest.issues.updateComment({
+            issue_number: ${{ github.event.issue.number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: ${{steps.build-status-comment.outputs.comment-id}},
+            body: commentBody
+          })
   monitoring:
     name: "Install Monitoring Satellite"
     needs: [ infrastructure, build-previewctl ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
         # if: github.event_name == 'pull_request' && github.event.action == 'opened'
         id: build-status-comment
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: output
+              body: `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`;
             });
   configuration:
     name: Configure job parameters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         id: build-status-comment
         with:
-          github-token: ${{github.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
             `* 🏷️ **Name** - ${{github.head_ref}}\`
@@ -378,7 +378,7 @@ jobs:
       id: update-comment
       uses: actions/github-script@v6
       with:
-        github-token: ${{ github.token }}
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
             `* 🏷️ **Name** - ${{github.head_ref}}\`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,7 @@ jobs:
         id: build-status-comment
         with:
           script: |
-            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-            `* 🏷️ **Name** - ${{github.head_ref}}\`
-            `* 🔖 **Latest commit** - ${{github.sha}}\`
-            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -399,12 +395,7 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-            `* 🏷️ **Name** - ${{github.head_ref}}\`
-            `* 🔖 **Latest commit** - ${{github.sha}}\`
-            `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
-            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+          const output = `✅ Gitpod is deployed to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
           github.rest.issues.updateComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
         # if: github.event_name == 'pull_request' && github.event.action == 'opened'
         id: build-status-comment
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
             `* 🏷️ **Name** - ${{github.head_ref}}\`
@@ -41,10 +40,10 @@ jobs:
             `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
             `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
             github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: output
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
             });
   configuration:
     name: Configure job parameters
@@ -399,7 +398,6 @@ jobs:
 
       uses: actions/github-script@v6
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
             `* 🏷️ **Name** - ${{github.head_ref}}\`
@@ -408,7 +406,7 @@ jobs:
             `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
             `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
           github.rest.issues.updateComment({
-            issue_number: ${{ github.event.issue.number }},
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: ${{steps.build-status-comment.outputs.comment-id}},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,22 +19,34 @@ jobs:
       group: ${{ github.head_ref || github.ref_name }}-configuration
     steps:
       - name: Create comment
-        uses: actions/github-script@v6
-        id: build-status-comment
+        uses: peter-evans/create-or-update-comment@v3
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-            `* 🏷️ **Name** - ${{github.head_ref}}\`
-            `* 🔖 **Latest commit** - ${{github.sha}}\`
-            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
-            github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: output
-            });
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
+            * 🏷️ **Name** - ${{github.head_ref}}\n
+            * 🔖 **Latest commit** - ${{github.sha}}\n
+            * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
+            * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n
+          reactions: rocket
+
+        # uses: actions/github-script@v6
+        # # if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        # id: build-status-comment
+        # with:
+        #   github-token: ${{secrets.GITHUB_TOKEN}}
+        #   script: |
+        #     const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+        #     `* 🏷️ **Name** - ${{github.head_ref}}\`
+        #     `* 🔖 **Latest commit** - ${{github.sha}}\`
+        #     `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+        #     `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+        #     github.issues.createComment({
+        #     issue_number: context.issue.number,
+        #     owner: context.repo.owner,
+        #     repo: context.repo.repo,
+        #     body: output
+        #     });
   configuration:
     name: Configure job parameters
     runs-on: [ self-hosted ]
@@ -374,24 +386,35 @@ jobs:
     runs-on: [ self-hosted ]
     steps:
     - name: Update comment
-      id: update-comment
-      uses: actions/github-script@v6
+      uses: peter-evans/create-or-update-comment@v3
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
-            `* 🏷️ **Name** - ${{github.head_ref}}\`
-            `* 🔖 **Latest commit** - ${{github.sha}}\`
-            `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
-            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
-            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
-          github.rest.issues.updateComment({
-            issue_number: ${{ github.event.issue.number }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            comment_id: ${{steps.build-status-comment.outputs.comment-id}},
-            body: commentBody
-          })
+        comment-id: ${{ steps.build-status-comment.outputs.comment-id }}
+        body: |
+          🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n
+          * 🏷️ **Name** - ${{github.head_ref}}\n
+          * 🔖 **Latest commit** - ${{github.sha}}\n
+          * 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\n
+          * 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n
+          * 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})
+        reactions: hooray
+
+      # uses: actions/github-script@v6
+      # with:
+      #   github-token: ${{secrets.GITHUB_TOKEN}}
+      #   script: |
+      #     const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+      #       `* 🏷️ **Name** - ${{github.head_ref}}\`
+      #       `* 🔖 **Latest commit** - ${{github.sha}}\`
+      #       `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
+      #       `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+      #       `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+      #     github.rest.issues.updateComment({
+      #       issue_number: ${{ github.event.issue.number }},
+      #       owner: context.repo.owner,
+      #       repo: context.repo.repo,
+      #       comment_id: ${{steps.build-status-comment.outputs.comment-id}},
+      #       body: commentBody
+      #     })
   monitoring:
     name: "Install Monitoring Satellite"
     needs: [ infrastructure, build-previewctl ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`;
+              body: `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\n* 🏷️ **Name** - ${{github.head_ref}}\n* 🔖 **Latest commit** - ${{github.sha}}\n* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.\n* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\n`
             });
   configuration:
     name: Configure job parameters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create comment
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        if: github.event_name == 'pull_request'
         id: build-status-comment
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,30 @@ on:
         default: "false"
 
 jobs:
+  create-comment:
+    name: Create comment
+    runs-on: [ self-hosted ]
+    concurrency:
+      group: ${{ github.head_ref || github.ref_name }}-configuration
+    steps:
+      - name: Create comment
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        id: build-status-comment
+        with:
+          github-token: ${{github.token}}
+          script: |
+            const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+            `* 🏷️ **Name** - ${{github.head_ref}}\`
+            `* 🔖 **Latest commit** - ${{github.sha}}\`
+            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+            github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+            });
   configuration:
     name: Configure job parameters
     runs-on: [ self-hosted ]
@@ -345,6 +369,30 @@ jobs:
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
 
+  update-comment:
+    name: "Update comment"
+    needs: [ create-comment, configuration, build-previewctl, build-gitpod, infrastructure, install ]
+    runs-on: [ self-hosted ]
+    steps:
+    - name: Update comment
+      id: update-comment
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const output = `🏗️ Gitpod is deploying to your Preview Environment. It will take a few minutes to get ready.\`
+            `* 🏷️ **Name** - ${{github.head_ref}}\`
+            `* 🔖 **Latest commit** - ${{github.sha}}\`
+            `* 🔗 **URL** - [Preview Environment](${{steps.deploy-gitpod.outputs.url}})\`
+            `* 📚 **Documentation** - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.`
+            `* 📄 **Logs** - [_View build logs_](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})\`;
+          github.rest.issues.updateComment({
+            issue_number: ${{ github.event.issue.number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: ${{steps.build-status-comment.outputs.comment-id}},
+            body: commentBody
+          })
   monitoring:
     name: "Install Monitoring Satellite"
     needs: [ infrastructure, build-previewctl ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
