### PR TITLE
Streamline dedicated login/signup

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -227,8 +227,10 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                                         </button>
                                     ))
                                 )}
-
-                                <SSOLoginForm onSuccess={authorizeSuccessful} />
+                                <SSOLoginForm
+                                    onSuccess={authorizeSuccessful}
+                                    singleOrgMode={!!authProviders.data && authProviders.data.length === 0}
+                                />
                             </div>
                             {errorMessage && <ErrorMessage imgSrc={exclamation} message={errorMessage} />}
                         </div>

--- a/components/dashboard/src/login/SSOLoginForm.tsx
+++ b/components/dashboard/src/login/SSOLoginForm.tsx
@@ -4,40 +4,26 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useEffect, useState } from "react";
+import { FC, useCallback, useState } from "react";
 import Alert from "../components/Alert";
 import { Button } from "../components/Button";
 import { TextInputField } from "../components/forms/TextInputField";
 import { useOnBlurError } from "../hooks/use-onblur-error";
 import { openOIDCStartWindow } from "../provider-utils";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 type Props = {
+    singleOrgMode?: boolean;
     onSuccess: () => void;
 };
-export const SSOLoginForm: FC<Props> = ({ onSuccess }) => {
+export const SSOLoginForm: FC<Props> = ({ singleOrgMode, onSuccess }) => {
     const [orgSlug, setOrgSlug] = useState("");
     const [error, setError] = useState("");
-    const [showSSO, setShowSSO] = useState<boolean>(false);
-
-    useEffect(() => {
-        try {
-            const content = window.localStorage.getItem("gitpod-ui-experiments");
-            const object = content && JSON.parse(content);
-            if (object["ssoLogin"] === true) {
-                setShowSSO(true);
-            }
-        } catch {
-            // ignore as non-critical
-        }
-    }, []);
+    const oidcServiceEnabled = useFeatureFlag("oidcServiceEnabled");
 
     const openLoginWithSSO = useCallback(
         async (e) => {
             e.preventDefault();
-
-            if (!orgSlug.trim()) {
-                return;
-            }
 
             try {
                 await openOIDCStartWindow({
@@ -66,23 +52,29 @@ export const SSOLoginForm: FC<Props> = ({ onSuccess }) => {
     );
 
     // Don't render anything if not enabled
-    if (!showSSO) {
+    if (!oidcServiceEnabled) {
         return null;
     }
 
     return (
         <form onSubmit={openLoginWithSSO}>
             <div className="mt-10 space-y-2">
-                <TextInputField
-                    label="Organization Slug"
-                    placeholder="my-team"
-                    value={orgSlug}
-                    onChange={setOrgSlug}
-                    error={slugError.message}
-                    onBlur={slugError.onBlur}
-                />
-                <Button className="w-full" type="secondary" disabled={!orgSlug.trim() || !slugError.isValid}>
-                    Continue with SSO
+                {!singleOrgMode && (
+                    <TextInputField
+                        label="Organization Slug"
+                        placeholder="my-company"
+                        value={orgSlug}
+                        onChange={setOrgSlug}
+                        error={slugError.message}
+                        onBlur={slugError.onBlur}
+                    />
+                )}
+                <Button
+                    className="w-full"
+                    type="secondary"
+                    disabled={!singleOrgMode && (!orgSlug.trim() || !slugError.isValid)}
+                >
+                    Continue {singleOrgMode ? "" : "with SSO"}
                 </Button>
                 {error && <Alert type="info">{error}</Alert>}
             </div>

--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -144,7 +144,7 @@ async function openOIDCStartWindow(params: OpenOIDCStartWindowParams) {
     const url = gitpodHostUrl
         .with((url) => ({
             pathname: `/iam/oidc/start`,
-            search: `orgSlug=${orgSlug}&returnTo=${encodeURIComponent(returnTo)}`,
+            search: `${orgSlug ? "orgSlug=" + orgSlug + "&" : ""}returnTo=${encodeURIComponent(returnTo)}`,
         }))
         .toString();
 

--- a/components/gitpod-db/go/team.go
+++ b/components/gitpod-db/go/team.go
@@ -75,3 +75,25 @@ func GetTeamBySlug(ctx context.Context, conn *gorm.DB, slug string) (Team, error
 
 	return team, nil
 }
+
+// GetTheSingleTeam returns the single team in the database.
+// If there is more than one team, an error is returned.
+func GetTheSingleTeam(ctx context.Context, conn *gorm.DB) (Team, error) {
+	var teams []Team
+
+	// find the single team and throw error if more than one team exists
+	tx := conn.WithContext(ctx).Where("deleted != TRUE").Find(&teams)
+
+	if tx.Error != nil {
+		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+			return Team{}, fmt.Errorf("No single team found: %w", ErrorNotFound)
+		}
+		return Team{}, fmt.Errorf("Failed to retrieve team: %v", tx.Error)
+	}
+
+	if len(teams) != 1 {
+		return Team{}, fmt.Errorf("No single team found: %w", ErrorNotFound)
+	}
+
+	return teams[0], nil
+}

--- a/components/gitpod-db/go/team_test.go
+++ b/components/gitpod-db/go/team_test.go
@@ -56,3 +56,40 @@ func Test_GetTeamBySlug(t *testing.T) {
 	require.Equal(t, team.Name, read.Name)
 	require.Equal(t, team.Slug, read.Slug)
 }
+
+func Test_GetTheSingleTeam(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	conn.Delete(&db.Team{}, "1=1")
+
+	_, err := db.GetTheSingleTeam(context.Background(), conn)
+	require.Error(t, err)
+
+	// create a single team
+	team := db.Team{
+		ID:   uuid.New(),
+		Name: "Team1",
+		Slug: "team1",
+	}
+
+	_, err = db.CreateTeam(context.Background(), conn, team)
+	require.NoError(t, err)
+
+	read, err := db.GetTheSingleTeam(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, team.Name, read.Name)
+	require.Equal(t, team.Slug, read.Slug)
+
+	// create a second team
+	team2 := db.Team{
+		ID:   uuid.New(),
+		Name: "Team1",
+		Slug: "team1",
+	}
+
+	_, err = db.CreateTeam(context.Background(), conn, team2)
+	require.NoError(t, err)
+
+	_, err = db.GetTheSingleTeam(context.Background(), conn)
+	require.Error(t, err)
+}

--- a/components/public-api-server/pkg/oidc/service.go
+++ b/components/public-api-server/pkg/oidc/service.go
@@ -128,6 +128,16 @@ func randString(size int) (string, error) {
 
 func (s *Service) GetClientConfigFromStartRequest(r *http.Request) (*ClientConfig, error) {
 	orgSlug := r.URL.Query().Get("orgSlug")
+	idParam := r.URL.Query().Get("id")
+
+	// if no org slug is given, we assume the request is for the default org
+	if orgSlug == "" && idParam == "" {
+		org, err := db.GetTheSingleTeam(r.Context(), s.dbConn)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to find team: %w", err)
+		}
+		orgSlug = org.Slug
+	}
 	if orgSlug != "" {
 		dbEntry, err := db.GetOIDCClientConfigByOrgSlug(r.Context(), s.dbConn, orgSlug)
 		if err != nil {
@@ -142,7 +152,6 @@ func (s *Service) GetClientConfigFromStartRequest(r *http.Request) (*ClientConfi
 		return &config, nil
 	}
 
-	idParam := r.URL.Query().Get("id")
 	if idParam == "" {
 		return nil, fmt.Errorf("missing id parameter")
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For Gitpod installations that don't have global authproviders we assume a single org with SSO (dedicated).
Users that are owned by an org will not get an org when they are created.

The login screen for dedicated users:

<img width="1006" alt="Screenshot 2023-04-28 at 13 34 07" src="https://user-images.githubusercontent.com/372735/235137165-7395c5b3-b6f3-4975-9855-c8dc03fe39c1.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-48
Fixes WEB-272

## How to test
<!-- Provide steps to test this PR -->

1. Log in: https://se-dedicated-login.preview.gitpod-dev.com/workspaces
2. Verify you are a member of ACME and no other org

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-dedicated-login</li>
        <li><b>🔗 URL</b> - <a href="https://se-dedicated-login.preview.gitpod-dev.com/workspaces" target="_blank">se-dedicated-login.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
