### PR TITLE
[agent-smith] Remove unused webhooks - WEB-219

### DIFF
--- a/components/ee/agent-smith/cmd/run.go
+++ b/components/ee/agent-smith/cmd/run.go
@@ -6,26 +6,21 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/gitpod-io/gitpod/agent-smith/pkg/common"
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 
-	slack "github.com/ashwanthkumar/slack-go-webhook"
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/agent"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
 )
 
 // runCmd represents the run command
@@ -72,27 +67,6 @@ var runCmd = &cobra.Command{
 
 		go smith.Start(ctx, func(violation agent.InfringingWorkspace, penalties []config.PenaltyKind) {
 			log.WithField("violation", violation).WithField("penalties", penalties).Info("Found violation")
-
-			if cfg.SlackWebhooks != nil {
-				for _, i := range violation.Infringements {
-					// Need to set err to nil to eliminate the chance of logging previous errors after the loop.
-					err = nil
-
-					if i.Kind.Severity() == common.SeverityAudit {
-						err = notifySlack(cfg.SlackWebhooks.Audit, cfg.Config.GitpodAPI.HostURL, violation, penalties)
-						break
-					} else if i.Kind.Severity() != common.SeverityBarely {
-						err = notifySlack(cfg.SlackWebhooks.Warning, cfg.Config.GitpodAPI.HostURL, violation, penalties)
-						break
-					}
-				}
-				if err != nil {
-					log.WithError(err).Warn("error while notifying Slack")
-				}
-
-				// Don't send a slack message in case the infrignments are only "barely severe"
-				return
-			}
 		})
 
 		if cfg.MaxSysMemMib > 0 {
@@ -130,76 +104,4 @@ func startMemoryWatchdog(maxSysMemMib uint64) {
 
 		<-t.C
 	}
-}
-
-func notifySlack(webhook string, hostURL string, ws agent.InfringingWorkspace, penalties []config.PenaltyKind) error {
-	var (
-		region           = os.Getenv("GITPOD_REGION")
-		lblDetails       = "Details"
-		lblActions       = "Actions"
-		lblPenalties     = "Penalties"
-		lblInfringements = "Long Infringements details"
-	)
-
-	attachments := []slack.Attachment{
-		{
-			Title: &lblDetails,
-			Fields: []*slack.Field{
-				{Title: "pod", Value: ws.Pod},
-				{Title: "owner", Value: ws.Owner},
-				{Title: "workspace", Value: ws.WorkspaceID},
-				{Title: "region", Value: region},
-			},
-		},
-	}
-	if len(penalties) > 0 {
-		vs := make([]*slack.Field, len(penalties))
-		for i, p := range penalties {
-			vs[i] = &slack.Field{Title: "enforced", Value: string(p)}
-		}
-		attachments = append(attachments, slack.Attachment{
-			Title:  &lblPenalties,
-			Fields: vs,
-		})
-	}
-	attachments = append(attachments,
-		slack.Attachment{
-			Title: &lblActions,
-			Fields: []*slack.Field{
-				{Title: "User Admin", Value: fmt.Sprintf("%s/admin/users/%s", hostURL, ws.Owner)},
-				{Title: "Workspace Admin", Value: fmt.Sprintf("%s/admin/workspaces/%s", hostURL, ws.WorkspaceID)},
-			},
-			Actions: []*slack.Action{
-				{Type: "button", Text: "Block User", Url: fmt.Sprintf("%s/api/enforcement/block-user/%s", hostURL, ws.Owner)},
-			},
-		},
-	)
-
-	infringements := make([]*slack.Field, len(ws.Infringements))
-	for _, v := range ws.Infringements {
-		infringements = append(infringements, &slack.Field{
-			Title: string(v.Kind), Value: v.Description,
-		})
-	}
-
-	attachments = append(attachments,
-		slack.Attachment{Title: &lblInfringements, Fields: infringements},
-	)
-
-	payload := slack.Payload{
-		Text:        fmt.Sprintf("Agent Smith: %s", ws.DescribeInfringements(150)),
-		IconEmoji:   ":-(",
-		Attachments: attachments,
-	}
-
-	errs := slack.Send(webhook, "", payload)
-	if len(errs) > 0 {
-		allerr := make([]string, len(errs))
-		for i, err := range errs {
-			allerr[i] = err.Error()
-		}
-		return xerrors.Errorf("notifySlack: %s", strings.Join(allerr, ", "))
-	}
-
-	return nil
 }

--- a/components/ee/agent-smith/pkg/config/config.go
+++ b/components/ee/agent-smith/pkg/config/config.go
@@ -172,7 +172,6 @@ type Config struct {
 
 	Enforcement       Enforcement        `json:"enforcement,omitempty"`
 	ExcessiveCPUCheck *ExcessiveCPUCheck `json:"excessiveCPUCheck,omitempty"`
-	SlackWebhooks     *SlackWebhooks     `json:"slackWebhooks,omitempty"`
 	Kubernetes        Kubernetes         `json:"kubernetes"`
 
 	ProbePath string `json:"probePath,omitempty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Config is never set, removed. If needed, it's in git history.

Will also remove the endpoints used in the webhook payload in WEB-219

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
