### PR TITLE
[orgs-only] Show Information before migration.

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -11,6 +11,8 @@ import { useCurrentOrg } from "./data/organizations/orgs-query";
 import { useAnalyticsTracking } from "./hooks/use-analytics-tracking";
 import { useUserLoader } from "./hooks/use-user-loader";
 import { Login } from "./Login";
+import { useFeatureFlags } from "./contexts/FeatureFlagContext";
+import { MigrationPage } from "./whatsnew/MigrationPage";
 
 // Wrap the App in an ErrorBoundary to catch User/Org loading errors
 // This will also catch any errors that happen to bubble all the way up to the top
@@ -22,6 +24,7 @@ const AppWithErrorBoundary: FC = () => {
 const App: FC = () => {
     const { user, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
+    const { orgOnlyAttribution } = useFeatureFlags();
 
     // Setup analytics/tracking
     useAnalyticsTracking();
@@ -34,6 +37,11 @@ const App: FC = () => {
     // At this point if there's no user, they should Login
     if (!user) {
         return <Login />;
+    }
+
+    // If orgOnlyAttribution is enabled and the user hasn't been migrated, yet, we need to show the migration page
+    if (orgOnlyAttribution && !user.additionalData?.isMigratedToTeamOnlyAttribution) {
+        return <MigrationPage />;
     }
 
     // At this point we want to make sure that we never render AppRoutes prematurely, e.g. without finishing loading the orgs

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -30,6 +30,7 @@ const defaultFeatureFlags = {
     newSignupFlow: false,
     linkedinConnectionForOnboarding: false,
     paymentVerificationFlow: false,
+    orgOnlyAttribution: false,
 };
 
 const FeatureFlagContext = createContext<FeatureFlagsType>(defaultFeatureFlags);
@@ -49,6 +50,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [newSignupFlow, setNewSignupFlow] = useState<boolean>(false);
     const [linkedinConnectionForOnboarding, setLinkedinConnectionForOnboarding] = useState<boolean>(false);
     const [paymentVerificationFlow, setPaymentVerificationFlow] = useState<boolean>(false);
+    const [orgOnlyAttribution, setOrgOnlyAttribution] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -68,6 +70,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 newSignupFlow: { defaultValue: false, setter: setNewSignupFlow },
                 linkedinConnectionForOnboarding: { defaultValue: false, setter: setLinkedinConnectionForOnboarding },
                 paymentVerificationFlow: { defaultValue: false, setter: setPaymentVerificationFlow },
+                team_only_attribution: { defaultValue: false, setter: setOrgOnlyAttribution },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -116,6 +119,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
             newSignupFlow,
             linkedinConnectionForOnboarding,
             paymentVerificationFlow,
+            orgOnlyAttribution,
         };
     }, [
         startWithOptions,
@@ -128,6 +132,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         newSignupFlow,
         linkedinConnectionForOnboarding,
         paymentVerificationFlow,
+        orgOnlyAttribution,
     ]);
 
     return <FeatureFlagContext.Provider value={flags}>{children}</FeatureFlagContext.Provider>;

--- a/components/dashboard/src/onboarding/OnboardingStep.tsx
+++ b/components/dashboard/src/onboarding/OnboardingStep.tsx
@@ -60,6 +60,7 @@ export const OnboardingStep: FC<Props> = ({
                         type={submitButtonType || "primary"}
                         disabled={!isValid || isSaving}
                         size="block"
+                        loading={isSaving}
                     >
                         {submitButtonText || "Continue"}
                     </Button>

--- a/components/dashboard/src/whatsnew/MigrationPage.tsx
+++ b/components/dashboard/src/whatsnew/MigrationPage.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { OnboardingStep } from "../onboarding/OnboardingStep";
+import { User } from "@gitpod/gitpod-protocol";
+import { getGitpodService } from "../service/service";
+import { useOrganizationsInvalidator } from "../data/organizations/orgs-query";
+import { Separator } from "../components/Separator";
+import gitpodIcon from "../icons/gitpod.svg";
+import { useContext } from "react";
+import { UserContext, useCurrentUser } from "../user-context";
+import { Heading3 } from "../components/typography/headings";
+import { Link } from "react-router-dom";
+
+export function MigrationPage() {
+    const migrateUsers = useMigrateUserMutation();
+    const user = useCurrentUser();
+
+    return (
+        <div className="container">
+            <div className="app-container">
+                <div className="flex items-center justify-center py-3">
+                    <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
+                </div>
+                <Separator />
+                <div className="mt-24">
+                    <OnboardingStep
+                        title="It's now easier to collaborate"
+                        subtitle="Your personal account is now an organization."
+                        isValid={true}
+                        isSaving={migrateUsers.isLoading}
+                        onSubmit={migrateUsers.mutateAsync}
+                    >
+                        <Heading3>What's different?</Heading3>
+                        <p className="text-gray-500 text-base mb-4">
+                            Your personal account (<b>{user?.fullName || user?.name}</b>) is converted to an
+                            organization. Any workspaces, projects and configuration has been moved with it.
+                            Additionally, usage cost will now be attributed to the organization that owns the workspace,
+                            allowing for better cost control.{" "}
+                            <a className="gp-link" href="https://gitpod.io/blog/organizations">
+                                Learn more -&gt;
+                            </a>
+                        </p>
+                        <Heading3>Who has access to this organization?</Heading3>
+                        <p className="text-gray-500 text-base mb-4">
+                            Just you. You are the only member of this organization. You can invite members to join your
+                            org or continue working by yourself.
+                        </p>
+                        <Heading3>What do I need to do?</Heading3>
+                        <p className="text-gray-500 text-base mb-4">
+                            Nothing. There are no changes to your resources or monthly cost. You can manage organization
+                            settings, billing, or invite others to your organization at any time.
+                        </p>
+                    </OnboardingStep>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function useMigrateUserMutation() {
+    const invalidateOrgs = useOrganizationsInvalidator();
+    const { setUser } = useContext(UserContext);
+
+    return useMutation<User, Error>({
+        mutationFn: async () => {
+            const user = await getGitpodService().server.migrateLoggedInUserToOrgOnlyMode();
+            setUser(user);
+            return user;
+        },
+        onSuccess(updatedOrg) {
+            invalidateOrgs();
+        },
+    });
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -75,6 +75,7 @@ export const GitpodServer = Symbol("GitpodServer");
 export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, IDEServer {
     // User related API
     getLoggedInUser(): Promise<User>;
+    migrateLoggedInUserToOrgOnlyMode(): Promise<User>;
     updateLoggedInUser(user: Partial<User>): Promise<User>;
     sendPhoneNumberVerificationToken(phoneNumber: string): Promise<void>;
     verifyPhoneNumberVerificationToken(phoneNumber: string, token: string): Promise<boolean>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -44,6 +44,7 @@ export function isValidFunctionName(name: string): boolean {
 
 const defaultFunctions: FunctionsConfig = {
     getLoggedInUser: { group: "default", points: 1 },
+    migrateLoggedInUserToOrgOnlyMode: { group: "default", points: 1 },
     updateLoggedInUser: { group: "default", points: 1 },
     sendPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },
     verifyPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -355,17 +355,6 @@ export class UserService {
     }
 
     async onAfterUserLoad(user: User): Promise<User> {
-        try {
-            // migrate user to team only attribution
-            const shouldMigrate = this.configCatClientFactory().getValueAsync("team_only_attribution", false, {
-                user,
-            });
-            if (User.is(user) && (await this.migrationService.needsMigration(user)) && (await shouldMigrate)) {
-                return await this.migrationService.migrateUser(user);
-            }
-        } catch (error) {
-            log.error({ user }, `Migrating user to team-only attribution failed`);
-        }
         return user;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Moves the automatic migration on login, to an explicit migration, that the user triggers themselves after they have read information about the change wánd what it means.

**Attention**
The design and text is not finished yet, obviously 🤣. I'm waiting for input from @gtsiolis.
But the general code changes can be reviewed already.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-186

## How to test
<!-- Provide steps to test this PR -->

Login and see the information as the first thing. We will not show this to new users in prod, but because we don't have existing users in preview environments I configured the feature flags so that it happens for new users as well.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-show-info</li>
	<li><b>🔗 URL</b> - <a href="https://se-show-info.preview.gitpod-dev.com/workspaces" target="_blank">se-show-info.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
