### PR TITLE
Removing ONBOARDING_IN_PROGRESS condition

### DIFF
--- a/components/dashboard/src/components/error-boundaries/QueryErrorBoundary.tsx
+++ b/components/dashboard/src/components/error-boundaries/QueryErrorBoundary.tsx
@@ -52,15 +52,6 @@ const ExpectedQueryErrorsFallback: FC<FallbackProps> = ({ error, resetErrorBound
     }
 
     // Setup needed before proceeding
-    if (caughtError.code === ErrorCodes.ONBOARDING_IN_PROGRESS) {
-        return (
-            <Suspense fallback={<AppLoading />}>
-                <DedicatedOnboarding onComplete={resetErrorBoundary} />
-            </Suspense>
-        );
-    }
-
-    // Setup needed before proceeding
     if (caughtError.code === ErrorCodes.SETUP_REQUIRED) {
         return (
             <Suspense fallback={<AppLoading />}>

--- a/components/gitpod-protocol/go/error.go
+++ b/components/gitpod-protocol/go/error.go
@@ -27,9 +27,6 @@ const (
 	// 411 No User
 	NEEDS_VERIFICATION = 411
 
-	// 412 Dedicated Cell is in "onboarding" mode
-	ONBOARDING_IN_PROGRESS = 412
-
 	// 429 Too Many Requests
 	TOO_MANY_REQUESTS = 429
 

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -26,9 +26,6 @@ export namespace ErrorCodes {
     // 411 No User
     export const NEEDS_VERIFICATION = 411;
 
-    // 412 Dedicated Cell is in "onboarding" mode
-    export const ONBOARDING_IN_PROGRESS = 412;
-
     // 429 Too Many Requests
     export const TOO_MANY_REQUESTS = 429;
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -599,7 +599,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         // But we need to make sure, it's not triggered if the new Dedicated Onboarding is active.
         // TODO(gpl): Remove the outer condition once we have an onboarding setup
         if (!this.enableDedicatedOnboardingFlow) {
-            if (this.showSetupCondition?.value && !this.showOnboardingFlowCondition?.value) {
+            if (this.showSetupCondition?.value) {
                 throw new ResponseError(ErrorCodes.SETUP_REQUIRED, "Setup required.");
             }
         }
@@ -622,12 +622,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             }
             log.debug(userContext, methodName, payload);
         }
-
-        // A session is required to continue with an activated onboarding flow.
-        // TODO(gpl): Re-enable once we have an onboarding setup view
-        // if (this.showOnboardingFlowCondition?.value) {
-        //     throw new ResponseError(ErrorCodes.ONBOARDING_IN_PROGRESS, "Dedicated Onboarding Flow in progress.");
-        // }
 
         return this.user;
     }
@@ -672,7 +666,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     protected showSetupCondition: { value: boolean } | undefined = undefined;
-    protected showOnboardingFlowCondition: { value: boolean } | undefined = undefined;
     protected enableDedicatedOnboardingFlow: boolean = false; // TODO(gpl): Remove once we have an onboarding setup
     protected async doUpdateUser(): Promise<void> {
         // Conditionally enable Dedicated Onboarding Flow
@@ -683,16 +676,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 gitpodHost: new URL(this.config.hostUrl.toString()).host,
             },
         );
-        if (this.enableDedicatedOnboardingFlow) {
-            const someOrgWithSSOExists = await this.teamDB.someOrgWithSSOExists();
-            const shouldShowOnboardingFlow = !someOrgWithSSOExists;
-            this.showOnboardingFlowCondition = { value: shouldShowOnboardingFlow };
-            if (shouldShowOnboardingFlow) {
-                console.log(`Dedicated Onboarding flow is active.`);
-            }
-        } else {
-            this.showOnboardingFlowCondition = { value: false };
-        }
         // execute the check for the setup to be shown until the setup is not required.
         // cf. evaluation of the condition in `checkUser`
         if (!this.config.showSetupModal) {


### PR DESCRIPTION
Because it blocks all API calls needed during the onboarding flow.

Partially reverts #17303. 

The new plan is to add a page for the onboarding flow and redirect to it. It might require to guard access to to afterwards. 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-rm-onboc0047292d5</li>
	<li><b>🔗 URL</b> - <a href="https://at-rm-onboc0047292d5.preview.gitpod-dev.com/workspaces" target="_blank">at-rm-onboc0047292d5.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
