### PR TITLE
[preview] Use cert-manager namespace for satellite, not certmanager namespace

### DIFF
--- a/dev/preview/workflow/config/monitoring-satellite.yaml
+++ b/dev/preview/workflow/config/monitoring-satellite.yaml
@@ -7,6 +7,7 @@ tracing:
     preview.name: ${PREVIEW_NAME}
 certmanager:
   installServiceMonitors: true
+  namespace: cert-manager
 pyrra:
   install: true
 prometheus:

--- a/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
+++ b/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
@@ -41,7 +41,7 @@ kubectl \
 kubectl \
     --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
     --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    create ns certmanager --dry-run=client -o yaml \
+    create ns cert-manager --dry-run=client -o yaml \
 | kubectl \
     --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
     --context "${PREVIEW_K3S_KUBE_CONTEXT}" \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In an existing preview env, we still see `certmanager` namespace :upside_down_face: :
```
gitpod /workspace/gitpod (aledbf/remove-psp) $ kubens
cert-manager
certmanager
default
kube-node-lease
kube-public
kube-system
monitoring-satellite
rook-ceph
werft
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-71

## How to test
<!-- Provide steps to test this PR -->
Assert this preview environment has `cert-manager` and not `certmanager` namespace, and start a workspace in it.
```
gitpod /workspace/gitpod (kylos101/certmanager) $ kubectx -c
kylos101-certmanager
gitpod /workspace/gitpod (kylos101/certmanager) $ kubens
cert-manager
default
kube-node-lease
kube-public
kube-system
monitoring-satellite
rook-ceph
werft
gitpod /workspace/gitpod (kylos101/certmanager) $ kubectl get all -n cert-manager
NAME                                          READY   STATUS      RESTARTS   AGE
pod/cert-manager-7c76fc4765-x4twh             1/1     Running     0          51m
pod/cert-manager-cainjector-7fd9c56d4-tqhl8   1/1     Running     0          51m
pod/cert-manager-startupapicheck-hkmvc        0/1     Completed   0          51m
pod/cert-manager-webhook-58c7ccdbd5-wl5vp     1/1     Running     0          51m
pod/trust-manager-6469bc889d-6vsgn            1/1     Running     0          48m

NAME                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/cert-manager            ClusterIP   10.43.202.14    <none>        9402/TCP   51m
service/cert-manager-webhook    ClusterIP   10.43.75.217    <none>        443/TCP    51m
service/certmanager-metrics     ClusterIP   10.43.140.182   <none>        9402/TCP   3m47s
service/trust-manager           ClusterIP   10.43.251.61    <none>        443/TCP    48m
service/trust-manager-metrics   ClusterIP   10.43.95.198    <none>        9402/TCP   48m

NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cert-manager              1/1     1            1           51m
deployment.apps/cert-manager-cainjector   1/1     1            1           51m
deployment.apps/cert-manager-webhook      1/1     1            1           51m
deployment.apps/trust-manager             1/1     1            1           48m

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/cert-manager-7c76fc4765             1         1         1       51m
replicaset.apps/cert-manager-cainjector-7fd9c56d4   1         1         1       51m
replicaset.apps/cert-manager-webhook-58c7ccdbd5     1         1         1       51m
replicaset.apps/trust-manager-6469bc889d            1         1         1       48m

NAME                                     COMPLETIONS   DURATION   AGE
job.batch/cert-manager-startupapicheck   1/1           71s        51m
gitpod /workspace/gitpod (kylos101/certmanager) $ kubectl get all -n monitoring-satellite
NAME                                     READY   STATUS    RESTARTS   AGE
pod/alertmanager-main-0                  2/2     Running   0          3m24s
pod/grafana-646d749bb6-vsjm4             1/1     Running   0          2m
pod/http-prober-867c755dd-6jm6l          1/1     Running   0          2m4s
pod/kube-state-metrics-876578749-zlp4h   3/3     Running   0          3m30s
pod/node-exporter-fvp5d                  1/1     Running   0          3m31s
pod/otel-collector-8644865b8f-r2tvk      1/1     Running   0          3m29s
pod/prometheus-k8s-0                     2/2     Running   0          3m24s
pod/prometheus-operator-7f5444cc-pcnnx   2/2     Running   0          3m28s
pod/pyrra-api-7944b86bfd-c9w87           1/1     Running   0          3m28s
pod/pyrra-kubernetes-7dd5d8dd46-89fw8    1/1     Running   0          3m27s

NAME                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                       AGE
service/alertmanager-main       ClusterIP   10.43.73.69     <none>        9093/TCP,8080/TCP             3m54s
service/alertmanager-operated   ClusterIP   None            <none>        9093/TCP,9094/TCP,9094/UDP    3m24s
service/grafana                 ClusterIP   10.43.44.43     <none>        3000/TCP                      2m6s
service/http-prober             ClusterIP   10.43.134.78    <none>        8080/TCP                      2m3s
service/kube-state-metrics      ClusterIP   10.43.243.138   <none>        8443/TCP,9443/TCP             3m36s
service/node-exporter           ClusterIP   10.43.238.73    <none>        9100/TCP                      3m35s
service/otel-collector          ClusterIP   10.43.150.146   <none>        14268/TCP,4317/TCP,8888/TCP   3m34s
service/prometheus-k8s          ClusterIP   10.43.154.228   <none>        9090/TCP,8080/TCP             3m34s
service/prometheus-operated     ClusterIP   None            <none>        9090/TCP                      3m24s
service/prometheus-operator     ClusterIP   10.43.141.60    <none>        8443/TCP                      3m33s
service/pyrra-api               ClusterIP   10.43.150.44    <none>        9099/TCP                      3m32s
service/pyrra-kubernetes        ClusterIP   10.43.24.97     <none>        9444/TCP                      3m31s

NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/node-exporter   1         1         1       1            1           <none>          3m31s

NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/grafana               1/1     1            1           2m10s
deployment.apps/http-prober           1/1     1            1           2m4s
deployment.apps/kube-state-metrics    1/1     1            1           3m30s
deployment.apps/otel-collector        1/1     1            1           3m29s
deployment.apps/prometheus-operator   1/1     1            1           3m28s
deployment.apps/pyrra-api             1/1     1            1           3m28s
deployment.apps/pyrra-kubernetes      1/1     1            1           3m27s

NAME                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/grafana-646d749bb6             1         1         1       2m
replicaset.apps/grafana-6c695596d              0         0         0       2m10s
replicaset.apps/http-prober-867c755dd          1         1         1       2m4s
replicaset.apps/kube-state-metrics-876578749   1         1         1       3m30s
replicaset.apps/otel-collector-8644865b8f      1         1         1       3m29s
replicaset.apps/prometheus-operator-7f5444cc   1         1         1       3m28s
replicaset.apps/pyrra-api-7944b86bfd           1         1         1       3m28s
replicaset.apps/pyrra-kubernetes-7dd5d8dd46    1         1         1       3m27s

NAME                                 READY   AGE
statefulset.apps/alertmanager-main   1/1     3m24s
statefulset.apps/prometheus-k8s      1/1     3m24s
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
