### PR TITLE
[db] Unblock admin-user by default

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1682510207256-UnblockAdminuser.ts
+++ b/components/gitpod-db/src/typeorm/migration/1682510207256-UnblockAdminuser.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "../../user-db";
+
+export class UnblockAdminuser1682510207256 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE d_b_user SET blocked = FALSE WHERE id = '${BUILTIN_INSTLLATION_ADMIN_USER_ID}'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE d_b_user SET blocked = TRUE WHERE id = '${BUILTIN_INSTLLATION_ADMIN_USER_ID}'`);
+    }
+}


### PR DESCRIPTION
## Description

This additional safe-guard is not necessary anymore because we guard admin credential creation by other means.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-235

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
