### PR TITLE
[ws-manager-mk2] Fix slow p25 workspace startup time

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -435,7 +435,7 @@ func createWorkspaceContainer(sctx *startWorkspaceContext) (*corev1.Container, e
 		readinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/_supervisor/v1/status/content/wait/true",
+					Path:   "/_supervisor/v1/status/ide/wait/true",
 					Port:   intstr.FromInt((int)(sctx.SupervisorPort)),
 					Scheme: corev1.URISchemeHTTP,
 				},
@@ -447,7 +447,7 @@ func createWorkspaceContainer(sctx *startWorkspaceContext) (*corev1.Container, e
 			PeriodSeconds:       1,
 			SuccessThreshold:    1,
 			TimeoutSeconds:      1,
-			InitialDelaySeconds: 3,
+			InitialDelaySeconds: 1,
 		}
 	)
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -157,13 +157,16 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 			// moving back to Initializing and becoming unusable.
 			workspace.Status.Phase = workspacev1.WorkspacePhaseRunning
 		} else {
-			var ready bool
+			contentReady := wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady))
+			var ideReady bool
 			for _, cs := range pod.Status.ContainerStatuses {
 				if cs.Ready {
-					ready = true
+					ideReady = true
 					break
 				}
 			}
+			ready := contentReady && ideReady
+
 			if ready {
 				// workspace is ready - hence content init is done
 				workspace.Status.Phase = workspacev1.WorkspacePhaseRunning

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -75,6 +75,10 @@ var _ = Describe("WorkspaceController", func() {
 				}}
 			})
 
+			updateObjWithRetries(k8sClient, ws, true, func(ws *workspacev1.Workspace) {
+				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionTrue, workspacev1.ReasonInitializationSuccess, ""))
+			})
+
 			expectPhaseEventually(ws, workspacev1.WorkspacePhaseRunning)
 			expectSecretCleanup(envSecret)
 			expectSecretCleanup(tokenSecret)


### PR DESCRIPTION
## Description
We have observed that compared to mk1 the p25 workspace startup time for mk2 workspace is slightly worse. With mk2 we have relied on the readiness probe of the workspace to transition the workspace to `Running`. This introduces an additional delay before we detect that the workspace is ready. Instead we now use ide readiness to ensure that the IDE is available and the ContentInit condition to ensure that the content is initialized.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-120

## How to test
- Open https://github.com/gitpod-io/empty 
- Workspace should enter Running phase faster

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-p25-latency</li>
	<li><b>🔗 URL</b> - <a href="https://fo-p25-latency.preview.gitpod-dev.com/workspaces" target="_blank">fo-p25-latency.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
