### PR TITLE
[jetbrains] send ide heartbeat telemetry

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -67,12 +67,12 @@ class HeartbeatService : Disposable {
         while (isActive) {
             try {
                 manager.trackEvent("ide_heartbeat", mapOf(
-                    "clientKind" to "jetbrains"
-                    "totalCount" to totalCount
-                    "successfulCount" to successfulCount
-                    "workspaceId" to info.workspaceId
-                    "instanceId" to info.instanceId
-                    "gitpodHost" to info.gitpodApi.host
+                    "clientKind" to "jetbrains",
+                    "totalCount" to totalCount,
+                    "successfulCount" to successfulCount,
+                    "workspaceId" to info.workspaceId,
+                    "instanceId" to info.instanceId,
+                    "gitpodHost" to info.gitpodApi.host,
                     "debugWorkspace" to info.debug.toString()
                 ))
             } catch (t: Throwable) {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -20,6 +20,10 @@ class HeartbeatService : Disposable {
 
     private val manager = service<GitpodManager>()
 
+    // define property to store successfulCount and totalCount
+    private var successfulCount = 0
+    private var totalCount = 0
+
     private val job = GlobalScope.launch {
         val info = manager.pendingInfo.await()
         val intervalInSeconds = 30
@@ -57,26 +61,23 @@ class HeartbeatService : Disposable {
         }
     }
 
-    // define property to store successfulCount and totalCount
-    private val successfulCount = 0
-    private val totalCount = 0
-
     // define job to start interval per 15 minutes
     private val telemetryJob = GlobalScope.launch {
         val info = manager.pendingInfo.await()
         while (isActive) {
             try {
                 manager.trackEvent("ide_heartbeat", mapOf(
-                    "clientKind" to "jetbrains",
-                    "totalCount" to totalCount,
-                    "successfulCount" to successfulCount,
-                    "workspaceId" to info.workspaceId,
-                    "instanceId" to info.instanceId,
-                    "gitpodHost" to info.gitpodApi.host,
-                    "debugWorkspace" to info.debug.toString()
+                        "clientKind" to "jetbrains",
+                        "totalCount" to totalCount,
+                        "successfulCount" to successfulCount,
+                        "workspaceId" to info.workspaceId,
+                        "instanceId" to info.instanceId,
+                        "gitpodHost" to info.gitpodApi.host,
+                // TODO: Identify if it's debug workspace
+                // "debugWorkspace" to "false"
                 ))
             } catch (t: Throwable) {
-                thisLogger().error("gitpod: failed to send hearbeat telemetry:", t)
+                thisLogger().error("gitpod: failed to send heartbeat telemetry:", t)
             }
             delay(15 * 60 * 1000L)
         }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -70,8 +70,6 @@ class HeartbeatService : Disposable {
                         "clientKind" to "jetbrains",
                         "totalCount" to totalCount,
                         "successfulCount" to successfulCount,
-                        "workspaceId" to info.workspaceId,
-                        "instanceId" to info.instanceId,
                         "gitpodHost" to info.gitpodApi.host,
                 // TODO: Identify if it's debug workspace
                 // "debugWorkspace" to "false"

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -13,6 +13,8 @@ import io.gitpod.jetbrains.remote.GitpodManager
 import io.gitpod.jetbrains.remote.services.ControllerStatusService.ControllerStatus
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.random.Random.Default.nextInt
 
 @Service
@@ -23,6 +25,7 @@ class HeartbeatService : Disposable {
     // define property to store successfulCount and totalCount
     private var successfulCount = 0
     private var totalCount = 0
+    private val counterMutex = Mutex()
 
     private val job = GlobalScope.launch {
         val info = manager.pendingInfo.await()
@@ -32,6 +35,7 @@ class HeartbeatService : Disposable {
                 secondsSinceLastActivity = 0
         )
         while (isActive) {
+            var hbSucceed = false
             try {
                 val previous = current;
                 current = ControllerStatusService.fetch()
@@ -44,7 +48,7 @@ class HeartbeatService : Disposable {
                 }
                 if (wasClosed != null) {
                     manager.client.server.sendHeartBeat(SendHeartBeatOptions(info.instanceId, wasClosed)).await()
-                    successfulCount += 1
+                    hbSucceed = true
                     if (wasClosed) {
                         manager.trackEvent("ide_close_signal", mapOf(
                                 "clientKind" to "jetbrains"
@@ -54,7 +58,12 @@ class HeartbeatService : Disposable {
             } catch (t: Throwable) {
                 thisLogger().error("gitpod: failed to check activity:", t)
             } finally {
-                totalCount += 1
+                counterMutex.withLock {
+                    if (hbSucceed) {
+                        successfulCount += 1
+                    }
+                    totalCount += 1
+                }
             }
 
             delay(intervalInSeconds * 1000L)
@@ -63,21 +72,35 @@ class HeartbeatService : Disposable {
 
     // define job to start interval per 15 minutes
     private val telemetryJob = GlobalScope.launch {
-        val info = manager.pendingInfo.await()
-        while (isActive) {
-            try {
-                manager.trackEvent("ide_heartbeat", mapOf(
+        try {
+            while (isActive) {
+                sendIDEHeartbeat()
+                delay(15 * 60 * 1000L)
+            }
+        } finally {
+            sendIDEHeartbeat()
+        }
+    }
+
+    private suspend fun sendIDEHeartbeat() {
+        try {
+            var props: Map<String, Any> = mapOf()
+            val info = manager.pendingInfo.await()
+            counterMutex.withLock {
+                props = mapOf(
                         "clientKind" to "jetbrains",
                         "totalCount" to totalCount,
                         "successfulCount" to successfulCount,
                         "gitpodHost" to info.gitpodApi.host,
-                // TODO: Identify if it's debug workspace
-                // "debugWorkspace" to "false"
-                ))
-            } catch (t: Throwable) {
-                thisLogger().error("gitpod: failed to send heartbeat telemetry:", t)
+                        // TODO: Identify if it's debug workspace
+                        // "debugWorkspace" to "false"
+                )
+                totalCount = 0
+                successfulCount = 0
             }
-            delay(15 * 60 * 1000L)
+            manager.trackEvent("ide_heartbeat", props)
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: failed to send heartbeat telemetry:", t)
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Align and send ide heartbeat telemetry

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [Linear](https://linear.app/gitpod/issue/IDE-21/jetbrains)

## How to test
<!-- Provide steps to test this PR -->
- Start workspace in preview env with JetBrains IDEs
- Wait for 15 minutes, it should send `ide_heartbeat` telemetry [[segemnt](https://app.segment.com/gitpod/sources/staging_trusted/debugger)]

✅ 
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/20944364/234294849-1282cf12-9306-4bf0-a16b-b0d3ce7ab472.png">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - huiwen-idec4b6fe19b3</li>
	<li><b>🔗 URL</b> - <a href="https://huiwen-idec4b6fe19b3.preview.gitpod-dev.com/workspaces" target="_blank">huiwen-idec4b6fe19b3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
