### PR TITLE
[dashboard] invite link for SSO orgs

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -184,7 +184,7 @@ export const AppRoutes = () => {
                     <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositories} />
                     <AdminRoute path="/admin/settings" component={AdminSettings} />
 
-                    <Route path={["/", "/login"]} exact>
+                    <Route path={["/", "/login", "/login/:orgSlug"]} exact>
                         <Redirect to={workspacesPathMain} />
                     </Route>
                     <Route path={[settingsPathMain]} exact>

--- a/components/dashboard/src/login/SSOLoginForm.tsx
+++ b/components/dashboard/src/login/SSOLoginForm.tsx
@@ -11,19 +11,29 @@ import { TextInputField } from "../components/forms/TextInputField";
 import { useOnBlurError } from "../hooks/use-onblur-error";
 import { openOIDCStartWindow } from "../provider-utils";
 import { useFeatureFlag } from "../data/featureflag-query";
+import { useLocation } from "react-router";
 
 type Props = {
     singleOrgMode?: boolean;
     onSuccess: () => void;
 };
+
+function getOrgSlugFromPath(path: string) {
+    return path.split("/")[2];
+}
+
 export const SSOLoginForm: FC<Props> = ({ singleOrgMode, onSuccess }) => {
-    const [orgSlug, setOrgSlug] = useState("");
+    const location = useLocation();
+    const [orgSlug, setOrgSlug] = useState(
+        getOrgSlugFromPath(location.pathname) || window.localStorage.getItem("sso-org-slug") || "",
+    );
     const [error, setError] = useState("");
     const oidcServiceEnabled = useFeatureFlag("oidcServiceEnabled");
 
     const openLoginWithSSO = useCallback(
         async (e) => {
             e.preventDefault();
+            window.localStorage.setItem("sso-org-slug", orgSlug.trim());
 
             try {
                 await openOIDCStartWindow({

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -41,5 +41,5 @@ export interface TeamDB {
     findOrgSettings(teamId: string): Promise<OrganizationSettings | undefined>;
     setOrgSettings(teamId: string, settings: Partial<OrganizationSettings>): Promise<void>;
 
-    hasAnyOrgWithActiveSSO(): Promise<boolean>;
+    hasActiveSSO(organizationId: string): Promise<boolean>;
 }

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -379,7 +379,7 @@ export class TeamDBImpl implements TeamDB {
         }
     }
 
-    public async hasAnyOrgWithActiveSSO(): Promise<boolean> {
+    public async hasActiveSSO(organizationId: string): Promise<boolean> {
         const repo = await this.getTeamRepo();
         const result = await repo.query(
             `select org.id from d_b_team as org inner join d_b_oidc_client_config as oidc on org.id = oidc.organizationId
@@ -387,7 +387,9 @@ export class TeamDBImpl implements TeamDB {
                 and oidc.deleted = 0
                 and org.deleted = 0
                 and org.markedDeleted = 0
+                and org.id = ?
                 limit 1;`,
+            [organizationId],
         );
         return result.length === 1;
     }

--- a/components/public-api-server/debug.sh
+++ b/components/public-api-server/debug.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+source /workspace/gitpod/scripts/ws-deploy.sh deployment public-api-server


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
SSO enabled orgs are inviting through their SSO login.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-270

## How to test
<!-- Provide steps to test this PR -->

Join my org https://se-sso-invites.preview.gitpod-dev.com/login/my-org

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-sso-invites</li>
	<li><b>🔗 URL</b> - <a href="https://se-sso-invites.preview.gitpod-dev.com/workspaces" target="_blank">se-sso-invites.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
