### PR TITLE
[ws-manager-mk2] Run integration tests against mk2 by default in GHA (+ preview fixes)

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             version: ${{ needs.configuration.outputs.version}}
             previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}
-            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != "false" }}
+            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -206,7 +206,7 @@ jobs:
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
 
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != "false" }}"
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 
@@ -251,7 +251,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 != "false" }})"
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }})"
 
     delete:
       name: Delete preview environment

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -3,11 +3,11 @@ on:
     workflow_dispatch:
         inputs:
             name:
-                required: true
-                description: "The name of the preview environment"
+                required: false
+                description: "The name of the preview environment. Leave empty to run against latest build on main"
             version:
-                required: true
-                description: "The version of Gitpod to install"
+                required: false
+                description: "The version of Gitpod to install (ignored if name is empty)"
             skip_deploy:
                 required: false
                 type: boolean

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -4,10 +4,10 @@ on:
         inputs:
             name:
                 required: false
-                description: "The name of the preview environment. Leave empty to run against latest build on main"
+                description: "The name of the preview environment, or leave empty to use a default name"
             version:
                 required: false
-                description: "The version of Gitpod to install (ignored if name is empty)"
+                description: "The version of Gitpod to install (use `latest` to target the latest build on main)"
             skip_deploy:
                 required: false
                 type: boolean
@@ -67,11 +67,19 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  if [[ '${{ github.event.inputs.name }}' != '' && '${{ github.event.inputs.name }}' != 'latest' ]]; then
-                      # The workflow was triggered by workflow_dispatch
+                  if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+                      {
+                          echo "name=${{ github.event.inputs.name }}"
+                      } >> $GITHUB_OUTPUT
+                  else
+                      {
+                          echo "name=workspace-integration-test-${{ github.run_id }}-${{ github.run_attempt }}"
+                      } >> $GITHUB_OUTPUT
+                  fi
+
+                  if [[ '${{ github.event.inputs.version }}' != 'latest' ]]; then
                       {
                           echo "version=${{ github.event.inputs.version }}"
-                          echo "name=${{ github.event.inputs.name }}"
                       } >> $GITHUB_OUTPUT
                   else
                       # others
@@ -83,7 +91,6 @@ jobs:
 
                       {
                           echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
-                          echo "name=workspace-integration-test-${{ github.run_id }}-${{ github.run_attempt }}"
                       } >> $GITHUB_OUTPUT
                   fi
             - name: Set previewctl version

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -92,6 +92,10 @@ jobs:
                           echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
                       } >> $GITHUB_OUTPUT
                   fi
+
+                  {
+                      echo "Using ws-manager-mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}"
+                  } >> "${GITHUB_STEP_SUMMARY}"
             - name: Slack Notification
               uses: rtCamp/action-slack-notify@v2
               if: failure()

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -35,7 +35,6 @@ jobs:
         outputs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
-            previewctl_hash: ${{ steps.set-previewctl-version.outputs.previewctl_version }}
         steps:
             # sometimes auth fails with:
             # google-github-actions/setup-gcloud failed with: EACCES: permission denied, mkdir '/__t/gcloud'
@@ -93,17 +92,6 @@ jobs:
                           echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
                       } >> $GITHUB_OUTPUT
                   fi
-            - name: Set previewctl version
-              id: set-previewctl-version
-              run: |
-                PREVIEWCTL_VERSION=$(\
-                    gcloud container images list-tags eu.gcr.io/gitpod-core-dev/build/previewctl \
-                        --filter="tags:main-gha.*" \
-                        --limit=1 \
-                        --format=json \
-                    | jq --raw-output '.[0].tags[0]'
-                )
-                echo "previewctl_version=$PREVIEWCTL_VERSION" >> "$GITHUB_OUTPUT"
             - name: Slack Notification
               uses: rtCamp/action-slack-notify@v2
               if: failure()
@@ -126,7 +114,6 @@ jobs:
             name: ${{ needs.configuration.outputs.name }}
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             infrastructure_provider: gce
-            previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}
             large_vm: true
         - name: Deploy Gitpod to the preview environment
           if: github.event.inputs.skip_deploy != 'true'
@@ -136,7 +123,6 @@ jobs:
             name: ${{ needs.configuration.outputs.name }}
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             version: ${{ needs.configuration.outputs.version}}
-            previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}
             wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
@@ -276,4 +262,3 @@ jobs:
           with:
               name: ${{ needs.configuration.outputs.name }}
               sa_key: ${{ secrets.GCP_CREDENTIALS }}
-              previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -19,6 +19,7 @@ on:
             wsman_mk2:
                 required: false
                 type: boolean
+                default: true
                 description: "Run tests against ws-manager-mk2"
     schedule:
         - cron: "0 3,12 * * *"
@@ -130,7 +131,7 @@ jobs:
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             version: ${{ needs.configuration.outputs.version}}
             previewctl_hash: ${{needs.configuration.outputs.previewctl_hash }}
-            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 }}
+            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != "false" }}
 
     check:
         name: Check for regressions
@@ -205,7 +206,7 @@ jobs:
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
 
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 }}"
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != "false" }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 
@@ -250,7 +251,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 }})"
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 != "false" }})"
 
     delete:
       name: Delete preview environment

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -7,7 +7,7 @@ on:
                 description: "The name of the preview environment, or leave empty to use a default name"
             version:
                 required: false
-                description: "The version of Gitpod to install (use `latest` to target the latest build on main)"
+                description: "The version of Gitpod to install (leave empty to target the latest build on main)"
             skip_deploy:
                 required: false
                 type: boolean
@@ -77,7 +77,7 @@ jobs:
                       } >> $GITHUB_OUTPUT
                   fi
 
-                  if [[ '${{ github.event.inputs.version }}' != 'latest' ]]; then
+                  if [[ '${{ github.event.inputs.version }}' != '' ]]; then
                       {
                           echo "version=${{ github.event.inputs.version }}"
                       } >> $GITHUB_OUTPUT
@@ -101,8 +101,7 @@ jobs:
                         --filter="tags:main-gha.*" \
                         --limit=1 \
                         --format=json \
-                    | jq --raw-output '.[0].tags[0]' \
-                    | cut -c 6-
+                    | jq --raw-output '.[0].tags[0]'
                 )
                 echo "previewctl_version=$PREVIEWCTL_VERSION" >> "$GITHUB_OUTPUT"
             - name: Slack Notification

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -598,7 +598,9 @@ pushd temp-installer
 yq4 -s '.kind + "_" + (.metadata.namespace // "") + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
 rm .yml || true # this one is a leftover from the split
 # shellcheck disable=SC2038
-find . | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
+# Apply namespaces first, as other resources might depend on these and would fail to apply if its namespace doesn't exist.
+find . | grep "Namespace" | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
+find . | grep --invert-match "Namespace" | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
 log_info "Applied all"
 popd
 rm -rf temp-installer

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -609,7 +609,11 @@ rm -f "${INSTALLER_RENDER_PATH}"
 # =========================
 # Wait for objects to be ready
 # =========================
-for item in deployment.apps/blobserve deployment.apps/content-service deployment.apps/dashboard deployment.apps/ide-metrics deployment.apps/ide-proxy deployment.apps/ide-service deployment.apps/image-builder-mk3 deployment.apps/minio deployment.apps/node-labeler deployment.apps/proxy deployment.apps/public-api-server deployment.apps/redis deployment.apps/server deployment.apps/spicedb deployment.apps/usage deployment.apps/ws-manager deployment.apps/ws-manager-bridge deployment.apps/ws-proxy statefulset.apps/messagebus statefulset.apps/mysql statefulset.apps/openvsx-proxy daemonset.apps/agent-smith daemonset.apps/fluent-bit daemonset.apps/registry-facade daemonset.apps/ws-daemon; do
+ws_man_deploy="deployment.apps/ws-manager"
+if [[ "${GITPOD_WSMANAGER_MK2}" == "true" ]]; then
+  ws_man_deploy="deployment.apps/ws-manager-mk2"
+fi
+for item in deployment.apps/blobserve deployment.apps/content-service deployment.apps/dashboard deployment.apps/ide-metrics deployment.apps/ide-proxy deployment.apps/ide-service deployment.apps/image-builder-mk3 deployment.apps/minio deployment.apps/node-labeler deployment.apps/proxy deployment.apps/public-api-server deployment.apps/redis deployment.apps/server deployment.apps/spicedb deployment.apps/usage "$ws_man_deploy" deployment.apps/ws-manager-bridge deployment.apps/ws-proxy statefulset.apps/messagebus statefulset.apps/mysql statefulset.apps/openvsx-proxy daemonset.apps/agent-smith daemonset.apps/fluent-bit daemonset.apps/registry-facade daemonset.apps/ws-daemon; do
   kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" rollout status "${item}" --namespace="${PREVIEW_NAMESPACE}"
 done
 

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -599,8 +599,9 @@ yq4 -s '.kind + "_" + (.metadata.namespace // "") + "_" + .metadata.name' "../${
 rm .yml || true # this one is a leftover from the split
 # shellcheck disable=SC2038
 # Apply namespaces first, as other resources might depend on these and would fail to apply if its namespace doesn't exist.
-find . | grep "Namespace" | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
-find . | grep --invert-match "Namespace" | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
+# The `|| test $? = 1` is to prevent grep from failing if no matches are found.
+find . | { grep "Namespace" || test $? = 1; } | xargs -r -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
+find . | grep --invert-match "Namespace" | xargs -r -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
 log_info "Applied all"
 popd
 rm -rf temp-installer

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -1043,10 +1043,6 @@ func (c *ComponentAPI) ImageBuilder(opts ...APIImageBuilderOpt) (imgbldr.ImageBu
 	}
 
 	imgbuilder := ComponentImageBuilderMK3
-	if UseWsmanMk2() {
-		imgbuilder = ComponentImageBuilderMK3Wsman
-	}
-
 	err := func() error {
 		if c.imgbldStatus.Port == 0 {
 			c.imgbldStatusMu.Lock()

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -612,8 +612,6 @@ const (
 	ComponentWorkspace ComponentType = "workspace"
 	// ComponentImageBuilderMK3 points to the image-builder-mk3
 	ComponentImageBuilderMK3 ComponentType = "image-builder-mk3"
-	// ComponentImageBuilderMK3Wsman points to ws-manager-mk2's image-builder-mk3
-	ComponentImageBuilderMK3Wsman ComponentType = "image-builder-mk3-wsman"
 )
 
 func waitForPodRunningReady(c kubernetes.Interface, podName string, namespace string, timeout time.Duration) error {

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -145,7 +145,6 @@ func waitOnGitpodRunning(namespace string, waitTimeout time.Duration) env.Func {
 		imgBuilder := "image-builder-mk3"
 		wsman := "ws-manager"
 		if UseWsmanMk2() {
-			imgBuilder = "image-builder-mk3-wsman"
 			wsman = "ws-manager-mk2"
 		}
 


### PR DESCRIPTION
## Description
Runs workspace integration tests against mk2 by default (both in the scheduled job, and in manual dispatch inputs)

Also includes several fixes and improvements needed to run the tests:
- Update `name` and `version` workflow inputs to not be required, and allow either one to be set without the other
- Remove previewctl hash, this was causing not-found errors when downloading the `previewctl` binary as the hash was constructed incorrectly. Not specifying any hash will also try to download the latest version which is what we want
- Fix preview environment sometimes failing to create with mk2 enabled, due to namespaces sometimes being applied after the manifests in that namespace, causing those manifests to fail to apply. Specifically this was failing for the `workspace-secrets` namespace used for mk2. Fixed by first applying namespaces to the preview env, and then all other manifests.
- Fix preview env creation failing with mk2 enabled, as it's waiting for the non-existent mk1 deployment
- Fix tests still trying to use the removed `image-builder-mk3-wsman` deploy

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-98

## How to test
<!-- Provide steps to test this PR -->

1. Run the workspace integration tests GHA workflow from this branch, for mk1 and for mk2
2. Build a preview environment, ensure that flow still works

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - wv-mk2-rund31883caca</li>
	<li><b>🔗 URL</b> - <a href="https://wv-mk2-rund31883caca.preview.gitpod-dev.com/workspaces" target="_blank">wv-mk2-rund31883caca.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
