### PR TITLE
[ws-manager-mk2] Run e2e tests against mk2 by default

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -205,7 +205,7 @@ jobs:
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
 
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 }}"
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,7 @@ If you want to run an entire test suite, the easiest is to use `./test/run.sh`:
 If you're iterating on a single test, the easiest is to use `go test` directly.
 If your integration tests depends on having having a user token available, then you'll have to set `USER_TOKEN` manually (see `test/run.sh` on how to fetch the credentials that are used during our build)
 
-If you want to run the workspace tests against `ws-manager-mk2`, set the `WS_MANAGER_MK2=true` env var when running the tests.
+By default the workspace tests run against `ws-manager-mk2`, set `WS_MANAGER_MK2=false` to run against mk1.
 
 ```console
 cd test

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -230,5 +230,5 @@ func getNamespace(path string) (string, error) {
 }
 
 func UseWsmanMk2() bool {
-	return os.Getenv("WS_MANAGER_MK2") == "true"
+	return os.Getenv("WS_MANAGER_MK2") != "false"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Runs the e2e tests against mk2 by default

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-98

## How to test
<!-- Provide steps to test this PR -->

Run workspace integration tests without specifying the `WS_MANAGER_MK2` env var, and see it runs against mk2. Set `WS_MANAGER_MK2=false` should run against mk1.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
