### PR TITLE
[server] Metrics for sessions with JWTs WEB-102

### DIFF
--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -76,7 +76,7 @@ class TestAuthJWT {
         const encoded = await sign({}, keypair.privateKey, {
             algorithm: "RS512",
             expiresIn: "1d",
-            issuer: this.config.hostUrl.toStringWoRootSlash(),
+            issuer: "https://mp-server-d7650ec945.preview.gitpod-dev.com",
             keyid: keypair.id,
             subject,
         });

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -26,6 +26,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(spicedbClientLatency);
     registry.registerMetric(dashboardErrorBoundary);
     registry.registerMetric(jwtCookieIssued);
+    registry.registerMetric(sessionsWithJWTs);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -65,6 +66,16 @@ const jwtCookieIssued = new prometheusClient.Counter({
 
 export function reportJWTCookieIssued() {
     jwtCookieIssued.inc();
+}
+
+const sessionsWithJWTs = new prometheusClient.Counter({
+    name: "gitpod_server_sessions_with_jwts_total",
+    help: "Total number of sessions which did/or did not contain JWTs",
+    labelNames: ["present"],
+});
+
+export function reportSessionHasJWT(jwtPresent: boolean) {
+    sessionsWithJWTs.inc({ present: `${jwtPresent}` });
 }
 
 const apiConnectionClosedCounter = new prometheusClient.Counter({

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -42,21 +42,13 @@ export class SessionHandlerProvider {
 
         options.store = this.createStore();
 
-        this.sessionHandler = async (req: express.Request, res: express.Response) => {
-            const isJWTCookieEnabled = await getExperimentsClientForBackend().getValueAsync(
-                "jwtSessionCookieEnabled",
-                false,
-                {},
-            );
+        this.sessionHandler = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+            const jwt = req.cookies[SessionHandlerProvider.getJWTCookieName(this.config.hostUrl)];
+            const containedJWT = !!jwt;
 
-            if (isJWTCookieEnabled && req.cookies) {
-                const jwt = req.cookies[SessionHandlerProvider.getJWTCookieName(this.config.hostUrl)];
-                const containedJWT = !!jwt;
+            reportSessionHasJWT(containedJWT);
 
-                reportSessionHasJWT(containedJWT);
-            }
-
-            return session(options);
+            return session(options)(req, res, next);
         };
     }
 

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -16,7 +16,6 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config as DBConfig } from "@gitpod/gitpod-db/lib/config";
 import { Config } from "./config";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { reportSessionHasJWT } from "./prometheus-metrics";
 
 @injectable()

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -43,16 +43,13 @@ export class SessionHandlerProvider {
         options.store = this.createStore();
 
         this.sessionHandler = async (req: express.Request, res: express.Response) => {
-            const user = req.user;
             const isJWTCookieEnabled = await getExperimentsClientForBackend().getValueAsync(
                 "jwtSessionCookieEnabled",
                 false,
-                {
-                    user,
-                },
+                {},
             );
 
-            if (isJWTCookieEnabled) {
+            if (isJWTCookieEnabled && req.cookies) {
                 const jwt = req.cookies[SessionHandlerProvider.getJWTCookieName(this.config.hostUrl)];
                 const containedJWT = !!jwt;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Expose metrics on number of sessions which contained JWT cookie

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-bd3882035f</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-bd3882035f.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-bd3882035f.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
