### PR TITLE
[server] Load auth-pki into server config - WEB-100

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -196,6 +196,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	_, _, adminCredentialsPath := getAdminCredentials()
 
+	_, _, authPKI := getAuthPKI()
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -297,6 +299,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			CredentialsPath:         adminCredentialsPath,
 		},
 		ShowSetupModal: showSetupModal,
+		Auth: AuthConfig{
+			PKI: authPKI,
+		},
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -30,6 +30,7 @@ func TestConfigMap(t *testing.T) {
 		JWTSecret                         string
 		SessionSecret                     string
 		GitHubApp                         experimental.GithubApp
+		Auth                              AuthConfig
 	}
 
 	expectation := Expectation{
@@ -51,6 +52,14 @@ func TestConfigMap(t *testing.T) {
 			MarketplaceName: "some-marketplace-name",
 			WebhookSecret:   "some-webhook-secret",
 			CertSecretName:  "some-cert-secret-name",
+		},
+		Auth: AuthConfig{
+			PKI: AuthPKIConfig{
+				Signing: KeyPair{
+					PrivateKeyPath: "/secrets/auth-pki/signing/tls.key",
+					PublicKeyPath:  "/secrets/auth-pki/signing/tls.crt",
+				},
+			},
 		},
 	}
 
@@ -122,6 +131,7 @@ func TestConfigMap(t *testing.T) {
 			WebhookSecret:   config.GitHubApp.WebhookSecret,
 			CertSecretName:  config.GitHubApp.CertSecretName,
 		},
+		Auth: config.Auth,
 	}
 
 	assert.Equal(t, expectation, actual)

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -281,6 +281,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	volumes = append(volumes, adminCredentialsVolume)
 	volumeMounts = append(volumeMounts, adminCredentialsMount)
 
+	authPKIVolumes, authPKIMounts, _ := getAuthPKI()
+	volumes = append(volumes, authPKIVolumes...)
+	volumeMounts = append(volumeMounts, authPKIMounts...)
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -13,32 +13,33 @@ import (
 
 // ConfigSerialized interface from components/server/src/config.ts
 type ConfigSerialized struct {
-	Version                           string   `json:"version"`
-	HostURL                           string   `json:"hostUrl"`
-	InstallationShortname             string   `json:"installationShortname"`
-	DevBranch                         string   `json:"devBranch"`
-	InsecureNoDomain                  bool     `json:"insecureNoDomain"`
-	License                           string   `json:"license"`
-	DefinitelyGpDisabled              bool     `json:"definitelyGpDisabled"`
-	EnableLocalApp                    bool     `json:"enableLocalApp"`
-	DisableDynamicAuthProviderLogin   bool     `json:"disableDynamicAuthProviderLogin"`
-	MaxEnvvarPerUserCount             int32    `json:"maxEnvvarPerUserCount"`
-	MaxConcurrentPrebuildsPerRef      int32    `json:"maxConcurrentPrebuildsPerRef"`
-	MakeNewUsersAdmin                 bool     `json:"makeNewUsersAdmin"`
-	DefaultBaseImageRegistryWhitelist []string `json:"defaultBaseImageRegistryWhitelist"`
-	RunDbDeleter                      bool     `json:"runDbDeleter"`
-	ContentServiceAddr                string   `json:"contentServiceAddr"`
-	UsageServiceAddr                  string   `json:"usageServiceAddr"`
-	IDEServiceAddr                    string   `json:"ideServiceAddr"`
-	MaximumEventLoopLag               float64  `json:"maximumEventLoopLag"`
-	VSXRegistryUrl                    string   `json:"vsxRegistryUrl"`
-	ChargebeeProviderOptionsFile      string   `json:"chargebeeProviderOptionsFile"`
-	StripeSecretsFile                 string   `json:"stripeSecretsFile"`
-	StripeConfigFile                  string   `json:"stripeConfigFile"`
-	EnablePayment                     bool     `json:"enablePayment"`
-	LinkedInSecretsFile               string   `json:"linkedInSecretsFile"`
-	PATSigningKeyFile                 string   `json:"patSigningKeyFile"`
-	ShowSetupModal                    bool     `json:"showSetupModal"`
+	Version                           string     `json:"version"`
+	HostURL                           string     `json:"hostUrl"`
+	InstallationShortname             string     `json:"installationShortname"`
+	DevBranch                         string     `json:"devBranch"`
+	InsecureNoDomain                  bool       `json:"insecureNoDomain"`
+	License                           string     `json:"license"`
+	DefinitelyGpDisabled              bool       `json:"definitelyGpDisabled"`
+	EnableLocalApp                    bool       `json:"enableLocalApp"`
+	DisableDynamicAuthProviderLogin   bool       `json:"disableDynamicAuthProviderLogin"`
+	MaxEnvvarPerUserCount             int32      `json:"maxEnvvarPerUserCount"`
+	MaxConcurrentPrebuildsPerRef      int32      `json:"maxConcurrentPrebuildsPerRef"`
+	MakeNewUsersAdmin                 bool       `json:"makeNewUsersAdmin"`
+	DefaultBaseImageRegistryWhitelist []string   `json:"defaultBaseImageRegistryWhitelist"`
+	RunDbDeleter                      bool       `json:"runDbDeleter"`
+	ContentServiceAddr                string     `json:"contentServiceAddr"`
+	UsageServiceAddr                  string     `json:"usageServiceAddr"`
+	IDEServiceAddr                    string     `json:"ideServiceAddr"`
+	MaximumEventLoopLag               float64    `json:"maximumEventLoopLag"`
+	VSXRegistryUrl                    string     `json:"vsxRegistryUrl"`
+	ChargebeeProviderOptionsFile      string     `json:"chargebeeProviderOptionsFile"`
+	StripeSecretsFile                 string     `json:"stripeSecretsFile"`
+	StripeConfigFile                  string     `json:"stripeConfigFile"`
+	EnablePayment                     bool       `json:"enablePayment"`
+	LinkedInSecretsFile               string     `json:"linkedInSecretsFile"`
+	PATSigningKeyFile                 string     `json:"patSigningKeyFile"`
+	ShowSetupModal                    bool       `json:"showSetupModal"`
+	Auth                              AuthConfig `json:"auth"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`
 	WorkspaceDefaults          WorkspaceDefaults          `json:"workspaceDefaults"`
@@ -63,6 +64,23 @@ type ConfigSerialized struct {
 }
 type CodeSyncResources struct {
 	RevLimit int32 `json:"revLimit"`
+}
+
+type AuthConfig struct {
+	PKI AuthPKIConfig `json:"pki"`
+}
+
+type AuthPKIConfig struct {
+	// Signing KeyPair is always used to issue new auth tokens
+	Signing KeyPair `json:"signing"`
+
+	// Validating KeyPairs are used for checking validity only
+	Validating []KeyPair `json:"validating,omitempty"`
+}
+
+type KeyPair struct {
+	PrivateKeyPath string `json:"privateKeyPath"`
+	PublicKeyPath  string `json:"publicKeyPath"`
 }
 
 type CodeSync struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Takes secret generated from https://github.com/gitpod-io/gitpod/pull/17205 and mounts and loads the private/public keys into server

#### Preview status

gitpod:summary

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

You can see this in action in https://github.com/gitpod-io/gitpod/pull/17200 PR's preview env

## How to test
<!-- Provide steps to test this PR -->
1. Preview kubectx
2. Check auth-pki mounted as volume
3. Check auth-pki refrences in servers' config
4. Check server is running

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
