### PR TITLE
[admin] show workspace instances and organization

### DIFF
--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -4,29 +4,29 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
-import { UserContextProvider } from "./user-context";
-import { AdminContextProvider } from "./admin-context";
-import { PaymentContextProvider } from "./payment-context";
-import { LicenseContextProvider } from "./license-context";
-import { ProjectContextProvider } from "./projects/project-context";
-import { ThemeContextProvider } from "./theme-context";
-import { FeatureFlagContextProvider } from "./contexts/FeatureFlagContext";
-import { StartWorkspaceModalContextProvider } from "./workspaces/start-workspace-modal-context";
-import { BrowserRouter } from "react-router-dom";
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
-import { getURLHash, isGitpodIo } from "./utils";
-import { isWebsiteSlug } from "./utils";
-import { setupQueryClientProvider } from "./data/setup";
-import { ConfettiContextProvider } from "./contexts/ConfettiContext";
+import React from "react";
+import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import { AdminContextProvider } from "./admin-context";
 import { QueryErrorBoundary } from "./components/error-boundaries/QueryErrorBoundary";
 import { ReloadPageErrorBoundary } from "./components/error-boundaries/ReloadPageErrorBoundary";
-import "./index.css";
 import { ToastContextProvider } from "./components/toasts/Toasts";
+import { ConfettiContextProvider } from "./contexts/ConfettiContext";
+import { FeatureFlagContextProvider } from "./contexts/FeatureFlagContext";
+import { setupQueryClientProvider } from "./data/setup";
+import "./index.css";
+import { LicenseContextProvider } from "./license-context";
+import { PaymentContextProvider } from "./payment-context";
+import { ProjectContextProvider } from "./projects/project-context";
+import { ThemeContextProvider } from "./theme-context";
+import { UserContextProvider } from "./user-context";
+import { getURLHash, isGitpodIo, isWebsiteSlug } from "./utils";
+import { StartWorkspaceModalContextProvider } from "./workspaces/start-workspace-modal-context";
 
 const bootApp = () => {
     // gitpod.io specific boot logic
@@ -54,6 +54,7 @@ const bootApp = () => {
     // Configure libraries
     dayjs.extend(relativeTime);
     dayjs.extend(utc);
+    dayjs.extend(duration);
 
     // Render the App
     ReactDOM.render(

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -36,6 +36,7 @@ export interface AdminServer {
 
     adminGetWorkspaces(req: AdminGetWorkspacesRequest): Promise<AdminGetListResult<WorkspaceAndInstance>>;
     adminGetWorkspace(id: string): Promise<WorkspaceAndInstance>;
+    adminGetWorkspaceInstances(workspaceId: string): Promise<WorkspaceInstance[]>;
     adminForceStopWorkspace(id: string): Promise<void>;
     adminRestoreSoftDeletedWorkspace(id: string): Promise<void>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -726,6 +726,15 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         return result;
     }
 
+    async adminGetWorkspaceInstances(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInstance[]> {
+        traceAPIParams(ctx, { workspaceId });
+
+        await this.guardAdminAccess("adminGetWorkspaceInstances", { id: workspaceId }, Permission.ADMIN_WORKSPACES);
+
+        const result = await this.workspaceDb.trace(ctx).findInstances(workspaceId);
+        return result || [];
+    }
+
     async adminForceStopWorkspace(ctx: TraceContext, workspaceId: string): Promise<void> {
         traceAPIParams(ctx, { workspaceId });
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -152,6 +152,7 @@ const defaultFunctions: FunctionsConfig = {
     adminSetTeamMemberRole: { group: "default", points: 1 },
     adminGetWorkspaces: { group: "default", points: 1 },
     adminGetWorkspace: { group: "default", points: 1 },
+    adminGetWorkspaceInstances: { group: "default", points: 1 },
     adminForceStopWorkspace: { group: "default", points: 1 },
     adminRestoreSoftDeletedWorkspace: { group: "default", points: 1 },
     adminGetProjectsBySearchTerm: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2865,6 +2865,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 
+    async adminGetWorkspaceInstances(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInstance[]> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
     async adminForceStopWorkspace(ctx: TraceContext, id: string): Promise<void> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }


### PR DESCRIPTION
## Description
enhances the Workspace details in the admin dashboard by showing the organization as well as all previous instances.

<img width="1601" alt="Screenshot 2023-04-21 at 19 32 43" src="https://user-images.githubusercontent.com/372735/233699379-0bfdceea-72e2-4aea-9986-141a505671ce.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-175
Fixes WEB-176

## How to test
<!-- Provide steps to test this PR -->
login to preview create a workspace and restart it a couple of times. Go to admin dashboard and look up that workspace.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-admin-workspaces</li>
	<li><b>🔗 URL</b> - <a href="https://se-admin-workspaces.preview.gitpod-dev.com/workspaces" target="_blank">se-admin-workspaces.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
