### PR TITLE
[server] Set JWT cookie on sign-in  WEB-100

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -70,6 +70,7 @@
     "is-reachable": "^5.2.1",
     "js-yaml": "^3.10.0",
     "json-stream": "^1.0.0",
+    "jsonwebtoken": "^9.0.0",
     "lodash.debounce": "^4.0.8",
     "longjohn": "^0.2.12",
     "minio": "^7.0.12",

--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import { AuthJWT, sign, verify } from "./jwt";
+import { Container } from "inversify";
+import { Config } from "../config";
+import * as crypto from "crypto";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import * as chai from "chai";
+
+const expect = chai.expect;
+
+@suite()
+class TestAuthJWT {
+    private container: Container;
+
+    private signingKeyPair = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+    private validatingKeyPair1 = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+    private validatingKeyPair2 = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+    private config: Config = {
+        hostUrl: new GitpodHostUrl("https://mp-server-d7650ec945.preview.gitpod-dev.com"),
+        auth: {
+            pki: {
+                signing: toKeyPair(this.signingKeyPair),
+                validating: [toKeyPair(this.validatingKeyPair1), toKeyPair(this.validatingKeyPair2)],
+            },
+        },
+    } as Config;
+
+    async before() {
+        this.container = new Container();
+        this.container.bind(Config).toConstantValue(this.config);
+        this.container.bind(AuthJWT).toSelf().inSingletonScope();
+    }
+
+    @test
+    async test_sign() {
+        const sut = this.container.get<AuthJWT>(AuthJWT);
+
+        const subject = "user-id";
+        const encoded = await sut.sign(subject, {});
+
+        const decoded = await verify(encoded, this.config.auth.pki.signing.publicKey, {
+            algorithms: ["RS512"],
+        });
+
+        expect(decoded["sub"]).to.equal(subject);
+        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+    }
+
+    @test
+    async test_verify_uses_primary_first() {
+        const sut = this.container.get<AuthJWT>(AuthJWT);
+
+        const subject = "user-id";
+        const encoded = await sut.sign(subject, {});
+
+        const decoded = await sut.verify(encoded);
+
+        expect(decoded["sub"]).to.equal(subject);
+        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+    }
+
+    @test
+    async test_verify_validates_older_keys() {
+        const sut = this.container.get<AuthJWT>(AuthJWT);
+
+        const subject = "user-id";
+        const encoded = await sign({}, this.config.auth.pki.validating[1].privateKey, {
+            algorithm: "RS512",
+            expiresIn: "1d",
+            issuer: this.config.hostUrl.url.hostname,
+            subject,
+        });
+
+        // should use the second validating key and succesfully verify
+        const decoded = await sut.verify(encoded);
+
+        expect(decoded["sub"]).to.equal(subject);
+        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+    }
+}
+
+function toKeyPair(kp: crypto.KeyPairKeyObjectResult): {
+    privateKey: string;
+    publicKey: string;
+} {
+    return {
+        privateKey: kp.privateKey
+            .export({
+                type: "pkcs1",
+                format: "pem",
+            })
+            .toString(),
+        publicKey: kp.publicKey
+            .export({
+                type: "pkcs1",
+                format: "pem",
+            })
+            .toString(),
+    };
+}
+
+module.exports = new TestAuthJWT();

--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -50,7 +50,7 @@ class TestAuthJWT {
         });
 
         expect(decoded["sub"]).to.equal(subject);
-        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+        expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");
     }
 
     @test
@@ -63,7 +63,7 @@ class TestAuthJWT {
         const decoded = await sut.verify(encoded);
 
         expect(decoded["sub"]).to.equal(subject);
-        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+        expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");
     }
 
     @test
@@ -74,7 +74,7 @@ class TestAuthJWT {
         const encoded = await sign({}, this.config.auth.pki.validating[1].privateKey, {
             algorithm: "RS512",
             expiresIn: "1d",
-            issuer: this.config.hostUrl.url.hostname,
+            issuer: this.config.hostUrl.toStringWoRootSlash(),
             subject,
         });
 
@@ -82,7 +82,7 @@ class TestAuthJWT {
         const decoded = await sut.verify(encoded);
 
         expect(decoded["sub"]).to.equal(subject);
-        expect(decoded["iss"]).to.equal("mp-server-d7650ec945.preview.gitpod-dev.com");
+        expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");
     }
 }
 

--- a/components/server/src/auth/jwt.ts
+++ b/components/server/src/auth/jwt.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as jsonwebtoken from "jsonwebtoken";
+import { Config } from "../config";
+import { inject, injectable } from "inversify";
+
+const algorithm: jsonwebtoken.Algorithm = "RS512";
+
+@injectable()
+export class AuthJWT {
+    @inject(Config) protected config: Config;
+
+    async sign(subject: string, payload: object | Buffer, expiresIn: string = `${24 * 7}h`) {
+        const opts: jsonwebtoken.SignOptions = {
+            algorithm,
+            expiresIn,
+            issuer: this.config.hostUrl.toString(),
+            subject,
+        };
+
+        return new Promise((resolve, reject) => {
+            jsonwebtoken.sign(payload, this.config.auth.pki.signing.privateKey, opts, (err, encoded) => {
+                if (err || !encoded) {
+                    return reject(err);
+                }
+                return resolve(encoded);
+            });
+        });
+    }
+
+    async verify(encoded: string): Promise<object> {
+        const publicKeys = [
+            this.config.auth.pki.signing.publicKey, // signing key is checked first
+            ...this.config.auth.pki.validating.map((keypair) => keypair.publicKey),
+        ];
+
+        let lastErr;
+        for (let publicKey of publicKeys) {
+            try {
+                const decoded = verify(encoded, publicKey, {
+                    algorithms: [algorithm],
+                });
+                return decoded;
+            } catch (err) {
+                lastErr = err;
+            }
+        }
+
+        throw lastErr;
+    }
+}
+
+async function verify(
+    encoded: string,
+    publicKey: string,
+    opts: jsonwebtoken.VerifyOptions,
+): Promise<jsonwebtoken.JwtPayload> {
+    return new Promise((resolve, reject) => {
+        jsonwebtoken.verify(encoded, publicKey, opts, (err, decoded) => {
+            if (err || !decoded) {
+                return reject(err);
+            }
+            resolve(decoded);
+        });
+    });
+}
+
+export async function newSessionJWT(userID: string): Promise<string> {
+    const payload = {
+        // subject
+        sub: userID,
+        // issuer
+        iss: "gitpod.io",
+    };
+    const temporaryTestKeyForExperimentation = "my-secret";
+
+    return new Promise((resolve, reject) => {
+        jsonwebtoken.sign(payload, temporaryTestKeyForExperimentation, { algorithm: "HS256" }, function (err, token) {
+            if (err || !token) {
+                return reject(err);
+            }
+            return resolve(token);
+        });
+    });
+}

--- a/components/server/src/auth/jwt.ts
+++ b/components/server/src/auth/jwt.ts
@@ -41,13 +41,10 @@ export class AuthJWT {
             ...validatingPublicKeys,
         ];
 
-        console.log("verifying with keys", publicKeys);
         let lastErr;
-        let c = 0;
         for (let publicKey of publicKeys) {
-            console.log("trying ", c, publicKey);
             try {
-                const decoded = verify(encoded, publicKey, {
+                const decoded = await verify(encoded, publicKey, {
                     algorithms: [algorithm],
                 });
                 return decoded;
@@ -55,7 +52,6 @@ export class AuthJWT {
                 log.debug(`Failed to verify JWT token using public key.`, err);
                 lastErr = err;
             }
-            c += 1;
         }
 
         log.error(`Failed to verify JWT using any available public key.`, lastErr, {

--- a/components/server/src/auth/jwt.ts
+++ b/components/server/src/auth/jwt.ts
@@ -19,7 +19,7 @@ export class AuthJWT {
         const opts: jsonwebtoken.SignOptions = {
             algorithm,
             expiresIn,
-            issuer: this.config.hostUrl.url.hostname,
+            issuer: this.config.hostUrl.toStringWoRootSlash(),
             subject,
         };
 

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -94,7 +94,7 @@ export class LoginCompletionHandler {
             );
         }
 
-        const jwt = newSessionJWT(user.id);
+        const jwt = await newSessionJWT(user.id);
 
         response.cookie("_gitpod_jwt_", jwt, {
             maxAge: 7 * 24 * 60 * 60,

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -108,7 +108,7 @@ export class LoginCompletionHandler {
             const token = await this.authJWT.sign(user.id, {});
 
             response.cookie(SessionHandlerProvider.getJWTCookieName(this.config.hostUrl), token, {
-                maxAge: 7 * 24 * 60 * 60, // 7 days
+                maxAge: this.config.session.maxAgeMs,
                 httpOnly: true,
                 sameSite: "lax",
                 secure: true,

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -117,6 +117,7 @@ import { APIUserService } from "./api/user";
 import { APITeamsService } from "./api/teams";
 import { API } from "./api/server";
 import { LinkedInService } from "./linkedin-service";
+import { AuthJWT } from "./auth/jwt";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -324,4 +325,6 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(APIUserService).toSelf().inSingletonScope();
     bind(APITeamsService).toSelf().inSingletonScope();
     bind(API).toSelf().inSingletonScope();
+
+    bind(AuthJWT).toSelf().inSingletonScope();
 });

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -25,6 +25,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(centralizedPermissionsValidationsTotal);
     registry.registerMetric(spicedbClientLatency);
     registry.registerMetric(dashboardErrorBoundary);
+    registry.registerMetric(jwtCookieIssued);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -55,6 +56,15 @@ const apiConnectionCounter = new prometheusClient.Counter({
 
 export function increaseApiConnectionCounter() {
     apiConnectionCounter.inc();
+}
+
+const jwtCookieIssued = new prometheusClient.Counter({
+    name: "gitpod_server_jwt_cookie_issued_total",
+    help: "Total number of JWT cookies issued for login sessions",
+});
+
+export function reportJWTCookieIssued() {
+    jwtCookieIssued.inc();
 }
 
 const apiConnectionClosedCounter = new prometheusClient.Counter({

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -53,7 +53,7 @@ export class SessionHandlerProvider {
             path: "/", // default
             httpOnly: true, // default
             secure: false, // default, TODO SSL! Config proxy
-            maxAge: config.session.maxAgeMs, // configured in Helm chart, defaults to 3 days.
+            maxAge: config.session.maxAgeMs,
             sameSite: "lax", // default: true. "Lax" needed for OAuth.
         };
     }

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -66,13 +66,6 @@ export class SessionHandlerProvider {
         return `${derived}v2_`;
     }
 
-    static getOldCookieName(config: Config) {
-        return config.hostUrl
-            .toString()
-            .replace(/https?/, "")
-            .replace(/[\W_]+/g, "_");
-    }
-
     static getJWTCookieName(hostURL: GitpodHostUrl) {
         const derived = hostURL
             .toString()
@@ -88,6 +81,8 @@ export class SessionHandlerProvider {
         delete options.expires;
         delete options.maxAge;
         res.clearCookie(name, options);
+
+        res.clearCookie(SessionHandlerProvider.getJWTCookieName(this.config.hostUrl));
     }
 
     protected createStore(): any | undefined {

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -15,6 +15,7 @@ const MySQLStore = mysqlstore(session);
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config as DBConfig } from "@gitpod/gitpod-db/lib/config";
 import { Config } from "./config";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 @injectable()
 export class SessionHandlerProvider {
@@ -70,6 +71,14 @@ export class SessionHandlerProvider {
             .toString()
             .replace(/https?/, "")
             .replace(/[\W_]+/g, "_");
+    }
+
+    static getJWTCookieName(hostURL: GitpodHostUrl) {
+        const derived = hostURL
+            .toString()
+            .replace(/https?/, "")
+            .replace(/[\W_]+/g, "_");
+        return `${derived}jwt_`;
     }
 
     public clearSessionCookie(res: express.Response, config: Config): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

On succesful sign-in, a JWT cookie is generated and stored in the client session.

Feature is behind a feature flag.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Fixes WEB-100
* Depends on https://github.com/gitpod-io/gitpod/pull/17214

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Sign-in
3. Observe there's a new cookie assigned with `_jwt_` suffix

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
