### PR TITLE
internal analytics endpoint

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -139,6 +139,13 @@
 	}
 }
 
+# Internal analytics endpoint
+:9546 {
+	handle /analytics* {
+		gitpod.analytics
+	}
+}
+
 # public-api
 api.{$GITPOD_DOMAIN} {
 	log {

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -468,7 +468,7 @@ if [[ "${GITPOD_ANALYTICS}" == "segment" ]]; then
 
   yq w -i "${INSTALLER_CONFIG_PATH}" analytics.writer segment
   yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"
-  yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentEndpoint "https://${DOMAIN}/analytics"
+  yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentEndpoint "http://proxy:9546/analytics"
   # configure proxy analyitcs plugin
   yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.analyticsPlugin.trustedSegmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"
   yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.analyticsPlugin.untrustedSegmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -468,7 +468,7 @@ if [[ "${GITPOD_ANALYTICS}" == "segment" ]]; then
 
   yq w -i "${INSTALLER_CONFIG_PATH}" analytics.writer segment
   yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"
-  yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentEndpoint "http://proxy:9546/analytics"
+  yq w -i "${INSTALLER_CONFIG_PATH}" analytics.segmentEndpoint "http://proxy.default.svc.cluster.local:9546/analytics"
   # configure proxy analyitcs plugin
   yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.analyticsPlugin.trustedSegmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"
   yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.analyticsPlugin.untrustedSegmentKey "${GITPOD_ANALYTICS_SEGMENT_TOKEN}"

--- a/install/installer/pkg/components/proxy/constants.go
+++ b/install/installer/pkg/components/proxy/constants.go
@@ -7,19 +7,21 @@ package proxy
 import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 const (
-	Component             = common.ProxyComponent
-	ContainerHTTPPort     = common.ProxyContainerHTTPPort
-	ContainerHTTPName     = common.ProxyContainerHTTPName
-	ContainerHTTPSPort    = common.ProxyContainerHTTPSPort
-	ContainerHTTPSName    = common.ProxyContainerHTTPSName
-	ContainerSSHPort      = 22
-	ContainerSSHName      = "ssh"
-	InitContainerImage    = "library/alpine"
-	InitContainerTag      = "3.16"
-	KubeRBACProxyRepo     = common.KubeRBACProxyRepo
-	KubeRBACProxyImage    = common.KubeRBACProxyImage
-	KubeRBACProxyTag      = common.KubeRBACProxyTag
-	ReadinessPort         = 8003
-	RegistryAuthSecret    = common.RegistryAuthSecret
-	RegistryTLSCertSecret = common.RegistryTLSCertSecret
+	Component              = common.ProxyComponent
+	ContainerHTTPPort      = common.ProxyContainerHTTPPort
+	ContainerHTTPName      = common.ProxyContainerHTTPName
+	ContainerHTTPSPort     = common.ProxyContainerHTTPSPort
+	ContainerHTTPSName     = common.ProxyContainerHTTPSName
+	ContainerSSHPort       = 22
+	ContainerSSHName       = "ssh"
+	InitContainerImage     = "library/alpine"
+	InitContainerTag       = "3.16"
+	KubeRBACProxyRepo      = common.KubeRBACProxyRepo
+	KubeRBACProxyImage     = common.KubeRBACProxyImage
+	KubeRBACProxyTag       = common.KubeRBACProxyTag
+	ReadinessPort          = 8003
+	RegistryAuthSecret     = common.RegistryAuthSecret
+	RegistryTLSCertSecret  = common.RegistryTLSCertSecret
+	ContainerAnalyticsPort = 9546
+	ContainerAnalyticsName = "analytics"
 )

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -233,7 +233,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ContainerPort: ContainerSSHPort,
 								Name:          ContainerSSHName,
 								Protocol:      *common.TCPProtocol,
-							}, prometheusPort},
+							}, prometheusPort, {
+								ContainerPort: ContainerAnalyticsPort,
+								Name:          ContainerAnalyticsName,
+							}},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               pointer.Bool(false),
 								AllowPrivilegeEscalation: pointer.Bool(false),

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -39,6 +39,9 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 				}, {
 					Protocol: common.TCPProtocol,
 					Port:     &intstr.IntOrString{IntVal: ContainerSSHPort},
+				}, {
+					Protocol: common.TCPProtocol,
+					Port:     &intstr.IntOrString{IntVal: ContainerAnalyticsPort},
 				}},
 			}, {
 				Ports: []networkingv1.NetworkPolicyPort{{

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -39,9 +39,6 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 				}, {
 					Protocol: common.TCPProtocol,
 					Port:     &intstr.IntOrString{IntVal: ContainerSSHPort},
-				}, {
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: ContainerAnalyticsPort},
 				}},
 			}, {
 				Ports: []networkingv1.NetworkPolicyPort{{
@@ -52,6 +49,16 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"chart": common.MonitoringChart,
 					}},
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.ServerComponent,
+					}},
+				}},
+			}, {
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: common.TCPProtocol,
+					Port:     &intstr.IntOrString{IntVal: ContainerAnalyticsPort},
+				}},
+				From: []networkingv1.NetworkPolicyPeer{{
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": common.ServerComponent,
 					}},

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -62,6 +62,14 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": common.ServerComponent,
 					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.WSManagerBridgeComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.WSProxyComponent,
+					}},
 				}},
 			}},
 		},

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -70,6 +70,11 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ContainerPort: baseserver.BuiltinMetricsPort,
 			ServicePort:   baseserver.BuiltinMetricsPort,
 		},
+		{
+			Name:          ContainerAnalyticsName,
+			ContainerPort: ContainerAnalyticsPort,
+			ServicePort:   ContainerAnalyticsPort,
+		},
 	}
 	if ctx.Config.SSHGatewayHostKey != nil {
 		ports = append(ports, common.ServicePort{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

to prevent triggering rate limiting on analytics from internal components 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

see https://gitpod.slack.com/archives/C02EN94AEPL/p1682493547309509

## How to test
<!-- Provide steps to test this PR -->

- Start a workpace in previe envs, connect via SSH.
- Check that events from server, bridge and ws-proxy are registered in segment.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-interna297d9dfe48</li>
	<li><b>🔗 URL</b> - <a href="https://ak-interna297d9dfe48.preview.gitpod-dev.com/workspaces" target="_blank">ak-interna297d9dfe48.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
