### PR TITLE
Enable ws-manager-mk2 in preview environments by default

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -29,7 +29,7 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 PREVIEW_NAME="$(previewctl get-name --branch "${INPUT_NAME}")"
 export PREVIEW_NAME
 
-for var in WSMANAGER_MK2 WITH_DEDICATED_EMU ANALYTICS WORKSPACE_FEATURE_FLAGS; do
+for var in WITH_DEDICATED_EMU ANALYTICS WORKSPACE_FEATURE_FLAGS; do
   input_var="INPUT_${var}"
   if [[ -n "${!input_var:-}" ]];then
     export "GITPOD_${var}"="${!input_var}"

--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -13,9 +13,6 @@ inputs:
     previewctl_hash:
         description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
         required: false
-    wsmanager_mk2:
-        description: "Use WS Manager MK2"
-        required: false
     with_dedicated_emu:
         description: "Dedicated Config"
         required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,6 @@ gitpod:summary
 
 - [ ] analytics=segment
 - [ ] with-dedicated-emulation
-- [x] with-ws-manager-mk2
 - [ ] workspace-feature-flags
   Add desired feature flags to the end of the line above, space separated
 </details>
@@ -63,5 +62,5 @@ gitpod:summary
 - [ ] with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
 </details>
- 
+
 /hold

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
+          with_dedicated_emu: ${{needs.configuration.outputs.with_dedicated_emulation}}
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
       - uses: actions/github-script@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,10 @@ jobs:
       preview_infra_provider: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-gce-vm') && 'gce' || 'harvester' }}
       build_no_cache: ${{ contains( steps.pr-details.outputs.pr_body, '[x] leeway-no-cache') }}
       build_no_test: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft no-test') }}
-      with_large_vm: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-large-vm') }}
-      publish_to_npm: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft publish-to-npm') }}
-      publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft publish-to-jb-marketplace') }}
-      with_ws_manager_mk2: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-ws-manager-mk2') }}
-      with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-dedicated-emulation') }}
+      with_large_vm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft with-large-vm') }}
+      publish_to_npm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-npm') }}
+      publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-jb-marketplace') }}
+      with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-dedicated-emulation') }}
       analytics: ${{ steps.output.outputs.analytics }}
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
@@ -342,8 +341,7 @@ jobs:
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          wsmanager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
-          with_dedicated_emu: ${{needs.configuration.outputs.with_dedicated_emulation}}
+          with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
       - uses: actions/github-script@v6

--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -41,7 +41,7 @@ interface DeploymentConfig {
 }
 
 export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobConfig) {
-    const { version, cleanSlateDeployment, withObservability, installEELicense, workspaceFeatureFlags, useWsManagerMk2 } = jobConfig;
+    const { version, cleanSlateDeployment, withObservability, installEELicense, workspaceFeatureFlags } = jobConfig;
 
     const { destname, namespace } = jobConfig.previewEnvironment;
 
@@ -110,7 +110,6 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
             withEELicense: deploymentConfig.installEELicense,
             workspaceFeatureFlags: workspaceFeatureFlags,
             withDedicatedEmulation: jobConfig.withDedicatedEmulation,
-            useWsManagerMk2: useWsManagerMk2,
         });
         try {
             werft.log(installerSlices.INSTALL, "deploying using installer");

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -11,7 +11,6 @@ export type InstallerOptions = {
     withEELicense: boolean;
     workspaceFeatureFlags: string[];
     withDedicatedEmulation: boolean;
-    useWsManagerMk2: boolean;
 };
 
 export class Installer {
@@ -31,7 +30,6 @@ export class Installer {
             GITPOD_ANALYTICS: this.options.analytics,
             GITPOD_WORKSPACE_FEATURE_FLAGS: this.options.workspaceFeatureFlags.join(" "),
             GITPOD_WITH_DEDICATED_EMU: this.options.withDedicatedEmulation,
-            GITPOD_WSMANAGER_MK2: this.options.useWsManagerMk2,
         };
         const variables = Object.entries(environment)
             .map(([key, value]) => `${key}="${value}"`)

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -44,7 +44,6 @@ export interface JobConfig {
     recreatePreview: boolean;
     recreateVm: boolean;
     withWerft: boolean;
-    useWsManagerMk2: boolean;
     withGceVm: boolean;
 }
 
@@ -127,7 +126,6 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     }
     const certIssuer = buildConfig["cert-issuer"];
 
-    const useWsManagerMk2 = "with-wsman-mk2" in buildConfig;
     const repository: Repository = {
         owner: context.Repository.owner,
         repo: context.Repository.repo,
@@ -187,7 +185,6 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         recreateVm,
         withWerft,
         withDedicatedEmulation,
-        useWsManagerMk2,
         withGceVm,
     };
 


### PR DESCRIPTION
## Description
Disable ws-manager-mk1 preview environments entirely

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-162

## How to test
- Create preview environment
- Get kubecontext and check that mk2 has been deployed

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-mk2-defec8f7f9906</li>
	<li><b>🔗 URL</b> - <a href="https://fo-mk2-defec8f7f9906.preview.gitpod-dev.com/workspaces" target="_blank">fo-mk2-defec8f7f9906.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
