### PR TITLE
Compute onboarding state – WEB-287

### DIFF
--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -41,5 +41,5 @@ export interface TeamDB {
     findOrgSettings(teamId: string): Promise<OrganizationSettings | undefined>;
     setOrgSettings(teamId: string, settings: Partial<OrganizationSettings>): Promise<void>;
 
-    someOrgWithSSOExists(): Promise<boolean>;
+    hasAnyOrgWithActiveSSO(): Promise<boolean>;
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -175,6 +175,9 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getOrgAuthProviders(params: GitpodServer.GetOrgAuthProviderParams): Promise<AuthProviderEntry[]>;
     deleteOrgAuthProvider(params: GitpodServer.DeleteOrgAuthProviderParams): Promise<void>;
 
+    // Dedicated, Dedicated, Dedicated
+    getOnboardingState(): Promise<GitpodServer.OnboardingState>;
+
     // Projects
     getProviderRepositoriesForUser(params: GetProviderRepositoriesParams): Promise<ProviderRepository[]>;
     createProject(params: CreateProjectParams): Promise<Project>;
@@ -472,6 +475,17 @@ export namespace GitpodServer {
         name?: string;
         type: GitpodTokenType;
         scopes?: string[];
+    }
+    export interface OnboardingState {
+        /**
+         * Whether this Gitpod instance is already configured with SSO.
+         */
+        readonly isCompleted: boolean;
+
+        /**
+         * Whether this Gitpod instance has at least one org.
+         */
+        readonly hasAnyOrg: boolean;
     }
 }
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -204,6 +204,7 @@ const defaultFunctions: FunctionsConfig = {
     updateWorkspaceTimeoutSetting: { group: "default", points: 1 },
     getIDToken: { group: "default", points: 1 },
     reportErrorBoundary: { group: "default", points: 1 },
+    getOnboardingState: { group: "default", points: 1 },
 };
 
 function getConfig(config: RateLimiterConfig): RateLimiterConfig {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3980,6 +3980,51 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
     }
 
+    protected _getOnboardingState: GitpodServer.OnboardingState | undefined;
+
+    async getOnboardingState(ctx: TraceContext): Promise<GitpodServer.OnboardingState> {
+        this.checkAndBlockUser("getOnboardingState");
+
+        if (this._getOnboardingState) {
+            return this._getOnboardingState;
+        }
+
+        // A shortcut for gitpod.io, but also for Dedicated PoC.
+        // This is controlled by feature flag (per Gitpod host.)
+        if (!this.enableDedicatedOnboardingFlow) {
+            return {
+                isCompleted: true,
+                hasAnyOrg: true,
+            };
+        }
+
+        // Optimized check for completed setup
+        const hasAnyOrgWithActiveSSO = await this.teamDB.hasAnyOrgWithActiveSSO();
+        if (hasAnyOrgWithActiveSSO) {
+            // Let's cache the state at least per connection.
+            this._getOnboardingState = {
+                isCompleted: true,
+                hasAnyOrg: true,
+            };
+            return this._getOnboardingState;
+        }
+
+        // Find useful details about the state of the Gitpod installation.
+        const { rows } = await this.teamDB.findTeams(
+            0 /* offset */,
+            1 /* limit */,
+            "creationTime" /* order by */,
+            "ASC",
+            "" /* empty search term returns any */,
+        );
+        const hasAnyOrg = rows.length > 0;
+
+        return {
+            isCompleted: false,
+            hasAnyOrg,
+        };
+    }
+
     protected async guardWithFeatureFlag(flagName: string, teamId: string) {
         // Guard method w/ a feature flag check
         const isEnabled = await this.configCatClientFactory().getValueAsync(flagName, false, {


### PR DESCRIPTION
## Description
A pragmatic approach to compute the state of the cell to tell if the Dedicated Onboarding flow should be shown.

This adds `getOnboardingState` to server which result resolves to 
```ts
    interface OnboardingState {
        /**
         * Whether this Gitpod instance is already configured with SSO.
         */
        readonly isCompleted: boolean;

        /**
         * Whether this Gitpod instance has at least one org.
         */
        readonly hasAnyOrg: boolean;
    }
```



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-287

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-onboarding-state</li>
	<li><b>🔗 URL</b> - <a href="https://at-onboarding-state.preview.gitpod-dev.com/workspaces" target="_blank">at-onboarding-state.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
