### PR TITLE
[db] Purge all Chargebee-related DB tables

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -82,22 +82,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: "deleted",
         },
         {
-            name: "d_b_account_entry",
-            primaryKeys: ["uid"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_subscription",
-            primaryKeys: ["uid"],
-            timeColumn: "_lastModified",
-            dependencies: ["d_b_user"],
-        },
-        {
-            name: "d_b_subscription_additional_data",
-            primaryKeys: ["paymentReference"],
-            timeColumn: "lastModified",
-        },
-        {
             name: "d_b_identity",
             primaryKeys: ["authProviderId", "authId"],
             timeColumn: "_lastModified",
@@ -163,16 +147,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             name: "d_b_token_entry",
             primaryKeys: ["uid"],
             deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_team_subscription",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_team_subscription_slot",
-            primaryKeys: ["id"],
             timeColumn: "_lastModified",
         },
         {
@@ -257,12 +231,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
         {
             name: "d_b_project_usage",
             primaryKeys: ["projectId"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_team_subscription2",
-            primaryKeys: ["id"],
             deletionColumn: "deleted",
             timeColumn: "_lastModified",
         },

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -64,12 +64,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_pending_github_event",
-            primaryKeys: ["id"],
-            timeColumn: "creationDate",
-            deletionColumn: "deleted",
-        },
-        {
             name: "d_b_volume_snapshot",
             primaryKeys: ["id"],
             timeColumn: "_lastModified",

--- a/components/gitpod-db/src/typeorm/migration/1681829114367-DropChargebeeSubscriptionTables.ts
+++ b/components/gitpod-db/src/typeorm/migration/1681829114367-DropChargebeeSubscriptionTables.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class DropChargebeeSubscriptionTables1681829114367 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_account_entry`");
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_subscription`");
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_team_subscription`");
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_team_subscription_slot`");
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_team_subscription2`");
+        if (await columnExists(queryRunner, "d_b_team_membership", "subscriptionId")) {
+            await queryRunner.query("ALTER TABLE `d_b_team_membership` DROP COLUMN `subscriptionId`");
+        }
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_subscription_additional_data`");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_account_entry (  id int(11) DEFAULT NULL,  userId char(36) NOT NULL,  amount double NOT NULL,  date varchar(255) NOT NULL,  expiryDate varchar(255) NOT NULL DEFAULT '',  kind char(7) NOT NULL,  description text,  uid char(36) NOT NULL,  creditId char(36) DEFAULT NULL,  _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  PRIMARY KEY (uid),  KEY ind_dbsync (_lastModified),  KEY ind_expiryDate (expiryDate)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_subscription (  id int(11) DEFAULT NULL,  userId char(36) NOT NULL,  startDate varchar(255) NOT NULL,  endDate varchar(255) NOT NULL DEFAULT '',  amount double NOT NULL,  uid char(36) NOT NULL,  _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  planId varchar(255) NOT NULL DEFAULT 'free',  paymentReference varchar(255) NOT NULL DEFAULT '',  deleted tinyint(4) NOT NULL DEFAULT '0',  cancellationDate varchar(255) NOT NULL DEFAULT '',  paymentData text,  teamSubscriptionSlotId char(255) NOT NULL DEFAULT '',  firstMonthAmount double DEFAULT NULL, teamMembershipId char(36) NOT NULL DEFAULT '',  PRIMARY KEY (uid),  KEY ind_user_paymentReference (userId,paymentReference),  KEY ind_dbsync (_lastModified),  KEY ind_planId (planId)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_team_subscription (  id varchar(255) NOT NULL,  userId char(36) NOT NULL,  paymentReference varchar(255) NOT NULL,  startDate varchar(255) NOT NULL,  endDate varchar(255) NOT NULL DEFAULT '',  planId varchar(255) NOT NULL,  quantity int(11) NOT NULL,  cancellationDate varchar(255) NOT NULL DEFAULT '',  deleted tinyint(4) NOT NULL DEFAULT '0',  _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  PRIMARY KEY (id),  KEY ind_user_paymentReference (userId,paymentReference),  KEY ind_user_startDate (userId,startDate),  KEY ind_dbsync (_lastModified)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_team_subscription_slot (  id char(36) NOT NULL,  teamSubscriptionId char(36) NOT NULL,  assigneeId char(36) NOT NULL DEFAULT '',  assigneeIdentifier text,  subscriptionId char(36) NOT NULL DEFAULT '',  cancellationDate varchar(255) NOT NULL DEFAULT '',  _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  PRIMARY KEY (id),  KEY ind_tsid (teamSubscriptionId),  KEY ind_dbsync (_lastModified)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_team_subscription2` (`id` char(36) NOT NULL, `teamId` char(36) NOT NULL, `paymentReference` varchar(255) NOT NULL, `startDate` varchar(255) NOT NULL, `endDate` varchar(255) NOT NULL DEFAULT '', `planId` varchar(255) NOT NULL, `quantity` int(11) NOT NULL, `cancellationDate` varchar(255) NOT NULL DEFAULT '', `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`), KEY `ind_team_paymentReference` (`teamId`, `paymentReference`), KEY `ind_team_startDate` (`teamId`, `startDate`), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+        );
+        if (!(await columnExists(queryRunner, "d_b_team_membership", "subscriptionId"))) {
+            await queryRunner.query(
+                "ALTER TABLE `d_b_team_membership` ADD COLUMN `subscriptionId` char(36) NOT NULL DEFAULT ''",
+            );
+        }
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_subscription_additional_data (  paymentReference varchar(255) NOT NULL,  mrr int(11) NOT NULL,  coupons text,  lastInvoiceAmount int(11) NOT NULL,  nextBilling varchar(255) NOT NULL DEFAULT '',  lastInvoice varchar(255) NOT NULL DEFAULT '',  lastUpdated varchar(255) NOT NULL DEFAULT '',  lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  PRIMARY KEY (paymentReference)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1681829127935-DropPendingGitHubEvents.ts
+++ b/components/gitpod-db/src/typeorm/migration/1681829127935-DropPendingGitHubEvents.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropPendingGitHubEvents1681829127935 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_pending_github_event`");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS d_b_pending_github_event (  id char(36) NOT NULL,  githubUserId varchar(36) NOT NULL,  creationDate timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),  type varchar(128) NOT NULL,  event text, deleted tinyint(4) NOT NULL DEFAULT '0',  PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`,
+        );
+    }
+}


### PR DESCRIPTION
## Description

Removes all (now unused) Chargebee-related DB models and DB tables. Let's wait with merging for a couple of hours.

## Related Issue(s)
Depends on https://github.com/gitpod-io/gitpod/pull/17287 to be rolled out.
Fixes WEB-147

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
