### PR TITLE
Normalize log in and log out verbs

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -231,7 +231,7 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, withFeedb
                     },
                     ...extraSection,
                     {
-                        title: "Logout",
+                        title: "Log out",
                         href: gitpodHostUrl.asApiLogout().toString(),
                     },
                 ]}

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -29,7 +29,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 separator: true,
             },
             {
-                title: "Login",
+                title: "Log in",
                 onClick: () => {
                     window.location.href = gitpodHostUrl
                         .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })


### PR DESCRIPTION
## Description

This will update and normalize log in an log out verbs, see [relevant discussion](https://gitpod.slack.com/archives/C01KGM9DVRC/p1682689148308139) (internal).

Cc @mbrevoort @atduarte @lucasvaltl @svenefftinge 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. Once you log in, go to the user menu and notice the new _Log out_ verb.
2. Inside an org, after adding an OIDC client, open the more actions menu and notice the new _Log in_ verb.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-normalif4dddf2da2</li>
	<li><b>🔗 URL</b> - <a href="https://gt-normalif4dddf2da2.preview.gitpod-dev.com/workspaces" target="_blank">gt-normalif4dddf2da2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
