### PR TITLE
[common-go] add custom attribute "gitpod-host"

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -19,6 +19,7 @@ const (
 	teamIDAttribute         = "team_id"
 	teamNameAttribute       = "team_name"
 	vscodeClientIDAttribute = "vscode_client_id"
+	gitpodHost              = "gitpod_host"
 )
 
 func newConfigCatClient(config configcat.Config) *configCatClient {
@@ -78,6 +79,10 @@ func attributesToUser(attributes Attributes) *configcat.UserData {
 
 	if attributes.VSCodeClientID != "" {
 		custom[vscodeClientIDAttribute] = attributes.VSCodeClientID
+	}
+
+	if attributes.GitpodHost != "" {
+		custom[gitpodHost] = attributes.GitpodHost
 	}
 
 	return &configcat.UserData{

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -31,6 +31,8 @@ type Attributes struct {
 
 	// this is vscode header `x-market-client-id`
 	VSCodeClientID string
+
+	GitpodHost string
 }
 
 type ClientOpt func(o *options)


### PR DESCRIPTION
The custom attribute "gitpod-host" was added in `server` component, but is missing on the golang side.

https://github.com/gitpod-io/gitpod/pull/17303#discussion_r1173710700



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
