### PR TITLE
added dark theme

### DIFF
--- a/components/ws-proxy/public/port-not-found.html
+++ b/components/ws-proxy/public/port-not-found.html
@@ -96,6 +96,29 @@
       color: #A8A29E;
     }
 
+    /* Dark Theme */
+    .dark-body{
+      background-color: #222;
+    }
+
+    .dark-button{
+      border: none;
+      color: #F5F5F4;
+      background-color: #454545;
+    }
+
+    .dark-button:hover{
+      background-color: #555;
+    }
+
+    .dark-title{
+      color: #F5F5F4;
+    }
+
+    .dark-text{
+      color: #A8A29E;
+    }
+
   </style>
   <div id="root" style="display: flex; align-items: center; height: 100vh;">
     <div style="max-width: 64em; margin: auto; padding: 6em 2em; text-align: center;">
@@ -121,6 +144,19 @@
     </div>
   </div>
   <script>
+    //set dark theme
+    if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      const body = document.body;
+      const button = document.button;
+      const title = document.getElementsByClassName("title");
+      const text = document.getElementsByClassName("text");
+
+      body.classList.toggle('dark-body');
+      button.classList.toggle('dark-button');
+      title.classList.toggle('dark-title');
+      text.classList.toggle('dark-text');
+    }
+
     let port = parseInt(window.location.hostname.split('-')[0], 10);
     if (port) {
       document.getElementById('port').textContent = port;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
added a dark theme for [port-not-found.html](https://github.com/gitpod-io/gitpod/blob/main/components/ws-proxy/public/port-not-found.html)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7274

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`