### PR TITLE
[server] Generate key-pair for signing JWT sessions WEB-100

### DIFF
--- a/install/installer/pkg/components/server/authpki.go
+++ b/install/installer/pkg/components/server/authpki.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func authPKI(ctx *common.RenderContext) ([]runtime.Object, error) {
+	serverAltNames := []string{
+		fmt.Sprintf("gitpod.%s", ctx.Namespace),
+		fmt.Sprintf("%s.%s.svc", Component, ctx.Namespace),
+		Component,
+		fmt.Sprintf("%s-dev", Component),
+	}
+
+	return []runtime.Object{
+		&certmanagerv1.Certificate{
+			TypeMeta: common.TypeMetaCertificate,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AuthPKISecretName,
+				Namespace: ctx.Namespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			Spec: certmanagerv1.CertificateSpec{
+				Duration: &metav1.Duration{
+					Duration: time.Duration(math.MaxInt64), // never expire automatically
+				},
+				SecretName: AuthPKISecretName,
+				DNSNames:   serverAltNames,
+				IssuerRef: cmmeta.ObjectReference{
+					Name:  common.CertManagerCAIssuer,
+					Kind:  certmanagerv1.ClusterIssuerKind,
+					Group: "cert-manager.io",
+				},
+				PrivateKey: &certmanagerv1.CertificatePrivateKey{
+					Encoding:  certmanagerv1.PKCS8,
+					Size:      4096,
+					Algorithm: certmanagerv1.RSAKeyAlgorithm,
+				},
+				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
+					Labels: common.DefaultLabels(Component),
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -31,6 +31,8 @@ const (
 	AdminCredentialsSecretMountPath = "/credentials/admin"
 	AdminCredentialsSecretKey       = "admin.json"
 
+	AuthPKISecretName = "auth-pki"
+
 	GRPCAPIName = "grpc"
 	GRPCAPIPort = common.ServerGRPCAPIPort
 )

--- a/install/installer/pkg/components/server/objects.go
+++ b/install/installer/pkg/components/server/objects.go
@@ -60,4 +60,5 @@ var Objects = common.CompositeRenderFunc(
 		},
 	}),
 	common.DefaultServiceAccount(Component),
+	authPKI,
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
