### PR TITLE
Update LinkedIn banner style

### DIFF
--- a/components/dashboard/src/onboarding/LinkedInBanner.tsx
+++ b/components/dashboard/src/onboarding/LinkedInBanner.tsx
@@ -56,7 +56,7 @@ export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
                 className={classNames(
                     "mt-6 p-6",
                     "border-2 border-dashed rounded-md space-y-4",
-                    "bg-gray-50 dark:bg-gray-800",
+                    "bg-gray-50 dark:bg-gray-800 dark:border-gray-600",
                 )}
             >
                 <div className="flex items-center justify-center space-x-6">


### PR DESCRIPTION
## Description

Minor style change for the LinkedIn banner on dark theme. 🌔 

See [relevant discussion](https://gitpod.slack.com/archives/C04PH56LZK5/p1681301914362189?thread_ts=1680877128.918449&cid=C04PH56LZK5) (internal). Cc @atduarte 

| BEFORE | AFTER |
|--------|--------|
| <img width="364" alt="banner-before" src="https://user-images.githubusercontent.com/120486/234083741-50541f49-29f1-4d58-b2f6-36f6e3c72e7d.png"> | <img width="364" alt="banner-after" src="https://user-images.githubusercontent.com/120486/234083753-b84d66c9-a9a0-4353-befb-fb0c1963a68a.png"> | 

## How to test

Join the preview environment using the dark theme.

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
