### PR TITLE
[workspace list] filter by org

### DIFF
--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
@@ -8,15 +8,20 @@ import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { getGitpodService } from "../../service/service";
-import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import {
+    getListWorkspacesQueryKey,
+    ListWorkspacesQueryResult,
+    useOrganizationIdForWorkspaceList,
+} from "./list-workspaces-query";
 
 export const useListenToWorkspacesWSMessages = () => {
     const queryClient = useQueryClient();
+    const organizationId = useOrganizationIdForWorkspaceList();
 
     useEffect(() => {
         const disposable = getGitpodService().registerClient({
             onInstanceUpdate: (instance: WorkspaceInstance) => {
-                const queryKey = getListWorkspacesQueryKey();
+                const queryKey = getListWorkspacesQueryKey(organizationId);
                 let foundWorkspaces = false;
 
                 // Update the workspace with the latest instance
@@ -44,5 +49,5 @@ export const useListenToWorkspacesWSMessages = () => {
         return () => {
             disposable.dispose();
         };
-    }, [queryClient]);
+    }, [organizationId, queryClient]);
 };

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -43,7 +43,7 @@ export function CreateWorkspacePage() {
     const user = useCurrentUser();
     const currentOrg = useCurrentOrg().data;
     const projects = useListProjectsQuery();
-    const workspaces = useListWorkspacesQuery({ limit: 50, orgId: currentOrg?.id });
+    const workspaces = useListWorkspacesQuery({ limit: 50 });
     const location = useLocation();
     const history = useHistory();
     const props = StartWorkspaceOptions.parseSearchParams(location.search);

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -224,6 +224,9 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         if (options.pinnedOnly) {
             qb.andWhere("ws.pinned = true");
         }
+        if (options.organizationId) {
+            qb.andWhere("ws.organizationId = :organizationId", { organizationId: options.organizationId });
+        }
         const projectIds = typeof options.projectId === "string" ? [options.projectId] : options.projectId;
         if (projectIds !== undefined) {
             if (projectIds.length === 0 && !options.includeWithoutProject) {

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -28,6 +28,7 @@ export type MaybeWorkspaceInstance = WorkspaceInstance | undefined;
 
 export interface FindWorkspacesOptions {
     userId: string;
+    organizationId?: string;
     projectId?: string | string[];
     includeWithoutProject?: boolean;
     limit?: number;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -456,6 +456,7 @@ export namespace GitpodServer {
         pinnedOnly?: boolean;
         projectId?: string | string[];
         includeWithoutProject?: boolean;
+        organizationId?: string;
     }
     export interface GetAccountStatementOptions {
         date?: string;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The workspaces list currently shows all workspaces. After this change users that have been migrated to teams-only will only see the workspaces in the list that are owned by the currently selected org.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-org-worceca37c05a</li>
	<li><b>🔗 URL</b> - <a href="https://se-org-worceca37c05a.preview.gitpod-dev.com/workspaces" target="_blank">se-org-worceca37c05a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-130

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
