### PR TITLE
Adds org naming step in dedicated setup flow

### DIFF
--- a/components/dashboard/src/data/organizations/create-org-mutation.ts
+++ b/components/dashboard/src/data/organizations/create-org-mutation.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Organization } from "@gitpod/gitpod-protocol";
+import { useMutation } from "@tanstack/react-query";
+import { useOrganizationsInvalidator } from "./orgs-query";
+import { publicApiTeamToProtocol, teamsService } from "../../service/public-api";
+
+type UpdateOrgArgs = Pick<Organization, "name" | "slug">;
+
+export const useCreateOrgMutation = () => {
+    const invalidateOrgs = useOrganizationsInvalidator();
+
+    return useMutation<Organization, Error, UpdateOrgArgs>({
+        mutationFn: async ({ name }) => {
+            const { team } = await teamsService.createTeam({ name });
+            if (!team) {
+                throw new Error("Error creating team");
+            }
+
+            const org = publicApiTeamToProtocol(team);
+            return org;
+        },
+        onSuccess(newOrg) {
+            invalidateOrgs();
+        },
+    });
+};

--- a/components/dashboard/src/data/organizations/create-org-mutation.ts
+++ b/components/dashboard/src/data/organizations/create-org-mutation.ts
@@ -9,12 +9,12 @@ import { useMutation } from "@tanstack/react-query";
 import { useOrganizationsInvalidator } from "./orgs-query";
 import { publicApiTeamToProtocol, teamsService } from "../../service/public-api";
 
-type UpdateOrgArgs = Pick<Organization, "name" | "slug">;
+type CreateOrgArgs = Pick<Organization, "name">;
 
 export const useCreateOrgMutation = () => {
     const invalidateOrgs = useOrganizationsInvalidator();
 
-    return useMutation<Organization, Error, UpdateOrgArgs>({
+    return useMutation<Organization, Error, CreateOrgArgs>({
         mutationFn: async ({ name }) => {
             const { team } = await teamsService.createTeam({ name });
             if (!team) {

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -6,9 +6,8 @@
 
 import { FC, useCallback, useEffect } from "react";
 import { Button } from "../components/Button";
-import gitpodIcon from "../icons/gitpod.svg";
 import { Heading1, Subheading } from "../components/typography/headings";
-import "./styles.css";
+import { SetupLayout } from "./SetupLayout";
 
 type Props = {
     onComplete?: () => void;
@@ -27,27 +26,18 @@ const DedicatedSetup: FC<Props> = ({ onComplete }) => {
     }, []);
 
     return (
-        <div className="container">
-            <div className="app-container">
-                <div className="flex items-center justify-start items-center py-3 space-x-1">
-                    <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
-                    <span className="text-lg">Gitpod</span>
-                </div>
-                <div className="mt-24 max-w-sm">
-                    <Heading1>Let's get started</Heading1>
-                    {/* TODO: verify this is the copy we want to use */}
-                    <Subheading>
-                        Spin up fresh cloud development environments for each task, fully automated, in seconds.
-                    </Subheading>
+        <SetupLayout>
+            <Heading1>Let's get started</Heading1>
+            <Subheading>
+                Spin up fresh cloud development environments for each task, fully automated, in seconds.
+            </Subheading>
 
-                    <div className="mt-6">
-                        <Button size="block" onClick={handleGetStarted}>
-                            Get Started
-                        </Button>
-                    </div>
-                </div>
+            <div className="mt-6">
+                <Button size="block" onClick={handleGetStarted}>
+                    Get Started
+                </Button>
             </div>
-        </div>
+        </SetupLayout>
     );
 };
 

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -4,40 +4,57 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useEffect } from "react";
-import { Button } from "../components/Button";
-import { Heading1, Subheading } from "../components/typography/headings";
-import { SetupLayout } from "./SetupLayout";
+import { FC, useCallback, useState } from "react";
+import { GettingStartedStep } from "./GettingStartedStep";
+import { OrgNamingStep } from "./OrgNamingStep";
+import { SSOSetupStep } from "./SSOSetupStep";
+import { useConfetti } from "../contexts/ConfettiContext";
+import { SetupCompleteStep } from "./SetupCompleteStep";
+import { useHistory } from "react-router";
+
+const STEPS = {
+    GETTING_STARTED: "getting-started",
+    ORG_NAMING: "org-naming",
+    SSO_SETUP: "sso-setup",
+    COMPLETE: "complete",
+};
 
 type Props = {
     onComplete?: () => void;
 };
 const DedicatedSetup: FC<Props> = ({ onComplete }) => {
-    const handleGetStarted = useCallback(() => {
-        console.log("getting started");
-    }, []);
+    const { dropConfetti } = useConfetti();
+    // TODO: try and determine what step we should start on based on current state, i.e. org/sso already exists
+    const [step, setStep] = useState<typeof STEPS[keyof typeof STEPS]>(STEPS.GETTING_STARTED);
+    const history = useHistory();
 
-    useEffect(() => {
-        document.body.classList.add("honeycomb-bg");
+    // useEffect(() => {
+    //     document.body.classList.add("honeycomb-bg");
 
-        return () => {
-            document.body.classList.remove("honeycomb-bg");
-        };
-    }, []);
+    //     return () => {
+    //         document.body.classList.remove("honeycomb-bg");
+    //     };
+    // }, []);
+
+    const handleSetupComplete = useCallback(() => {
+        // celebrate 🎉
+        dropConfetti();
+        // Transition to completed view
+        setStep(STEPS.COMPLETE);
+    }, [dropConfetti]);
+
+    const handleEndSetup = useCallback(() => {
+        history.push("/settings/git");
+    }, [history]);
 
     return (
-        <SetupLayout>
-            <Heading1>Let's get started</Heading1>
-            <Subheading>
-                Spin up fresh cloud development environments for each task, fully automated, in seconds.
-            </Subheading>
-
-            <div className="mt-6">
-                <Button size="block" onClick={handleGetStarted}>
-                    Get Started
-                </Button>
-            </div>
-        </SetupLayout>
+        // TODO: Should we shift SetupLayout to render at this level?
+        <>
+            {step === STEPS.GETTING_STARTED && <GettingStartedStep onComplete={() => setStep(STEPS.ORG_NAMING)} />}
+            {step === STEPS.ORG_NAMING && <OrgNamingStep onComplete={() => setStep(STEPS.SSO_SETUP)} />}
+            {step === STEPS.SSO_SETUP && <SSOSetupStep onComplete={handleSetupComplete} />}
+            {step === STEPS.COMPLETE && <SetupCompleteStep onComplete={handleEndSetup} />}
+        </>
     );
 };
 

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -17,7 +17,8 @@ const STEPS = {
     ORG_NAMING: "org-naming",
     SSO_SETUP: "sso-setup",
     COMPLETE: "complete",
-};
+} as const;
+type StepsValue = typeof STEPS[keyof typeof STEPS];
 
 type Props = {
     onComplete?: () => void;
@@ -25,16 +26,8 @@ type Props = {
 const DedicatedSetup: FC<Props> = ({ onComplete }) => {
     const { dropConfetti } = useConfetti();
     // TODO: try and determine what step we should start on based on current state, i.e. org/sso already exists
-    const [step, setStep] = useState<typeof STEPS[keyof typeof STEPS]>(STEPS.GETTING_STARTED);
+    const [step, setStep] = useState<StepsValue>(STEPS.GETTING_STARTED);
     const history = useHistory();
-
-    // useEffect(() => {
-    //     document.body.classList.add("honeycomb-bg");
-
-    //     return () => {
-    //         document.body.classList.remove("honeycomb-bg");
-    //     };
-    // }, []);
 
     const handleSetupComplete = useCallback(() => {
         // celebrate 🎉

--- a/components/dashboard/src/dedicated-setup/GettingStartedStep.tsx
+++ b/components/dashboard/src/dedicated-setup/GettingStartedStep.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Button } from "../components/Button";
+import { Heading1, Subheading } from "../components/typography/headings";
+import { SetupLayout } from "./SetupLayout";
+
+type Props = {
+    onComplete: () => void;
+};
+export const GettingStartedStep: FC<Props> = ({ onComplete }) => {
+    return (
+        <SetupLayout>
+            <Heading1>Let's get started</Heading1>
+            <Subheading>
+                Spin up fresh cloud development environments for each task, fully automated, in seconds.
+            </Subheading>
+
+            <div className="mt-6">
+                <Button size="block" onClick={onComplete}>
+                    Get Started
+                </Button>
+            </div>
+        </SetupLayout>
+    );
+};

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback, useState } from "react";
+import { SetupLayout } from "./SetupLayout";
+import { Heading1, Subheading } from "../components/typography/headings";
+import { TextInputField } from "../components/forms/TextInputField";
+import { Button } from "../components/Button";
+
+export const OrgNamingStep: FC = () => {
+    // TODO: if there's already an org create, set initial value to current org
+    const [orgName, setOrgName] = useState("");
+
+    const handleContinue = useCallback(() => {
+        console.log("continue", orgName);
+    }, [orgName]);
+
+    return (
+        <SetupLayout>
+            {/* TODO: Push this into SetupLayout? */}
+            <div className="mb-10">
+                <Heading1>Name your organization</Heading1>
+                <Subheading>
+                    Your Gitpod organization allows you to manage settings, projects and collaborate with teammates.
+                </Subheading>
+            </div>
+
+            <TextInputField
+                label="Organization Name"
+                placeholder="e.g. ACME Inc"
+                hint="The name of your company or organization."
+                value={orgName}
+                onChange={setOrgName}
+            />
+
+            <div className="mt-6">
+                <Button size="block" onClick={handleContinue}>
+                    Continue
+                </Button>
+            </div>
+        </SetupLayout>
+    );
+};

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -21,8 +21,8 @@ export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
     const [orgName, setOrgName] = useState("");
     const createOrg = useCreateOrgMutation();
 
-    const handleContinue = useCallback(async () => {
-        createOrg.mutate({ name: orgName }, { onSuccess: () => onComplete() });
+    const handleContinue = useCallback(() => {
+        createOrg.mutate({ name: orgName }, { onSuccess: onComplete });
     }, [createOrg, onComplete, orgName]);
 
     const nameError = useOnBlurError("Please provide a name", orgName.trim().length > 0);

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -17,7 +17,7 @@ type Props = {
     onComplete: () => void;
 };
 export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
-    // TODO: if there's already an org create, set initial value to current org
+    // TODO: if there's already an org created, set initial value to current org, or we could skip this step
     const [orgName, setOrgName] = useState("");
     const createOrg = useCreateOrgMutation();
 

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -29,15 +29,18 @@ export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
 
     return (
         <SetupLayout>
+            {/* TODO: extract this into SetupLayout and accept props to control progress indicator */}
+            <div className="flex flex-row space-x-2 mb-4">
+                <div className="w-5 h-5 bg-gray-400 rounded-full" />
+                <div className="w-5 h-5 border-2 border-dashed rounded-full border-gray-400" />
+            </div>
             <div className="mb-10">
                 <Heading1>Name your organization</Heading1>
                 <Subheading>
                     Your Gitpod organization allows you to manage settings, projects and collaborate with teammates.
                 </Subheading>
             </div>
-
             {createOrg.isError && <Alert type="danger">{createOrg.error.message}</Alert>}
-
             <TextInputField
                 label="Organization Name"
                 placeholder="e.g. ACME Inc"
@@ -47,7 +50,6 @@ export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
                 onChange={setOrgName}
                 onBlur={nameError.onBlur}
             />
-
             <div className="mt-6">
                 <Button
                     size="block"

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -9,18 +9,26 @@ import { SetupLayout } from "./SetupLayout";
 import { Heading1, Subheading } from "../components/typography/headings";
 import { TextInputField } from "../components/forms/TextInputField";
 import { Button } from "../components/Button";
+import { useOnBlurError } from "../hooks/use-onblur-error";
+import { useCreateOrgMutation } from "../data/organizations/create-org-mutation";
+import Alert from "../components/Alert";
 
-export const OrgNamingStep: FC = () => {
+type Props = {
+    onComplete: () => void;
+};
+export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
     // TODO: if there's already an org create, set initial value to current org
     const [orgName, setOrgName] = useState("");
+    const createOrg = useCreateOrgMutation();
 
-    const handleContinue = useCallback(() => {
-        console.log("continue", orgName);
-    }, [orgName]);
+    const handleContinue = useCallback(async () => {
+        createOrg.mutate({ name: orgName }, { onSuccess: () => onComplete() });
+    }, [createOrg, onComplete, orgName]);
+
+    const nameError = useOnBlurError("Please provide a name", orgName.trim().length > 0);
 
     return (
         <SetupLayout>
-            {/* TODO: Push this into SetupLayout? */}
             <div className="mb-10">
                 <Heading1>Name your organization</Heading1>
                 <Subheading>
@@ -28,16 +36,25 @@ export const OrgNamingStep: FC = () => {
                 </Subheading>
             </div>
 
+            {createOrg.isError && <Alert type="danger">{createOrg.error.message}</Alert>}
+
             <TextInputField
                 label="Organization Name"
                 placeholder="e.g. ACME Inc"
                 hint="The name of your company or organization."
                 value={orgName}
+                error={nameError.message}
                 onChange={setOrgName}
+                onBlur={nameError.onBlur}
             />
 
             <div className="mt-6">
-                <Button size="block" onClick={handleContinue}>
+                <Button
+                    size="block"
+                    onClick={handleContinue}
+                    disabled={!nameError.isValid}
+                    loading={createOrg.isLoading}
+                >
                     Continue
                 </Button>
             </div>

--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback } from "react";
+import { Button } from "../components/Button";
+import { Heading1, Subheading } from "../components/typography/headings";
+import { SetupLayout } from "./SetupLayout";
+
+type Props = {
+    onComplete: () => void;
+};
+export const SSOSetupStep: FC<Props> = ({ onComplete }) => {
+    const handleVerify = useCallback(() => {
+        console.log("verify");
+
+        onComplete();
+    }, [onComplete]);
+
+    return (
+        <SetupLayout>
+            <Heading1>Configure single sign-on</Heading1>
+            <Subheading>
+                {/* TODO: Find what link we want to use here */}
+                Enable single sign-on for your organization using the OpenID Connect (OIDC) standard.{" "}
+                <a href="https://gitpod.io">Learn more</a>
+            </Subheading>
+
+            <p>placeholder step...</p>
+
+            <div className="mt-6">
+                <Button size="block" onClick={handleVerify} disabled>
+                    Verify SSO Configuration
+                </Button>
+            </div>
+        </SetupLayout>
+    );
+};

--- a/components/dashboard/src/dedicated-setup/SetupCompleteStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SetupCompleteStep.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Button } from "../components/Button";
+import { Heading1, Subheading } from "../components/typography/headings";
+import { SetupLayout } from "./SetupLayout";
+
+type Props = {
+    onComplete: () => void;
+};
+export const SetupCompleteStep: FC<Props> = ({ onComplete }) => {
+    return (
+        <SetupLayout>
+            <Heading1>Welcome to Gitpod</Heading1>
+            <Subheading>Your teammates can now sign in to Gitpod using single sign-on (SSO).</Subheading>
+
+            <p>placeholder step...</p>
+
+            <div className="mt-6">
+                <Button size="block" onClick={onComplete} disabled>
+                    Add a Git Integration
+                </Button>
+            </div>
+        </SetupLayout>
+    );
+};

--- a/components/dashboard/src/dedicated-setup/SetupLayout.tsx
+++ b/components/dashboard/src/dedicated-setup/SetupLayout.tsx
@@ -4,11 +4,19 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import gitpodIcon from "../icons/gitpod.svg";
 import "./styles.css";
 
 export const SetupLayout: FC = ({ children }) => {
+    useEffect(() => {
+        document.body.classList.add("honeycomb-bg");
+
+        return () => {
+            document.body.classList.remove("honeycomb-bg");
+        };
+    }, []);
+
     return (
         <div className="container">
             <div className="app-container">

--- a/components/dashboard/src/dedicated-setup/SetupLayout.tsx
+++ b/components/dashboard/src/dedicated-setup/SetupLayout.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import gitpodIcon from "../icons/gitpod.svg";
+import "./styles.css";
+
+export const SetupLayout: FC = ({ children }) => {
+    return (
+        <div className="container">
+            <div className="app-container">
+                <div className="flex items-center justify-start items-center py-3 space-x-1">
+                    <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
+                    <span className="text-lg">Gitpod</span>
+                </div>
+                <div className="mt-24 max-w-md">{children}</div>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds the org naming (and creation) step to the dedicated setup flow. I also stubbed out the sso config step, and final completed view so that they're ready to build out in subsequent PRs.

![image](https://user-images.githubusercontent.com/367275/235265723-66eeeb44-216e-48b1-a069-93db29bf6fbe.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-244

## How to test
<!-- Provide steps to test this PR -->
* Since the setup flow isn't complete end to end yet, the easiest way to test this it to start a workspace using this PR/branch, and point gitpod-staging at your workspace dashboard assets w/ the `x-frontend-dev-url` header.
* Load up gitpod staging and set a query param that will initiate the flow.
* https://gitpod-staging.com/workspaces?dedicated-setup=force
* You should see the getting started step, and after proceeding, you can name your org. 
* After that completes you should land on a placeholder for the sso setup page in the flow.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-dedicaad8deebe14</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-dedicaad8deebe14.preview.gitpod-dev.com/workspaces" target="_blank">bmh-dedicaad8deebe14.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
