### PR TITLE
[workspaces] move workspace to other orgs

### DIFF
--- a/components/dashboard/src/data/workspaces/list-workspaces-query.ts
+++ b/components/dashboard/src/data/workspaces/list-workspaces-query.ts
@@ -5,7 +5,7 @@
  */
 
 import { WorkspaceInfo } from "@gitpod/gitpod-protocol";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { useCurrentUser } from "../../user-context";
@@ -58,4 +58,9 @@ export const useListWorkspacesQuery = ({ limit }: UseListWorkspacesQueryArgs) =>
     });
 };
 
-export const getListWorkspacesQueryKey = (orgId?: string) => ["workspaces", "list", orgId || "noorg"];
+export function getListWorkspacesQueryKey(orgId?: string) {
+    if (!orgId) {
+        return ["workspaces", "list"];
+    }
+    return ["workspaces", "list", orgId];
+}

--- a/components/dashboard/src/data/workspaces/move-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/move-workspace-mutation.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
+
+type MoveWorkspaceMutationArgs = {
+    workspaceId: string;
+    targetOrganizationId: string;
+};
+
+export const useMoveWorkspaceMutation = () => {
+    const queryClient = useQueryClient();
+    const currentOrg = useCurrentOrg();
+
+    return useMutation({
+        mutationFn: async (args: MoveWorkspaceMutationArgs) => {
+            return await getGitpodService().server.moveWorkspace(args.workspaceId, args.targetOrganizationId);
+        },
+        onSuccess: (_, { workspaceId }) => {
+            // Update workspaces list immediately
+            queryClient.setQueryData<ListWorkspacesQueryResult>(
+                getListWorkspacesQueryKey(currentOrg.data?.id),
+                (oldWorkspaceData) => {
+                    return oldWorkspaceData?.filter((info) => info.workspace.id === workspaceId);
+                },
+            );
+
+            queryClient.invalidateQueries({ queryKey: getListWorkspacesQueryKey() });
+        },
+    });
+};

--- a/components/dashboard/src/workspaces/MoveWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/MoveWorkspaceModal.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Organization, Workspace } from "@gitpod/gitpod-protocol";
+import { FunctionComponent, useState } from "react";
+import { DropDown2 } from "../components/DropDown2";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
+import { OrgIcon } from "../components/org-icon/OrgIcon";
+import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
+import { useMoveWorkspaceMutation } from "../data/workspaces/move-workspace-mutation";
+import { useCurrentUser } from "../user-context";
+
+type Props = {
+    workspace: Workspace;
+    onClose(): void;
+};
+
+export function useCanMoveWorkspace(): boolean {
+    const user = useCurrentUser();
+    const currentOrg = useCurrentOrg();
+    const orgs = useOrganizations();
+    return !!(
+        orgs.data &&
+        orgs.data.length > 1 &&
+        currentOrg.data?.members.some((m) => m.userId === user?.id && m.role === "owner")
+    );
+}
+
+export const MoveWorkspaceModal: FunctionComponent<Props> = ({ workspace, onClose }) => {
+    const orgs = useOrganizations();
+    const currentOrg = useCurrentOrg();
+    const [targetOrganizationId, setTargetOrganizationId] = useState(workspace.description || "");
+    const moveWorkspaceMutation = useMoveWorkspaceMutation();
+
+    const selectableOrgs = orgs.data?.filter((org) => org.id !== currentOrg.data?.id) || [];
+
+    const moveWorkspace = async () => {
+        try {
+            await moveWorkspaceMutation.mutateAsync({ workspaceId: workspace.id, targetOrganizationId });
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return (
+        <Modal
+            visible
+            onClose={onClose}
+            onEnter={async () => {
+                await moveWorkspace();
+                return true;
+            }}
+        >
+            <ModalHeader>Move Workspace</ModalHeader>
+            <ModalBody noScroll={true}>
+                <DropDown2
+                    getElements={() =>
+                        selectableOrgs.map((o) => {
+                            return {
+                                id: o.id,
+                                element: renderOrganization(o),
+                                isSelectable: true,
+                            };
+                        })
+                    }
+                    onSelectionChange={setTargetOrganizationId}
+                    searchPlaceholder="Select Target Organization"
+                    disableSearch={true}
+                >
+                    {renderOrganization(orgs.data?.find((o) => o.id === targetOrganizationId))}
+                </DropDown2>
+                <div className="mt-3 py-2 whitespace-normal">
+                    <p className="text-gray-500">This moves the workspace to the selected organization.</p>
+                    <p className="text-gray-500">
+                        Please note, that past workspace sessions are not moved and are still listed as usage of the
+                        current organization.
+                    </p>
+                </div>
+            </ModalBody>
+            <ModalFooter>
+                <button disabled={moveWorkspaceMutation.isLoading} className="secondary" onClick={onClose}>
+                    Cancel
+                </button>
+                <button
+                    disabled={moveWorkspaceMutation.isLoading}
+                    className="ml-2"
+                    type="submit"
+                    onClick={async () => {
+                        await moveWorkspace();
+                        onClose();
+                    }}
+                >
+                    Move Workspace
+                </button>
+            </ModalFooter>
+        </Modal>
+    );
+};
+
+function renderOrganization(o?: Organization) {
+    return (
+        <div className="px-2 py-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
+            {o ? (
+                <>
+                    <OrgIcon id={o?.id} name={o.name} size="small" className="mr-2" />
+                    {o.name}
+                </>
+            ) : (
+                <>Select target organization</>
+            )}
+        </div>
+    );
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -134,6 +134,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     setWorkspaceDescription(id: string, desc: string): Promise<void>;
     controlAdmission(id: string, level: GitpodServer.AdmissionLevel): Promise<void>;
     resolveContext(contextUrl: string): Promise<WorkspaceContext>;
+    moveWorkspace(workspaceId: string, targetOrganizationId: string): Promise<void>;
 
     updateWorkspaceUserPin(id: string, action: GitpodServer.PinAction): Promise<void>;
     sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -76,6 +76,7 @@ const defaultFunctions: FunctionsConfig = {
     startWorkspace: { group: "startWorkspace", points: 1 },
     stopWorkspace: { group: "default", points: 1 },
     deleteWorkspace: { group: "default", points: 1 },
+    moveWorkspace: { group: "default", points: 1 },
     setWorkspaceDescription: { group: "default", points: 1 },
     controlAdmission: { group: "default", points: 1 },
     updateWorkspaceUserPin: { group: "default", points: 1 },


### PR DESCRIPTION
## Description
Allow users to move their workspace to other orgs they are a member of.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-move-ws</li>
	<li><b>🔗 URL</b> - <a href="https://se-move-ws.preview.gitpod-dev.com/workspaces" target="_blank">se-move-ws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-155

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow moving workspaces to other organizations
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
