### PR TITLE
[server] Use redlock for webhook gc WEB-224

### DIFF
--- a/components/server/src/projects/webhook-event-garbage-collector.ts
+++ b/components/server/src/projects/webhook-event-garbage-collector.ts
@@ -27,7 +27,7 @@ export class WebhookEventGarbageCollector {
         const intervalMs = WebhookEventGarbageCollector.GC_CYCLE_INTERVAL_SECONDS * 1000;
         return repeat(async () => {
             try {
-                await this.mutex.client().using(["workspace-gc"], intervalMs, async (signal) => {
+                await this.mutex.using(["workspace-gc"], intervalMs, async (signal) => {
                     log.info("webhook-event-gc: acquired workspace-gc lock. Collecting old workspaces");
                     try {
                         await this.collectObsoleteWebhookEvents();
@@ -37,7 +37,7 @@ export class WebhookEventGarbageCollector {
                 });
             } catch (err) {
                 if (err instanceof ResourceLockedError) {
-                    log.info(
+                    log.debug(
                         "webhook-event-gc: failed to acquire workspace-gc lock, another instance already has the lock",
                         err,
                     );

--- a/components/server/src/projects/webhook-event-garbage-collector.ts
+++ b/components/server/src/projects/webhook-event-garbage-collector.ts
@@ -8,29 +8,43 @@ import { injectable, inject } from "inversify";
 import * as opentracing from "opentracing";
 import { DBWithTracing, TracedWorkspaceDB, WorkspaceDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { Disposable } from "@gitpod/gitpod-protocol";
-import { ConsensusLeaderQorum } from "../consensus/consensus-leader-quorum";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { RedisMutex } from "../mutex/redlock";
+import { ResourceLockedError } from "redlock";
 
 @injectable()
 export class WebhookEventGarbageCollector {
     static readonly GC_CYCLE_INTERVAL_SECONDS = 4 * 60; // every 6 minutes
 
+    @inject(TracedWorkspaceDB) protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
     @inject(WebhookEventDB) protected readonly db: WebhookEventDB;
 
-    @inject(ConsensusLeaderQorum) protected readonly leaderQuorum: ConsensusLeaderQorum;
-    @inject(TracedWorkspaceDB) protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
+    @inject(RedisMutex) protected readonly mutex: RedisMutex;
 
     public async start(intervalSeconds?: number): Promise<Disposable> {
         const intervalSecs = intervalSeconds || WebhookEventGarbageCollector.GC_CYCLE_INTERVAL_SECONDS;
         return repeat(async () => {
             try {
-                if (await this.leaderQuorum.areWeLeader()) {
-                    await this.collectObsoleteWebhookEvents();
-                }
+                await this.mutex.client().using(["workspace-gc"], 30 * 1000, async (signal) => {
+                    log.info("webhook-event-gc: acquired workspace-gc lock. Collecting old workspaces");
+                    try {
+                        await this.collectObsoleteWebhookEvents();
+                    } catch (err) {
+                        log.error("webhook-event-gc: failed to collect obsolte events", err);
+                    }
+                });
             } catch (err) {
-                log.error("webhook event garbage collector", err);
+                if (err instanceof ResourceLockedError) {
+                    log.info(
+                        "webhook-event-gc: failed to acquire workspace-gc lock, another instance already has the lock",
+                        err,
+                    );
+                    return;
+                }
+
+                log.error("webhookgc: failed to acquire workspace-gc lock", err);
             }
         }, intervalSecs * 1000);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-0a41d11a34</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-0a41d11a34.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-0a41d11a34.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
