### PR TITLE
[oidc] Restrict actions to team owners WEB-284

### DIFF
--- a/components/gitpod-db/go/dbtest/team_membership.go
+++ b/components/gitpod-db/go/dbtest/team_membership.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"testing"
+	"time"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func NewTeamMembership(t *testing.T, membership db.TeamMembership) db.TeamMembership {
+	t.Helper()
+
+	result := db.TeamMembership{
+		ID:           uuid.New(),
+		TeamID:       uuid.New(),
+		UserID:       uuid.New(),
+		Role:         db.TeamMembershipRole_Member,
+		CreationTime: db.NewVarCharTime(time.Now()),
+	}
+
+	if membership.ID != uuid.Nil {
+		result.ID = membership.ID
+	}
+	if membership.TeamID != uuid.Nil {
+		result.TeamID = membership.TeamID
+	}
+	if membership.UserID != uuid.Nil {
+		result.UserID = membership.UserID
+	}
+	if membership.Role != "" {
+		result.Role = membership.Role
+	}
+	if membership.CreationTime.IsSet() {
+		result.CreationTime = membership.CreationTime
+	}
+
+	return result
+}
+
+func CreateTeamMembership(t *testing.T, conn *gorm.DB, memberships ...db.TeamMembership) []db.TeamMembership {
+	t.Helper()
+
+	var records []db.TeamMembership
+	var ids []uuid.UUID
+	for _, m := range memberships {
+		record := NewTeamMembership(t, m)
+		records = append(records, record)
+		ids = append(ids, record.ID)
+	}
+
+	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
+
+	t.Cleanup(func() {
+		if len(ids) > 0 {
+			require.NoError(t, conn.Where(ids).Delete(db.TeamMembership{}).Error)
+		}
+
+	})
+
+	return records
+}

--- a/components/gitpod-db/go/dbtest/user.go
+++ b/components/gitpod-db/go/dbtest/user.go
@@ -70,7 +70,9 @@ func CreatUser(t *testing.T, conn *gorm.DB, user ...User) []User {
 	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
 
 	t.Cleanup(func() {
-		require.NoError(t, conn.Where(ids).Delete(&User{}).Error)
+		if len(ids) > 0 {
+			require.NoError(t, conn.Where(ids).Delete(&User{}).Error)
+		}
 	})
 
 	return records

--- a/components/gitpod-db/go/team_membership_test.go
+++ b/components/gitpod-db/go/team_membership_test.go
@@ -7,95 +7,55 @@ package db_test
 import (
 	"context"
 
+	"testing"
+
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-func TestTeamMembership_WriteRead(t *testing.T) {
-	conn := dbtest.ConnectForTests(t)
+func TestGetTeamMembership(t *testing.T) {
 
-	membership := &db.TeamMembership{
-		ID:     uuid.New(),
-		TeamID: uuid.New(),
-		UserID: uuid.New(),
-		Role:   db.TeamMembershipRole_Member,
-	}
+	t.Run("membership does not exist", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		_, err := db.GetTeamMembership(context.Background(), conn, uuid.New(), uuid.New())
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
 
-	tx := conn.Create(membership)
-	require.NoError(t, tx.Error)
+	t.Run("ignores deleted records", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		membership := dbtest.CreateTeamMembership(t, conn, db.TeamMembership{})[0]
 
-	read := &db.TeamMembership{ID: membership.ID}
-	tx = conn.First(read)
-	require.NoError(t, tx.Error)
-	require.Equal(t, membership, read)
+		err := db.DeleteTeamMembership(context.Background(), conn, membership.UserID, membership.TeamID)
+		require.NoError(t, err)
+
+		_, err = db.GetTeamMembership(context.Background(), conn, membership.UserID, membership.TeamID)
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
+
+	t.Run("retrieves membership", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		membership := dbtest.CreateTeamMembership(t, conn, db.TeamMembership{})[0]
+
+		retrieved, err := db.GetTeamMembership(context.Background(), conn, membership.UserID, membership.TeamID)
+		require.NoError(t, err)
+
+		require.Equal(t, membership.ID, retrieved.ID)
+		require.Equal(t, membership.Role, retrieved.Role)
+		require.Equal(t, membership.UserID, retrieved.UserID)
+		require.Equal(t, membership.TeamID, retrieved.TeamID)
+	})
 }
 
-func TestListTeamMembershipsForUserIDs(t *testing.T) {
-	conn := dbtest.ConnectForTests(t)
-	userWithTwoTeams := uuid.New()
-	memberships := []db.TeamMembership{
-		{
-			ID:     uuid.New(),
-			TeamID: uuid.New(),
-			UserID: uuid.New(),
-			Role:   db.TeamMembershipRole_Member,
-		},
-		{
-			ID:     uuid.New(),
-			TeamID: uuid.New(),
-			UserID: userWithTwoTeams,
-			Role:   db.TeamMembershipRole_Member,
-		},
-		{
-			ID:     uuid.New(),
-			TeamID: uuid.New(),
-			UserID: userWithTwoTeams,
-			Role:   db.TeamMembershipRole_Member,
-		},
-	}
+func TestDeleteTeamMembership(t *testing.T) {
 
-	tx := conn.Create(&memberships)
-	require.NoError(t, tx.Error)
-
-	for _, scenario := range []struct {
-		Name     string
-		UserIDs  []uuid.UUID
-		Expected int
-	}{
-		{
-			Name:     "no user ids return empty",
-			UserIDs:  nil,
-			Expected: 0,
-		},
-		{
-			Name:     "no matching user IDs returns empty",
-			UserIDs:  []uuid.UUID{uuid.New()},
-			Expected: 0,
-		},
-		{
-			Name:     "one matching, and one not returns only one record",
-			UserIDs:  []uuid.UUID{memberships[0].UserID, uuid.New()},
-			Expected: 1,
-		},
-		{
-			Name:     "all matching returns all records (with duplicate userID in query)",
-			UserIDs:  []uuid.UUID{memberships[0].UserID, memberships[1].UserID, memberships[2].UserID},
-			Expected: 3,
-		},
-		{
-			Name:     "one ID with multiple memberships returns all membership for the ID",
-			UserIDs:  []uuid.UUID{userWithTwoTeams},
-			Expected: 2,
-		},
-	} {
-		t.Run(scenario.Name, func(t *testing.T) {
-			retrieved, err := db.ListTeamMembershipsForUserIDs(context.Background(), conn, scenario.UserIDs)
-			require.NoError(t, err)
-
-			require.Len(t, retrieved, scenario.Expected)
-		})
-	}
+	t.Run("not found when membership does not exist", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		err := db.DeleteTeamMembership(context.Background(), conn, uuid.New(), uuid.New())
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ensures that only team owners can perform actions on OIDC Client Configs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-oidc-au11b8dbf2e7</li>
	<li><b>🔗 URL</b> - <a href="https://mp-oidc-au11b8dbf2e7.preview.gitpod-dev.com/workspaces" target="_blank">mp-oidc-au11b8dbf2e7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
