### PR TITLE
[ws-manager-mk2] Always send OnReconcile events

### DIFF
--- a/dev/loadgen/README.md
+++ b/dev/loadgen/README.md
@@ -18,7 +18,7 @@ You can find a short explanation of this tool in this [loom video](https://www.l
   ```
 - Port-forward ws-manager
   ```console
-  kubectl port-forward deployment/ws-manager 12001:8080
+  while true; do kubectl port-forward deployment/ws-manager 12001:8080; done
   ```
 - Compile loadgen
   ```console


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes prebuilds getting stuck in a `Running` state under high load.

This was due to the workspace controller not sending workspace events to subscribers (i.e. ws-manager-bridge) on reconcile errors. Under load there seems to be a higher chance of conflict errors when updating the status, making it more likely that some events don't get send to bridge. Bridge would then miss the event where the workspace is in a `Stopping` state _and_ has the snapshot url set (usually only 1/2 of these events are sent before `Stopped` gets sent), and never update the prebuild status in the DB to `Ready` ([bridge ignores `Stopped` prebuild events](https://github.com/gitpod-io/gitpod/blob/bcca71039ca01f0d833b487d036b1b03cb4c3335/components/ws-manager-bridge/src/prebuild-state-mapper.ts#L20)).

By always sending the workspace event on each reconcile, even if the reconcile returns an error, bridge will receive the Stopping state + snapshot ID event and mark the prebuild as ready.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-24

## How to test
<!-- Provide steps to test this PR -->

Tested in an ephemeral cluster:
- Run `loadgen benchmark` with 200 workspaces
- Simultaneously create 50 prebuilds using https://github.com/wverlaek/prebuild-experiment/blob/main/load-test.sh

Without this fix, a number of prebuilds would end up stuck in a `Running` state. With the fix, this can't be reproduced.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
