### PR TITLE
Add focus ring for `<SelectableCardSolid>`

### DIFF
--- a/components/dashboard/src/components/SelectableCardSolid.tsx
+++ b/components/dashboard/src/components/SelectableCardSolid.tsx
@@ -51,6 +51,7 @@ function SelectableCardSolid(props: SelectableCardSolidProps) {
                     checked={props.selected}
                     onFocus={handleFocus}
                     onBlur={handleBlur}
+                    aria-label={props.title}
                 />
             </div>
             {props.children}

--- a/components/dashboard/src/components/SelectableCardSolid.tsx
+++ b/components/dashboard/src/components/SelectableCardSolid.tsx
@@ -28,7 +28,7 @@ function SelectableCardSolid(props: SelectableCardSolidProps) {
     return (
         <div
             className={`rounded-xl px-3 py-3 flex flex-col cursor-pointer group transition ease-in-out ${
-                isFocused ? "focus:ring-2 focus:ring-blue-500" : ""
+                isFocused ? "ring-2 ring-blue-500" : ""
             } ${
                 props.selected
                     ? "bg-gray-800 dark:bg-gray-100"

--- a/components/dashboard/src/components/SelectableCardSolid.tsx
+++ b/components/dashboard/src/components/SelectableCardSolid.tsx
@@ -4,6 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { useState } from "react";
+
 export interface SelectableCardSolidProps {
     title: string;
     selected: boolean;
@@ -13,9 +15,21 @@ export interface SelectableCardSolidProps {
 }
 
 function SelectableCardSolid(props: SelectableCardSolidProps) {
+    const [isFocused, setIsFocused] = useState(false);
+
+    const handleFocus = () => {
+        setIsFocused(true);
+    };
+
+    const handleBlur = () => {
+        setIsFocused(false);
+    };
+
     return (
         <div
             className={`rounded-xl px-3 py-3 flex flex-col cursor-pointer group transition ease-in-out ${
+                isFocused ? "focus:ring-2 focus:ring-blue-500" : ""
+            } ${
                 props.selected
                     ? "bg-gray-800 dark:bg-gray-100"
                     : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
@@ -31,7 +45,13 @@ function SelectableCardSolid(props: SelectableCardSolidProps) {
                 >
                     {props.title}
                 </p>
-                <input className="opacity-0" type="radio" checked={props.selected} />
+                <input
+                    className="opacity-0"
+                    type="radio"
+                    checked={props.selected}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                />
             </div>
             {props.children}
         </div>


### PR DESCRIPTION
## Description

Adds focus rings to the cards component for improved accessibility. 

## Related Issue(s)

Split from https://github.com/gitpod-io/gitpod/pull/17053

Partly addresses https://github.com/gitpod-io/gitpod/issues/16723

## How to test

Go to the preview environment, to user preferences, and <kbd>Tab</kbd> your way through to the Theme selection. It should always be clear which one is selected.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-selecta9ef3ce70f0</li>
	<li><b>🔗 URL</b> - <a href="https://ft-selecta9ef3ce70f0.preview.gitpod-dev.com/workspaces" target="_blank">ft-selecta9ef3ce70f0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
