### PR TITLE
Enable dashboard linter for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,4 +72,12 @@ repos:
     hooks:
       - id: gitleaks
 
+  - repo: local
+    hooks:
+      - id: dashboard-linter
+        name: dashboard-linter
+        entry: leeway run components/dashboard:lint
+        language: system
+        pass_filenames: false
+
 exclude: ^install/installer/.*/.*\.golden$

--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -51,6 +51,9 @@ packages:
         - ${imageRepoBase}/dashboard:${version}
         - ${imageRepoBase}/dashboard:commit-${__git_commit}
 scripts:
+  - name: lint
+    script: |-
+      yarn run lint
   - name: telepresence
     script: |-
       trap "kill 0" EXIT

--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -53,7 +53,7 @@ packages:
 scripts:
   - name: lint
     script: |-
-      yarn run lint
+      yarn run eslint --max-warnings=0 $(git diff --cached --relative --name-only --diff-filter=ACMRTUXB | grep  -E "\.(js|ts|tsx)$")
   - name: telepresence
     script: |-
       trap "kill 0" EXIT

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build --verbose",
-    "lint": "eslint --ext=.jsx,.js,.tsx,.ts ./src",
+    "lint": "eslint --max-warnings=0 --ext=.jsx,.js,.tsx,.ts ./src",
     "test": "yarn test:unit && ./scripts/run-integration-tests.sh",
     "test:unit": "craco test --all --watchAll=false",
     "test:unit:watch": "craco test --all",

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -55,9 +55,6 @@ export default function UserDetail(p: { user: User }) {
         setUsageLimit(costCenter.spendingLimit);
     }, [costCenter, user]);
 
-    const email = User.getPrimaryEmail(p.user);
-    const emailDomain = email ? email.split("@")[email.split("@").length - 1] : undefined;
-
     const updateUser: UpdateUserFunction = async (fun) => {
         setActivity(true);
         try {

--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -7,7 +7,6 @@
 import { User, WorkspaceAndInstance, ContextURL, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Heading2, Subheading } from "../components/typography/headings";

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -11,7 +11,6 @@ import { useCurrentUser } from "../user-context";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
-import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useLocation } from "react-router";
 import { User } from "@gitpod/gitpod-protocol";
 
@@ -20,7 +19,6 @@ export default function OrganizationSelector() {
     const orgs = useOrganizations();
     const currentOrg = useCurrentOrg();
     const { data: userBillingMode } = useUserBillingMode();
-    const { data: orgBillingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
 
     // we should have an API to ask for permissions, until then we duplicate the logic here

--- a/components/dashboard/src/onboarding/StepOrgInfo.tsx
+++ b/components/dashboard/src/onboarding/StepOrgInfo.tsx
@@ -15,7 +15,6 @@ import { EXPLORE_REASON_WORK, getExplorationReasons } from "./exploration-reason
 import { getJobRoleOptions, JOB_ROLE_OTHER } from "./job-roles";
 import { OnboardingStep } from "./OnboardingStep";
 import { getSignupGoalsOptions, SIGNUP_GOALS_OTHER } from "./signup-goals";
-import isURL from "validator/lib/isURL";
 import { getCompanySizeOptions } from "./company-size";
 
 type Props = {

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -131,7 +131,7 @@ export function StartPage(props: StartPageProps) {
                     </Alert>
                 )}
                 <div className="absolute bottom-4 right-4 text-gray-400 dark:text-gray-500 text-xs font-medium tracking-wide">
-                    <a href="https://cdeuniverse.com/" target="_blank">
+                    <a href="https://cdeuniverse.com/" target="_blank" rel="noreferrer noopener">
                         <span>
                             <img src={CDEUniverseLogo} alt="CDE Universe logo" className="h-4 inline mr-1" />
                             <span className="font-semibold">CDE Universe</span>: June 1 & 2 ↗


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds dashboard linting to pre-commit hooks so we won't commit any error/warnings the linter spots.

Linter errors can be seen in the git hook output or by manually running the linter.

```bash
# w/ leeway
leeway run components/dashboard:lint
# or from the dashboard component directory w/ yarn
yarn run lint
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-111

## How to test
<!-- Provide steps to test this PR -->
I was able to test this while making these changes, but changing any ts/js file in the dashboard component so it has a linter error/warning, and trying to commit it should cause the hook to fail. 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
