### PR TITLE
[server] fix login regression

### DIFF
--- a/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
@@ -144,7 +144,18 @@ describe("Migration Service", () => {
             migrationService.migrateUser(user),
             migrationService.migrateUser(user),
         ]);
-        let teams = await teamDB.findTeamsByUser(user.id);
+        const teams = await teamDB.findTeamsByUser(user.id);
         expect(teams.length).to.be.eq(1);
+    });
+
+    it("should append 'Organization' to too short names", async () => {
+        await wipeRepo();
+        const user = await userDB.newUser();
+        user.fullName = "X";
+        await userDB.storeUser(user);
+
+        await migrationService.migrateUser(user);
+        const teams = await teamDB.findTeamsByUser(user.id);
+        expect(teams[0].name).to.be.eq("X Organization");
     });
 });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In PR #17432 I messed up the order of how users are stored in the DB and the team migration were ignoring the passed user object and reload what ever state is in the DB, resulting in creating two orgs one with a UUID. This PR fixes that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #17460 
Fixes WEB-283
## How to test
<!-- Provide steps to test this PR -->

login to the preview environment and verify that you don't see a second org named by a UUID.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - svenefftin9a21e320f5</li>
	<li><b>🔗 URL</b> - <a href="https://svenefftin9a21e320f5.preview.gitpod-dev.com/workspaces" target="_blank">svenefftin9a21e320f5.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
