### PR TITLE
`experimental` IDEs feature flag

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -5,10 +5,11 @@
  */
 
 import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { DropDown2, DropDown2Element } from "./DropDown2";
 import Editor from "../icons/Editor.svg";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 interface SelectIDEComponentProps {
     selectedIdeOption?: string;
@@ -17,8 +18,16 @@ interface SelectIDEComponentProps {
     setError?: (error?: string) => void;
 }
 
+function filteredIdeOptions(ideOptions: IDEOptions, experimentalTurnedOn: boolean) {
+    return IDEOptions.asArray(ideOptions)
+        .filter((x) => !x.hidden)
+        .filter((x) => (x.experimental ? experimentalTurnedOn : true));
+}
+
 export default function SelectIDEComponent(props: SelectIDEComponentProps) {
     const [ideOptions, setIdeOptions] = useState<IDEOptions>();
+    const { experimentalIdes } = useContext(FeatureFlagContext);
+
     useEffect(() => {
         getGitpodService().server.getIDEOptions().then(setIdeOptions);
     }, []);
@@ -27,7 +36,7 @@ export default function SelectIDEComponent(props: SelectIDEComponentProps) {
             if (!ideOptions) {
                 return [];
             }
-            const options = IDEOptions.asArray(ideOptions);
+            const options = filteredIdeOptions(ideOptions, experimentalIdes);
             const result: DropDown2Element[] = [];
             for (const ide of options.filter((ide) =>
                 `${ide.label}${ide.title}${ide.notes}${ide.id}`.toLowerCase().includes(search.toLowerCase()),
@@ -48,7 +57,7 @@ export default function SelectIDEComponent(props: SelectIDEComponentProps) {
             }
             return result;
         },
-        [ideOptions, props.useLatest],
+        [experimentalIdes, ideOptions, props.useLatest],
     );
     const internalOnSelectionChange = (id: string) => {
         const { ide, useLatest } = parseId(id);

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -31,6 +31,7 @@ const defaultFeatureFlags = {
     userGitAuthProviders: false,
     newSignupFlow: false,
     linkedinConnectionForOnboarding: false,
+    experimentalIdes: false,
 };
 
 const FeatureFlagContext = createContext<FeatureFlagsType>(defaultFeatureFlags);
@@ -51,6 +52,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [userGitAuthProviders, setUserGitAuthProviders] = useState<boolean>(false);
     const [newSignupFlow, setNewSignupFlow] = useState<boolean>(false);
     const [linkedinConnectionForOnboarding, setLinkedinConnectionForOnboarding] = useState<boolean>(false);
+    const [experimentalIdes, setExperimentalIdes] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -71,6 +73,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 userGitAuthProviders: { defaultValue: false, setter: setUserGitAuthProviders },
                 newSignupFlow: { defaultValue: false, setter: setNewSignupFlow },
                 linkedinConnectionForOnboarding: { defaultValue: false, setter: setLinkedinConnectionForOnboarding },
+                experimentalIdes: { defaultValue: false, setter: setExperimentalIdes },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -120,6 +123,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
             userGitAuthProviders,
             newSignupFlow,
             linkedinConnectionForOnboarding,
+            experimentalIdes,
         };
     }, [
         enablePersonalAccessTokens,
@@ -133,6 +137,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         startWithOptions,
         usePublicApiWorkspacesService,
         userGitAuthProviders,
+        experimentalIdes,
     ]);
 
     return <FeatureFlagContext.Provider value={flags}>{children}</FeatureFlagContext.Provider>;

--- a/components/gitpod-protocol/src/ide-protocol.ts
+++ b/components/gitpod-protocol/src/ide-protocol.ts
@@ -106,6 +106,11 @@ export interface IDEOption {
     hidden?: boolean;
 
     /**
+     * If `true` this IDE option is conditionally shown in the IDE preferences
+     */
+    experimental?: boolean;
+
+    /**
      * The image ref to the IDE image.
      */
     image: string;

--- a/components/ide-service-api/go/config/ideconfig.go
+++ b/components/ide-service-api/go/config/ideconfig.go
@@ -44,6 +44,8 @@ type IDEOption struct {
 	Notes []string `json:"notes,omitempty"`
 	// Hidden this IDE option is not visible in the IDE preferences.
 	Hidden bool `json:"hidden,omitempty"`
+	// Experimental this IDE option is to only be shown to some users
+	Experimental bool `json:"experimental,omitempty"`
 	// Image ref to the IDE image.
 	Image string `json:"image"`
 	// LatestImage ref to the IDE image, this image ref always resolve to digest.

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -88,6 +88,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					ImageLayers:       []string{codeWebExtensionImage, codeHelperImage},
 					LatestImage:       resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
 					LatestImageLayers: []string{codeWebExtensionImage, codeHelperImage},
+					Experimental:      true,
 				},
 				codeDesktop: {
 					OrderKey:    "02",


### PR DESCRIPTION
## Description
Introduces a new feature flag which enables IDEs to be optionally marked as `experimental`. When an IDE is `experimental`, it will only show to users whose ConfigCat response for `experimentalIdes` returns true. 

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-experi28316dc360</li>
	<li><b>🔗 URL</b> - <a href="https://ide-experi28316dc360.preview.gitpod-dev.com/workspaces" target="_blank">ide-experi28316dc360.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Related Issue(s)

Needed to introduce https://github.com/gitpod-io/gitpod/pull/17196.

## How to test
- In the preview environment, the VS Code Browser option should not be available, unless you add yourself to the corresponding ConfigCat flag -- `experimentalIdes` in [our non-prod ConfigCat](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853). 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
