### PR TITLE
[usage] Sequentialize usage tests

### DIFF
--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -23,7 +23,16 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestUsageService_ReconcileUsage(t *testing.T) {
+// TestRunAllUsageApiTests runs all tests sequentially to avoid race conditions on the DB
+func TestRunAllUsageApiTests(t *testing.T) {
+	t.Run("ReconcileUsage", testReconcileUsage)
+	t.Run("Reconcile", testReconcile)
+	t.Run("GetAndSetCostCenter", testGetAndSetCostCenter)
+	t.Run("ListUsage", testListUsage)
+	t.Run("AddUsageCreditNote", testAddUsageCreditNote)
+}
+
+func testReconcileUsage(t *testing.T) {
 	dbconn := dbtest.ConnectForTests(t)
 	from := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
 	to := time.Date(2022, 05, 1, 1, 00, 00, 00, time.UTC)
@@ -95,7 +104,7 @@ func newUsageService(t *testing.T, dbconn *gorm.DB) v1.UsageServiceClient {
 	return client
 }
 
-func TestReconcile(t *testing.T) {
+func testReconcile(t *testing.T) {
 	now := time.Date(2022, 9, 1, 10, 0, 0, 0, time.UTC)
 	pricer, err := NewWorkspacePricer(map[string]float64{
 		"default":              0.1666666667,
@@ -249,7 +258,7 @@ func TestReconcile(t *testing.T) {
 	})
 }
 
-func TestGetAndSetCostCenter(t *testing.T) {
+func testGetAndSetCostCenter(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 	costCenterUpdates := []*v1.CostCenter{
 		{
@@ -287,7 +296,7 @@ func TestGetAndSetCostCenter(t *testing.T) {
 	}
 }
 
-func TestListUsage(t *testing.T) {
+func testListUsage(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 
 	start := time.Date(2022, 7, 1, 0, 0, 0, 0, time.UTC)
@@ -366,7 +375,7 @@ func TestListUsage(t *testing.T) {
 
 }
 
-func TestAddUSageCreditNote(t *testing.T) {
+func testAddUsageCreditNote(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 
 	attributionID := db.NewTeamAttributionID(uuid.New().String())


### PR DESCRIPTION
## Description

I bet there is a "nicer" way to do this, but: This makes my builds work again. :slightly_smiling_face: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-240

## How to test
- open workspace
- `leeway run components/gitpod-db:init-testdb`
- `(components/usage && go test -v ./...)`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
