### PR TITLE
[ws-manager-mk2] Add alerts

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -25,6 +25,17 @@ spec:
         description: '{{ printf "%.2f" $value }} regular workspaces are stuck on stopped for more than 20 minutes. Current status: {{ $labels.reason }}'
       expr: |
         sum(gitpod_ws_manager_workspace_phase_total{phase="STOPPED", cluster!~"ephemeral.*"}) > 5
+    - alert: GitpodWorkspaceStuckOnStoppedMk2
+      labels:
+        severity: warning
+        team: workspace
+      for: 20m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopped.md
+        summary: Workspaces are stuck in STOPPED phase on cluster {{ $labels.cluster }}.
+        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on stopped for more than 20 minutes. Current status: {{ $labels.reason }}'
+      expr: |
+        sum(gitpod_ws_manager_mk2_workspace_phase_total{phase="STOPPED", cluster!~"ephemeral.*"}) > 5
 
     - alert: GitpodWorkspaceStuckOnStopping
       labels:
@@ -38,6 +49,18 @@ spec:
         sum(
           gitpod_ws_manager_workspace_phase_total{type="REGULAR", phase="STOPPING", cluster!~"ephemeral.*"}
         ) without(phase) > 15
+    - alert: GitpodWorkspaceStuckOnStoppingMk2
+      labels:
+        severity: critical
+      for: 30m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
+        summary: 15 or more workspaces are stuck on stopping in cluster {{ $labels.cluster }}.
+        description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.'
+      expr: |
+        sum(
+          gitpod_ws_manager_mk2_workspace_phase_total{type="REGULAR", phase="STOPPING", cluster!~"ephemeral.*"}
+        ) without(phase) > 15
 
     - alert: GitpodWorkspaceHighFailureRate
       labels:
@@ -48,6 +71,15 @@ spec:
         description: Multiple workspaces are failing for the last 5 minutes
       expr: |
           rate(gitpod_ws_manager_workspace_stops_total{reason="failed", type="REGULAR", cluster!~"ephemeral.*"}[5m]) >= 1
+    - alert: GitpodWorkspaceHighFailureRateMk2
+      labels:
+        severity: critical
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceHighFailureRate.md
+        summary: Workspaces are failing in cluster {{ $labels.cluster }}.
+        description: Multiple workspaces are failing for the last 5 minutes
+      expr: |
+          rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed", type="REGULAR", cluster!~"ephemeral.*"}[5m]) >= 1
 
     - alert: GitpodWorkspaceStatusUpdatesCeased
       labels:
@@ -69,6 +101,16 @@ spec:
         description: regular workspaces are stuck in pending phase in cluster {{ $labels.cluster }}.
       expr: |
         gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="REGULAR", cluster!~"ephemeral.*"} > 20
+    - alert: GitpodTooManyWorkspacesInPendingMk2
+      labels:
+        severity: critical
+      for: 15m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyWorkspacesInPending.md
+        summary: workspaces are in pending phase
+        description: regular workspaces are stuck in pending phase in cluster {{ $labels.cluster }}.
+      expr: |
+        gitpod_ws_manager_mk2_workspace_phase_total{phase="PENDING", type="REGULAR", cluster!~"ephemeral.*"} > 20
 
     - alert: GitpodTooManyPrebuildsInPending
       labels:
@@ -80,6 +122,16 @@ spec:
         description: prebuilds are stuck in pending phase in cluster {{ $labels.cluster }}.
       expr: |
         gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="PREBUILD", cluster!~"ephemeral.*"} > 20
+    - alert: GitpodTooManyPrebuildsInPendingMk2
+      labels:
+        severity: critical
+      for: 15m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyPrebuildsInPending.md
+        summary: workspaces are in pending phase
+        description: prebuilds are stuck in pending phase in cluster {{ $labels.cluster }}.
+      expr: |
+        gitpod_ws_manager_mk2_workspace_phase_total{phase="PENDING", type="PREBUILD", cluster!~"ephemeral.*"} > 20
 
     - alert: GitpodWorkspaceTooLongTerminating
       labels:
@@ -114,3 +166,14 @@ spec:
         description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
       expr: |
         (1 - (sum(rate(gitpod_ws_manager_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_ws_manager_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99
+    - alert: GitpodImagebuildStartSuccess
+      labels:
+        severity: critical
+        team: workspace
+      for: 2h
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildStartSuccess.md
+        summary: imagebuild start success rate is failing in cluster {{ $labels.cluster }}.
+        description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
+      expr: |
+        (1 - (sum(rate(gitpod_ws_manager_mk2_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_ws_manager_mk2_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -22,3 +22,12 @@ spec:
         description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
       expr: |
         increase(kube_pod_container_status_restarts_total{container="ws-manager", cluster!~"ephemeral.*"}[10m]) > 0
+    - alert: GitpodWsManagerCrashLoopingMk2
+      labels:
+        severity: critical
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
+        summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
+        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+      expr: |
+        increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[10m]) > 0

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -16,6 +16,9 @@ spec:
     - record: gitpod_workspace_regular_not_active_percentage
       expr: |
         gitpod_ws_manager_workspace_activity_total{active="false"} / gitpod_ws_manager_workspace_activity_total
+    - record: gitpod_workspace_regular_not_active_percentage_mk2
+      expr: |
+        gitpod_ws_manager_mk2_workspace_activity_total{active="false"} / gitpod_ws_manager_mk2_workspace_activity_total
 
   - name: workspace-alerts
     rules:
@@ -31,6 +34,18 @@ spec:
         gitpod_workspace_regular_not_active_percentage > 0.10
         AND
         sum(gitpod_ws_manager_workspace_activity_total) by(cluster) > 20
+    - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
+      labels:
+        severity: critical
+      for: 10m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
+        summary: too many running but inactive workspaces
+        description: too many running but inactive workspaces.
+      expr: |
+        gitpod_workspace_regular_not_active_percentage_mk2 > 0.10
+        AND
+        sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 20
 
     - alert: GitpodWorkspacesNotStarting
       labels:
@@ -44,3 +59,15 @@ spec:
         avg_over_time(gitpod_workspace_regular_not_active_percentage[1m]) > 0
         AND
         rate(gitpod_ws_manager_workspace_startup_seconds_sum{type="REGULAR"}[1m]) == 0
+    - alert: GitpodWorkspacesNotStartingMk2
+      labels:
+        severity: critical
+      for: 10m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md
+        summary: workspaces are not starting.
+        description: inactive regular workspaces exists but workspaces are not being started.
+      expr: |
+        avg_over_time(gitpod_workspace_regular_not_active_percentage_mk2[1m]) > 0
+        AND
+        rate(gitpod_ws_manager_mk2_workspace_startup_seconds_sum{type="REGULAR"}[1m]) == 0


### PR DESCRIPTION
## Description
Add alerts for ws-manager-mk2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-111


#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
