### PR TITLE
[server] Remove reading of license file - WEB-171

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -22,13 +22,7 @@ import { PrebuildRateLimiters } from "./workspace/prebuild-rate-limiter";
 export const Config = Symbol("Config");
 export type Config = Omit<
     ConfigSerialized,
-    | "hostUrl"
-    | "stripeSecretsFile"
-    | "stripeConfigFile"
-    | "linkedInSecretsFile"
-    | "licenseFile"
-    | "patSigningKeyFile"
-    | "auth"
+    "hostUrl" | "stripeSecretsFile" | "stripeConfigFile" | "linkedInSecretsFile" | "patSigningKeyFile" | "auth"
 > & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
@@ -108,10 +102,6 @@ export interface ConfigSerialized {
     installationShortname: string;
     devBranch?: string;
     insecureNoDomain: boolean;
-
-    // Use one or other - licenseFile reads from a file and populates license
-    license?: string;
-    licenseFile?: string;
 
     workspaceHeartbeat: {
         intervalSeconds: number;
@@ -336,11 +326,7 @@ export namespace ConfigFile {
                 log.error("Could not load LinkedIn secrets", error);
             }
         }
-        let license = config.license;
-        const licenseFile = config.licenseFile;
-        if (licenseFile) {
-            license = fs.readFileSync(filePathTelepresenceAware(licenseFile), "utf-8");
-        }
+
         let inactivityPeriodForReposInDays: number | undefined;
         if (typeof config.inactivityPeriodForReposInDays === "number") {
             if (config.inactivityPeriodForReposInDays >= 1) {
@@ -396,7 +382,6 @@ export namespace ConfigFile {
             stripeSecrets,
             linkedInSecrets,
             twilioConfig,
-            license,
             workspaceGarbageCollection: {
                 ...config.workspaceGarbageCollection,
                 startDate: config.workspaceGarbageCollection.startDate


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
