### PR TITLE
[pr] update desc with summary

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -39,3 +39,10 @@ done
 previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 leeway run dev/preview:deploy-gitpod
 previewctl report >> "${GITHUB_STEP_SUMMARY}"
+
+report=$(previewctl report | base64)
+{
+  echo "report<<$EOF"
+  echo "$report"
+  echo "$EOF"
+} >> "$GITHUB_OUTPUT"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## Description
 <!-- Describe your changes in detail -->
 
+gitpod:summary
+
 ## Related Issue(s)
 <!-- List the issue(s) this PR solves -->
 Fixes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## Description
 <!-- Describe your changes in detail -->
 
+#### Preview status
+
 gitpod:summary
 
 ## Related Issue(s)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       latest_ide_version: ${{ contains( steps.pr-details.outputs.pr_body, '[x] latest-ide-version=true') }}
       leeway_cache_bucket: ${{ steps.output.outputs.leeway_cache_bucket }}
       pr_number: ${{ steps.pr-details.outputs.number }}
+      pr_body: ${{ steps.pr-details.outputs.pr_body }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -115,69 +116,6 @@ jobs:
           export LEEWAY_WORKSPACE_ROOT="$(pwd)"
           leeway build dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}"
           echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}" -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
-
-  update_pr_desc:
-    name: Update PR summary
-    needs: [ configuration ]
-    if: needs.configuration.outputs.pr_number != ''
-    concurrency:
-      group: ${{ github.head_ref || github.ref_name }}-update-pr-desc
-    runs-on: [ self-hosted ]
-    container:
-        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
-        volumes:
-          - /var/tmp:/var/tmp
-          - /tmp:/tmp
-    steps:
-      - uses: actions/checkout@v3
-      - name: Configure workspace
-        run: |
-          sudo chown -R gitpod:gitpod /__t
-          # Needed by docker/login-action
-          sudo chmod goa+rw /var/run/docker.sock
-      - name: Set outputs
-        id: outputs
-        shell: bash
-        env:
-          HOME: /home/gitpod
-          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-        run: |
-          # Authenticate with GCP so we can use the Leeway cache
-          export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
-          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-          leeway run dev/preview/previewctl:install
-
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-
-          summary=$(previewctl report | base64)
-          echo "summary<<$EOF" >> $GITHUB_OUTPUT
-          echo "$summary" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            const prNumber = ${{ needs.configuration.outputs.pr_number }};
-
-            const summaryEncoded = `${{ steps.outputs.outputs.summary }}`;
-            const summary = Buffer.from(summaryEncoded, 'base64').toString('utf8');
-
-            const { data: pr } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: prNumber,
-            });
-
-            const prBody = pr.body;
-
-            const newBody = prBody.replace('gitpod:summary', summary);
-
-            await github.rest.pulls.update({
-              ...context.repo,
-              pull_number: prNumber,
-              body: newBody,
-            });
 
   infrastructure:
     needs: [ configuration, build-previewctl ]
@@ -408,6 +346,29 @@ jobs:
           with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
+      - uses: actions/github-script@v6
+        if: needs.configuration.outputs.pr_number != '' && contains(needs.configuration.outputs.pr_body, 'gitpod:summary')
+        with:
+          script: |
+            const prNumber = ${{ needs.configuration.outputs.pr_number }};
+
+            const summaryEncoded = `${{ steps.deploy-gitpod.outputs.report }}`;
+            const summary = Buffer.from(summaryEncoded, 'base64').toString('utf8');
+
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: prNumber,
+            });
+
+            const prBody = pr.body;
+
+            const newBody = prBody.replace('gitpod:summary', summary);
+
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: prNumber,
+              body: newBody,
+            });
 
   monitoring:
     name: "Install Monitoring Satellite"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       with_integration_tests: ${{ steps.output.outputs.with_integration_tests }}
       latest_ide_version: ${{ contains( steps.pr-details.outputs.pr_body, '[x] latest-ide-version=true') }}
       leeway_cache_bucket: ${{ steps.output.outputs.leeway_cache_bucket }}
+      pr_number: ${{ steps.pr-details.outputs.number }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -114,6 +115,69 @@ jobs:
           export LEEWAY_WORKSPACE_ROOT="$(pwd)"
           leeway build dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}"
           echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}" -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
+
+  update_pr_desc:
+    name: Update PR summary
+    needs: [ configuration ]
+    if: needs.configuration.outputs.pr_number != ''
+    concurrency:
+      group: ${{ github.head_ref || github.ref_name }}-update-pr-desc
+    runs-on: [ self-hosted ]
+    container:
+        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+        volumes:
+          - /var/tmp:/var/tmp
+          - /tmp:/tmp
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          sudo chown -R gitpod:gitpod /__t
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
+      - name: Set outputs
+        id: outputs
+        shell: bash
+        env:
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+        run: |
+          # Authenticate with GCP so we can use the Leeway cache
+          export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+          export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+          leeway run dev/preview/previewctl:install
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+
+          summary=$(previewctl report | base64)
+          echo "summary<<$EOF" >> $GITHUB_OUTPUT
+          echo "$summary" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = ${{ needs.configuration.outputs.pr_number }};
+
+            const summaryEncoded = `${{ steps.outputs.outputs.summary }}`;
+            const summary = Buffer.from(summaryEncoded, 'base64').toString('utf8');
+
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: prNumber,
+            });
+
+            const prBody = pr.body;
+
+            const newBody = prBody.replace('gitpod:summary', summary);
+
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: prNumber,
+              body: newBody,
+            });
 
   infrastructure:
     needs: [ configuration, build-previewctl ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a special property to the PR desc which gets replaced by the deployment job. It was already replaced below.

#### Preview status

gitpod:summary

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
