### PR TITLE
[db] directly delete workspaces

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -927,29 +927,23 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         const prebuild = await this.findPrebuildByWorkspaceID(workspaceId);
         if (prebuild !== undefined) {
             // There are prebuilds linked to this workspace. We need to delete these first.
-            const prebuildsDeleted = await (
-                await this.getPrebuiltWorkspaceRepo()
-            ).update({ id: prebuild.id }, { deleted: true });
+            const prebuildsDeleted = await (await this.getPrebuiltWorkspaceRepo()).delete({ id: prebuild.id });
             log.info(logCtx, `Hard deleted ${prebuildsDeleted.affected} prebuilds.`);
             reportPrebuiltWorkspacePurged(prebuildsDeleted.affected || 0);
 
-            const updatableDeletes = await (
-                await this.getPrebuiltWorkspaceUpdatableRepo()
-            ).update({ id: prebuild.id }, { deleted: true });
+            const updatableDeletes = await (await this.getPrebuiltWorkspaceUpdatableRepo()).delete({ id: prebuild.id });
             log.info(logCtx, `Hard deleted ${updatableDeletes.affected} prebuild updatables.`);
             reportPrebuiltWorkspaceUpdatablePurged(updatableDeletes.affected || 0);
 
-            const prebuildInfos = await (
-                await this.getPrebuildInfoRepo()
-            ).update({ prebuildId: prebuild.id }, { deleted: true });
+            const prebuildInfos = await (await this.getPrebuildInfoRepo()).delete({ prebuildId: prebuild.id });
             log.info(logCtx, `Hard deleted ${prebuildInfos.affected} prebuild infos.`);
             reportPrebuildInfoPurged(prebuildInfos.affected || 0);
         }
-        const instances = await (await this.getWorkspaceInstanceRepo()).update({ workspaceId }, { deleted: true });
+        const instances = await (await this.getWorkspaceInstanceRepo()).delete({ workspaceId });
         log.info(logCtx, `Hard deleted ${instances.affected} workspace instances.`);
         reportWorkspaceInstancePurged(instances.affected || 0);
 
-        const workspaces = await (await this.getWorkspaceRepo()).update(workspaceId, { deleted: true });
+        const workspaces = await (await this.getWorkspaceRepo()).delete({ id: workspaceId });
         log.info(logCtx, `Hard deleted ${workspaces.affected} workspaces.`);
         reportWorkspacePurged(workspaces.affected || 0);
     }

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -792,5 +792,17 @@ class WorkspaceDBSpec {
 
         expect(result.length).to.eq(0);
     }
+
+    @test(timeout(10000))
+    public async hardDeleteWorkspace() {
+        await this.db.store(this.ws);
+        await this.db.storeInstance(this.wsi1);
+        await this.db.storeInstance(this.wsi2);
+        let result = await this.db.findInstances(this.ws.id);
+        expect(result.length).to.eq(2);
+        await this.db.hardDeleteWorkspace(this.ws.id);
+        result = await this.db.findInstances(this.ws.id);
+        expect(result.length).to.eq(0);
+    }
 }
 module.exports = new WorkspaceDBSpec();

--- a/components/server/src/workspace/workspace-deletion-service.ts
+++ b/components/server/src/workspace/workspace-deletion-service.ts
@@ -109,7 +109,7 @@ export class WorkspaceDeletionService {
      * @param ws
      * @param includeSnapshots
      */
-    protected async deleteWorkspaceStorage(
+    private async deleteWorkspaceStorage(
         ctx: TraceContext,
         ws: WorkspaceAndOwner,
         includeSnapshots: boolean,


### PR DESCRIPTION
## Description
We no longer need the periodic deleter (non more db-sync).
So as a step towards getting rid of it, workspaces are going to be directly deleted.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-250

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
