### PR TITLE
[preview] Configure with-dedicated-emulation

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1682403474866-AdminUserOnboardedTimestamp.ts
+++ b/components/gitpod-db/src/typeorm/migration/1682403474866-AdminUserOnboardedTimestamp.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "../../user-db";
+
+export class AdminUserOnboardedTimestamp1682403474866 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE d_b_user SET additionalData = '{"profile": {"onboardedTimestamp": "2023-04-24T09:00:00.000Z"}}' WHERE id = '${BUILTIN_INSTLLATION_ADMIN_USER_ID}'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE d_b_user SET additionalData = NULL WHERE id = '${BUILTIN_INSTLLATION_ADMIN_USER_ID}'`,
+        );
+    }
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -123,6 +123,11 @@ export namespace User {
         if (!!user.organizationId) {
             return false;
         }
+        // If a user has already been onboarded
+        // Also, used to rule out "admin-user"
+        if (!!user.additionalData?.profile?.onboardedTimestamp) {
+            return false;
+        }
         return !hasPreferredIde(user);
     }
 

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -377,6 +377,9 @@ then
   yq d -i stripe-api-keys.secret.yaml metadata.resourceVersion
   diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" stripe-api-keys.secret.yaml
   rm -f stripe-api-keys.secret.yaml
+
+  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeSecret" "stripe-api-keys"
+  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "stripe-config"
 fi
 
 #
@@ -391,6 +394,8 @@ then
   yq d -i linked-in.secret.yaml metadata.resourceVersion
   diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" linked-in.secret.yaml
   rm -f linked-in.secret.yaml
+
+  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.linkedInSecret" "linked-in"
 fi
 
 #
@@ -499,18 +504,6 @@ fi
 if [[ "${GITPOD_WSMANAGER_MK2}" == "true" ]]; then
   yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.workspace.useWsmanagerMk2" "true"
 fi
-
-
-#
-# Stripe
-#
-yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeSecret" "stripe-api-keys"
-yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "stripe-config"
-
-#
-# LinkedIn
-#
-yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.linkedInSecret" "linked-in"
 
 #
 # Enable SpiceDB on all preview envs

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -382,13 +382,16 @@ fi
 #
 # configureLinkedIn
 #
-kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret linked-in -o yaml > linked-in.secret.yaml
-yq w -i linked-in.secret.yaml metadata.namespace "default"
-yq d -i linked-in.secret.yaml metadata.creationTimestamp
-yq d -i linked-in.secret.yaml metadata.uid
-yq d -i linked-in.secret.yaml metadata.resourceVersion
-diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" linked-in.secret.yaml
-rm -f linked-in.secret.yaml
+if [[ "${GITPOD_WITH_DEDICATED_EMU}" != "true" ]]
+then
+  kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret linked-in -o yaml > linked-in.secret.yaml
+  yq w -i linked-in.secret.yaml metadata.namespace "default"
+  yq d -i linked-in.secret.yaml metadata.creationTimestamp
+  yq d -i linked-in.secret.yaml metadata.uid
+  yq d -i linked-in.secret.yaml metadata.resourceVersion
+  diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" linked-in.secret.yaml
+  rm -f linked-in.secret.yaml
+fi
 
 #
 # configureSSHGateway

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -359,7 +359,6 @@ fi
 #
 # configure dedicated emulation
 #
-
 if [[ "${GITPOD_WITH_DEDICATED_EMU}" == "true" ]]
 then
   # Suppress the Self-Hosted setup modal
@@ -369,13 +368,16 @@ fi
 #
 # configureStripeAPIKeys
 #
-kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret stripe-api-keys -o yaml > stripe-api-keys.secret.yaml
-yq w -i stripe-api-keys.secret.yaml metadata.namespace "default"
-yq d -i stripe-api-keys.secret.yaml metadata.creationTimestamp
-yq d -i stripe-api-keys.secret.yaml metadata.uid
-yq d -i stripe-api-keys.secret.yaml metadata.resourceVersion
-diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" stripe-api-keys.secret.yaml
-rm -f stripe-api-keys.secret.yaml
+if [[ "${GITPOD_WITH_DEDICATED_EMU}" != "true" ]]
+then
+  kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret stripe-api-keys -o yaml > stripe-api-keys.secret.yaml
+  yq w -i stripe-api-keys.secret.yaml metadata.namespace "default"
+  yq d -i stripe-api-keys.secret.yaml metadata.creationTimestamp
+  yq d -i stripe-api-keys.secret.yaml metadata.uid
+  yq d -i stripe-api-keys.secret.yaml metadata.resourceVersion
+  diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" stripe-api-keys.secret.yaml
+  rm -f stripe-api-keys.secret.yaml
+fi
 
 #
 # configureLinkedIn


### PR DESCRIPTION
## Description

This PR:
 - disables SaaS related secrets (linkedin, stripe) if `with-dedicated-emulation` is set
 - disable the Onboarding flow for the `admin-user` ([commit](https://github.com/gitpod-io/gitpod/pull/17337/commits/c7b2a62cd17b7492181d67c746cecadc55289b64)): Not very fond of the solution, and definitely open for alternative suggestions!

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-213

## How to test
 - `previewctl admin credentials create`
 - visit `https://gpl-dedica693133f791.preview.gitpod-dev.com/api/login/ots/admin/your-token`
 - notice the "new org" screen :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-dedica693133f791</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-dedica693133f791.preview.gitpod-dev.com/workspaces" target="_blank">gpl-dedica693133f791.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
