### PR TITLE
[obs] right align image builds in the Running Workspaces pane

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-overview-mk2.json
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-overview-mk2.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 90,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -94,7 +94,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -177,7 +177,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -236,7 +236,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -318,7 +318,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -326,19 +326,14 @@
       "seriesOverrides": [
         {
           "$$hashKey": "object:146",
-          "alias": "REGULAR",
+          "alias": "Regular",
           "color": "#73BF69"
         },
         {
           "$$hashKey": "object:147",
-          "alias": "PREBUILD",
+          "alias": "Prebuild",
           "color": "#5794F2",
           "yaxis": 1
-        },
-        {
-          "$$hashKey": "object:148",
-          "alias": "PROBE",
-          "color": "#B877D9"
         },
         {
           "$$hashKey": "object:149",
@@ -347,7 +342,7 @@
         },
         {
           "$$hashKey": "object:389",
-          "alias": "IMAGEBUILD",
+          "alias": "ImageBuild",
           "color": "#6ED0E0",
           "dashLength": 8,
           "dashes": true,
@@ -484,7 +479,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -657,7 +652,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "repeat": "cluster",
       "targets": [
         {
@@ -752,7 +747,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -911,7 +906,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1121,9 +1116,13 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "uid": "$datasource"
@@ -1181,6 +1180,6 @@
   "timezone": "utc",
   "title": "Gitpod / Overview Mk2",
   "uid": "nqIHyqPVk",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
w/o this change, it becomes difficult to see image builds, because they're visible on the left Y axis, rather than the right.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-138

## How to test
<!-- Provide steps to test this PR -->
Before this change, Running image builds use the left axis. After this change, they use the right axis.

Before:
![image](https://user-images.githubusercontent.com/1272076/235511740-c1689117-444a-4cc1-8771-a9d68a7ddfb2.png)

After:
![image](https://user-images.githubusercontent.com/1272076/235511562-a3a9d607-55a1-4a5c-8f61-94aa86d50d4f.png)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
