### PR TITLE
[server] Remove chargebee config reading WEB-144

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -11,7 +11,7 @@ import { NamedWorkspaceFeatureFlag } from "@gitpod/gitpod-protocol";
 
 import { RateLimiterConfig } from "./auth/rate-limiter";
 import { CodeSyncConfig } from "./code-sync/code-sync-service";
-import { ChargebeeProviderOptions, readOptionsFromFile } from "@gitpod/gitpod-payment-endpoint/lib/chargebee";
+import { ChargebeeProviderOptions } from "@gitpod/gitpod-payment-endpoint/lib/chargebee";
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -23,7 +23,6 @@ export const Config = Symbol("Config");
 export type Config = Omit<
     ConfigSerialized,
     | "hostUrl"
-    | "chargebeeProviderOptionsFile"
     | "stripeSecretsFile"
     | "stripeConfigFile"
     | "linkedInSecretsFile"
@@ -220,7 +219,6 @@ export interface ConfigSerialized {
     /**
      * Payment related options
      */
-    chargebeeProviderOptionsFile?: string;
     stripeSecretsFile?: string;
     stripeConfigFile?: string;
     enablePayment?: boolean;
@@ -317,9 +315,7 @@ export namespace ConfigFile {
         authProviderConfigs = normalizeAuthProviderParams(authProviderConfigs);
 
         const builtinAuthProvidersConfigured = authProviderConfigs.length > 0;
-        const chargebeeProviderOptions = readOptionsFromFile(
-            filePathTelepresenceAware(config.chargebeeProviderOptionsFile || ""),
-        );
+
         let stripeSecrets: { publishableKey: string; secretKey: string } | undefined;
         if (config.enablePayment && config.stripeSecretsFile) {
             try {
@@ -397,7 +393,6 @@ export namespace ConfigFile {
             hostUrl,
             authProviderConfigs,
             builtinAuthProvidersConfigured,
-            chargebeeProviderOptions,
             stripeSecrets,
             linkedInSecrets,
             twilioConfig,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
