### PR TITLE
[wsman-mk2] Set workspace class environment variables

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -531,6 +531,7 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 	result = append(result, corev1.EnvVar{Name: "GITPOD_HOST", Value: sctx.Config.GitpodHostURL})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_URL", Value: wsUrl})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_CLUSTER_HOST", Value: sctx.Config.WorkspaceClusterHost})
+	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_CLASS", Value: sctx.Workspace.Spec.Class})
 	result = append(result, corev1.EnvVar{Name: "THEIA_SUPERVISOR_ENDPOINT", Value: fmt.Sprintf(":%d", sctx.SupervisorPort)})
 	// TODO(ak) remove THEIA_WEBVIEW_EXTERNAL_ENDPOINT and THEIA_MINI_BROWSER_HOST_PATTERN when Theia is removed
 	result = append(result, corev1.EnvVar{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"})
@@ -559,7 +560,9 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 			"GITPOD_TASKS",
 			"GITPOD_RESOLVED_EXTENSIONS",
 			"GITPOD_EXTERNAL_EXTENSIONS",
-			"GITPOD_IDE_ALIAS":
+			"GITPOD_WORKSPACE_CLASS_INFO",
+			"GITPOD_IDE_ALIAS",
+			"GITPOD_RLIMIT_CORE":
 			// these variables are allowed - don't skip them
 		default:
 			if strings.HasPrefix(e.Name, "GITPOD_") {


### PR DESCRIPTION
## Description
Set missing workspace class and workspace class info environment variables (also rlimit)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-93

## How to test
- Open workspace in preview environment and check that environment variables are set

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
