### PR TITLE
[server] Use redlock for periodic db deleter

### DIFF
--- a/components/gitpod-db/src/periodic-deleter.ts
+++ b/components/gitpod-db/src/periodic-deleter.ts
@@ -9,69 +9,56 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 import { GitpodTableDescriptionProvider, TableDescription } from "./tables";
 import { TypeORM } from "./typeorm/typeorm";
-import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
 
 @injectable()
 export class PeriodicDbDeleter {
     @inject(GitpodTableDescriptionProvider) protected readonly tableProvider: GitpodTableDescriptionProvider;
     @inject(TypeORM) protected readonly typeORM: TypeORM;
 
-    start(shouldRunFn: () => Promise<boolean>) {
-        log.info("[PeriodicDbDeleter] Start ...");
-        this.sync(shouldRunFn).catch((err) => log.error("[PeriodicDbDeleter] sync failed", err));
-    }
-
-    protected async sync(shouldRunFn: () => Promise<boolean>) {
-        const doSync = async () => {
-            const shouldRun = await shouldRunFn();
-            if (!shouldRun) {
-                return;
+    async runOnce() {
+        const tickID = new Date().toISOString();
+        log.info("[PeriodicDbDeleter] Starting to collect deleted rows.", {
+            periodicDeleterTickId: tickID,
+        });
+        const sortedTables = this.tableProvider.getSortedTables();
+        const toBeDeleted: { table: string; deletions: string[] }[] = [];
+        for (const table of sortedTables) {
+            const rowsForTableToDelete = await this.collectRowsToBeDeleted(table);
+            if (rowsForTableToDelete.deletions.length === 0) {
+                continue;
             }
-
-            const tickID = new Date().toISOString();
-            log.info("[PeriodicDbDeleter] Starting to collect deleted rows.", {
-                periodicDeleterTickId: tickID,
-            });
-            const sortedTables = this.tableProvider.getSortedTables();
-            const toBeDeleted: { table: string; deletions: string[] }[] = [];
-            for (const table of sortedTables) {
-                const rowsForTableToDelete = await this.collectRowsToBeDeleted(table);
-                if (rowsForTableToDelete.deletions.length === 0) {
-                    continue;
-                }
-                log.info(
-                    `[PeriodicDbDeleter] Identified ${rowsForTableToDelete.deletions.length} entries in ${rowsForTableToDelete.table} to be deleted.`,
-                    {
-                        periodicDeleterTickId: tickID,
-                    },
-                );
-                toBeDeleted.push(rowsForTableToDelete);
-            }
-            // when collecting the deletions do so in the inverse order as during update (delete dependency targes first)
-            const pendingDeletions: Promise<void>[] = [];
-            for (const { deletions } of toBeDeleted.reverse()) {
-                for (const deletion of deletions) {
-                    pendingDeletions.push(
-                        this.query(deletion).catch((err) =>
-                            log.error(
-                                `[PeriodicDbDeleter] sync error`,
-                                {
-                                    periodicDeleterTickId: tickID,
-                                    query: deletion,
-                                },
-                                err,
-                            ),
+            log.info(
+                `[PeriodicDbDeleter] Identified ${rowsForTableToDelete.deletions.length} entries in ${rowsForTableToDelete.table} to be deleted.`,
+                {
+                    periodicDeleterTickId: tickID,
+                },
+            );
+            toBeDeleted.push(rowsForTableToDelete);
+        }
+        // when collecting the deletions do so in the inverse order as during update (delete dependency targes first)
+        const pendingDeletions: Promise<void>[] = [];
+        for (const { deletions } of toBeDeleted.reverse()) {
+            for (const deletion of deletions) {
+                pendingDeletions.push(
+                    this.query(deletion).catch((err) =>
+                        log.error(
+                            `[PeriodicDbDeleter] sync error`,
+                            {
+                                periodicDeleterTickId: tickID,
+                                query: deletion,
+                            },
+                            err,
                         ),
-                    );
-                }
+                    ),
+                );
             }
-            await Promise.all(pendingDeletions);
-            log.info("[PeriodicDbDeleter] Finished deleting records.", {
-                periodicDeleterTickId: tickID,
-            });
-        };
-        repeat(doSync, 30000); // deletion is never time-critical, so we should ensure we do not spam ourselves
+        }
+        await Promise.all(pendingDeletions);
+        log.info("[PeriodicDbDeleter] Finished deleting records.", {
+            periodicDeleterTickId: tickID,
+        });
     }
+
     protected async collectRowsToBeDeleted(table: TableDescription): Promise<{ table: string; deletions: string[] }> {
         try {
             await this.query(`SELECT COUNT(1) FROM ${table.name}`);

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -360,7 +360,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         const intervalMs = 30 * 1000;
         repeat(async () => {
             try {
-                await this.mutex.client().using(["database-deleter"], intervalMs, async (signal) => {
+                await this.mutex.using(["database-deleter"], intervalMs, async (signal) => {
                     try {
                         await this.periodicDbDeleter.runOnce();
                     } catch (err) {
@@ -369,7 +369,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 });
             } catch (err) {
                 if (err instanceof ResourceLockedError) {
-                    log.info(
+                    log.debug(
                         "[PeriodicDbDeleter] failed to acquire database-deleter lock, another instance already has the lock",
                         err,
                     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-6ebe3a0f55</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-6ebe3a0f55.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-6ebe3a0f55.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
