### PR TITLE
[ws-manager-mk2] Fix abort prebuild failure

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	config "github.com/gitpod-io/gitpod/ws-manager/api/config"
@@ -17,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -30,6 +30,10 @@ const (
 	// containerUnknownExitCode is the exit code containerd uses if it cannot determine the cause/exit status of
 	// a stopped container.
 	containerUnknownExitCode = 255
+
+	// headlessTaskFailedPrefix is the prefix of the pod termination message if a headless task failed (e.g. user error
+	// or aborted prebuild).
+	headlessTaskFailedPrefix = "headless task failed: "
 )
 
 func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace, pods corev1.PodList, cfg *config.Configuration) error {
@@ -114,18 +118,11 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 
 	switch {
 	case isPodBeingDeleted(pod):
-		workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
-
-		if controllerutil.ContainsFinalizer(pod, workspacev1.GitpodFinalizerName) {
-			if isDisposalFinished(workspace) {
-				workspace.Status.Phase = workspacev1.WorkspacePhaseStopped
-			}
-
-		} else {
-			// We do this independently of the dispostal status because pods only get their finalizer
-			// once they're running. If they fail before they reach the running phase we'll never see
-			// a disposal status, hence would never stop the workspace.
+		if workspace.Status.Phase == workspacev1.WorkspacePhaseStopping && isDisposalFinished(workspace) {
 			workspace.Status.Phase = workspacev1.WorkspacePhaseStopped
+		} else if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped {
+			// Move to (or stay in) Stopping if not yet Stopped.
+			workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
 		}
 
 	case pod.Status.Phase == corev1.PodPending:
@@ -177,13 +174,14 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		}
 
 	case workspace.IsHeadless() && (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed):
-		// Don't start disposal if maintenance mode is enabled.
-		if !r.maintenance.IsEnabled() {
-			workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
-		}
-
-		if isDisposalFinished(workspace) {
+		if workspace.Status.Phase == workspacev1.WorkspacePhaseStopping && isDisposalFinished(workspace) {
 			workspace.Status.Phase = workspacev1.WorkspacePhaseStopped
+		} else if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped {
+			// Should be in Stopping phase, but isn't yet.
+			// Move to Stopping to start disposal, but only if maintenance mode is disabled.
+			if !r.maintenance.IsEnabled() {
+				workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
+			}
 		}
 
 	case pod.Status.Phase == corev1.PodUnknown:
@@ -286,6 +284,11 @@ func (r *WorkspaceReconciler) extractFailure(ctx context.Context, ws *workspacev
 							return "", nil
 						}
 					}
+				}
+
+				if ws.IsHeadless() && strings.HasPrefix(terminationState.Message, headlessTaskFailedPrefix) {
+					// Headless task failed, not a workspace failure.
+					return "", nil
 				}
 
 				// the container itself told us why it was terminated - use that as failure reason

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -151,7 +151,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return result, fmt.Errorf("failed to act on status: %w", err)
 	}
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods corev1.PodList) (ctrl.Result, error) {


### PR DESCRIPTION
## Description
Fixes an aborted prebuild getting a `Failed` condition, due to supervisor exiting with a non-zero exit code due to a cancelled context. Supervisor exits with message `headless task failed: context canceled`, this PR now considers any (headless) termination message starting with `headless task failed: ` as a headless task failure instead of a workspace failure.

Also changes the reconciler such that stopping workspaces move through `Stopping` before `Stopped`, as otherwise it's possible in some scenarios to miss the `Stopping` phase (e.g. when aborting a prebuild). `ws-manager-bridge` relies on prebuilds to move through the `Stopping` phase to determine the outcome of the prebuild, without this fix some prebuilds would get stuck in `Running`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-136

## How to test
<!-- Provide steps to test this PR -->

In a mk2 preview env, repeatedly start prebuilds from this branch: https://github.com/WVerlaek/prebuild-experiment/tree/timeout-task by committing+pushing an empty commit, such that newer commits cancel the previously started prebuilds.
- In the dashboard, all prebuilds (except the last) should move to a `CANCELED` state. Without the fix, some would end up in a `SYSTEM ERROR` state.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
