### PR TITLE
[ws-manager-mk2] Fix headless task failures

### DIFF
--- a/components/image-builder-mk3/pkg/orchestrator/monitor.go
+++ b/components/image-builder-mk3/pkg/orchestrator/monitor.go
@@ -232,7 +232,7 @@ func extractBuildResponse(status *wsmanapi.WorkspaceStatus) *api.BuildResponse {
 		info = extractBuildStatus(status)
 		msg  = status.Message
 	)
-	if status.Phase == wsmanapi.WorkspacePhase_STOPPING {
+	if status.Phase == wsmanapi.WorkspacePhase_STOPPING || status.Phase == wsmanapi.WorkspacePhase_STOPPED {
 		if status.Conditions.Failed != "" {
 			msg = status.Conditions.Failed
 		} else if status.Conditions.HeadlessTaskFailed != "" {

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -210,6 +210,15 @@ func NewWorkspaceConditionDeployed() metav1.Condition {
 	}
 }
 
+func NewWorkspaceConditionHeadlessTaskFailed(message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(WorkspaceConditionsHeadlessTaskFailed),
+		LastTransitionTime: metav1.Now(),
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	}
+}
+
 func NewWorkspaceConditionFailed(message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(WorkspaceConditionFailed),


### PR DESCRIPTION
## Description

Fixes headless task failures to get reported through the `HeadlessTaskFailed` condition instead of the `Failed` condition.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-122

## How to test
<!-- Provide steps to test this PR -->

Tested image build failures using: https://github.com/wverlaek/gitpod-testing/tree/fail-image-build

Verify that the `gitpod_ws_manager_mk2_workspace_stops_total{reason="failed"}` metric doesn't get incremented on headless task failures

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
