### PR TITLE
[dashboard] fix button rendering

### DIFF
--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -7,6 +7,7 @@
 import { Link } from "react-router-dom";
 import { Heading2 } from "../components/typography/headings";
 import { StartWorkspaceModalKeyBinding } from "../App";
+import { Button } from "../components/Button";
 
 export const EmptyWorkspacesContent = () => {
     return (
@@ -31,8 +32,10 @@ export const EmptyWorkspacesContent = () => {
                         </div>
                         <span>
                             <Link to={"/new"}>
-                                New Workspace{" "}
-                                <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                                <Button>
+                                    New Workspace{" "}
+                                    <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                                </Button>
                             </Link>
                         </span>
                     </>

--- a/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
@@ -9,6 +9,7 @@ import { Link } from "react-router-dom";
 import { StartWorkspaceModalKeyBinding } from "../App";
 import DropDown from "../components/DropDown";
 import search from "../icons/search.svg";
+import { Button } from "../components/Button";
 
 type WorkspacesSearchBarProps = {
     searchTerm: string;
@@ -66,8 +67,10 @@ export const WorkspacesSearchBar: FunctionComponent<WorkspacesSearchBarProps> = 
                     ]}
                 />
             </div>
-            <Link to={"/new"} className="ml-2">
-                New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+            <Link to={"/new"}>
+                <Button className="ml-2">
+                    New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                </Button>
             </Link>
         </div>
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The new workspace button on the workspaces list is not rendered properly.

<img width="378" alt="Screenshot 2023-05-03 at 10 19 08" src="https://user-images.githubusercontent.com/372735/235865003-84a4de37-cfbb-4673-82e8-08f11b69d739.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-button-fix</li>
	<li><b>🔗 URL</b> - <a href="https://se-button-fix.preview.gitpod-dev.com/workspaces" target="_blank">se-button-fix.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
