### PR TITLE
[baseserver] Test port is 0

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -368,7 +368,14 @@ func (s *Server) HealthAddr() string {
 func (s *Server) HTTPAddress() string {
 	return httpAddress(s.options.config.Services.HTTP, s.httpListener)
 }
-func (s *Server) GRPCAddress() string { return s.options.config.Services.GRPC.GetAddress() }
+func (s *Server) GRPCAddress() string {
+	// If the server hasn't started, it won't have a listener yet
+	if s.grpcListener == nil {
+		return ""
+	}
+
+	return s.grpcListener.Addr().String()
+}
 
 const (
 	BuiltinDebugPort   = 6060

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -49,15 +49,11 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 			var opts []baseserver.Option
 			opts = append(opts, baseserver.WithUnderTest())
 			if test.StartHTTP {
-				opts = append(opts, baseserver.WithHTTP(&baseserver.ServerConfiguration{
-					Address: "localhost:0",
-				}))
+				opts = append(opts, baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)))
 			}
 
 			if test.StartGRPC {
-				opts = append(opts, baseserver.WithGRPC(&baseserver.ServerConfiguration{
-					Address: "localhost:0",
-				}))
+				opts = append(opts, baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)))
 			}
 
 			srv, err := baseserver.New("test_server", opts...)
@@ -84,9 +80,7 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 
 func TestServer_Metrics_gRPC(t *testing.T) {
 	ctx := context.Background()
-	srv := baseserver.NewForTests(t, baseserver.WithGRPC(&baseserver.ServerConfiguration{
-		Address: "localhost:0",
-	}))
+	srv := baseserver.NewForTests(t, baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)))
 
 	// At this point, there must be metrics registry available for use
 	require.NotNil(t, srv.MetricsRegistry())
@@ -113,9 +107,7 @@ func TestServer_Metrics_gRPC(t *testing.T) {
 }
 
 func TestServer_Metrics_HTTP(t *testing.T) {
-	srv := baseserver.NewForTests(t, baseserver.WithHTTP(&baseserver.ServerConfiguration{
-		Address: "localhost:0",
-	}))
+	srv := baseserver.NewForTests(t, baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)))
 
 	// At this point, there must be metrics registry available for use
 	require.NotNil(t, srv.MetricsRegistry())

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -29,7 +29,7 @@ func TestServer_StartStop(t *testing.T) {
 	baseserver.StartServerForTests(t, srv)
 
 	require.Equal(t, "http://127.0.0.1:8765", srv.HTTPAddress())
-	require.Equal(t, "localhost:8766", srv.GRPCAddress())
+	require.Equal(t, "127.0.0.1:8766", srv.GRPCAddress())
 	require.NoError(t, srv.Close())
 }
 

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -50,13 +50,13 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 			opts = append(opts, baseserver.WithUnderTest())
 			if test.StartHTTP {
 				opts = append(opts, baseserver.WithHTTP(&baseserver.ServerConfiguration{
-					Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+					Address: "localhost:0",
 				}))
 			}
 
 			if test.StartGRPC {
 				opts = append(opts, baseserver.WithGRPC(&baseserver.ServerConfiguration{
-					Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+					Address: "localhost:0",
 				}))
 			}
 
@@ -85,7 +85,7 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 func TestServer_Metrics_gRPC(t *testing.T) {
 	ctx := context.Background()
 	srv := baseserver.NewForTests(t, baseserver.WithGRPC(&baseserver.ServerConfiguration{
-		Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+		Address: "localhost:0",
 	}))
 
 	// At this point, there must be metrics registry available for use
@@ -114,7 +114,7 @@ func TestServer_Metrics_gRPC(t *testing.T) {
 
 func TestServer_Metrics_HTTP(t *testing.T) {
 	srv := baseserver.NewForTests(t, baseserver.WithHTTP(&baseserver.ServerConfiguration{
-		Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+		Address: "localhost:0",
 	}))
 
 	// At this point, there must be metrics registry available for use

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -7,7 +7,6 @@ package baseserver
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -46,20 +45,7 @@ func MustUseRandomLocalAddress(t *testing.T) *ServerConfiguration {
 func MustFindFreePort(t *testing.T) int {
 	t.Helper()
 
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("cannot find free port: %v", err)
-		return 0
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		t.Fatalf("cannot find free port: %v", err)
-		return 0
-	}
-	defer l.Close()
-
-	return l.Addr().(*net.TCPAddr).Port
+	return 0
 }
 
 // StartServerForTests starts the server for test purposes.

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -38,14 +38,8 @@ func MustUseRandomLocalAddress(t *testing.T) *ServerConfiguration {
 	t.Helper()
 
 	return &ServerConfiguration{
-		Address: fmt.Sprintf("localhost:%d", MustFindFreePort(t)),
+		Address: "localhost:0",
 	}
-}
-
-func MustFindFreePort(t *testing.T) int {
-	t.Helper()
-
-	return 0
 }
 
 // StartServerForTests starts the server for test purposes.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Instead of looking for a free port, we can use the port 0 which will automatically assign a port when it binds the listener. This solves a current race where we would:
1. Look for a port
2. Create a listener on it
3. Determine the port number
4. Close the listener
5. Use the port to start an actual server

This lead to clashes with the acquired port. Using port 0 instead ensures that we also claim the port when it is assigned by the OS, removing the race.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Existing unit tests pass

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
