### PR TITLE
[obs] Include p01, p25 and p75 in success criteria

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/success-criteria.json
+++ b/operations/observability/mixins/workspace/dashboards/success-criteria.json
@@ -271,6 +271,20 @@
           "legendFormat": "P25",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.01, \n  sum(\n      rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type!=\"PREBUILD\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P01",
+          "range": true,
+          "refId": "E"
         }
       ],
       "title": "Workspace Startup Time Mk1",
@@ -379,6 +393,20 @@
           "legendFormat": "P25",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.01, \n  sum(\n      rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{type!=\"Prebuild\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P1",
+          "range": true,
+          "refId": "E"
         }
       ],
       "title": "Workspace Startup Time Mk2",

--- a/operations/observability/mixins/workspace/dashboards/success-criteria.json
+++ b/operations/observability/mixins/workspace/dashboards/success-criteria.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 91,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -39,6 +38,7 @@
             "fixedColor": "blue",
             "mode": "fixed"
           },
+          "decimals": 4,
           "mappings": [],
           "max": 1,
           "min": 0.9,
@@ -79,7 +79,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -94,7 +94,7 @@
           "refId": "A"
         }
       ],
-      "title": "Workspace Success Rate",
+      "title": "Workspace Success Rate Mk1",
       "type": "stat"
     },
     {
@@ -108,6 +108,7 @@
             "fixedColor": "blue",
             "mode": "fixed"
           },
+          "decimals": 4,
           "mappings": [],
           "max": 1,
           "min": 0.9,
@@ -148,7 +149,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -216,7 +217,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -237,14 +238,42 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.5, \n  sum(\n      rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type!=\"PREBUILD\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "expr": "histogram_quantile(\n  0.75, \n  sum(\n      rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type!=\"PREBUILD\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
           "hide": false,
-          "legendFormat": "P50",
+          "legendFormat": "P75",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.50, \n  sum(\n      rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type!=\"PREBUILD\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.25, \n  sum(\n      rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type!=\"PREBUILD\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P25",
+          "range": true,
+          "refId": "D"
         }
       ],
-      "title": "Workspace Startup Time",
+      "title": "Workspace Startup Time Mk1",
       "type": "stat"
     },
     {
@@ -296,7 +325,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -317,11 +346,39 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.5, \n  sum(\n      rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{type!=\"Prebuild\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "expr": "histogram_quantile(\n  0.75, \n  sum(\n      rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{type!=\"Prebuild\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
           "hide": false,
-          "legendFormat": "P50",
+          "legendFormat": "P75",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.50, \n  sum(\n      rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{type!=\"Prebuild\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.25, \n  sum(\n      rate(gitpod_ws_manager_mk2_workspace_startup_seconds_bucket{type!=\"Prebuild\",cluster!~\"prod-meta.*|ephemeral.*\"}[1d])\n    ) by (le)\n  )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "P25",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Workspace Startup Time Mk2",
@@ -739,8 +796,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -867,6 +923,6 @@
   "timezone": "",
   "title": "Success Criteria",
   "uid": "h2qYC3P4k",
-  "version": 7,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
Include p01, p25 and p75 in success criteria

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-147

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
