### PR TITLE
[dev] use hardcode seed value in preview environment

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -539,6 +539,7 @@ installer --debug-version-file="/tmp/versions.yaml" validate config --config "$I
 log_info "Rendering manifests"
 installer --debug-version-file="/tmp/versions.yaml" render \
   --use-experimental-config \
+  --seed=200 \
   --namespace "${PREVIEW_NAMESPACE}" \
   --config "${INSTALLER_CONFIG_PATH}" > "${INSTALLER_RENDER_PATH}"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->


<img width="603" alt="image" src="https://user-images.githubusercontent.com/8299500/234362377-5eb14d6e-ed52-4e2f-8c1a-b2191a4659ab.png">

<img width="731" alt="image" src="https://user-images.githubusercontent.com/8299500/234362506-ce35b8ab-7135-416e-9332-8b6f509526a7.png">

The reason why we get this error is because we generate those secret every time, and `ws-daemon` might not restart to apply these change, this PR change it to hardcode random seed so that can make sure every time it's generate same secret.

It's safe because we don't expose internal service to internet (i.e. mysql/minio/rabbitmq)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start workspace in this branch
2. kubectl get secret minio -oyaml
3. re-run github action
4. check secret again, it should keep same
5. try start workspace in this preview env, it should success

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fix-unsca00845e2d</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fix-unsca00845e2d.preview.gitpod-dev.com/workspaces" target="_blank">pd-fix-unsca00845e2d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
