### PR TITLE
[dashboard] Always use these options for repository

### DIFF
--- a/components/dashboard/src/start/start-workspace-options.ts
+++ b/components/dashboard/src/start/start-workspace-options.ts
@@ -4,8 +4,13 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { GitpodServer } from "@gitpod/gitpod-protocol";
+import { IDESettings } from "@gitpod/gitpod-protocol";
 
+export interface StartWorkspaceOptions {
+    workspaceClass?: string;
+    ideSettings?: IDESettings;
+    autostart?: boolean;
+}
 export namespace StartWorkspaceOptions {
     // The workspace class to use for the workspace. If not specified, the default workspace class is used.
     export const WORKSPACE_CLASS = "workspaceClass";
@@ -13,9 +18,12 @@ export namespace StartWorkspaceOptions {
     // The editor to use for the workspace. If not specified, the default editor is used.
     export const EDITOR = "editor";
 
-    export function parseSearchParams(search: string): GitpodServer.StartWorkspaceOptions {
+    // whether the workspace should automatically start
+    export const AUTOSTART = "autostart";
+
+    export function parseSearchParams(search: string): StartWorkspaceOptions {
         const params = new URLSearchParams(search);
-        const options: GitpodServer.StartWorkspaceOptions = {};
+        const options: StartWorkspaceOptions = {};
         const workspaceClass = params.get(StartWorkspaceOptions.WORKSPACE_CLASS);
         if (workspaceClass) {
             options.workspaceClass = workspaceClass;
@@ -34,10 +42,13 @@ export namespace StartWorkspaceOptions {
                 };
             }
         }
+        if (params.get(StartWorkspaceOptions.AUTOSTART) === "true") {
+            options.autostart = true;
+        }
         return options;
     }
 
-    export function toSearchParams(options: GitpodServer.StartWorkspaceOptions): string {
+    export function toSearchParams(options: StartWorkspaceOptions): string {
         const params = new URLSearchParams();
         if (options.workspaceClass) {
             params.set(StartWorkspaceOptions.WORKSPACE_CLASS, options.workspaceClass);
@@ -46,6 +57,9 @@ export namespace StartWorkspaceOptions {
             const ide = options.ideSettings.defaultIde;
             const latest = options.ideSettings.useLatestVersion;
             params.set(StartWorkspaceOptions.EDITOR, latest ? ide + "-latest" : ide);
+        }
+        if (options.autostart) {
+            params.set(StartWorkspaceOptions.AUTOSTART, "true");
         }
         return params.toString();
     }

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -11,7 +11,7 @@ import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { ThemeSelector } from "../components/ThemeSelector";
 import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
-import { Heading2, Subheading } from "../components/typography/headings";
+import { Heading2, Heading3, Subheading } from "../components/typography/headings";
 import { useUserMaySetTimeout } from "../data/current-user/may-set-timeout-query";
 import { Button } from "../components/Button";
 import SelectIDE from "./SelectIDE";
@@ -19,6 +19,7 @@ import { InputField } from "../components/forms/InputField";
 import { TextInput } from "../components/forms/TextInputField";
 import { useToast } from "../components/toasts/Toasts";
 import { useUpdateCurrentUserDotfileRepoMutation } from "../data/current-user/update-mutation";
+import { AdditionalUserData } from "@gitpod/gitpod-protocol";
 
 export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "preferences";
 
@@ -67,12 +68,22 @@ export default function Preferences() {
         [toast, setUser, workspaceTimeout],
     );
 
+    const clearAutostartWorkspaceOptions = useCallback(async () => {
+        if (!user) {
+            return;
+        }
+        AdditionalUserData.set(user, { workspaceAutostartOptions: [] });
+        setUser(user);
+        await getGitpodService().server.updateLoggedInUser(user);
+        toast("Your autostart options were cleared.");
+    }, [setUser, toast, user]);
+
     return (
         <div>
             <PageWithSettingsSubMenu>
-                <Heading2>Editor</Heading2>
+                <Heading2>New Workspaces</Heading2>
                 <Subheading>
-                    Choose the editor for opening workspaces.{" "}
+                    Choose your default editor.{" "}
                     <a
                         className="gp-link"
                         href="https://www.gitpod.io/docs/references/ides-and-editors"
@@ -83,6 +94,11 @@ export default function Preferences() {
                     </a>
                 </Subheading>
                 <SelectIDE location="preferences" />
+                <Heading3 className="mt-12">Autostart Options</Heading3>
+                <Subheading>Forget any saved autostart options for all repositories.</Subheading>
+                <Button className="mt-4" type="secondary" onClick={clearAutostartWorkspaceOptions}>
+                    Reset Options
+                </Button>
 
                 <ThemeSelector className="mt-12" />
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -9,6 +9,7 @@ import { RoleOrPermission } from "./permission";
 import { Project } from "./teams-projects-protocol";
 import { createHash } from "crypto";
 import { AttributionId } from "./attribution";
+import { WorkspaceRegion } from "./workspace-cluster";
 
 export interface UserInfo {
     name?: string;
@@ -273,7 +274,19 @@ export interface AdditionalUserData extends Partial<WorkspaceTimeoutSetting> {
     // whether the user has been migrated to team attribution.
     // a corresponding feature flag (team_only_attribution) triggers the migration.
     isMigratedToTeamOnlyAttribution?: boolean;
+
+    // remembered workspace auto start options
+    workspaceAutostartOptions?: WorkspaceAutostartOption[];
 }
+
+interface WorkspaceAutostartOption {
+    cloneURL: string;
+    organizationId: string;
+    workspaceClass?: string;
+    ideSettings?: IDESettings;
+    region?: WorkspaceRegion;
+}
+
 export namespace AdditionalUserData {
     export function set(user: User, partialData: Partial<AdditionalUserData>): User {
         if (!user.additionalData) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Add a checkbox, so that users don't need to always manually trigger the workspace start.
- introduces a search param `autoStart=true` that allows to create Gitpod start links that auto start the workspace

<img width="514" alt="Screenshot 2023-05-02 at 13 45 43" src="https://user-images.githubusercontent.com/372735/235657426-e0ae0589-c193-4360-8d96-4142e4f80079.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-192

## How to test
<!-- Provide steps to test this PR -->
Try the new option with different repositories and orgs.
Try an autostart link:
  https://se-dont-ask.preview.gitpod-dev.com/?autostart=true#https://github.com/gitpod-io/gitpod

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-dont-ask</li>
	<li><b>🔗 URL</b> - <a href="https://se-dont-ask.preview.gitpod-dev.com/workspaces" target="_blank">se-dont-ask.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
