### PR TITLE
 [installer] Add JWT cookie opts to config WEB-101

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -54,6 +54,7 @@ type AuthConfiguration struct {
 type SessionConfig struct {
 	LifetimeSeconds int64  `json:"lifetimeSeconds"`
 	Issuer          string `json:"issuer"`
+	CookieName      string `json:"cookieName"`
 }
 
 type AuthPKIConfiguration struct {

--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -52,9 +52,17 @@ type AuthConfiguration struct {
 }
 
 type SessionConfig struct {
-	LifetimeSeconds int64  `json:"lifetimeSeconds"`
-	Issuer          string `json:"issuer"`
-	CookieName      string `json:"cookieName"`
+	LifetimeSeconds int64        `json:"lifetimeSeconds"`
+	Issuer          string       `json:"issuer"`
+	Cookie          CookieConfig `json:"cookie"`
+}
+
+type CookieConfig struct {
+	Name     string `json:"name"`
+	MaxAge   int64  `json:"maxAge"`
+	SameSite string `json:"sameSite"`
+	Secure   bool   `json:"secure"`
+	HTTPOnly bool   `json:"httpOnly"`
 }
 
 type AuthPKIConfiguration struct {

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -100,11 +100,11 @@ export class LoginCompletionHandler {
         if (isJWTCookieExperimentEnabled) {
             const token = await this.authJWT.sign(user.id, {});
 
-            response.cookie(SessionHandlerProvider.getJWTCookieName(this.config.hostUrl), token, {
-                maxAge: this.config.session.maxAgeMs,
-                httpOnly: true,
-                sameSite: "lax",
-                secure: true,
+            response.cookie(SessionHandlerProvider.getJWTCookieName(this.config), token, {
+                maxAge: this.config.auth.session.cookie.maxAge,
+                httpOnly: this.config.auth.session.cookie.httpOnly,
+                sameSite: this.config.auth.session.cookie.sameSite,
+                secure: this.config.auth.session.cookie.secure,
             });
 
             reportJWTCookieIssued();

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -55,7 +55,7 @@ export type Config = Omit<
         session: {
             lifetimeSeconds: number;
             issuer: string;
-            cookieName: string;
+            cookie: CookieConfig;
         };
     };
 };
@@ -259,9 +259,17 @@ export interface ConfigSerialized {
         session: {
             lifetimeSeconds: number;
             issuer: string;
-            cookieName: string;
+            cookie: CookieConfig;
         };
     };
+}
+
+export interface CookieConfig {
+    name: string;
+    maxAge: number;
+    sameSite: boolean | "lax" | "strict" | "none";
+    secure: boolean;
+    httpOnly: boolean;
 }
 
 export interface AuthPKIConfig {

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -55,6 +55,7 @@ export type Config = Omit<
         session: {
             lifetimeSeconds: number;
             issuer: string;
+            cookieName: string;
         };
     };
 };
@@ -258,6 +259,7 @@ export interface ConfigSerialized {
         session: {
             lifetimeSeconds: number;
             issuer: string;
+            cookieName: string;
         };
     };
 }

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -15,7 +15,6 @@ const MySQLStore = mysqlstore(session);
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config as DBConfig } from "@gitpod/gitpod-db/lib/config";
 import { Config } from "./config";
-import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 @injectable()
 export class SessionHandlerProvider {
@@ -66,12 +65,8 @@ export class SessionHandlerProvider {
         return `${derived}v2_`;
     }
 
-    static getJWTCookieName(hostURL: GitpodHostUrl) {
-        const derived = hostURL
-            .toString()
-            .replace(/https?/, "")
-            .replace(/[\W_]+/g, "_");
-        return `${derived}jwt_`;
+    static getJWTCookieName(config: Config) {
+        return config.auth.session.cookieName;
     }
 
     public clearSessionCookie(res: express.Response, config: Config): void {
@@ -82,7 +77,7 @@ export class SessionHandlerProvider {
         delete options.maxAge;
         res.clearCookie(name, options);
 
-        res.clearCookie(SessionHandlerProvider.getJWTCookieName(this.config.hostUrl));
+        res.clearCookie(SessionHandlerProvider.getJWTCookieName(this.config));
     }
 
     protected createStore(): any | undefined {

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -66,7 +66,7 @@ export class SessionHandlerProvider {
     }
 
     static getJWTCookieName(config: Config) {
-        return config.auth.session.cookieName;
+        return config.auth.session.cookie.name;
     }
 
     public clearSessionCookie(res: express.Response, config: Config): void {

--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -44,6 +44,7 @@ func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount
 			LifetimeSeconds: lifetime,
 			Issuer:          fmt.Sprintf("https://%s", ctx.Config.Domain),
 			Cookie: CookieConfig{
+				// Caution: changing these have security implications for the application. Make sure you understand what you're doing.
 				Name:     cookieNameFromDomain(ctx.Config.Domain),
 				MaxAge:   lifetime,
 				SameSite: "lax",

--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -23,6 +24,7 @@ type SessionConfig struct {
 	// How long shoud the session be valid for?
 	LifetimeSeconds int64  `json:"lifetimeSeconds"`
 	Issuer          string `json:"issuer"`
+	CookieName      string `json:"cookieName"`
 }
 
 func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount, Config) {
@@ -32,6 +34,13 @@ func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount
 		Session: SessionConfig{
 			LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
 			Issuer:          fmt.Sprintf("https://%s", ctx.Config.Domain),
+			CookieName:      cookieNameFromDomain(ctx.Config.Domain),
 		},
 	}
+}
+
+func cookieNameFromDomain(domain string) string {
+	// replace all non-word characters with underscores
+	derived := regexp.MustCompile(`[\W_]+`).ReplaceAllString(domain, "_")
+	return "_" + derived + "_jwt_"
 }

--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -22,19 +22,34 @@ type Config struct {
 
 type SessionConfig struct {
 	// How long shoud the session be valid for?
-	LifetimeSeconds int64  `json:"lifetimeSeconds"`
-	Issuer          string `json:"issuer"`
-	CookieName      string `json:"cookieName"`
+	LifetimeSeconds int64        `json:"lifetimeSeconds"`
+	Issuer          string       `json:"issuer"`
+	Cookie          CookieConfig `json:"cookie"`
+}
+
+type CookieConfig struct {
+	Name     string `json:"name"`
+	MaxAge   int64  `json:"maxAge"`
+	SameSite string `json:"sameSite"`
+	Secure   bool   `json:"secure"`
+	HTTPOnly bool   `json:"httpOnly"`
 }
 
 func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount, Config) {
 	volumes, mounts, pki := getPKI()
+	lifetime := int64((7 * 24 * time.Hour).Seconds())
 	return volumes, mounts, Config{
 		PKI: pki,
 		Session: SessionConfig{
-			LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
+			LifetimeSeconds: lifetime,
 			Issuer:          fmt.Sprintf("https://%s", ctx.Config.Domain),
-			CookieName:      cookieNameFromDomain(ctx.Config.Domain),
+			Cookie: CookieConfig{
+				Name:     cookieNameFromDomain(ctx.Config.Domain),
+				MaxAge:   lifetime,
+				SameSite: "lax",
+				Secure:   true,
+				HTTPOnly: true,
+			},
 		},
 	}
 }

--- a/install/installer/pkg/components/auth/config_test.go
+++ b/install/installer/pkg/components/auth/config_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package auth
+
+import "testing"
+
+func TestCookieNameFromDomain(t *testing.T) {
+	tests := []struct {
+		name            string
+		domain          string
+		expectedOutcome string
+	}{
+		{
+			name:            "Simple Domain",
+			domain:          "example.com",
+			expectedOutcome: "_example_com_jwt_",
+		},
+		{
+			name:            "Domain with Underscore",
+			domain:          "example_test.com",
+			expectedOutcome: "_example_test_com_jwt_",
+		},
+		{
+			name:            "Domain with Hyphen",
+			domain:          "example-test.com",
+			expectedOutcome: "_example_test_com_jwt_",
+		},
+		{
+			name:            "Domain with Special Characters",
+			domain:          "example&test.com",
+			expectedOutcome: "_example_test_com_jwt_",
+		},
+		{
+			name:            "Subdomain",
+			domain:          "subdomain.example.com",
+			expectedOutcome: "_subdomain_example_com_jwt_",
+		},
+		{
+			name:            "Subdomain with Hyphen",
+			domain:          "sub-domain.example.com",
+			expectedOutcome: "_sub_domain_example_com_jwt_",
+		},
+		{
+			name:            "Subdomain with Underscore",
+			domain:          "sub_domain.example.com",
+			expectedOutcome: "_sub_domain_example_com_jwt_",
+		},
+		{
+			name:            "Subdomain with Special Characters",
+			domain:          "sub&domain.example.com",
+			expectedOutcome: "_sub_domain_example_com_jwt_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := cookieNameFromDomain(tt.domain)
+			if actual != tt.expectedOutcome {
+				t.Errorf("expected %q, got %q", tt.expectedOutcome, actual)
+			}
+		})
+	}
+}

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -74,7 +74,13 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Session: config.SessionConfig{
 				LifetimeSeconds: authCfg.Session.LifetimeSeconds,
 				Issuer:          authCfg.Session.Issuer,
-				CookieName:      authCfg.Session.CookieName,
+				Cookie: config.CookieConfig{
+					Name:     authCfg.Session.Cookie.Name,
+					MaxAge:   authCfg.Session.Cookie.MaxAge,
+					SameSite: authCfg.Session.Cookie.SameSite,
+					Secure:   authCfg.Session.Cookie.Secure,
+					HTTPOnly: authCfg.Session.Cookie.HTTPOnly,
+				},
 			},
 		},
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -74,6 +74,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Session: config.SessionConfig{
 				LifetimeSeconds: authCfg.Session.LifetimeSeconds,
 				Issuer:          authCfg.Session.Issuer,
+				CookieName:      authCfg.Session.CookieName,
 			},
 		},
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -69,7 +69,13 @@ func TestConfigMap(t *testing.T) {
 			Session: config.SessionConfig{
 				LifetimeSeconds: int64((24 * 7 * time.Hour).Seconds()),
 				Issuer:          "https://test.domain.everything.awesome.is",
-				CookieName:      "_test_domain_everything_awesome_is_jwt_",
+				Cookie: config.CookieConfig{
+					Name:     "_test_domain_everything_awesome_is_jwt_",
+					MaxAge:   int64((24 * 7 * time.Hour).Seconds()),
+					SameSite: "lax",
+					Secure:   true,
+					HTTPOnly: true,
+				},
 			},
 		},
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -69,6 +69,7 @@ func TestConfigMap(t *testing.T) {
 			Session: config.SessionConfig{
 				LifetimeSeconds: int64((24 * 7 * time.Hour).Seconds()),
 				Issuer:          "https://test.domain.everything.awesome.is",
+				CookieName:      "_test_domain_everything_awesome_is_jwt_",
 			},
 		},
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -66,7 +66,13 @@ func TestConfigMap(t *testing.T) {
 			Session: auth.SessionConfig{
 				LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
 				Issuer:          "https://awesome.domain",
-				CookieName:      "_awesome_domain_jwt_",
+				Cookie: auth.CookieConfig{
+					Name:     "_awesome_domain_jwt_",
+					MaxAge:   int64((7 * 24 * time.Hour).Seconds()),
+					SameSite: "lax",
+					Secure:   true,
+					HTTPOnly: true,
+				},
 			},
 		},
 	}

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -66,6 +66,7 @@ func TestConfigMap(t *testing.T) {
 			Session: auth.SessionConfig{
 				LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
 				Issuer:          "https://awesome.domain",
+				CookieName:      "_awesome_domain_jwt_",
 			},
 		},
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We want to be able to create/read cookies on both Public API and Server. For that, we should have a shared understanding of the cookie names to look for when extracting the (JWT) session.

* Cookie Name, and opts are specified in `auth.session.cookie` config, used by both server and public-api

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17314

## How to test
<!-- Provide steps to test this PR -->
Unit tests

Preview
1. View
2. Check JWT cookie is set, and the naming
3. Check both server & public-api receive the config in their configmap

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-config-6a7121c1a4</li>
	<li><b>🔗 URL</b> - <a href="https://mp-config-6a7121c1a4.preview.gitpod-dev.com/workspaces" target="_blank">mp-config-6a7121c1a4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
