### PR TITLE
[server] fix prebuild organizationId

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -174,7 +174,7 @@ export class PrebuildManager {
                     }
                 }
             }
-            if (project && context.ref && !project.settings?.keepOutdatedPrebuildsRunning) {
+            if (context.ref && !project.settings?.keepOutdatedPrebuildsRunning) {
                 try {
                     await this.abortPrebuildsForBranch({ span }, project, user, context.ref);
                 } catch (e) {
@@ -222,17 +222,10 @@ export class PrebuildManager {
                 }
             }
 
-            let organizationId = (await this.teamDB.findTeamById(project.id))?.id;
-            if (!user.additionalData?.isMigratedToTeamOnlyAttribution) {
-                // If the user is not migrated to team-only attribution, we retrieve the organization from the attribution logic.
-                const attributionId = await this.userService.getWorkspaceUsageAttributionId(user, project.id);
-                organizationId = attributionId.kind === "team" ? attributionId.teamId : undefined;
-            }
-
             const workspace = await this.workspaceFactory.createForContext(
                 { span },
                 user,
-                organizationId,
+                project.teamId,
                 project,
                 prebuildContext,
                 context.normalizedContextURL!,


### PR DESCRIPTION
## Description
The logic to retrieve organizationId on prebuilds was broken.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-85

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-prebuild-orgid</li>
	<li><b>🔗 URL</b> - <a href="https://se-prebuild-orgid.preview.gitpod-dev.com/workspaces" target="_blank">se-prebuild-orgid.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
