### PR TITLE
[ws-proxy] send ide heartbeat telemetry

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -135,9 +135,7 @@ var runCmd = &cobra.Command{
 				log.WithError(err).Fatal("cannot connect to ws-manager")
 			}
 
-			heartbeat = &sshproxy.WorkspaceManagerHeartbeat{
-				Client: wsmanapi.NewWorkspaceManagerClient(conn),
-			}
+			heartbeat = sshproxy.NewWorkspaceManagerHeartbeat(cfg.Proxy.GitpodInstallation.HostName, wsmanapi.NewWorkspaceManagerClient(conn))
 		}
 
 		// SSH Gateway

--- a/components/ws-proxy/pkg/sshproxy/forward.go
+++ b/components/ws-proxy/pkg/sshproxy/forward.go
@@ -119,6 +119,7 @@ func startHeartbeatingChannel(c ssh.Channel, heartbeat Heartbeat, session *Sessi
 		t:       time.NewTicker(30 * time.Second),
 		cancel:  cancel,
 	}
+	go heartbeat.ScheduleIDEHeartbeatTelemetry(ctx, session)
 	go func() {
 		for {
 			select {

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -8,13 +8,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/gitpod-io/gitpod/common-go/analytics"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+	tracker "github.com/gitpod-io/gitpod/ws-proxy/pkg/analytics"
 )
 
 type Heartbeat interface {
 	// SendHeartbeat sends a heartbeat for a workspace
 	SendHeartbeat(instanceID string, isClosed, ignoreIfActive bool)
+	// ScheduleIDEHeartbeatTelemetry starts a schedules the IDE heartbeat telemetry per 15 minutes
+	ScheduleIDEHeartbeatTelemetry(ctx context.Context, session *Session)
 }
 
 type noHeartbeat struct{}
@@ -23,6 +27,22 @@ func (noHeartbeat) SendHeartbeat(instanceID string, isClosed, ignoreIfActive boo
 
 type WorkspaceManagerHeartbeat struct {
 	Client wsmanapi.WorkspaceManagerClient
+
+	gitpodHost      string
+	totalCount      int
+	successfulCount int
+}
+
+var _ Heartbeat = &WorkspaceManagerHeartbeat{}
+
+func NewWorkspaceManagerHeartbeat(gitpodHost string, client wsmanapi.WorkspaceManagerClient) *WorkspaceManagerHeartbeat {
+	m := &WorkspaceManagerHeartbeat{
+		Client:          client,
+		gitpodHost:      gitpodHost,
+		totalCount:      0,
+		successfulCount: 0,
+	}
+	return m
 }
 
 func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string, isClosed, ignoreIfActive bool) {
@@ -33,9 +53,45 @@ func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string, isClosed, i
 		Closed:         isClosed,
 		IgnoreIfActive: ignoreIfActive,
 	})
+	m.totalCount += 1
 	if err != nil {
 		log.WithError(err).Warn("cannot send heartbeat for workspace instance")
 	} else {
+		m.successfulCount += 1
 		log.WithField("instanceId", instanceID).Debug("sent heartbeat to ws-manager")
 	}
+}
+
+func (m *WorkspaceManagerHeartbeat) ScheduleIDEHeartbeatTelemetry(ctx context.Context, session *Session) {
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.sendIDEHeartbeatTelemetry(session)
+		case <-ctx.Done():
+			m.sendIDEHeartbeatTelemetry(session)
+			return
+		}
+	}
+}
+
+func (m *WorkspaceManagerHeartbeat) sendIDEHeartbeatTelemetry(session *Session) {
+	propertics := make(map[string]interface{})
+	propertics["clientKind"] = "ssh"
+	propertics["totalCount"] = m.totalCount
+	propertics["successfulCount"] = m.successfulCount
+	propertics["workspaceId"] = session.WorkspaceID
+	propertics["instanceId"] = session.InstanceID
+	propertics["gitpodHost"] = m.gitpodHost
+	// TODO: Identify if it's debug workspace or not
+	// propertics["debugWorkspace"] = "false"
+
+	tracker.Track(analytics.TrackMessage{
+		Identity:   analytics.Identity{UserID: session.OwnerUserId},
+		Event:      "ide_heartbeat",
+		Properties: propertics,
+	})
+	m.totalCount = 0
+	m.successfulCount = 0
 }

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -91,7 +91,6 @@ func (m *WorkspaceManagerHeartbeat) sendIDEHeartbeatTelemetry(session *Session) 
 	// TODO: Identify if it's debug workspace or not
 	// propertics["debugWorkspace"] = "false"
 
-	log.WithField("properties", properties).Info("send ide heartbeat telemetry")
 	tracker.Track(analytics.TrackMessage{
 		Identity:   analytics.Identity{UserID: session.OwnerUserId},
 		Event:      "ide_heartbeat",

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -23,7 +23,11 @@ type Heartbeat interface {
 
 type noHeartbeat struct{}
 
+var _ Heartbeat = &noHeartbeat{}
+
 func (noHeartbeat) SendHeartbeat(instanceID string, isClosed, ignoreIfActive bool) {}
+
+func (*noHeartbeat) ScheduleIDEHeartbeatTelemetry(ctx context.Context, session *Session) {}
 
 type WorkspaceManagerHeartbeat struct {
 	Client wsmanapi.WorkspaceManagerClient

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -91,6 +91,7 @@ func (m *WorkspaceManagerHeartbeat) sendIDEHeartbeatTelemetry(session *Session) 
 	// TODO: Identify if it's debug workspace or not
 	// propertics["debugWorkspace"] = "false"
 
+	log.WithField("properties", properties).Info("send ide heartbeat telemetry")
 	tracker.Track(analytics.TrackMessage{
 		Identity:   analytics.Identity{UserID: session.OwnerUserId},
 		Event:      "ide_heartbeat",

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -81,20 +81,20 @@ func (m *WorkspaceManagerHeartbeat) ScheduleIDEHeartbeatTelemetry(ctx context.Co
 }
 
 func (m *WorkspaceManagerHeartbeat) sendIDEHeartbeatTelemetry(session *Session) {
-	propertics := make(map[string]interface{})
-	propertics["clientKind"] = "ssh"
-	propertics["totalCount"] = m.totalCount
-	propertics["successfulCount"] = m.successfulCount
-	propertics["workspaceId"] = session.WorkspaceID
-	propertics["instanceId"] = session.InstanceID
-	propertics["gitpodHost"] = m.gitpodHost
+	properties := make(map[string]interface{})
+	properties["clientKind"] = "ssh"
+	properties["totalCount"] = m.totalCount
+	properties["successfulCount"] = m.successfulCount
+	properties["workspaceId"] = session.WorkspaceID
+	properties["instanceId"] = session.InstanceID
+	properties["gitpodHost"] = m.gitpodHost
 	// TODO: Identify if it's debug workspace or not
 	// propertics["debugWorkspace"] = "false"
 
 	tracker.Track(analytics.TrackMessage{
 		Identity:   analytics.Identity{UserID: session.OwnerUserId},
 		Event:      "ide_heartbeat",
-		Properties: propertics,
+		Properties: properties,
 	})
 	m.totalCount = 0
 	m.successfulCount = 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Align and send ide heartbeat telemetry

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [Linear](https://linear.app/gitpod/issue/IDE-20/ssh)

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env
- Connect with ssh
- Wait for 15 minutes, it should send ide_heartbeat telemetry

✅ after add debug loggings https://github.com/gitpod-io/gitpod/commit/9b21ffa59f36b96af545d1fcade86d84a591303c
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/20944364/234318800-dcba62d5-498d-442b-820b-a4c0190f1a99.png">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - huiwen-ide-20-ssh</li>
	<li><b>🔗 URL</b> - <a href="https://huiwen-ide-20-ssh.preview.gitpod-dev.com/workspaces" target="_blank">huiwen-ide-20-ssh.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
