### PR TITLE
[SSO] Use ClientConfigID & Subject as composite key for identities WEB-279

### DIFF
--- a/components/public-api-server/pkg/oidc/router.go
+++ b/components/public-api-server/pkg/oidc/router.go
@@ -130,7 +130,7 @@ func (s *Service) getCallbackHandler() http.HandlerFunc {
 			}
 		}
 
-		cookie, err := s.CreateSession(r.Context(), result, config.OrganizationID)
+		cookie, err := s.CreateSession(r.Context(), result, config)
 		if err != nil {
 			log.Warn("Failed to create session: " + err.Error())
 			http.Error(rw, "Failed to create session", http.StatusInternalServerError)

--- a/components/public-api-server/pkg/oidc/router.go
+++ b/components/public-api-server/pkg/oidc/router.go
@@ -130,7 +130,7 @@ func (s *Service) getCallbackHandler() http.HandlerFunc {
 			}
 		}
 
-		cookie, err := s.CreateSession(r.Context(), result, config)
+		cookie, _, err := s.CreateSession(r.Context(), result, config)
 		if err != nil {
 			log.Warn("Failed to create session: " + err.Error())
 			http.Error(rw, "Failed to create session", http.StatusInternalServerError)

--- a/components/public-api-server/pkg/oidc/service.go
+++ b/components/public-api-server/pkg/oidc/service.go
@@ -277,14 +277,16 @@ func (s *Service) Authenticate(ctx context.Context, params AuthenticateParams) (
 	}, nil
 }
 
-func (s *Service) CreateSession(ctx context.Context, flowResult *AuthFlowResult, organizationId string) (*http.Cookie, error) {
+func (s *Service) CreateSession(ctx context.Context, flowResult *AuthFlowResult, clientConfig *ClientConfig) (*http.Cookie, error) {
 	type CreateSessionPayload struct {
 		AuthFlowResult
 		OrganizationID string `json:"organizationId"`
+		ClientConfigID string `json:"oidcClientConfigId"`
 	}
 	sessionPayload := CreateSessionPayload{
 		AuthFlowResult: *flowResult,
-		OrganizationID: organizationId,
+		OrganizationID: clientConfig.OrganizationID,
+		ClientConfigID: clientConfig.ID,
 	}
 	payload, err := json.Marshal(sessionPayload)
 	if err != nil {

--- a/components/server/src/iam/iam-oidc-create-session-payload.ts
+++ b/components/server/src/iam/iam-oidc-create-session-payload.ts
@@ -14,7 +14,8 @@ export namespace OIDCCreateSessionPayload {
             "sub" in payload.claims &&
             "name" in payload.claims &&
             "email" in payload.claims &&
-            "organizationId" in payload
+            "organizationId" in payload &&
+            "oidcClientConfigId" in payload
         );
     }
 
@@ -34,10 +35,13 @@ export namespace OIDCCreateSessionPayload {
         if (isEmpty(payload.organizationId)) {
             throw new Error("OrganizationId is missing");
         }
+        if (isEmpty(payload.oidcClientConfigId)) {
+            throw new Error("OIDC client config id is missing");
+        }
     }
 
     function isEmpty(attribute: any) {
-        return typeof attribute !== "string" || attribute.length < 1;
+        return typeof attribute !== "string" || attribute.trim().length < 1;
     }
 }
 
@@ -63,4 +67,5 @@ export interface OIDCCreateSessionPayload {
         sub: string; // "1234567890"
     };
     organizationId: string; // TODO(gpl) Remove once we implemented either SKIM, or a proper UserService
+    oidcClientConfigId: string;
 }

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -71,6 +71,7 @@ class TestIamSessionApp {
             hd: "test.net",
         },
         organizationId: "test-org",
+        oidcClientConfigId: "oidc-client-123",
     };
 
     public before() {
@@ -164,6 +165,28 @@ class TestIamSessionApp {
             expect(result.statusCode, JSON.stringify(result.body)).to.equal(400);
             expect(result.body?.message).to.equal(c.expectedMessage);
         }
+    }
+
+    @test public async testInvalidPayload_no_org_id() {
+        const payload = { ...this.payload };
+        (payload.organizationId as any) = "";
+
+        const sr = request(this.app.create());
+        const result = await sr.post("/session").set("Content-Type", "application/json").send(JSON.stringify(payload));
+
+        expect(result.statusCode, JSON.stringify(result.body)).to.equal(400);
+        expect(result.body?.message).to.equal("OrganizationId is missing");
+    }
+
+    @test public async testInvalidPayload_no_config_id() {
+        const payload = { ...this.payload };
+        (payload.oidcClientConfigId as any) = "";
+
+        const sr = request(this.app.create());
+        const result = await sr.post("/session").set("Content-Type", "application/json").send(JSON.stringify(payload));
+
+        expect(result.statusCode, JSON.stringify(result.body)).to.equal(400);
+        expect(result.body?.message).to.equal("OIDC client config id is missing");
     }
 }
 


### PR DESCRIPTION
During the Dedicated Onboarding flow, we learned that it's necessary to have the Issuer (URL) updatable, which means, it will be updatable on the Org Settings page as well, which mean it cannot be used as part of the stable composite key for the SSO identity in the data model. 

This PR updates the composite key of SSO identities to be `(ClientConfigID & Subject)`, which should not change during the lifecycle of a SSO config. (Transitioning from one SSO config to another is not in scope.)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-279

## How to test
See unit test.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
