### PR TITLE
Close workspace delete confirmation modal on enter

### DIFF
--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from "classnames";
-import { FC, RefObject } from "react";
+import { FC, forwardRef } from "react";
 import SpinnerWhite from "../icons/SpinnerWhite.svg";
 
 export type ButtonProps = {
@@ -17,7 +17,6 @@ export type ButtonProps = {
     loading?: boolean;
     className?: string;
     autoFocus?: boolean;
-    ref?: RefObject<HTMLButtonElement>;
     htmlType?: "button" | "submit" | "reset";
     onClick?: ButtonOnClickHandler;
 };
@@ -25,18 +24,17 @@ export type ButtonProps = {
 // Allow w/ or w/o handling event argument
 type ButtonOnClickHandler = React.DOMAttributes<HTMLButtonElement>["onClick"] | (() => void);
 
-export const Button: FC<ButtonProps> = ({
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
     type = "primary",
     className,
     htmlType,
     disabled = false,
     loading = false,
     autoFocus = false,
-    ref,
     size,
     children,
     onClick,
-}) => {
+}, ref? ) => {
     return (
         <button
             type={htmlType}
@@ -77,7 +75,7 @@ export const Button: FC<ButtonProps> = ({
             <ButtonContent loading={loading}>{children}</ButtonContent>
         </button>
     );
-};
+});
 
 // TODO: Consider making this a LoadingButton variant instead
 type ButtonContentProps = {


### PR DESCRIPTION
## Description

Pick up changes from the https://github.com/gitpod-io/gitpod/labels/community-contribution in https://github.com/gitpod-io/gitpod/pull/17326. Cc @RayAsh37

For more context, see **[relevant section](https://www.notion.so/gitpod/How-we-develop-e8ce7e562478458a9223eb9b797415b2?pvs=4#ef8b432a56b6425db16039d603ac97f4)** in How we develop.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16717

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
