### PR TITLE
[previewctl] print admin link

### DIFF
--- a/dev/preview/previewctl/cmd/admin.go
+++ b/dev/preview/previewctl/cmd/admin.go
@@ -14,6 +14,7 @@ import (
 
 	"crypto/sha512"
 
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -56,13 +57,16 @@ func newCreateAdminCredentialsCmd(logger *logrus.Logger) *cobra.Command {
 			if err != nil {
 				logger.WithError(err).Fatal("Failed to create admin credentials.")
 			}
-
+			previewName, err := preview.GetName(branch)
+			if err != nil {
+				return err
+			}
 			logger.
 				WithField("hash", creds.TokenHash).
 				WithField("algo", creds.Algo).
 				WithField("expires_unix", creds.ExpiresAt).
 				WithField("expires", time.Unix(creds.ExpiresAt, 0).Format(time.RFC3339)).
-				Infof("Created new admin credentials: %s", token)
+				Infof("Created new admin credentials: https://%s.preview.gitpod-dev.com/api/login/ots/admin/%s", previewName, token)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description
print out the admin login link when generating the token

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
