### PR TITLE
[papi] Mount Auth PKI - WEB-101

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -32,6 +32,9 @@ type Configuration struct {
 	// Redis configures the connection to Redis
 	Redis RedisConfiguration `json:"redis"`
 
+	// Authentication configuration
+	Auth AuthConfiguration `json:"auth"`
+
 	Server *baseserver.Configuration `json:"server,omitempty"`
 }
 
@@ -39,4 +42,18 @@ type RedisConfiguration struct {
 
 	// Address configures the redis connection of this component
 	Address string `json:"address"`
+}
+
+type AuthConfiguration struct {
+	PKI AuthPKIConfiguration `json:"pki"`
+}
+
+type AuthPKIConfiguration struct {
+	Signing    KeyPair   `json:"signing"`
+	Validating []KeyPair `json:"validating"`
+}
+
+type KeyPair struct {
+	PublicKeyPath  string `json:"publicKeyPath"`
+	PrivateKeyPath string `json:"privateKeyPath"`
 }

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -61,6 +61,7 @@ const (
 	WorkspaceSecretsNamespace   = "workspace-secrets"
 	AnnotationConfigChecksum    = "gitpod.io/checksum_config"
 	DatabaseConfigMountPath     = "/secrets/database-config"
+	AuthPKISecretName           = "auth-pki"
 )
 
 var (

--- a/install/installer/pkg/components/public-api-server/authpki.go
+++ b/install/installer/pkg/components/public-api-server/authpki.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"path"
+
+	"github.com/gitpod-io/gitpod/components/public-api/go/config"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getAuthPKI() ([]corev1.Volume, []corev1.VolumeMount, config.AuthPKIConfiguration) {
+
+	dir := "/secrets/auth-pki"
+	signingDir := path.Join(dir, "signing")
+
+	volumes := []corev1.Volume{
+		{
+			Name: "auth-pki-signing",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.AuthPKISecretName,
+				},
+			},
+		},
+	}
+
+	mounts := []corev1.VolumeMount{
+		{
+			Name:      "auth-pki-signing",
+			MountPath: signingDir,
+			ReadOnly:  true,
+		},
+	}
+
+	cfg := config.AuthPKIConfiguration{
+		Signing: config.KeyPair{
+			PrivateKeyPath: path.Join(signingDir, "tls.key"),
+			PublicKeyPath:  path.Join(signingDir, "tls.crt"),
+		},
+	}
+	return volumes, mounts, cfg
+}

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -48,6 +48,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	_, _, databaseSecretMountPath := common.DatabaseEnvSecret(ctx.Config)
 
+	_, _, authPKI := getAuthPKI()
+
 	cfg := config.Configuration{
 		PublicURL:                         fmt.Sprintf("https://api.%s", ctx.Config.Domain),
 		GitpodServiceURL:                  common.ClusterURL("ws", server.Component, ctx.Namespace, server.ContainerPort),
@@ -59,6 +61,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		DatabaseConfigPath:                databaseSecretMountPath,
 		Redis: config.RedisConfiguration{
 			Address: common.ClusterAddress(redis.Component, ctx.Namespace, redis.Port),
+		},
+		Auth: config.AuthConfiguration{
+			PKI: authPKI,
 		},
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -57,6 +57,14 @@ func TestConfigMap(t *testing.T) {
 		Redis: config.RedisConfiguration{
 			Address: fmt.Sprintf("%s.%s.svc.cluster.local:%d", redis.Component, ctx.Namespace, redis.Port),
 		},
+		Auth: config.AuthConfiguration{
+			PKI: config.AuthPKIConfiguration{
+				Signing: config.KeyPair{
+					PublicKeyPath:  "/secrets/auth-pki/signing/tls.crt",
+					PrivateKeyPath: "/secrets/auth-pki/signing/tls.key",
+				},
+			},
+		},
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -91,6 +91,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	authPKIVolumes, authPKIMounts, _ := getAuthPKI()
+	volumes = append(volumes, authPKIVolumes...)
+	volumeMounts = append(volumeMounts, authPKIMounts...)
+
 	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
 	return []runtime.Object{
 		&appsv1.Deployment{

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -91,5 +91,13 @@ func TestDeployment_ServerArguments(t *testing.T) {
 				},
 			},
 		},
-	}, dpl.Spec.Template.Spec.Volumes, "must bind config as a volume")
+		{
+			Name: "auth-pki-signing",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "auth-pki",
+				},
+			},
+		},
+	}, dpl.Spec.Template.Spec.Volumes, "must bind volumes")
 }

--- a/install/installer/pkg/components/server/authpki.go
+++ b/install/installer/pkg/components/server/authpki.go
@@ -69,7 +69,7 @@ func getAuthPKI() ([]corev1.Volume, []corev1.VolumeMount, AuthPKIConfig) {
 			Name: "auth-pki-signing",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: AuthPKISecretName,
+					SecretName: common.AuthPKISecretName,
 				},
 			},
 		},

--- a/install/installer/pkg/components/server/authpki.go
+++ b/install/installer/pkg/components/server/authpki.go
@@ -31,7 +31,7 @@ func authPKI(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&certmanagerv1.Certificate{
 			TypeMeta: common.TypeMetaCertificate,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      AuthPKISecretName,
+				Name:      common.AuthPKISecretName,
 				Namespace: ctx.Namespace,
 				Labels:    common.DefaultLabels(Component),
 			},
@@ -39,7 +39,7 @@ func authPKI(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Duration: &metav1.Duration{
 					Duration: time.Duration(math.MaxInt64), // never expire automatically
 				},
-				SecretName: AuthPKISecretName,
+				SecretName: common.AuthPKISecretName,
 				DNSNames:   serverAltNames,
 				IssuerRef: cmmeta.ObjectReference{
 					Name:  common.CertManagerCAIssuer,

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -31,8 +31,6 @@ const (
 	AdminCredentialsSecretMountPath = "/credentials/admin"
 	AdminCredentialsSecretKey       = "admin.json"
 
-	AuthPKISecretName = "auth-pki"
-
 	GRPCAPIName = "grpc"
 	GRPCAPIPort = common.ServerGRPCAPIPort
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Mounts `auth-pki` secret onto public api, and feeds paths into public api config. This will be needed to validate incoming JWT cookies. 
The mounted files are not used in this PR, will be used in subsequent ones.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-papi-mo79f2f5a707</li>
	<li><b>🔗 URL</b> - <a href="https://mp-papi-mo79f2f5a707.preview.gitpod-dev.com/workspaces" target="_blank">mp-papi-mo79f2f5a707.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Public API starts
3. Public API config `k get configmap public-api-server` contains paths to keys
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
