### PR TITLE
[public-api] Implement UpdateOIDCClientConfig WEB-278

### DIFF
--- a/components/gitpod-db/go/dbtest/oidc_client_config.go
+++ b/components/gitpod-db/go/dbtest/oidc_client_config.go
@@ -19,7 +19,14 @@ func NewOIDCClientConfig(t *testing.T, record db.OIDCClientConfig) db.OIDCClient
 	t.Helper()
 
 	cipher, _ := GetTestCipher(t)
-	encrypted, err := db.EncryptJSON(cipher, db.OIDCSpec{})
+	encrypted, err := db.EncryptJSON(cipher, db.OIDCSpec{
+		ClientID:     "oidc-client-id",
+		ClientSecret: "oidc-client-secret",
+		RedirectURL:  "https://some-redirect-url.or/not",
+		Scopes: []string{
+			"aint", "never", "gonna", "give", "you", "up",
+		},
+	})
 	require.NoError(t, err)
 
 	now := time.Now().UTC().Truncate(time.Millisecond)

--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -195,47 +195,57 @@ func GetOIDCClientConfigByOrgSlug(ctx context.Context, conn *gorm.DB, slug strin
 
 // UpdateOIDCClientConfig performs an update of the OIDC Client config.
 // Only non-zero fields specified in the struct are updated.
-func UpdateOIDCSpec(ctx context.Context, conn *gorm.DB, cipher Cipher, id uuid.UUID, update OIDCSpec) error {
-	if id == uuid.Nil {
+// When updating the encrypted contents of the specUpdate, you can specify them in the update to have re-encrypted in a transaction.
+func UpdateOIDCClientConfig(ctx context.Context, conn *gorm.DB, cipher Cipher, update OIDCClientConfig, specUpdate *OIDCSpec) error {
+	if update.ID == uuid.Nil {
 		return errors.New("id is a required field")
 	}
 
 	txErr := conn.
 		WithContext(ctx).
 		Transaction(func(tx *gorm.DB) error {
-			existing, err := GetOIDCClientConfig(ctx, conn, id)
-			if err != nil {
-				return err
+			if specUpdate != nil {
+				// we also need to update the contents of the encrypted spec.
+				existing, err := GetOIDCClientConfig(ctx, conn, update.ID)
+				if err != nil {
+					return err
+				}
+
+				decrypted, err := existing.Data.Decrypt(cipher)
+				if err != nil {
+					return fmt.Errorf("failed to decrypt oidc spec: %w", err)
+				}
+
+				updatedSpec := partialUpdateOIDCSpec(decrypted, *specUpdate)
+
+				encrypted, err := EncryptJSON(cipher, updatedSpec)
+				if err != nil {
+					return fmt.Errorf("failed to encrypt oidc spec: %w", err)
+				}
+
+				// Set the serialized contents on our desired update object
+				update.Data = encrypted
 			}
 
-			decrypted, err := existing.Data.Decrypt(cipher)
-			if err != nil {
-				return fmt.Errorf("failed to decrypt oidc spec: %w", err)
-			}
-
-			updatedSpec := partialUpdateOIDCSpec(decrypted, update)
-
-			encrypted, err := EncryptJSON(cipher, updatedSpec)
-			if err != nil {
-				return fmt.Errorf("failed to encrypt oidc spec: %w", err)
-			}
-
-			existing.Data = encrypted
-
-			updateErr := tx.
+			updateTx := tx.
 				Model(&OIDCClientConfig{}).
-				Where("id = ?", id).
+				Where("id = ?", update.ID.String()).
 				Where("deleted = ?", 0).
-				Updates(existing).Error
-			if err != nil {
-				return fmt.Errorf("failed to update OIDC client: %w", updateErr)
+				Updates(update)
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update OIDC client: %w", updateTx.Error)
 			}
+
+			if updateTx.RowsAffected == 0 {
+				return fmt.Errorf("OIDC client config ID: %s does not exist: %w", update.ID.String(), ErrorNotFound)
+			}
+
 			// return nil will commit the whole transaction
 			return nil
 		})
 
 	if txErr != nil {
-		return fmt.Errorf("failed to update oidc spec ID: %s: %w", id.String(), txErr)
+		return fmt.Errorf("failed to update oidc spec ID: %s: %w", update.ID.String(), txErr)
 	}
 
 	return nil

--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -222,7 +222,11 @@ func UpdateOIDCSpec(ctx context.Context, conn *gorm.DB, cipher Cipher, id uuid.U
 
 			existing.Data = encrypted
 
-			updateErr := tx.Model(&OIDCClientConfig{}).Updates(existing).Error
+			updateErr := tx.
+				Model(&OIDCClientConfig{}).
+				Where("id = ?", id).
+				Where("deleted = ?", 0).
+				Updates(existing).Error
 			if err != nil {
 				return fmt.Errorf("failed to update OIDC client: %w", updateErr)
 			}
@@ -267,7 +271,7 @@ func partialUpdateOIDCSpec(old, new OIDCSpec) OIDCSpec {
 		old.RedirectURL = new.RedirectURL
 	}
 
-	if oidcScopesEqual(old.Scopes, new.Scopes) {
+	if !oidcScopesEqual(old.Scopes, new.Scopes) {
 		old.Scopes = new.Scopes
 	}
 

--- a/components/gitpod-db/go/oidc_client_config_test.go
+++ b/components/gitpod-db/go/oidc_client_config_test.go
@@ -146,3 +146,82 @@ func TestActivateClientConfig(t *testing.T) {
 	})
 
 }
+
+func TestUpdateOIDCSpec(t *testing.T) {
+
+	t.Run("no existing client config exists", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		cipher, _ := dbtest.GetTestCipher(t)
+
+		err := db.UpdateOIDCSpec(context.Background(), conn, cipher, uuid.New(), db.OIDCSpec{})
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
+
+	t.Run("partially updates client id and client secret", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		cipher, _ := dbtest.GetTestCipher(t)
+
+		created := dbtest.CreateOIDCClientConfigs(t, conn, db.OIDCClientConfig{})[0]
+
+		err := db.UpdateOIDCSpec(context.Background(), conn, cipher, created.ID, db.OIDCSpec{
+			ClientID:     "my-new-client-id",
+			ClientSecret: "new-client-secret",
+		})
+		require.NoError(t, err)
+
+		retrieved, err := db.GetOIDCClientConfig(context.Background(), conn, created.ID)
+		require.NoError(t, err)
+
+		decrypted, err := retrieved.Data.Decrypt(cipher)
+		require.NoError(t, err)
+		require.Equal(t, "my-new-client-id", decrypted.ClientID)
+		require.Equal(t, "new-client-secret", decrypted.ClientSecret)
+	})
+
+	t.Run("partially updates redirect url and scopes", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		cipher, _ := dbtest.GetTestCipher(t)
+
+		created := dbtest.CreateOIDCClientConfigs(t, conn, db.OIDCClientConfig{})[0]
+
+		err := db.UpdateOIDCSpec(context.Background(), conn, cipher, created.ID, db.OIDCSpec{
+			RedirectURL: "new-url",
+			Scopes:      []string{"hello"},
+		})
+		require.NoError(t, err)
+
+		retrieved, err := db.GetOIDCClientConfig(context.Background(), conn, created.ID)
+		require.NoError(t, err)
+
+		decrypted, err := retrieved.Data.Decrypt(cipher)
+		require.NoError(t, err)
+		require.Equal(t, "new-url", decrypted.RedirectURL)
+		require.Equal(t, []string{"hello"}, decrypted.Scopes)
+	})
+
+	t.Run("partially updates all spec fields", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		cipher, _ := dbtest.GetTestCipher(t)
+
+		created := dbtest.CreateOIDCClientConfigs(t, conn, db.OIDCClientConfig{})[0]
+
+		updateSpec := db.OIDCSpec{
+			RedirectURL:  "new-url",
+			ClientID:     "my-new-client-id",
+			ClientSecret: "new-client-secret",
+			Scopes:       []string{"hello"},
+		}
+
+		err := db.UpdateOIDCSpec(context.Background(), conn, cipher, created.ID, updateSpec)
+		require.NoError(t, err)
+
+		retrieved, err := db.GetOIDCClientConfig(context.Background(), conn, created.ID)
+		require.NoError(t, err)
+
+		decrypted, err := retrieved.Data.Decrypt(cipher)
+		require.NoError(t, err)
+		require.Equal(t, updateSpec, decrypted)
+	})
+
+}

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -206,7 +206,7 @@ func (s *OIDCService) UpdateClientConfig(ctx context.Context, req *connect.Reque
 
 	if err := db.UpdateOIDCSpec(ctx, s.dbConn, s.cipher, clientConfigID, updateSpec); err != nil {
 		if errors.Is(err, db.ErrorNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("OIDC Client Config %s for Organization %s does not exist", clientConfigID.String(), organizationID.String()))
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("OIDC Client Config %s does not exist", clientConfigID.String()))
 		}
 
 		log.Extract(ctx).WithError(err).Error("Failed to update OIDC Client config.")

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -225,6 +225,15 @@ func (s *OIDCService) UpdateClientConfig(ctx context.Context, req *connect.Reque
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Failed to update OIDC Client Config %s", clientConfigID.String()))
 	}
 
+	if err = db.DeactivateClientConfig(ctx, s.dbConn, clientConfigID); err != nil {
+		if errors.Is(err, db.ErrorNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("OIDC Client Config %s does not exist", clientConfigID.String()))
+		}
+
+		log.Extract(ctx).WithError(err).Error("Failed to deactivate OIDC Client config.")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Failed to deactivate OIDC Client Config %s", clientConfigID.String()))
+	}
+
 	return connect.NewResponse(&v1.UpdateClientConfigResponse{}), nil
 }
 

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -189,7 +189,7 @@ func (s *OIDCService) UpdateClientConfig(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
-	_, _, err = s.getUser(ctx, conn)
+	user, userID, err = s.getUser(ctx, conn)
 	if err != nil {
 		return nil, err
 	}

--- a/components/public-api-server/pkg/apiv1/oidc_test.go
+++ b/components/public-api-server/pkg/apiv1/oidc_test.go
@@ -348,7 +348,11 @@ func TestOIDCService_UpdateClientConfig_WithFeatureFlagDisabled(t *testing.T) {
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
 		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
-		_, err := client.UpdateClientConfig(context.Background(), connect.NewRequest(&v1.UpdateClientConfigRequest{}))
+		_, err := client.UpdateClientConfig(context.Background(), connect.NewRequest(&v1.UpdateClientConfigRequest{
+			Config: &v1.OIDCClientConfig{
+				Id: uuid.NewString(),
+			},
+		}))
 		require.Error(t, err)
 		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 	})


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements updating of OIDC Client Config with respect to the scope which we currently support.

Remaining to add:
* After the update, deactivate the OIDC config (done)
* Unit tests for the API layer (done)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
