### PR TITLE
[supervisor-frontend] fix metrics reporting

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -110,7 +110,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             // send last heartbeat (wasClosed: true)
             const data = { sessionId: this.sessionId };
             const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
-            const gitpodHostUrl = new GitpodHostUrl(new URL(window.location.toString()));
+            const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
             const url = gitpodHostUrl.withApi({ pathname: `/auth/workspacePageClose/${this.instanceID}` }).toString();
             navigator.sendBeacon(url, blob);
         });

--- a/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
@@ -16,7 +16,7 @@ class TestGenerateWorkspaceId {
     @test public async testGenerateWorkspaceId() {
         for (let i = 0; i < 10; i++) {
             const id = await generateWorkspaceID();
-            expect(new GitpodHostUrl().withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
+            expect(new GitpodHostUrl("https://gitpod.io").withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
         }
     }
 
@@ -50,7 +50,7 @@ class TestGenerateWorkspaceId {
         for (const d of data) {
             const id = await generateWorkspaceID(d[0], d[1]);
             expect(id).match(new RegExp("^" + d[2]));
-            expect(new GitpodHostUrl().withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
+            expect(new GitpodHostUrl("https://gitpod.io").withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
             expect(id.length <= 36, `"${id}" is longer than 36 chars (${id.length})`).to.be.true;
         }
     }

--- a/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
@@ -11,15 +11,8 @@ const expect = chai.expect;
 
 @suite
 export class GitpodHostUrlTest {
-    @test public parseWorkspaceId_pathBased() {
-        const actual = GitpodHostUrl.fromWorkspaceUrl(
-            "http://35.223.201.195/workspace/bc77e03d-c781-4235-bca0-e24087f5e472/",
-        ).workspaceId;
-        expect(actual).to.equal("bc77e03d-c781-4235-bca0-e24087f5e472");
-    }
-
     @test public parseWorkspaceId_hosts_withEnvVarsInjected() {
-        const actual = GitpodHostUrl.fromWorkspaceUrl(
+        const actual = new GitpodHostUrl(
             "https://gray-grasshopper-nfbitfia.ws-eu02.gitpod-staging.com/#passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo",
         ).workspaceId;
         expect(actual).to.equal("gray-grasshopper-nfbitfia");
@@ -27,21 +20,21 @@ export class GitpodHostUrlTest {
 
     @test public async testWithoutWorkspacePrefix() {
         expect(
-            GitpodHostUrl.fromWorkspaceUrl("https://3000-moccasin-ferret-155799b3.ws-eu02.gitpod-staging.com/")
+            new GitpodHostUrl("https://3000-moccasin-ferret-155799b3.ws-eu02.gitpod-staging.com/")
                 .withoutWorkspacePrefix()
                 .toString(),
         ).to.equal("https://gitpod-staging.com/");
     }
 
     @test public async testWithoutWorkspacePrefix2() {
-        expect(
-            GitpodHostUrl.fromWorkspaceUrl("https://gitpod-staging.com/").withoutWorkspacePrefix().toString(),
-        ).to.equal("https://gitpod-staging.com/");
+        expect(new GitpodHostUrl("https://gitpod-staging.com/").withoutWorkspacePrefix().toString()).to.equal(
+            "https://gitpod-staging.com/",
+        );
     }
 
     @test public async testWithoutWorkspacePrefix3() {
         expect(
-            GitpodHostUrl.fromWorkspaceUrl("https://gray-rook-5523v5d8.ws-dev.my-branch-1234.staging.gitpod-dev.com/")
+            new GitpodHostUrl("https://gray-rook-5523v5d8.ws-dev.my-branch-1234.staging.gitpod-dev.com/")
                 .withoutWorkspacePrefix()
                 .toString(),
         ).to.equal("https://my-branch-1234.staging.gitpod-dev.com/");
@@ -49,15 +42,13 @@ export class GitpodHostUrlTest {
 
     @test public async testWithoutWorkspacePrefix4() {
         expect(
-            GitpodHostUrl.fromWorkspaceUrl("https://my-branch-1234.staging.gitpod-dev.com/")
-                .withoutWorkspacePrefix()
-                .toString(),
+            new GitpodHostUrl("https://my-branch-1234.staging.gitpod-dev.com/").withoutWorkspacePrefix().toString(),
         ).to.equal("https://my-branch-1234.staging.gitpod-dev.com/");
     }
 
     @test public async testWithoutWorkspacePrefix5() {
         expect(
-            GitpodHostUrl.fromWorkspaceUrl("https://abc-nice-brunch-4224.staging.gitpod-dev.com/")
+            new GitpodHostUrl("https://abc-nice-brunch-4224.staging.gitpod-dev.com/")
                 .withoutWorkspacePrefix()
                 .toString(),
         ).to.equal("https://abc-nice-brunch-4224.staging.gitpod-dev.com/");
@@ -65,9 +56,7 @@ export class GitpodHostUrlTest {
 
     @test public async testWithoutWorkspacePrefix6() {
         expect(
-            GitpodHostUrl.fromWorkspaceUrl(
-                "https://gray-rook-5523v5d8.ws-dev.abc-nice-brunch-4224.staging.gitpod-dev.com/",
-            )
+            new GitpodHostUrl("https://gray-rook-5523v5d8.ws-dev.abc-nice-brunch-4224.staging.gitpod-dev.com/")
                 .withoutWorkspacePrefix()
                 .toString(),
         ).to.equal("https://abc-nice-brunch-4224.staging.gitpod-dev.com/");

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -24,21 +24,20 @@ const workspaceUrlPrefixRegex = RegExp(`^(([0-9]{4,6}|debug)-)?${baseWorkspaceID
 export class GitpodHostUrl {
     readonly url: URL;
 
-    constructor(urlParam?: string | URL) {
-        if (urlParam === undefined || typeof urlParam === "string") {
-            this.url = new URL(urlParam || "https://gitpod.io");
+    constructor(url: string) {
+        const urlParam = url as any;
+        if (typeof urlParam === "string") {
+            // public constructor
+            this.url = new URL(url);
             this.url.search = "";
             this.url.hash = "";
             this.url.pathname = "";
         } else if (urlParam instanceof URL) {
+            // internal constructor, see with
             this.url = urlParam;
         } else {
             log.error("Unexpected urlParam", { urlParam });
         }
-    }
-
-    static fromWorkspaceUrl(url: string) {
-        return new GitpodHostUrl(new URL(url));
     }
 
     withWorkspacePrefix(workspaceId: string, region: string) {

--- a/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
@@ -44,7 +44,7 @@ class TestBitbucketServerApi {
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
                 bind(Config).toConstantValue({
-                    hostUrl: new GitpodHostUrl(),
+                    hostUrl: new GitpodHostUrl("https://gitpod.io"),
                 });
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -44,7 +44,7 @@ class TestBitbucketServerContextParser {
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
                 bind(Config).toConstantValue({
-                    hostUrl: new GitpodHostUrl(),
+                    hostUrl: new GitpodHostUrl("https://gitpod.io"),
                 });
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {

--- a/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
@@ -54,7 +54,7 @@ class TestBitbucketServerFileProvider {
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
                 bind(Config).toConstantValue({
-                    hostUrl: new GitpodHostUrl(),
+                    hostUrl: new GitpodHostUrl("https://gitpod.io"),
                 });
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -54,7 +54,7 @@ class TestBitbucketServerRepositoryProvider {
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
                 bind(Config).toConstantValue({
-                    hostUrl: new GitpodHostUrl(),
+                    hostUrl: new GitpodHostUrl("https://gitpod.io"),
                 });
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {

--- a/components/server/src/prebuilds/bitbucket-server-service.spec.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.spec.ts
@@ -54,7 +54,7 @@ class TestBitbucketServerService {
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
                 bind(Config).toConstantValue({
-                    hostUrl: new GitpodHostUrl(),
+                    hostUrl: new GitpodHostUrl("https://gitpod.io"),
                 });
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {

--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -10,7 +10,7 @@ import {
     ContentStatusResponse,
 } from "@gitpod/supervisor-api-grpc/lib/status_pb";
 import { WorkspaceInfoResponse } from "@gitpod/supervisor-api-grpc/lib/info_pb";
-import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { workspaceUrl } from "../shared/urls";
 
 export class SupervisorServiceClient {
     private static _instance: SupervisorServiceClient | undefined;
@@ -41,7 +41,7 @@ export class SupervisorServiceClient {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }
         try {
-            const wsSupervisorStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href).with((url) => {
+            const wsSupervisorStatusUrl = workspaceUrl.with(() => {
                 return {
                     pathname: "/_supervisor/v1/status/supervisor/willShutdown/true",
                 };
@@ -85,7 +85,7 @@ export class SupervisorServiceClient {
             wait = "";
         }
         try {
-            const wsSupervisorStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href).with((url) => {
+            const wsSupervisorStatusUrl = workspaceUrl.with(() => {
                 return {
                     pathname: "/_supervisor/v1/status/" + kind + wait,
                 };
@@ -121,7 +121,7 @@ export class SupervisorServiceClient {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }
         try {
-            const getWorkspaceInfoUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href).with((url) => {
+            const getWorkspaceInfoUrl = workspaceUrl.with(() => {
                 return {
                     pathname: "_supervisor/v1/info/workspace",
                 };

--- a/components/supervisor/frontend/src/shared/urls.ts
+++ b/components/supervisor/frontend/src/shared/urls.ts
@@ -6,7 +6,7 @@
 
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
-export const workspaceUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href);
+export const workspaceUrl = new GitpodHostUrl(window.location.href);
 
 export const serverUrl = workspaceUrl.withoutWorkspacePrefix();
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

when workspace URL contains search, hash or path

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See https://gitpod.slack.com/archives/C045J13P8A1/p1682337644081519

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace and check network tabs for any errors doing following
- Prepend something to workspace URL like `?payload=[["logLevel", "debug"]]` and navigate
- Stop the workspace
- Start another workspace, but this time close the page and check that that it times out in 5 mins, i.e. close heartbeat is still registered.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-fix-metrcis-sup</li>
	<li><b>🔗 URL</b> - <a href="https://ak-fix-metrcis-sup.preview.gitpod-dev.com/workspaces" target="_blank">ak-fix-metrcis-sup.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
