### PR TITLE
Fix IDE integration test

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
               with:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
-                  infrastructure_provider: harvester
+                  infrastructure_provider: gce
                   large_vm: true
             - name: Deploy Gitpod to the preview environment
               id: deploy-gitpod
@@ -103,6 +103,9 @@ jobs:
                   USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
                   PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
                   PREVIEW_NAME: ${{ needs.configuration.outputs.name }}
+                  TEST_BUILD_ID: ${{ github.run_id }}
+                  TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes integration test, because it missing some params. And also change `infrastructure_provider` to gce, make test more stable

```
    gateway_test.go:178: POST https://api.github.com/repos/gitpod-io/gitpod/actions/workflows/jetbrains-integration-test.yml/dispatches: 422 No ref found for:  []

```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
