### PR TITLE
[server] Remove grant first user admin WEB-127

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -163,7 +163,6 @@ export interface ConfigSerialized {
     showSetupModal: boolean;
 
     admin: {
-        grantFirstUserAdminRole: boolean;
         credentialsPath: string;
     };
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -157,9 +157,6 @@ export class UserService {
             // blocked = if user already blocked OR is not allowed to pass
             newUser.blocked = newUser.blocked || !canPass;
         }
-        if (!newUser.blocked && isFirstUser && this.config.admin.grantFirstUserAdminRole) {
-            newUser.rolesOrPermissions = ["admin", "admin-permissions"];
-        }
     }
 
     protected async validateUsageAttributionId(user: User, usageAttributionId: string): Promise<AttributionId> {

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -288,8 +288,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,
 		PATSigningKeyFile:              personalAccessTokenSigningKeyPath,
 		Admin: AdminConfig{
-			GrantFirstUserAdminRole: false, // Use AdminCredentialsPath to seed the installation with admin credentials
-			CredentialsPath:         adminCredentialsPath,
+			CredentialsPath: adminCredentialsPath,
 		},
 		ShowSetupModal: showSetupModal,
 		Auth:           authCfg,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -179,8 +179,6 @@ type PrebuildRateLimiterConfig struct {
 }
 
 type AdminConfig struct {
-	GrantFirstUserAdminRole bool `json:"grantFirstUserAdminRole"`
-
 	// Absolute path to a file containg credentials (as JSON) which can be used to log-in as admin
 	CredentialsPath string `json:"credentialsPath"`
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* We use admin credentials to seed admin user
* This feature is no longer needed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17300

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
