### PR TITLE
Directly tunnel websocket connection to ssh server

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1265,7 +1265,7 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 			return
 		}
 		conn, err := gitpod.NewWebsocketConnection(ctx, wsConn, func(staleErr error) {
-			log.WithError(staleErr).Error("tunnel: closing stale connection")
+			log.WithError(staleErr).Error("tunnel ssh: closing stale connection")
 		})
 		if err != nil {
 			log.WithError(err).Error("tunnel ssh: upgrade to the WebSocket protocol failed")

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1258,30 +1258,29 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 		}
 		tunnelOverWebSocket(tunneled, conn)
 	}))
-	routes.Handle("/_supervisor/tunnel2", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	routes.Handle("/_supervisor/tunnel/ssh", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		wsConn, err := upgrader.Upgrade(rw, r, nil)
 		if err != nil {
-			log.WithError(err).Error("tunnel2: upgrade to the WebSocket protocol failed")
+			log.WithError(err).Error("tunnel ssh: upgrade to the WebSocket protocol failed")
 			return
 		}
 		conn, err := gitpod.NewWebsocketConnection(ctx, wsConn, func(staleErr error) {
 			log.WithError(staleErr).Error("tunnel: closing stale connection")
 		})
 		if err != nil {
-			log.WithError(err).Error("tunnel2: upgrade to the WebSocket protocol failed")
+			log.WithError(err).Error("tunnel ssh: upgrade to the WebSocket protocol failed")
 			return
 		}
 
 		conn2, err := net.Dial("tcp", net.JoinHostPort("localhost", strconv.FormatInt(int64(cfg.SSHPort), 10)))
 		if err != nil {
-			log.WithError(err).Error("tunnel2: dial to ssh server failed")
+			log.WithError(err).Error("tunnel ssh: dial to ssh server failed")
 			return
 		}
 
 		go io.Copy(conn2, conn)
 		_, _ = io.Copy(conn, conn2)
-		log.Infof("tunnel2: Disconnect from %s", conn.RemoteAddr())
-
+		log.Infof("tunnel ssh: Disconnect from %s", conn.RemoteAddr())
 	}))
 	if cfg.DebugEnable {
 		routes.Handle("/_supervisor/debug/tunnels", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Created another endpoint `tunnel2` for now to keep backwards compatibility for old versions of local-app

## How to test
<!-- Provide steps to test this PR -->
- Try connecting tunneling ssh over websocket, it should work

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-test-993</li>
	<li><b>🔗 URL</b> - <a href="https://jp-test-993.preview.gitpod-dev.com/workspaces" target="_blank">jp-test-993.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
