### PR TITLE
:tada: [feat]: Tooltip to display `absolute time` when using `relative date and time` format (#13764)

### DIFF
--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -16,6 +16,7 @@ import { AdminPageHeader } from "./AdminPageHeader";
 import Pagination from "../Pagination/Pagination";
 import { SpinnerLoader } from "../components/Loader";
 import searchIcon from "../icons/search.svg";
+import Tooltip from "../components/Tooltip";
 
 export default function ProjectsSearchPage() {
     return (
@@ -155,9 +156,11 @@ export function ProjectsSearch() {
                         <div className="text-gray-500 dark:text-gray-100 truncate">{p.project.cloneUrl}</div>
                     </div>
                     <div className="flex w-2/12 self-center">
-                        <div className="text-sm w-full text-gray-400 truncate">
-                            {dayjs(p.project.creationTime).fromNow()}
-                        </div>
+                        <Tooltip content={dayjs(p.project.creationTime).format("MMM D, YYYY")}>
+                            <div className="text-sm w-full text-gray-400 truncate">
+                                {dayjs(p.project.creationTime).fromNow()}
+                            </div>
+                        </Tooltip>
                     </div>
                 </div>
             </Link>

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -15,6 +15,7 @@ import { getGitpodService } from "../service/service";
 import { AdminPageHeader } from "./AdminPageHeader";
 import UserDetail from "./UserDetail";
 import searchIcon from "../icons/search.svg";
+import Tooltip from "../components/Tooltip";
 
 export default function UserSearch() {
     const location = useLocation();
@@ -144,7 +145,11 @@ function UserEntry(p: { user: User }) {
                     </div>
                 </div>
                 <div className="flex w-5/12 self-center">
-                    <div className="text-sm w-full text-gray-400 truncate">{dayjs(p.user.creationDate).fromNow()}</div>
+                    <Tooltip content={dayjs(p.user.creationDate).format("MMM D, YYYY")}>
+                        <div className="text-sm w-full text-gray-400 truncate">
+                            {dayjs(p.user.creationDate).fromNow()}
+                        </div>
+                    </Tooltip>
                 </div>
             </div>
         </Link>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -29,6 +29,7 @@ import { isGitpodIo } from "../utils";
 import { SpinnerLoader } from "../components/Loader";
 import { WorkspaceStatusIndicator } from "../workspaces/WorkspaceStatusIndicator";
 import searchIcon from "../icons/search.svg";
+import Tooltip from "../components/Tooltip";
 
 interface Props {
     user?: User;
@@ -192,9 +193,13 @@ function WorkspaceEntry(p: { ws: WorkspaceAndInstance }) {
                     </div>
                 </div>
                 <div className="flex w-2/12 self-center">
-                    <div className="text-sm w-full text-gray-400 truncate">
-                        {dayjs(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).fromNow()}
-                    </div>
+                    <Tooltip
+                        content={dayjs(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).format("MMM D, YYYY")}
+                    >
+                        <div className="text-sm w-full text-gray-400 truncate">
+                            {dayjs(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).fromNow()}
+                        </div>
+                    </Tooltip>
                 </div>
             </div>
         </Link>

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -23,6 +23,7 @@ import { Disposable } from "vscode-jsonrpc";
 import { useCurrentProject } from "./project-context";
 import { getProjectTabs } from "./projects.routes";
 import search from "../icons/search.svg";
+import Tooltip from "../components/Tooltip";
 
 export default function PrebuildsPage(props: { project?: Project; isAdminDashboard?: boolean }) {
     const currentProject = useCurrentProject();
@@ -222,7 +223,9 @@ export default function PrebuildsPage(props: { project?: Project; isAdminDashboa
                                                         alt={p.info.startedBy}
                                                     />
                                                 )}
-                                                Triggered {formatDate(p.info.startedAt)}
+                                                <Tooltip content={dayjs(p.info.startedAt).format("MMM D, YYYY")}>
+                                                    Triggered {formatDate(p.info.startedAt)}
+                                                </Tooltip>
                                             </p>
                                         </div>
                                     </ItemField>

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -24,6 +24,7 @@ import { useCurrentProject } from "./project-context";
 import { getProjectTabs } from "./projects.routes";
 import { shortCommitMessage, toRemoteURL } from "./render-utils";
 import search from "../icons/search.svg";
+import Tooltip from "../components/Tooltip";
 
 export default function ProjectsPage() {
     const history = useHistory();
@@ -334,10 +335,21 @@ export default function ProjectsPage() {
                                                         <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">
                                                             {shortCommitMessage(branch.changeTitle)}
                                                         </div>
-                                                        <p>
-                                                            {avatar}Authored {formatDate(branch.changeDate)} ·{" "}
-                                                            {branch.changeHash?.substring(0, 8)}
-                                                        </p>
+                                                        {branch.changeDate ? (
+                                                            <Tooltip
+                                                                content={dayjs(branch.changeDate).format("MMM D, YYYY")}
+                                                            >
+                                                                <p>
+                                                                    {avatar}Authored {formatDate(branch.changeDate)} ·{" "}
+                                                                    {branch.changeHash?.substring(0, 8)}
+                                                                </p>
+                                                            </Tooltip>
+                                                        ) : (
+                                                            <p>
+                                                                {avatar}Authored {formatDate(branch.changeDate)} ·{" "}
+                                                                {branch.changeHash?.substring(0, 8)}
+                                                            </p>
+                                                        )}
                                                     </div>
                                                 </ItemField>
                                                 <ItemField className="flex items-center my-auto">

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -16,6 +16,7 @@ import { gitpodHostUrl } from "../service/service";
 import { useLatestProjectPrebuildQuery } from "../data/prebuilds/latest-project-prebuild-query";
 import { StartWorkspaceModalContext } from "../workspaces/start-workspace-modal-context";
 import { useNewCreateWorkspacePage } from "../workspaces/CreateWorkspacePage";
+import Tooltip from "../components/Tooltip";
 
 type ProjectListItemProps = {
     project: Project;
@@ -102,9 +103,11 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                                 {prebuild?.info?.branch}
                             </div>
                             <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">·</span>
-                            <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">
-                                {dayjs(prebuild?.info?.startedAt).fromNow()}
-                            </div>
+                            <Tooltip content={dayjs(prebuild?.info?.startedAt).format("MMM D, YYYY")}>
+                                <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">
+                                    {dayjs(prebuild?.info?.startedAt).fromNow()}
+                                </div>
+                            </Tooltip>
                         </Link>
                         <Link
                             to={`/projects/${Project.slug(project!)}/prebuilds`}

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -187,7 +187,9 @@ export default function MembersPage() {
                                     </div>
                                 </ItemField>
                                 <ItemField className="my-auto">
-                                    <span className="text-gray-400">{dayjs(m.memberSince).fromNow()}</span>
+                                    <Tooltip content={dayjs(m.memberSince).format("MMM D, YYYY")}>
+                                        <span className="text-gray-400">{dayjs(m.memberSince).fromNow()}</span>
+                                    </Tooltip>
                                 </ItemField>
                                 <ItemField className="flex items-center my-auto">
                                     <span className="text-gray-400 capitalize">


### PR DESCRIPTION
## Description
- Display the `absolute time` in a tooltip when using the `relative date and time` format.

|_**Before**_|_**After**_|
|-------------|------------|
|![Screenshot (388)](https://user-images.githubusercontent.com/76192403/213012926-a0cc10fd-7f65-492b-acef-41faf40cb9f9.png)|![image](https://user-images.githubusercontent.com/76192403/213013095-d2dc332d-91a9-4234-96f2-3bd6df4d367b.png)|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13764 

## How to test
<!-- Provide steps to test this PR -->
- Hover mouse over any `relative date and time` format.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Display a tolltip with absolute date when using relative date format
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
