### PR TITLE
Revert "[dashboard] send heartbeat telemetry (#17358)"

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -17,12 +17,7 @@ import {
 import { WebSocketConnectionProvider } from "@gitpod/gitpod-protocol/lib/messaging/browser/connection";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import {
-    IDEFrontendDashboardService,
-    IDEHeartbeatTelemetryData,
-    IDEHeartbeatTelemetryEvent,
-    IDE_HEARTBEAT_TELEMETRY_INTERVAL_MS,
-} from "@gitpod/gitpod-protocol/lib/frontend-dashboard-service";
+import { IDEFrontendDashboardService } from "@gitpod/gitpod-protocol/lib/frontend-dashboard-service";
 import { RemoteTrackMessage } from "@gitpod/gitpod-protocol/lib/analytics";
 
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
@@ -81,14 +76,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
 
     private latestInfo?: IDEFrontendDashboardService.Status;
 
-    private gitpodHost: string;
-    private isDebugWorkspace: boolean;
-    private isWorkspaceRunning: boolean;
-    private heartbeatTelemetryData: Pick<IDEHeartbeatTelemetryData, "totalCount" | "successfulCount"> = {
-        totalCount: 0,
-        successfulCount: 0,
-    };
-
     private readonly onDidChangeEmitter = new Emitter<IDEFrontendDashboardService.SetStateData>();
     readonly onSetState = this.onDidChangeEmitter.event;
 
@@ -98,7 +85,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         private service: GitpodService,
         private clientWindow: Window,
     ) {
-        this.isWorkspaceRunning = false;
         this.processServerInfo();
         window.addEventListener("message", (event: MessageEvent) => {
             if (IDEFrontendDashboardService.isTrackEventData(event.data)) {
@@ -128,34 +114,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             const url = gitpodHostUrl.withApi({ pathname: `/auth/workspacePageClose/${this.instanceID}` }).toString();
             navigator.sendBeacon(url, blob);
         });
-
-        const workspaceUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href);
-        this.gitpodHost = workspaceUrl.withoutWorkspacePrefix().url.host;
-        this.isDebugWorkspace = workspaceUrl.debugWorkspace;
-        setInterval(() => {
-            if (!this.instanceID || !this.isWorkspaceRunning) {
-                return;
-            }
-            this.sendIDEHeartbeatTelemetry();
-        }, IDE_HEARTBEAT_TELEMETRY_INTERVAL_MS);
-    }
-
-    private async sendIDEHeartbeatTelemetry() {
-        const properties: IDEHeartbeatTelemetryData = {
-            successfulCount: this.heartbeatTelemetryData.successfulCount,
-            totalCount: this.heartbeatTelemetryData.totalCount,
-            workspaceId: this.workspaceID,
-            instanceId: this.instanceID ?? "",
-            gitpodHost: this.gitpodHost,
-            clientKind: "supervisor-frontend",
-            debugWorkspace: String(this.isDebugWorkspace) as any,
-        };
-        this.service.server.trackEvent({
-            event: IDEHeartbeatTelemetryEvent,
-            properties,
-        });
-        this.heartbeatTelemetryData.successfulCount = 0;
-        this.heartbeatTelemetryData.totalCount = 0;
     }
 
     private async processServerInfo() {
@@ -168,11 +126,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         this.ideCredentials = ideCredentials;
         const reconcile = () => {
             const info = this.parseInfo(listener.info);
-            const isRunning = info.statusPhase === "running";
-            if (this.isWorkspaceRunning && !isRunning) {
-                this.sendIDEHeartbeatTelemetry();
-            }
-            this.isWorkspaceRunning = isRunning;
             this.latestInfo = info;
             const oldInstanceID = this.instanceID;
             this.instanceID = info.instanceId;
@@ -230,21 +183,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
 
     private activeHeartbeat(): void {
         if (this.instanceID) {
-            let hbSucceed = false;
-            this.service.server
-                .sendHeartBeat({ instanceId: this.instanceID })
-                .then(() => {
-                    hbSucceed = true;
-                })
-                .catch((e) => {
-                    console.error("failed to send heartbeat:", e);
-                })
-                .finally(() => {
-                    if (hbSucceed) {
-                        this.heartbeatTelemetryData.successfulCount++;
-                    }
-                    this.heartbeatTelemetryData.totalCount++;
-                });
+            this.service.server.sendHeartBeat({ instanceId: this.instanceID });
         }
     }
 

--- a/components/gitpod-protocol/src/frontend-dashboard-service.ts
+++ b/components/gitpod-protocol/src/frontend-dashboard-service.ts
@@ -147,15 +147,3 @@ export namespace IDEFrontendDashboardService {
         return obj != null && typeof obj === "object" && obj.type === "ide-open-desktop";
     }
 }
-
-export const IDEHeartbeatTelemetryEvent = "ide_heartbeat";
-export interface IDEHeartbeatTelemetryData {
-    clientKind: "vscode-desktop" | "ssh" | "jetbrains" | "vscode-desktop" | "supervisor-frontend";
-    totalCount: number;
-    successfulCount: number;
-    workspaceId: string;
-    instanceId: string;
-    gitpodHost: string;
-    debugWorkspace: "true" | "false";
-}
-export const IDE_HEARTBEAT_TELEMETRY_INTERVAL_MS = 900000; // 15 minutes


### PR DESCRIPTION
This reverts commit c520c72398235104a2a870014d20e476ac211890.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/pull/17425

## How to test
<!-- Provide steps to test this PR -->
Build should pass

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
