### PR TITLE
[wsman-mk2] Schedule on non experimental nodes

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -337,6 +337,11 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 			Key:      "gitpod.io/experimental",
 			Operator: corev1.NodeSelectorOpExists,
 		})
+	} else {
+		matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
+			Key:      "gitpod.io/experimental",
+			Operator: corev1.NodeSelectorOpDoesNotExist,
+		})
 	}
 
 	affinity := &corev1.Affinity{

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -627,10 +627,4 @@ leeway run components:add-smith-token \
   -DPREVIEW_K3S_KUBE_CONTEXT="${PREVIEW_K3S_KUBE_CONTEXT}" \
   -DPREVIEW_NAMESPACE="${PREVIEW_NAMESPACE}"
 
-# Add experimental node label if ws-manager-mk2 is enabled.
-# Remove once mk2 workspaces no longer run on experimental nodes.
-if [[ "${GITPOD_WSMANAGER_MK2}" == "true" ]]; then
-  kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" --namespace="${PREVIEW_NAMESPACE}" label nodes "${PREVIEW_K3S_KUBE_CONTEXT}" gitpod.io/experimental="true" --overwrite
-fi
-
 log_success "Installation is happy: https://${DOMAIN}/workspaces"


### PR DESCRIPTION
## Description
Only schedule on on experimental nodes if experimental mode is disabled

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-123

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
