### PR TITLE
[org-only] relax org name restriction

### DIFF
--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -188,14 +188,25 @@ export class TeamDBImpl implements TeamDB {
         if (!name) {
             throw new ResponseError(ErrorCodes.BAD_REQUEST, "Name cannot be empty");
         }
-        if (!/^[A-Za-z0-9 '_-]+$/.test(name)) {
+        name = name.trim();
+        if (name.length < 3) {
             throw new ResponseError(
                 ErrorCodes.BAD_REQUEST,
-                "Please choose a name containing only letters, numbers, -, _, ', or spaces.",
+                "Please choose a name that is at least three characters long.",
             );
+        }
+        if (name.length > 64) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Please choose a name that is at most 64 characters long.");
         }
 
         let slug = slugify(name, { lower: true });
+
+        if (slug.length < 3) {
+            throw new ResponseError(
+                ErrorCodes.BAD_REQUEST,
+                "Please choose a name that is at least three characters long.",
+            );
+        }
 
         // Storing new entry in a TX to avoid potential dupes caused by racing requests.
         const em = await this.getEntityManager();

--- a/components/gitpod-db/src/user-to-team-migration-service.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.ts
@@ -56,6 +56,9 @@ export class UserToTeamMigrationService {
         while (!team && tries++ < 10) {
             try {
                 let name = user.fullName || user.name || user.id;
+                if (name.length > 64) {
+                    name = name.substring(0, 64);
+                }
                 if (tries > 1) {
                     name = name + " " + tries;
                 }
@@ -72,9 +75,6 @@ export class UserToTeamMigrationService {
         if (!team) {
             throw new ResponseError(ErrorCodes.CONFLICT, "Could not create team for user.", { userId: user.id });
         }
-        // add membership
-        await this.teamDB.addMemberToTeam(user.id, team.id);
-        await this.teamDB.setTeamMemberRole(user.id, team.id, "owner");
 
         const projects = await this.projectDB.findUserProjects(user.id);
         log.info(ctx, "Migrating projects.", { teamId: team.id, projects: projects.map((p) => p.id) });


### PR DESCRIPTION
## Description
Relaxes the unnecessary strict requirments for organization names.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-220

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-org-nam7ae9c219c3</li>
	<li><b>🔗 URL</b> - <a href="https://se-org-nam7ae9c219c3.preview.gitpod-dev.com/workspaces" target="_blank">se-org-nam7ae9c219c3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
