### PR TITLE
[server] use options from last instances on start

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -318,11 +318,11 @@ export interface EmailNotificationSettings {
 export type IDESettings = {
     settingVersion?: string;
     defaultIde?: string;
+    useLatestVersion?: boolean;
     // DEPRECATED: Use defaultIde after `settingVersion: 2.0`, no more specialify desktop or browser.
     useDesktopIde?: boolean;
     // DEPRECATED: Same with useDesktopIde.
     defaultDesktopIde?: string;
-    useLatestVersion?: boolean;
 };
 
 export interface WorkspaceClasses {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This change makes the workspace start reusing what has been used for IDE and workspace class on the previous workspace instance.

I think this change can land on its own. In a larger second PR we would allow users to start an existing workspace with options, so users can change/override what IDE and workspace class to use on subsequent workspace starts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-189

## How to test
<!-- Provide steps to test this PR -->

Create a workspace with non default IDE and was class. Stop the workspace and restart it. It should still use the previously selected IDE and class.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-start-ws-options</li>
	<li><b>🔗 URL</b> - <a href="https://se-start-ws-options.preview.gitpod-dev.com/workspaces" target="_blank">se-start-ws-options.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
