### PR TITLE
[dashboard] Remove superfluous usage_view feature flag

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -20,7 +20,6 @@ type FeatureFlagsType = {
 
 const defaultFeatureFlags = {
     startWithOptions: false,
-    showUsageView: false,
     showUseLastSuccessfulPrebuild: false,
     usePublicApiWorkspacesService: false,
     enablePersonalAccessTokens: false,
@@ -40,7 +39,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const { project } = useContext(ProjectContext);
     const currentOrg = useCurrentOrg();
     const [startWithOptions, setStartWithOptions] = useState<boolean>(false);
-    const [showUsageView, setShowUsageView] = useState<boolean>(false);
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
     const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
@@ -55,7 +53,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         (async () => {
             const featureFlags: FeatureFlagConfig = {
                 start_with_options: { defaultValue: false, setter: setStartWithOptions },
-                usage_view: { defaultValue: false, setter: setShowUsageView },
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
                 publicApiExperimentalWorkspaceService: {
@@ -107,7 +104,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const flags = useMemo(() => {
         return {
             startWithOptions,
-            showUsageView,
             showUseLastSuccessfulPrebuild,
             enablePersonalAccessTokens,
             usePublicApiWorkspacesService,
@@ -123,7 +119,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         newSignupFlow,
         oidcServiceEnabled,
         orgGitAuthProviders,
-        showUsageView,
         showUseLastSuccessfulPrebuild,
         startWithOptions,
         usePublicApiWorkspacesService,

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -10,7 +10,6 @@ import { OrgIcon, OrgIconProps } from "../components/org-icon/OrgIcon";
 import { useCurrentUser } from "../user-context";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
-import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useLocation } from "react-router";
@@ -23,7 +22,6 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
     const currentOrg = useCurrentOrg();
     const { data: userBillingMode } = useUserBillingMode();
     const { data: orgBillingMode } = useOrgBillingMode();
-    const { showUsageView } = useFeatureFlags();
     const getOrgURL = useGetOrgURL();
 
     const userFullName = user?.fullName || user?.name || "...";
@@ -74,7 +72,7 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
         BillingMode.showUsageBasedBilling(userBillingMode) &&
         !user?.additionalData?.isMigratedToTeamOnlyAttribution;
 
-    const showUsageForOrg = currentOrg.data?.isOwner && (orgBillingMode?.mode === "usage-based" || showUsageView);
+    const showUsageForOrg = currentOrg.data?.isOwner && orgBillingMode?.mode === "usage-based";
 
     if (showUsageForPersonalAccount || showUsageForOrg) {
         linkEntries.push({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-184

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
