### PR TITLE
[server] Fix parsing of go duration WEB-280

### DIFF
--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -54,6 +54,7 @@
         "js-yaml": "^3.10.0",
         "nice-grpc-common": "^2.0.0",
         "opentracing": "^0.14.5",
+        "parse-duration": "^1.0.3",
         "prom-client": "^13.2.0",
         "random-number-csprng": "^1.0.2",
         "react": "17.0.2",

--- a/components/gitpod-protocol/src/util/timeutil.spec.ts
+++ b/components/gitpod-protocol/src/util/timeutil.spec.ts
@@ -7,7 +7,7 @@
 import * as chai from "chai";
 const expect = chai.expect;
 import { suite, test } from "mocha-typescript";
-import { daysBefore, hoursBefore, oneMonthLater } from "./timeutil";
+import { daysBefore, goDurationToHumanReadable, hoursBefore, oneMonthLater, parseGoDurationToMs } from "./timeutil";
 
 @suite()
 export class TimeutilSpec {
@@ -64,6 +64,40 @@ export class TimeutilSpec {
         for (const t of tests) {
             const actual = daysBefore(t.date.toISOString(), t.daysEarlier);
             expect(actual).to.equal(t.expectation, `expected ${actual} to be equal ${t.expectation}`);
+        }
+    }
+
+    @test
+    testParseGoDurationToMs() {
+        const scenarios = [
+            { input: "1ms", out: 1 },
+            { input: "1m", out: 1 * 60 * 1000 },
+            { input: "1m0s", out: 1 * 60 * 1000 },
+            { input: "1m30s", out: 1 * 60 * 1000 + 30 * 1000 },
+            { input: "1h1m30s", out: 1 * 60 * 60 * 1000 + 1 * 60 * 1000 + 30 * 1000 },
+        ];
+
+        for (const t of scenarios) {
+            const actual = parseGoDurationToMs(t.input);
+            expect(actual).to.equal(t.out, `expected ${t.input} to be ${t.out} in MS`);
+        }
+    }
+
+    @test
+    testGoDurationToHumanReadable() {
+        const scenarios = [
+            { input: "1m", out: "1 minute" },
+            { input: "2m", out: "2 minutes" },
+            { input: "1m0s", out: "1 minute" },
+            { input: "2m0s", out: "2 minutes" },
+            { input: "1m30s", out: "1 minute 30 seconds" },
+            { input: "2m30s", out: "2 minutes 30 seconds" },
+            { input: "1h1m30s", out: "1 hour 1 minute 30 seconds" },
+        ];
+
+        for (const t of scenarios) {
+            const actual = goDurationToHumanReadable(t.input);
+            expect(actual).to.equal(t.out, `expected ${t.input} to be ${t.out} in human readable form`);
         }
     }
 }

--- a/components/gitpod-protocol/src/util/timeutil.ts
+++ b/components/gitpod-protocol/src/util/timeutil.ts
@@ -4,6 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import parseDuration from "parse-duration";
+
 /**
  * Returns the <code>day</code>th of the next month from <code>formDate</code>.
  * If the next month does not have a <code>day</code>th, the last day of that
@@ -83,4 +85,35 @@ export function millisecondsToHours(milliseconds: number): number {
 
 export function hoursToMilliseconds(hours: number): number {
     return hours * 60 * 60 * 1000;
+}
+
+export function goDurationToHumanReadable(goDuration: string): string {
+    const durationMs = parseGoDurationToMs(goDuration);
+
+    let remainingMs = durationMs;
+    const hours = Math.floor(remainingMs / (60 * 60 * 1000));
+    remainingMs = remainingMs - hours * 60 * 60 * 1000;
+
+    const minutes = Math.floor(remainingMs / (60 * 1000));
+    remainingMs = remainingMs - minutes * 60 * 1000;
+
+    const seconds = Math.floor(remainingMs / 1000);
+    remainingMs = remainingMs - seconds * 1000;
+
+    const segments: string[] = [];
+    if (hours) {
+        segments.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+    }
+    if (minutes) {
+        segments.push(`${minutes} minute${minutes === 1 ? "" : "s"}`);
+    }
+    if (seconds) {
+        segments.push(`${seconds} second${seconds === 1 ? "" : "s"}`);
+    }
+
+    return segments.join(" ");
+}
+
+export function parseGoDurationToMs(goDuration: string): number {
+    return parseDuration(goDuration);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13140,6 +13140,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-duration@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.0.3.tgz#b6681f5edcc2689643b34c09ea63f86f58a35814"
+  integrity sha512-o6NAh12na5VvR6nFejkU0gpQ8jmOY9Y9sTU2ke3L3G/d/3z8jqmbBbeyBGHU73P4JLXfc7tJARygIK3WGIkloA==
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-ae2fc95782</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-ae2fc95782.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-ae2fc95782.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
