### PR TITLE
[obs] mk2 dashboard, change startup time heatmap's rate to `rate interval`

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
+++ b/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
+  "id": 76,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -582,7 +582,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "repeatDirection": "h",
       "targets": [
         {
@@ -590,7 +590,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"Regular\"}[5m])\n  ) by (le)",
+          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"Regular\"}[$__rate_interval])\n  ) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -672,7 +672,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "repeatDirection": "h",
       "targets": [
         {
@@ -680,7 +680,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"ImageBuild\"}[5m])\n  ) by (le)",
+          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"ImageBuild\"}[$__rate_interval])\n  ) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -762,7 +762,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "repeatDirection": "h",
       "targets": [
         {
@@ -770,7 +770,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"Prebuild\"}[5m])\n  ) by (le)",
+          "expr": "sum(\n    rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{cluster=~\"$cluster\", type=\"Prebuild\"}[$__rate_interval])\n  ) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",
@@ -938,7 +938,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1036,7 +1036,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1154,7 +1154,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -1353,8 +1353,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1924,7 +1923,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 104
       },
       "id": 16,
       "panels": [],
@@ -2000,7 +1999,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 69
+        "y": 105
       },
       "id": 76,
       "options": {
@@ -2048,7 +2047,7 @@
         "h": 7,
         "w": 7,
         "x": 10,
-        "y": 69
+        "y": 105
       },
       "hiddenSeries": false,
       "id": 2,
@@ -2140,7 +2139,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 69
+        "y": 105
       },
       "hiddenSeries": false,
       "id": 4,
@@ -2244,7 +2243,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 6,
@@ -2334,7 +2333,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 8,
@@ -2423,7 +2422,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 119
       },
       "hiddenSeries": false,
       "id": 10,
@@ -2521,7 +2520,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 119
       },
       "hiddenSeries": false,
       "id": 57,
@@ -2619,7 +2618,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 119
       },
       "hiddenSeries": false,
       "id": 59,
@@ -2718,7 +2717,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 90
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2809,7 +2808,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 90
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 55,
@@ -2919,7 +2918,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 90
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 40,
@@ -3029,7 +3028,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 135
       },
       "id": 22,
       "panels": [],
@@ -3060,7 +3059,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 100
+        "y": 136
       },
       "hiddenSeries": false,
       "id": 32,
@@ -3154,7 +3153,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 100
+        "y": 136
       },
       "hiddenSeries": false,
       "id": 34,
@@ -3254,7 +3253,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 109
+        "y": 145
       },
       "hiddenSeries": false,
       "id": 26,
@@ -3351,7 +3350,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 109
+        "y": 145
       },
       "hiddenSeries": false,
       "id": 61,
@@ -3448,7 +3447,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 118
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 24,
@@ -3539,7 +3538,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 118
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 63,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A rate of 5m makes the graph too dense, and, it doesn't match the the overview dashboard's heatmap.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Refer to screenshots (will add).

**mk2 component dashboard**

While a rate of `5m`:
![image](https://user-images.githubusercontent.com/1272076/235508701-1bfb88fc-1082-46e2-86c4-bef12b319740.png)

When a rate of `$__rate_interval`:
![image](https://user-images.githubusercontent.com/1272076/235508841-0cc13635-13cc-49fb-ab5b-aef65fbf7e53.png)

**Overview Dashboard** with mk2, for comparison, this has not changed
![image](https://user-images.githubusercontent.com/1272076/235509095-21f31231-0ffd-4d8f-8ee8-049ad353d475.png)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
