### PR TITLE
[gha] Fix property propagation to "deploy-gitpod" action

### DIFF
--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -17,7 +17,7 @@ inputs:
         description: "Use WS Manager MK2"
         required: false
     with_dedicated_emu:
-        description: "Dedicated Auth"
+        description: "Dedicated Config"
         required: false
     with_ee_licencse:
         description: "Use EE license"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
           wsmanager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
-          with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
+          with_dedicated_emu: ${{needs.configuration.outputs.with_dedicated_emulation}}
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
       - uses: actions/github-script@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,14 @@ jobs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
       preview_enable: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-preview') }}
-      preview_infra_provider: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}
+      preview_infra_provider: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-gce-vm') && 'gce' || 'harvester' }}
       build_no_cache: ${{ contains( steps.pr-details.outputs.pr_body, '[x] leeway-no-cache') }}
       build_no_test: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft no-test') }}
-      with_large_vm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft with-large-vm') }}
-      publish_to_npm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-npm') }}
-      publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-jb-marketplace') }}
-      with_ws_manager_mk2: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-ws-manager-mk2') }}
-      with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-dedicated-emulation') }}
+      with_large_vm: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-large-vm') }}
+      publish_to_npm: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft publish-to-npm') }}
+      publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft publish-to-jb-marketplace') }}
+      with_ws_manager_mk2: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-ws-manager-mk2') }}
+      with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-dedicated-emulation') }}
       analytics: ${{ steps.output.outputs.analytics }}
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}


### PR DESCRIPTION
Extracting from https://github.com/gitpod-io/gitpod/pull/17303

This was necessary to get the `with-dedicated-emulation` running again

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
