### PR TITLE
[wsman-mk2] Use mk2 tls certificates for server and bridge

### DIFF
--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/components/spicedb"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+	wsmanagermk2 "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-mk2"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
@@ -262,11 +263,19 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	addWsManagerTls := common.WithLocalWsManager(ctx)
 	if addWsManagerTls {
+		secretName := wsmanager.TLSSecretNameClient
+		_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+			if cfg.Workspace != nil && cfg.Workspace.UseWsmanagerMk2 {
+				secretName = wsmanagermk2.TLSSecretNameClient
+			}
+			return nil
+		})
+
 		volumes = append(volumes, corev1.Volume{
 			Name: "ws-manager-client-tls-certs",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: wsmanager.TLSSecretNameClient,
+					SecretName: secretName,
 				},
 			},
 		})

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+	wsmanagermk2 "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-mk2"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,11 +37,19 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	addWsManagerTls := common.WithLocalWsManager(ctx)
 	if addWsManagerTls {
+		secretName := wsmanager.TLSSecretNameClient
+		_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+			if cfg.Workspace != nil && cfg.Workspace.UseWsmanagerMk2 {
+				secretName = wsmanagermk2.TLSSecretNameClient
+			}
+			return nil
+		})
+
 		volumes = append(volumes, corev1.Volume{
 			Name: "ws-manager-client-tls-certs",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: wsmanager.TLSSecretNameClient,
+					SecretName: secretName,
 				},
 			},
 		})


### PR DESCRIPTION
## Description
When we do a full installation of Gitpod (i.e. webapp and workspace components all within the same cluster) and ws-manager-mk2 is specified use the ws-manager-mk2 secret instead of the mk1 secret (mk1 will not exist). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-105

## How to test
- Use https://github.com/gitpod-io/workspace-preview to create a VM with a full installation of Gitpod. Make sure you have enabled mk2
- All components should get ready. None should get stuck because secrets cannot be mounted
- Start workspace

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
