### PR TITLE
[dashboard] create ws keep button enabled

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -255,7 +255,7 @@ export function CreateWorkspacePage() {
                         onClick={onClickCreate}
                         autoFocus={true}
                         size="block"
-                        loading={isStarting || isLoading}
+                        loading={isStarting}
                         disabled={
                             !contextURL ||
                             contextURL.length === 0 ||
@@ -264,7 +264,7 @@ export function CreateWorkspacePage() {
                             !!workspaceContext.error
                         }
                     >
-                        {isLoading ? "Loading ..." : isStarting ? "Creating Workspace ..." : "New Workspace"}
+                        {isStarting ? "Creating Workspace ..." : "New Workspace"}
                     </Button>
                 </div>
                 {existingWorkspaces.length > 0 && (


### PR DESCRIPTION
## Description
This changes keeps the "Create Workspace" button enabled during context resolution, so that users don'T need to wait for the context resolution to happen nor get distracting by a flashing button changing its state.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-136

## How to test
<!-- Provide steps to test this PR -->
Use create page and see that "loading ..." state doesn't happen anymore. 
https://se-button-enabled.preview.gitpod-dev.com/new/#github.com/gitpod-io/gitpod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
