### PR TITLE
[installer] add flags with ability to overwrite [repository, domain] in the config file for `mirror list`

### DIFF
--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -26,6 +26,8 @@ type mirrorListRepo struct {
 var mirrorListOpts struct {
 	ConfigFN          string
 	ExcludeThirdParty bool
+	Repository        string
+	Domain            string
 }
 
 // mirrorListCmd represents the mirror list command
@@ -63,6 +65,14 @@ image to the "target" repo`,
 			return err
 		}
 
+		if mirrorListOpts.Repository != "" {
+			cfg.Repository = mirrorListOpts.Repository
+		}
+
+		if mirrorListOpts.Domain != "" {
+			cfg.Domain = mirrorListOpts.Domain
+		}
+
 		images, err := generateMirrorList(cfgVersion, cfg)
 		if err != nil {
 			return err
@@ -84,6 +94,8 @@ func init() {
 
 	mirrorListCmd.Flags().BoolVar(&mirrorListOpts.ExcludeThirdParty, "exclude-third-party", false, "exclude non-Gitpod images")
 	mirrorListCmd.Flags().StringVarP(&mirrorListOpts.ConfigFN, "config", "c", os.Getenv("GITPOD_INSTALLER_CONFIG"), "path to the config file")
+	mirrorListCmd.Flags().StringVar(&mirrorListOpts.Repository, "repository", "", "overwrite the registry in the config")
+	mirrorListCmd.Flags().StringVar(&mirrorListOpts.Domain, "domain", "", "overwrite the domain in the config")
 }
 
 func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]string, error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes it possible to extract the list of images, without having to provide a completely valid configuration file.

```bash
installer mirror list --config gitpod.config.yaml --strict-parse=false --repository test --domain test.com

[
  {
    "original": "b.gcr.io/cloudsql-docker/gce-proxy:1.11",
    "target": "test/cloudsql-docker/gce-proxy:1.11"
  },
  {
    "original": "docker.io/bitnami/bitnami-shell:11-debian-11-r60",
    "target": "test/bitnami/bitnami-shell:11-debian-11-r60"
  },
  {
    "original": "docker.io/bitnami/minio:2022.12.12-debian-11-r0",
    "target": "test/bitnami/minio:2022.12.12-debian-11-r0"
  }
...
]
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
