### PR TITLE
[ws-manager-mk2] Fix prebuild start failure false positives

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -275,7 +275,7 @@ func newMetricState(ws *workspacev1.Workspace) metricState {
 		// each workspace.
 		recordedStartTime:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 		recordedInitFailure:     wsk8s.ConditionWithStatusAndReason(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure),
-		recordedStartFailure:    ws.Status.Phase == workspacev1.WorkspacePhaseStopped && !wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionEverReady)),
+		recordedStartFailure:    ws.Status.Phase == workspacev1.WorkspacePhaseStopped && isStartFailure(ws),
 		recordedFailure:         wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)),
 		recordedContentReady:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)),
 		recordedBackupFailed:    wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)),


### PR DESCRIPTION
## Description
Fixes two start failure false positives for prebuilds:
- Prebuilds with empty tasks finishing too quickly to observe the `Running` state, therefore missing the `EverReady` condition. This is fixed by retroactively adding the EverReady condition if we observe the prebuild has succeeded.
- Prebuilds that get aborted before becoming ready. They won't have been ready (and hence considered to have a start failure). Fixed by excluding aborted prebuilds in start failure recording

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-137

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env, by repeatedly creating prebuilds with an empty task, which exercises both aborting previous prebuilds, and prebuilds with empty tasks.
![image](https://user-images.githubusercontent.com/9721064/235687742-1577879a-31e3-44dd-9efe-01a7f020fcff.png)

Afterwards, observed the `ws-manager-mk2` metrics and find there are no longer start failures being recorded.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
