### PR TITLE
[dashboard] handle organization-owned users

### DIFF
--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -13,16 +13,18 @@ import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useLocation } from "react-router";
+import { User } from "@gitpod/gitpod-protocol";
 
-export interface OrganizationSelectorProps {}
-
-export default function OrganizationSelector(p: OrganizationSelectorProps) {
+export default function OrganizationSelector() {
     const user = useCurrentUser();
     const orgs = useOrganizations();
     const currentOrg = useCurrentOrg();
     const { data: userBillingMode } = useUserBillingMode();
     const { data: orgBillingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
+
+    // we should have an API to ask for permissions, until then we duplicate the logic here
+    const canCreateOrgs = user && !User.isOrganizationOwned(user);
 
     const userFullName = user?.fullName || user?.name || "...";
 
@@ -142,25 +144,29 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
               ]
             : []),
         ...otherOrgEntries,
-        {
-            title: "Create a new organization",
-            customContent: (
-                <div className="w-full text-gray-500 flex items-center">
-                    <span className="flex-1">New Organization</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5">
-                        <path
-                            fill="currentColor"
-                            fillRule="evenodd"
-                            d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z"
-                            clipRule="evenodd"
-                        />
-                    </svg>
-                </div>
-            ),
-            link: "/orgs/new",
-            // marking as active for styles
-            active: true,
-        },
+        ...(canCreateOrgs
+            ? [
+                  {
+                      title: "Create a new organization",
+                      customContent: (
+                          <div className="w-full text-gray-500 flex items-center">
+                              <span className="flex-1">New Organization</span>
+                              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5">
+                                  <path
+                                      fill="currentColor"
+                                      fillRule="evenodd"
+                                      d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z"
+                                      clipRule="evenodd"
+                                  />
+                              </svg>
+                          </div>
+                      ),
+                      link: "/orgs/new",
+                      // marking as active for styles
+                      active: true,
+                  },
+              ]
+            : []),
     ];
 
     const selectedTitle = currentOrg?.data ? currentOrg.data.name : userFullName;

--- a/components/dashboard/src/onboarding/use-show-user-onboarding.ts
+++ b/components/dashboard/src/onboarding/use-show-user-onboarding.ts
@@ -15,7 +15,7 @@ export const useShowUserOnboarding = () => {
     const search = useQueryParams();
     const newSignupFlow = useFeatureFlag("newSignupFlow");
 
-    if (!user) {
+    if (!user || User.isOrganizationOwned(user)) {
         return false;
     }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -131,6 +131,10 @@ export namespace User {
         return !hasPreferredIde(user);
     }
 
+    export function isOrganizationOwned(user: User) {
+        return !!user.organizationId;
+    }
+
     export function migrationIDESettings(user: User) {
         if (
             !user?.additionalData?.ideSettings ||


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- remove the "New Organization" button from the org selector if the user is organizationOwned. The server side already handles this.
- skip onboarding flow for organizationOwned users.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-276
Fixes WEB-30

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
