### PR TITLE
[installer] Remove chargebee refs - WEB-144

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -266,17 +266,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"shareSnapshot":    {Group: "inWorkspaceUserAction"},
 			},
 		},
-		ContentServiceAddr:           common.ClusterAddress(contentservice.Component, ctx.Namespace, contentservice.RPCPort),
-		UsageServiceAddr:             common.ClusterAddress(usage.Component, ctx.Namespace, usage.GRPCServicePort),
-		IDEServiceAddr:               common.ClusterAddress(ideservice.Component, ctx.Namespace, ideservice.GRPCServicePort),
-		MaximumEventLoopLag:          0.35,
-		CodeSync:                     CodeSync{},
-		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
-		EnablePayment:                stripeSecret != "" || stripeConfig != "",
-		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
-		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeSecretMountPath),
-		LinkedInSecretsFile:          fmt.Sprintf("%s/linkedin", linkedInSecretMountPath),
-		InsecureNoDomain:             false,
+		ContentServiceAddr:  common.ClusterAddress(contentservice.Component, ctx.Namespace, contentservice.RPCPort),
+		UsageServiceAddr:    common.ClusterAddress(usage.Component, ctx.Namespace, usage.GRPCServicePort),
+		IDEServiceAddr:      common.ClusterAddress(ideservice.Component, ctx.Namespace, ideservice.GRPCServicePort),
+		MaximumEventLoopLag: 0.35,
+		CodeSync:            CodeSync{},
+		VSXRegistryUrl:      fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
+		EnablePayment:       stripeSecret != "" || stripeConfig != "",
+		StripeSecretsFile:   fmt.Sprintf("%s/apikeys", stripeSecretMountPath),
+		LinkedInSecretsFile: fmt.Sprintf("%s/linkedin", linkedInSecretMountPath),
+		InsecureNoDomain:    false,
 		PrebuildLimiter: PrebuildRateLimiters{
 			// default limit for all cloneURLs
 			"*": PrebuildRateLimiterConfig{

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -14,7 +14,6 @@ const (
 	ContainerPortName                      = "http"
 	authProviderFilePath                   = "/gitpod/auth-providers"
 	licenseFilePath                        = "/gitpod/license"
-	chargebeeMountPath                     = "/chargebee"
 	stripeSecretMountPath                  = "/stripe-secret"
 	linkedInSecretMountPath                = "/linkedin-secret"
 	githubAppCertSecret                    = "github-app-cert-secret"

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -33,7 +33,6 @@ type ConfigSerialized struct {
 	IDEServiceAddr                    string     `json:"ideServiceAddr"`
 	MaximumEventLoopLag               float64    `json:"maximumEventLoopLag"`
 	VSXRegistryUrl                    string     `json:"vsxRegistryUrl"`
-	ChargebeeProviderOptionsFile      string     `json:"chargebeeProviderOptionsFile"`
 	StripeSecretsFile                 string     `json:"stripeSecretsFile"`
 	StripeConfigFile                  string     `json:"stripeConfigFile"`
 	EnablePayment                     bool       `json:"enablePayment"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -256,7 +256,6 @@ type ServerConfig struct {
 	OAuthServer                       OAuthServer       `json:"oauthServer"`
 	Session                           Session           `json:"session"`
 	GithubApp                         *GithubApp        `json:"githubApp"`
-	_                                 string            `json:"chargebeeSecret"`
 	StripeSecret                      string            `json:"stripeSecret"`
 	StripeConfig                      string            `json:"stripeConfig"`
 	LinkedInSecret                    string            `json:"linkedInSecret"`

--- a/install/installer/pkg/config/versions/versions.go
+++ b/install/installer/pkg/config/versions/versions.go
@@ -33,7 +33,6 @@ type Components struct {
 	InstallationTelemetry Versioned `json:"installationTelemetry"`
 	IntegrationTests      Versioned `json:"integrationTests"`
 	OpenVSXProxy          Versioned `json:"openVSXProxy"`
-	PaymentEndpoint       Versioned `json:"paymentEndpoint"`
 	Proxy                 Versioned `json:"proxy"`
 	PublicAPIServer       Versioned `json:"public-api-server"`
 	RefreshCredential     Versioned `json:"refreshCredential"`

--- a/install/installer/pkg/config/versions/versions.go
+++ b/install/installer/pkg/config/versions/versions.go
@@ -33,6 +33,7 @@ type Components struct {
 	InstallationTelemetry Versioned `json:"installationTelemetry"`
 	IntegrationTests      Versioned `json:"integrationTests"`
 	OpenVSXProxy          Versioned `json:"openVSXProxy"`
+	PaymentEndpoint       Versioned `json:"paymentEndpoint"`
 	Proxy                 Versioned `json:"proxy"`
 	PublicAPIServer       Versioned `json:"public-api-server"`
 	RefreshCredential     Versioned `json:"refreshCredential"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
