### PR TITLE
Stop asking for company website during user onboarding

### DIFF
--- a/components/dashboard/src/onboarding/StepOrgInfo.tsx
+++ b/components/dashboard/src/onboarding/StepOrgInfo.tsx
@@ -36,7 +36,6 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
     );
     const [signupGoals, setSignupGoals] = useState<string[]>(user.additionalData?.profile?.signupGoals ?? []);
     const [signupGoalsOther, setSignupGoalsOther] = useState(user.additionalData?.profile?.signupGoalsOther ?? "");
-    const [companyWebsite, setCompanyWebsite] = useState(user.additionalData?.profile?.companyWebsite ?? "");
     const [companySize, setCompanySize] = useState(user.additionalData?.profile?.companySize ?? "");
 
     const addSignupGoal = useCallback(
@@ -108,7 +107,6 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
                     explorationReasons: filteredReasons,
                     signupGoals: filteredGoals,
                     signupGoalsOther,
-                    companyWebsite,
                     companySize,
                 },
             },
@@ -122,7 +120,6 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
         }
     }, [
         companySize,
-        companyWebsite,
         explorationReasons,
         explorationReasonsOptions,
         jobRole,
@@ -136,17 +133,12 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
     ]);
 
     const jobRoleError = useOnBlurError("Please select one", !!jobRole);
-    const websiteError = useOnBlurError("Please enter a valid url", !companyWebsite || isURL(companyWebsite));
     const companySizeError = useOnBlurError(
         "Please select one",
         !explorationReasons.includes(EXPLORE_REASON_WORK) || !!companySize,
     );
     const isValid =
-        jobRoleError.isValid &&
-        websiteError.isValid &&
-        companySizeError.isValid &&
-        signupGoals.length > 0 &&
-        explorationReasons.length > 0;
+        jobRoleError.isValid && companySizeError.isValid && signupGoals.length > 0 && explorationReasons.length > 0;
 
     return (
         <OnboardingStep
@@ -179,15 +171,6 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
             {jobRole === JOB_ROLE_OTHER && (
                 <TextInputField value={jobRoleOther} onChange={setJobRoleOther} placeholder="Please share (optional)" />
             )}
-
-            <TextInputField
-                value={companyWebsite}
-                label="Company Website (optional)"
-                placeholder="example.com"
-                error={websiteError.message}
-                onChange={setCompanyWebsite}
-                onBlur={websiteError.onBlur}
-            />
 
             <CheckboxListField label="I'm exploring Gitpod...">
                 {explorationReasonsOptions.map((o) => (

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -169,7 +169,6 @@ export namespace User {
             email: User.getPrimaryEmail(user!) || "",
             company: user?.additionalData?.profile?.companyName,
             avatarURL: user?.avatarUrl,
-            companyWebsite: user?.additionalData?.profile?.companyWebsite,
             jobRole: user?.additionalData?.profile?.jobRole,
             jobRoleOther: user?.additionalData?.profile?.jobRoleOther,
             explorationReasons: user?.additionalData?.profile?.explorationReasons,
@@ -216,7 +215,6 @@ export namespace User {
         email: string;
         company?: string;
         avatarURL?: string;
-        companyWebsite?: string;
         jobRole?: string;
         jobRoleOther?: string;
         explorationReasons?: string[];
@@ -232,7 +230,6 @@ export namespace User {
                 before.email !== after.email ||
                 before.company !== after.company ||
                 before.avatarURL !== after.avatarURL ||
-                before.companyWebsite !== after.companyWebsite ||
                 before.jobRole !== after.jobRole ||
                 before.jobRoleOther !== after.jobRoleOther ||
                 // not checking explorationReasons or signupGoals atm as it's an array - need to check deep equality
@@ -296,8 +293,6 @@ export interface ProfileDetails {
     companyName?: string;
     // the user's email
     emailAddress?: string;
-    // the user's company website
-    companyWebsite?: string;
     // type of role user has in their job
     jobRole?: string;
     // freeform entry for job role user works in (when jobRole is "other")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Stop asking for company website during user onboarding

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes item 2. in [Slack message](https://gitpod.slack.com/archives/C04PH56LZK5/p1681917949501639?thread_ts=1681389401.968919&cid=C04PH56LZK5) (internal)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
