### PR TITLE
Repersist IDP public key when lost

### DIFF
--- a/components/public-api-server/pkg/identityprovider/cache_test.go
+++ b/components/public-api-server/pkg/identityprovider/cache_test.go
@@ -192,4 +192,17 @@ func TestRedisCacheSigner(t *testing.T) {
 	if err != nil {
 		t.Errorf("Returned signer does not sign with currently set key")
 	}
+
+	err = client.FlushAll(context.Background()).Err()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cache.Signer(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := client.Keys(context.Background(), redisIDPKeyPrefix+"*").Val()
+	if len(keys) == 0 {
+		t.Error("getting a new signer did not repersist the key")
+	}
 }


### PR DESCRIPTION
## Description
This change will improve the stability of the identity provider functionality. It does that by re-persisting a public key if it's been lost in the meantime, e.g. because Redis restarted. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-268

## How to test
See unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
