### PR TITLE
[ws-manager-mk2] Improve reconcile err logging

### DIFF
--- a/components/ws-daemon/pkg/controller/snapshot_controller.go
+++ b/components/ws-daemon/pkg/controller/snapshot_controller.go
@@ -91,7 +91,7 @@ func (ssc *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	snapshotURL, snapshotName, snapshotErr := ssc.operations.SnapshotIDs(ctx, snapshot.Spec.WorkspaceID)
 	if snapshotErr != nil {
-		return ctrl.Result{}, snapshotErr
+		return ctrl.Result{}, fmt.Errorf("failed to get snapshot name and URL: %w", snapshotErr)
 	}
 
 	err := retry.RetryOnConflict(retryParams, func() error {
@@ -106,7 +106,7 @@ func (ssc *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if err != nil {
 		log.Error(err, "could not set snapshot url", "workspace", snapshot.Spec.WorkspaceID)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("could not set snapshot url: %w", err)
 	}
 
 	snapshotErr = ssc.operations.Snapshot(ctx, snapshot.Spec.WorkspaceID, snapshotName)
@@ -130,6 +130,7 @@ func (ssc *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if err != nil {
 		log.Error(err, "could not set completion status for snapshot", "workspace", snapshot.Spec.WorkspaceID)
+		err = fmt.Errorf("could not set completion status for snapshot: %w", err)
 	}
 
 	ssc.emitEvent(&snapshot, snapshotErr)

--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -303,7 +303,7 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 	if err == nil {
 		wsc.metrics.recordFinalizeTime(time.Since(disposeStart).Seconds(), ws)
 	} else {
-		log.Error(err, "failed to set backup condition (disposeErr: %s): %w", disposeErr.Error(), err)
+		log.Error(err, "failed to set backup condition", "disposeErr", disposeErr)
 	}
 
 	if disposeErr != nil {

--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -168,7 +168,7 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 
 		init, err := wsc.prepareInitializer(ctx, ws)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to prepare initializer: %w", err)
 		}
 
 		initStart := time.Now()
@@ -199,6 +199,8 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 
 		if err == nil {
 			wsc.metrics.recordInitializeTime(time.Since(initStart).Seconds(), ws)
+		} else {
+			err = fmt.Errorf("failed to set content ready condition (failure: '%s'): %w", failure, err)
 		}
 
 		wsc.emitEvent(ws, "Content init", initErr)
@@ -247,7 +249,7 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 	} else {
 		snapshotUrl, snapshotName, err = wsc.operations.SnapshotIDs(ctx, ws.Name)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to get snapshot name and URL: %w", err)
 		}
 
 		// ws-manager-bridge expects to receive the snapshot url while the workspace
@@ -265,7 +267,7 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		})
 
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to set snapshot URL: %w", err)
 		}
 	}
 
@@ -300,6 +302,8 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 
 	if err == nil {
 		wsc.metrics.recordFinalizeTime(time.Since(disposeStart).Seconds(), ws)
+	} else {
+		log.Error(err, "failed to set backup condition (disposeErr: %s): %w", disposeErr.Error(), err)
 	}
 
 	if disposeErr != nil {
@@ -309,10 +313,10 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 	err = wsc.operations.DeleteWorkspace(ctx, ws.Name)
 	if err != nil {
 		wsc.emitEvent(ws, "Backup", fmt.Errorf("failed to clean up workspace: %w", err))
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to clean up workspace: %w", err)
 	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 func (wsc *WorkspaceController) prepareInitializer(ctx context.Context, ws *workspacev1.Workspace) (*csapi.WorkspaceInitializer, error) {

--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
@@ -67,7 +68,7 @@ func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		log.Error(err, "unable to fetch configmap")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to fetch configmap: %w", err)
 	}
 
 	configJson, ok := cm.Data["config.json"]

--- a/components/ws-manager-mk2/controllers/timeout_controller.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller.go
@@ -110,7 +110,7 @@ func (r *TimeoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return r.Status().Update(ctx, &workspace)
 	}); err != nil {
 		log.Error(err, "Failed to update workspace status with Timeout condition")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to add timeout condition: %w", err)
 	}
 
 	r.recorder.Event(&workspace, corev1.EventTypeNormal, "TimedOut", timedout)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -145,7 +145,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// Conflicts are to be expected, don't return as an error to reduce noise in
 			// our error logging. We still want to requeue asap though.
 			// `Requeue: true` has the same requeuing behaviour as returning an error.
-			log.Info("failed to update workspace status due to conflict: %w", err)
+			log.Info("failed to update workspace status due to conflict", "error", err)
 			return ctrl.Result{Requeue: true}, nil
 		} else {
 			return ctrl.Result{}, fmt.Errorf("failed to update workspace status: %w", err)

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -370,7 +370,7 @@ func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsman
 			ws.Status.SetCondition(workspacev1.NewWorkspaceConditionAborted("StopWorkspaceRequest"))
 			return nil
 		}); err != nil {
-			log.Error(err, "failed to add Aborted condition to workspace")
+			log.WithError(err).WithFields(owi).Error("failed to add Aborted condition to workspace")
 		}
 	}
 	err = wsm.modifyWorkspace(ctx, req.Id, true, func(ws *workspacev1.Workspace) error {


### PR DESCRIPTION
## Description

Improves reconciler error logging by wrapping returned errors with additional context.

Also logs workspace status update conflicts as Info level rather than Error, as they're expected in normal operations.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
