### PR TITLE
Persist new workspace contextURL on org change

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -96,6 +96,16 @@ export function CreateWorkspacePage() {
         }
     }, [project, props.workspaceClass]);
 
+    // In addition to updating state, we want to update the url hash as well
+    // This allows the contextURL to persist if user changes orgs, or copies/shares url
+    const handleContextURLChange = useCallback(
+        (newContextURL: string) => {
+            setContextURL(newContextURL);
+            history.replace(`#${newContextURL}`);
+        },
+        [history],
+    );
+
     const onSelectEditorChange = useCallback(
         (ide: string, useLatest: boolean) => {
             setSelectedIde(ide);
@@ -219,7 +229,7 @@ export function CreateWorkspacePage() {
                 </div>
                 <div className="-mx-6 px-6 mt-6 w-full">
                     <div className="pt-3">
-                        <RepositoryFinder setSelection={setContextURL} initialValue={contextURL} />
+                        <RepositoryFinder setSelection={handleContextURLChange} initialValue={contextURL} />
                         <ErrorMessage
                             error={
                                 (createWorkspaceMutation.error as StartWorkspaceError) ||


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR aims to maintain the context url from the new workspace page even as the org changes.

As the context url changes, this gets set in the url hash now, and the org switcher links have a special case to handle if we're on the `/new` route so that state from the url is maintained.

## Considerations
I would have liked a solution that didn't require a special case for the org switching urls, but considering other approaches of trying to track the state of the new workspace page, and persist/reload it in the right places, this felt simpler. I also opted to not try and maintain the other values on that form (the ide and ws class). We could explore tracking those as well (as query params maybe?) in a followup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-120

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-keep-c7205484caf.preview.gitpod-dev.com/new/#https://github.com/gitpod-io/gitpod

* Create at least a second org.
* Visit the new workspace page, select a repo.
* Change your org.
* Verify you're still on the new workspace page, same context url set, and new org selected. 

## Risk
Low risk. This page is only enabled internally, and is unlikely to break existing behavior on the create new workspace page.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
