### PR TITLE
[server] Report duration of jobs

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -28,6 +28,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(jwtCookieIssued);
     registry.registerMetric(jobStartedTotal);
     registry.registerMetric(jobsCompletedTotal);
+    registry.registerMetric(jobsDurationSeconds);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -277,3 +278,10 @@ export const jobsCompletedTotal = new prometheusClient.Counter({
 export function reportJobCompleted(name: string, success: boolean) {
     jobsCompletedTotal.inc({ name, success: String(success) });
 }
+
+export const jobsDurationSeconds = new prometheusClient.Histogram({
+    name: "gitpod_server_jobs_duration_seconds",
+    help: "Histogram of job duration",
+    buckets: [10, 30, 60, 2 * 60, 3 * 60, 5 * 60, 10 * 60, 15 * 60],
+    labelNames: ["name"],
+});


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reports duration of jobs, such that we can show it on a dashboard

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
