### PR TITLE
Also delete any LinkedIn profile when deleting a user account

### DIFF
--- a/components/gitpod-db/src/linked-in-profile-db.ts
+++ b/components/gitpod-db/src/linked-in-profile-db.ts
@@ -9,4 +9,5 @@ import { LinkedInProfile } from "@gitpod/gitpod-protocol";
 export const LinkedInProfileDB = Symbol("LinkedInProfileDB");
 export interface LinkedInProfileDB {
     storeProfile(userId: string, profile: LinkedInProfile): Promise<void>;
+    deleteProfile(userId: string): Promise<void>;
 }

--- a/components/gitpod-db/src/typeorm/linked-in-profile-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/linked-in-profile-db-impl.ts
@@ -41,4 +41,9 @@ export class LinkedInProfileDBImpl implements LinkedInProfileDB {
             creationTime: existingProfile?.creationTime || new Date().toISOString(),
         });
     }
+
+    public async deleteProfile(userId: string): Promise<void> {
+        const repo = await this.getRepo();
+        await repo.delete({ userId });
+    }
 }

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -26,6 +26,10 @@ export class LinkedInService {
         return profile;
     }
 
+    async deleteLinkedInProfile(userId: string): Promise<void> {
+        await this.linkedInProfileDB.deleteProfile(userId);
+    }
+
     private async getAccessToken(code: string) {
         const { clientId, clientSecret } = this.config.linkedInSecrets || {};
         if (!clientId || !clientSecret) {

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -17,6 +17,7 @@ import { Config } from "../config";
 import { StripeService } from "../../ee/src/user/stripe-service";
 import { BillingModes } from "../../ee/src/billing/billing-mode";
 import { WorkspaceStarter } from "../workspace/workspace-starter";
+import { LinkedInService } from "../linkedin-service";
 
 @injectable()
 export class UserDeletionService {
@@ -33,6 +34,7 @@ export class UserDeletionService {
     @inject(IAnalyticsWriter) protected readonly analytics: IAnalyticsWriter;
     @inject(StripeService) protected readonly stripeService: StripeService;
     @inject(BillingModes) protected readonly billingMode: BillingModes;
+    @inject(LinkedInService) protected readonly linkedInService: LinkedInService;
 
     /**
      * This method deletes a User logically. The contract here is that after running this method without receiving an
@@ -97,6 +99,8 @@ export class UserDeletionService {
             this.deleteTeamMemberships(id),
             // User projects
             this.deleteUserProjects(id),
+            // LinkedIn profile
+            this.deleteLinkedInProfile(id),
         ]);
 
         // Track the deletion Event for Analytics Purposes
@@ -179,6 +183,10 @@ export class UserDeletionService {
         const userProjects = await this.projectDb.findUserProjects(id);
 
         await Promise.all(userProjects.map((project) => this.projectDb.markDeleted(project.id)));
+    }
+
+    protected async deleteLinkedInProfile(userId: string) {
+        await this.linkedInService.deleteLinkedInProfile(userId);
     }
 
     anonymizeWorkspace(ws: Workspace) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Also delete any LinkedIn profile when deleting a user account

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/17074#issuecomment-1505173850
Fixes item 4. in [Slack message](https://gitpod.slack.com/archives/C04PH56LZK5/p1681917949501639?thread_ts=1681389401.968919&cid=C04PH56LZK5) (internal)
Fixes [Linear issue](https://linear.app/gitpod/issue/WEB-134/[gdpr]-delete-linkedin-data-when-user-deletes-account#comment-df4f5c49) (internal)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
