### PR TITLE
[dashboard] fix ws query invalidation

### DIFF
--- a/components/dashboard/src/data/workspaces/delete-inactive-workspaces-mutation.ts
+++ b/components/dashboard/src/data/workspaces/delete-inactive-workspaces-mutation.ts
@@ -9,6 +9,7 @@ import { useFeatureFlags } from "../../contexts/FeatureFlagContext";
 import { workspacesService } from "../../service/public-api";
 import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
 type DeleteInactiveWorkspacesArgs = {
     workspaceIds: string[];
@@ -16,6 +17,7 @@ type DeleteInactiveWorkspacesArgs = {
 export const useDeleteInactiveWorkspacesMutation = () => {
     const queryClient = useQueryClient();
     const { usePublicApiWorkspacesService } = useFeatureFlags();
+    const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceIds }: DeleteInactiveWorkspacesArgs) => {
@@ -37,7 +39,7 @@ export const useDeleteInactiveWorkspacesMutation = () => {
             return deletedWorkspaceIds;
         },
         onSuccess: (deletedWorkspaceIds) => {
-            const queryKey = getListWorkspacesQueryKey();
+            const queryKey = getListWorkspacesQueryKey(org.data?.id);
 
             // Remove deleted workspaces from cache so it's reflected right away
             // Using the result of the mutationFn so we only remove workspaces that were delete

--- a/components/dashboard/src/data/workspaces/delete-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/delete-workspace-mutation.ts
@@ -9,6 +9,7 @@ import { useFeatureFlags } from "../../contexts/FeatureFlagContext";
 import { workspacesService } from "../../service/public-api";
 import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
 type DeleteWorkspaceArgs = {
     workspaceId: string;
@@ -17,6 +18,7 @@ type DeleteWorkspaceArgs = {
 export const useDeleteWorkspaceMutation = () => {
     const queryClient = useQueryClient();
     const { usePublicApiWorkspacesService } = useFeatureFlags();
+    const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceId }: DeleteWorkspaceArgs) => {
@@ -25,7 +27,7 @@ export const useDeleteWorkspaceMutation = () => {
                 : await getGitpodService().server.deleteWorkspace(workspaceId);
         },
         onSuccess: (_, { workspaceId }) => {
-            const queryKey = getListWorkspacesQueryKey();
+            const queryKey = getListWorkspacesQueryKey(org.data?.id);
 
             // Remove workspace from cache so it's reflected right away
             queryClient.setQueryData<ListWorkspacesQueryResult>(queryKey, (oldWorkspacesData) => {

--- a/components/dashboard/src/data/workspaces/list-workspaces-query.ts
+++ b/components/dashboard/src/data/workspaces/list-workspaces-query.ts
@@ -58,4 +58,9 @@ export const useListWorkspacesQuery = ({ limit }: UseListWorkspacesQueryArgs) =>
     });
 };
 
-export const getListWorkspacesQueryKey = (orgId?: string) => ["workspaces", "list", orgId || "noorg"];
+export function getListWorkspacesQueryKey(orgId?: string) {
+    if (!orgId) {
+        return ["workspaces", "list"];
+    }
+    return ["workspaces", "list", orgId];
+}

--- a/components/dashboard/src/data/workspaces/toggle-workspace-pinned-mutation.ts
+++ b/components/dashboard/src/data/workspaces/toggle-workspace-pinned-mutation.ts
@@ -7,6 +7,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
 type ToggleWorkspacePinnedArgs = {
     workspaceId: string;
@@ -14,13 +15,14 @@ type ToggleWorkspacePinnedArgs = {
 
 export const useToggleWorkspacedPinnedMutation = () => {
     const queryClient = useQueryClient();
+    const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceId }: ToggleWorkspacePinnedArgs) => {
             return await getGitpodService().server.updateWorkspaceUserPin(workspaceId, "toggle");
         },
         onSuccess: (_, { workspaceId }) => {
-            const queryKey = getListWorkspacesQueryKey();
+            const queryKey = getListWorkspacesQueryKey(org.data?.id);
 
             // Update workspace.pinned to account for the toggle so it's reflected immediately
             queryClient.setQueryData<ListWorkspacesQueryResult>(queryKey, (oldWorkspaceData) => {

--- a/components/dashboard/src/data/workspaces/toggle-workspace-shared-mutation.ts
+++ b/components/dashboard/src/data/workspaces/toggle-workspace-shared-mutation.ts
@@ -8,6 +8,7 @@ import { GitpodServer } from "@gitpod/gitpod-protocol";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
 type ToggleWorkspaceSharedArgs = {
     workspaceId: string;
@@ -16,13 +17,14 @@ type ToggleWorkspaceSharedArgs = {
 
 export const useToggleWorkspaceSharedMutation = () => {
     const queryClient = useQueryClient();
+    const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceId, level }: ToggleWorkspaceSharedArgs) => {
             return await getGitpodService().server.controlAdmission(workspaceId, level);
         },
         onSuccess: (_, { workspaceId, level }) => {
-            const queryKey = getListWorkspacesQueryKey();
+            const queryKey = getListWorkspacesQueryKey(org.data?.id);
 
             // Update workspace.shareable to the level we set so it's reflected immediately
             queryClient.setQueryData<ListWorkspacesQueryResult>(queryKey, (oldWorkspacesData) => {

--- a/components/dashboard/src/data/workspaces/update-workspace-description-mutation.ts
+++ b/components/dashboard/src/data/workspaces/update-workspace-description-mutation.ts
@@ -7,6 +7,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
 type UpdateWorkspaceDescriptionArgs = {
     workspaceId: string;
@@ -14,13 +15,14 @@ type UpdateWorkspaceDescriptionArgs = {
 };
 export const useUpdateWorkspaceDescriptionMutation = () => {
     const queryClient = useQueryClient();
+    const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceId, newDescription }: UpdateWorkspaceDescriptionArgs) => {
             return await getGitpodService().server.setWorkspaceDescription(workspaceId, newDescription);
         },
         onSuccess: (_, { workspaceId, newDescription }) => {
-            const queryKey = getListWorkspacesQueryKey();
+            const queryKey = getListWorkspacesQueryKey(org.data?.id);
 
             // pro-actively update workspace description rather than reload all workspaces
             queryClient.setQueryData<ListWorkspacesQueryResult>(queryKey, (oldWorkspacesData) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes a regression, where the key for the workspaces-list would be wrong when used from migrations

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-204

## How to test
<!-- Provide steps to test this PR -->

delete a workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-delete-workspace</li>
	<li><b>🔗 URL</b> - <a href="https://se-delete-workspace.preview.gitpod-dev.com/workspaces" target="_blank">se-delete-workspace.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
