### PR TITLE
[server] Move snapshot service out of EE

### DIFF
--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -29,7 +29,6 @@ import { EMailDomainService, EMailDomainServiceImpl } from "./auth/email-domain-
 import { GitHubAppSupport } from "./github/github-app-support";
 import { GitLabAppSupport } from "./gitlab/gitlab-app-support";
 import { Config } from "../../src/config";
-import { SnapshotService } from "./workspace/snapshot-service";
 import { BitbucketAppSupport } from "./bitbucket/bitbucket-app-support";
 import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 import { EntitlementService } from "../../src/billing/entitlement-service";
@@ -64,7 +63,6 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     rebind(HostContainerMapping).to(HostContainerMappingEE).inSingletonScope();
     bind(EMailDomainService).to(EMailDomainServiceImpl).inSingletonScope();
     rebind(BlockedUserFilter).toService(EMailDomainService);
-    bind(SnapshotService).toSelf().inSingletonScope();
 
     // payment/billing
     bind(StripeService).toSelf().inSingletonScope();

--- a/components/server/ee/src/server.ts
+++ b/components/server/ee/src/server.ts
@@ -12,7 +12,6 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitLabApp } from "./prebuilds/gitlab-app";
 import { BitbucketApp } from "./prebuilds/bitbucket-app";
 import { GithubApp } from "./prebuilds/github-app";
-import { SnapshotService } from "./workspace/snapshot-service";
 import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
 import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 
@@ -21,17 +20,10 @@ export class ServerEE<C extends GitpodClient, S extends GitpodServer> extends Se
     @inject(GitLabApp) protected readonly gitLabApp: GitLabApp;
     @inject(BitbucketApp) protected readonly bitbucketApp: BitbucketApp;
     @inject(BitbucketServerApp) protected readonly bitbucketServerApp: BitbucketServerApp;
-    @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
     @inject(GitHubEnterpriseApp) protected readonly gitHubEnterpriseApp: GitHubEnterpriseApp;
 
     public async init(app: express.Application) {
         await super.init(app);
-
-        if (!this.config.completeSnapshotJob?.disabled) {
-            // Start Snapshot Service
-            log.info("Starting snapshot completion job...");
-            await this.snapshotService.start();
-        }
     }
 
     protected async registerRoutes(app: express.Application): Promise<void> {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -8,7 +8,6 @@ import { injectable, inject } from "inversify";
 import { GitpodServerImpl, traceAPIParams, traceWI, censor } from "../../../src/workspace/gitpod-server-impl";
 import { TraceContext, TraceContextWithSpan } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import {
-    GitpodServer,
     GitpodClient,
     AdminGetListRequest,
     User,
@@ -38,7 +37,6 @@ import {
     Project,
     StartPrebuildResult,
     ClientHeaderFields,
-    Workspace,
     FindPrebuildsParams,
     TeamMemberRole,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
@@ -47,7 +45,6 @@ import {
 } from "@gitpod/gitpod-protocol";
 import { ResponseError } from "vscode-jsonrpc";
 import {
-    TakeSnapshotRequest,
     AdmissionLevel,
     ControlAdmissionRequest,
     StopWorkspacePolicy,

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -74,7 +74,6 @@ import { StripeService } from "../user/stripe-service";
 import { GitHubAppSupport } from "../github/github-app-support";
 import { GitLabAppSupport } from "../gitlab/gitlab-app-support";
 import { Config } from "../../../src/config";
-import { SnapshotService, WaitForSnapshotOptions } from "./snapshot-service";
 import { ClientMetadata, traceClientMetadata } from "../../../src/websocket/websocket-connection-manager";
 import { BitbucketAppSupport } from "../bitbucket/bitbucket-app-support";
 import { URL } from "url";
@@ -106,8 +105,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     @inject(BitbucketAppSupport) protected readonly bitbucketAppSupport: BitbucketAppSupport;
 
     @inject(Config) protected readonly config: Config;
-
-    @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
 
     @inject(UserService) protected readonly userService: UserService;
 
@@ -371,101 +368,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             workspace.shareable = level === "everyone";
             await db.store(workspace);
         });
-    }
-
-    async takeSnapshot(ctx: TraceContext, options: GitpodServer.TakeSnapshotOptions): Promise<string> {
-        traceAPIParams(ctx, { options });
-        const { workspaceId, dontWait } = options;
-        traceWI(ctx, { workspaceId });
-
-        const user = this.checkAndBlockUser("takeSnapshot");
-
-        const workspace = await this.guardSnaphotAccess(ctx, user.id, workspaceId);
-
-        const instance = await this.workspaceDb.trace(ctx).findRunningInstance(workspaceId);
-        if (!instance) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} has no running instance`);
-        }
-        await this.guardAccess({ kind: "workspaceInstance", subject: instance, workspace }, "get");
-
-        const client = await this.workspaceManagerClientProvider.get(instance.region);
-        const request = new TakeSnapshotRequest();
-        request.setId(instance.id);
-        request.setReturnImmediately(true);
-
-        // this triggers the snapshots, but returns early! cmp. waitForSnapshot to wait for it's completion
-        const resp = await client.takeSnapshot(ctx, request);
-
-        const snapshot = await this.snapshotService.createSnapshot(options, resp.getUrl());
-
-        // to be backwards compatible during rollout, we require new clients to explicitly pass "dontWait: true"
-        const waitOpts = { workspaceOwner: workspace.ownerId, snapshot };
-        if (!dontWait) {
-            // this mimicks the old behavior: wait until the snapshot is through
-            await this.internalDoWaitForWorkspace(waitOpts);
-        } else {
-            // start driving the snapshot immediately
-            this.internalDoWaitForWorkspace(waitOpts).catch((err) =>
-                log.error({ userId: user.id, workspaceId: workspaceId }, "internalDoWaitForWorkspace", err),
-            );
-        }
-
-        return snapshot.id;
-    }
-
-    protected async guardSnaphotAccess(ctx: TraceContext, userId: string, workspaceId: string): Promise<Workspace> {
-        traceAPIParams(ctx, { userId, workspaceId });
-
-        const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
-        if (!workspace || workspace.ownerId !== userId) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} does not exist.`);
-        }
-        await this.guardAccess({ kind: "snapshot", subject: undefined, workspace }, "create");
-
-        return workspace;
-    }
-
-    /**
-     * @param snapshotId
-     * @throws ResponseError with either NOT_FOUND or SNAPSHOT_ERROR in case the snapshot is not done yet.
-     */
-    async waitForSnapshot(ctx: TraceContext, snapshotId: string): Promise<void> {
-        traceAPIParams(ctx, { snapshotId });
-
-        const user = this.checkAndBlockUser("waitForSnapshot");
-
-        const snapshot = await this.workspaceDb.trace(ctx).findSnapshotById(snapshotId);
-        if (!snapshot) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, `No snapshot with id '${snapshotId}' found.`);
-        }
-        const snapshotWorkspace = await this.guardSnaphotAccess(ctx, user.id, snapshot.originalWorkspaceId);
-        await this.internalDoWaitForWorkspace({ workspaceOwner: snapshotWorkspace.ownerId, snapshot });
-    }
-
-    protected async internalDoWaitForWorkspace(opts: WaitForSnapshotOptions) {
-        try {
-            await this.snapshotService.waitForSnapshot(opts);
-        } catch (err) {
-            // wrap in SNAPSHOT_ERROR to signal this call should not be retried.
-            throw new ResponseError(ErrorCodes.SNAPSHOT_ERROR, err.toString());
-        }
-    }
-
-    async getSnapshots(ctx: TraceContext, workspaceId: string): Promise<string[]> {
-        traceAPIParams(ctx, { workspaceId });
-        traceWI(ctx, { workspaceId });
-
-        const user = this.checkAndBlockUser("getSnapshots");
-
-        const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
-        if (!workspace || workspace.ownerId !== user.id) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} does not exist.`);
-        }
-
-        const snapshots = await this.workspaceDb.trace(ctx).findSnapshotsByWorkspaceId(workspaceId);
-        await Promise.all(snapshots.map((s) => this.guardAccess({ kind: "snapshot", subject: s, workspace }, "get")));
-
-        return snapshots.map((s) => s.id);
     }
 
     async adminGetUsers(ctx: TraceContext, req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>> {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -111,6 +111,7 @@ import { APITeamsService } from "./api/teams";
 import { API } from "./api/server";
 import { LinkedInService } from "./linkedin-service";
 import { AuthJWT } from "./auth/jwt";
+import { SnapshotService } from "./workspace/snapshot-service";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -136,6 +137,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(ConfigProvider).toSelf().inSingletonScope();
     bind(ConfigurationService).toSelf().inSingletonScope();
 
+    bind(SnapshotService).toSelf().inSingletonScope();
     bind(WorkspaceFactory).toSelf().inSingletonScope();
     bind(WorkspaceDeletionService).toSelf().inSingletonScope();
     bind(WorkspaceStarter).toSelf().inSingletonScope();

--- a/components/server/src/workspace/snapshot-service.ts
+++ b/components/server/src/workspace/snapshot-service.ts
@@ -8,10 +8,10 @@ import { inject, injectable } from "inversify";
 import { v4 as uuidv4 } from "uuid";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { Disposable, GitpodServer, Snapshot } from "@gitpod/gitpod-protocol";
-import { StorageClient } from "../../../src/storage/storage-client";
-import { ConsensusLeaderQorum } from "../../../src/consensus/consensus-leader-quorum";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { StorageClient } from "../storage/storage-client";
+import { ConsensusLeaderQorum } from "../consensus/consensus-leader-quorum";
 
 const SNAPSHOT_TIMEOUT_SECONDS = 60 * 30;
 const SNAPSHOT_POLL_INTERVAL_SECONDS = 5;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Moves Snapshot service out of EE, we don't have EE anymore so no need to keep it seperate

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-move-sn5410bfd74b</li>
	<li><b>🔗 URL</b> - <a href="https://mp-move-sn5410bfd74b.preview.gitpod-dev.com/workspaces" target="_blank">mp-move-sn5410bfd74b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
