### PR TITLE
[installer] Remove OIDC secret from public-api WEB-206

### DIFF
--- a/components/public-api-server/pkg/oidc/service_test.go
+++ b/components/public-api-server/pkg/oidc/service_test.go
@@ -229,12 +229,7 @@ func setupOIDCServiceForTests(t *testing.T) (*Service, *gorm.DB) {
 	sessionServerAddress := newFakeSessionServer(t)
 
 	keyset := jwstest.GenerateKeySet(t)
-<<<<<<< HEAD
 	signerVerifier := jws.NewHS256FromKeySet(keyset)
-=======
-	signerVerifier, err := jws.NewRSA256(keyset)
-	require.NoError(t, err)
->>>>>>> 96f540399 (Fix)
 
 	service := NewService(sessionServerAddress, dbConn, cipher, signerVerifier, 5*time.Minute)
 	service.skipVerifyIdToken = true

--- a/components/public-api-server/pkg/oidc/service_test.go
+++ b/components/public-api-server/pkg/oidc/service_test.go
@@ -229,7 +229,12 @@ func setupOIDCServiceForTests(t *testing.T) (*Service, *gorm.DB) {
 	sessionServerAddress := newFakeSessionServer(t)
 
 	keyset := jwstest.GenerateKeySet(t)
+<<<<<<< HEAD
 	signerVerifier := jws.NewHS256FromKeySet(keyset)
+=======
+	signerVerifier, err := jws.NewRSA256(keyset)
+	require.NoError(t, err)
+>>>>>>> 96f540399 (Fix)
 
 	service := NewService(sessionServerAddress, dbConn, cipher, signerVerifier, 5*time.Minute)
 	service.skipVerifyIdToken = true

--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -22,9 +22,6 @@ type Configuration struct {
 	// StripeWebhookSigningSecretPath is a filepath to a secret used to validate incoming webhooks from Stripe
 	StripeWebhookSigningSecretPath string `json:"stripeWebhookSigningSecretPath"`
 
-	// OIDCClientJWTSigningSecretPath is a filepath to a secret used to sign and validate JWTs used for OIDC flows
-	OIDCClientJWTSigningSecretPath string `json:"oidcClientJWTSigningSecretPath"`
-
 	// Path to file which contains personal access token singing key
 	PersonalAccessTokenSigningKeyPath string `json:"personalAccessTokenSigningKeyPath"`
 

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -427,11 +427,6 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.baseUrl "
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.pollInterval "1m"
 
 #
-# configure JWT signign key
-#
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.oidcClientJWTSigningKeySecretName "oidc-client-jwt-signing-key"
-
-#
 # configure Personal Access Token signign key
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName "personal-access-token-signing-key"

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -28,14 +28,8 @@ const (
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var oidcClientJWTSigningSecretPath string
 	var stripeSecretPath string
 	var personalAccessTokenSigningKeyPath string
-
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		_, _, oidcClientJWTSigningSecretPath, _ = getOIDCClientJWTSecretConfig(cfg)
-		return nil
-	})
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		_, _, stripeSecretPath, _ = getStripeConfig(cfg)
@@ -54,7 +48,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := config.Configuration{
 		PublicURL:                         fmt.Sprintf("https://api.%s", ctx.Config.Domain),
 		GitpodServiceURL:                  common.ClusterURL("ws", server.Component, ctx.Namespace, server.ContainerPort),
-		OIDCClientJWTSigningSecretPath:    oidcClientJWTSigningSecretPath,
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		BillingServiceAddress:             common.ClusterAddress(usage.Component, ctx.Namespace, usage.GRPCServicePort),
@@ -135,38 +128,6 @@ func getStripeConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMoun
 		Name:      "stripe-secret",
 		MountPath: stripeSecretMountPath,
 		SubPath:   "stripe-webhook-secret",
-		ReadOnly:  true,
-	}
-
-	return volume, mount, path, true
-}
-
-func getOIDCClientJWTSecretConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMount, string, bool) {
-	var volume corev1.Volume
-	var mount corev1.VolumeMount
-	var path string
-
-	if cfg == nil || cfg.WebApp == nil || cfg.WebApp.PublicAPI == nil || cfg.WebApp.PublicAPI.OIDCClientJWTSigningKeySecretName == "" {
-		return volume, mount, path, false
-	}
-
-	oidcClientJWTSigningKeySecretName := cfg.WebApp.PublicAPI.OIDCClientJWTSigningKeySecretName
-	path = oidcClientJWTSigningKeyMountPath
-
-	volume = corev1.Volume{
-		Name: "oidc-client-jwt-signing-key",
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: oidcClientJWTSigningKeySecretName,
-				Optional:   pointer.Bool(true),
-			},
-		},
-	}
-
-	mount = corev1.VolumeMount{
-		Name:      "oidc-client-jwt-signing-key",
-		MountPath: oidcClientJWTSigningKeyMountPath,
-		SubPath:   "oidc-client-jwt-signing-key",
 		ReadOnly:  true,
 	}
 

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -34,12 +34,6 @@ func TestConfigMap(t *testing.T) {
 		return nil
 	})
 
-	var oidcClientJWTSigningSecretPath string
-	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		_, _, oidcClientJWTSigningSecretPath, _ = getOIDCClientJWTSecretConfig(ucfg)
-		return nil
-	})
-
 	var personalAccessTokenSigningKeyPath string
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
 		_, _, personalAccessTokenSigningKeyPath, _ = getPersonalAccessTokenSigningKey(ucfg)
@@ -51,7 +45,6 @@ func TestConfigMap(t *testing.T) {
 		GitpodServiceURL:                  fmt.Sprintf("ws://server.%s.svc.cluster.local:3000", ctx.Namespace),
 		BillingServiceAddress:             fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
 		SessionServiceAddress:             fmt.Sprintf("server.%s.svc.cluster.local:9876", ctx.Namespace),
-		OIDCClientJWTSigningSecretPath:    oidcClientJWTSigningSecretPath,
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		DatabaseConfigPath:                "/secrets/database-config",

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -60,17 +60,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		volume, mount, _, ok := getOIDCClientJWTSecretConfig(cfg)
-		if !ok {
-			return nil
-		}
-
-		volumes = append(volumes, volume)
-		volumeMounts = append(volumeMounts, mount)
-		return nil
-	})
-
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		volume, mount, _, ok := getStripeConfig(cfg)
 		if !ok {
 			return nil

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -65,15 +65,6 @@ func TestDeployment_ServerArguments(t *testing.T) {
 			},
 		},
 		{
-			Name: "oidc-client-jwt-signing-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "oidc-client-jwt-signing-key",
-					Optional:   pointer.Bool(true),
-				},
-			},
-		},
-		{
 			Name: "stripe-secret",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -30,7 +30,6 @@ func renderContextWithPublicAPI(t *testing.T) *common.RenderContext {
 			WebApp: &experimental.WebAppConfig{
 				PublicAPI: &experimental.PublicAPIConfig{
 					StripeSecretName:                        "stripe-webhook-secret",
-					OIDCClientJWTSigningKeySecretName:       "oidc-client-jwt-signing-key",
 					PersonalAccessTokenSigningKeySecretName: "personal-access-token-signing-key",
 				},
 			},

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -301,9 +301,6 @@ type PublicAPIConfig struct {
 	// Name of the kubernetes secret to use for Stripe secrets
 	StripeSecretName string `json:"stripeSecretName"`
 
-	// Name of the kubernetes secret to use for signing JWTs
-	OIDCClientJWTSigningKeySecretName string `json:"oidcClientJWTSigningKeySecretName"`
-
 	// Name of the kubernetes secret to use for signature of Personal Access Tokens
 	PersonalAccessTokenSigningKeySecretName string `json:"personalAccessTokenSigningKeySecretName"`
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Removes OIDC symmetric key/secret, no longer needed as we are using RSA generated by cert manager

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17328

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-papi-re5b714b1e90</li>
	<li><b>🔗 URL</b> - <a href="https://mp-papi-re5b714b1e90.preview.gitpod-dev.com/workspaces" target="_blank">mp-papi-re5b714b1e90.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
