### PR TITLE
[server] Delete OTS directly, instead of through db deleter

### DIFF
--- a/components/gitpod-db/src/typeorm/one-time-secret-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/one-time-secret-db-impl.spec.db.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "../test-container";
+import { TypeORM } from "./typeorm";
+import { DBUser } from "./entity/db-user";
+import * as chai from "chai";
+import { OneTimeSecretDB } from "../one-time-secret-db";
+import { DBOneTimeSecret } from "./entity/db-one-time-secret";
+const expect = chai.expect;
+
+@suite(timeout(10000))
+export class OneTimeSecretSpec {
+    private readonly otsDB = testContainer.get<OneTimeSecretDB>(OneTimeSecretDB);
+
+    async before() {
+        await this.wipeRepo();
+    }
+
+    async after() {
+        await this.wipeRepo();
+    }
+
+    async wipeRepo() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        await manager.getRepository(DBOneTimeSecret).delete({});
+        await manager.getRepository(DBUser).delete({});
+    }
+
+    @test()
+    async testPruneExpired(): Promise<void> {
+        const today = new Date();
+        const yesterday = new Date(today);
+        yesterday.setDate(yesterday.getDate() - 1);
+        const tomorrow = new Date(today);
+        tomorrow.setDate(tomorrow.getDate() + 1);
+
+        await this.otsDB.register("secret", yesterday);
+        await this.otsDB.register("secret2", tomorrow);
+
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+
+        const beforePrune = await manager.getRepository(DBOneTimeSecret).count();
+        expect(beforePrune).to.be.eq(2);
+
+        await this.otsDB.pruneExpired();
+
+        const afterPrune = await manager.getRepository(DBOneTimeSecret).count();
+        expect(afterPrune).to.be.eq(1);
+    }
+}

--- a/components/gitpod-db/src/typeorm/one-time-secret-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/one-time-secret-db-impl.ts
@@ -64,8 +64,6 @@ export class TypeORMOneTimeSecretDBImpl implements OneTimeSecretDB {
     }
 
     public async pruneExpired(): Promise<void> {
-        await (
-            await this.getEntityManager()
-        ).query("UPDATE d_b_one_time_secret SET deleted = 1 WHERE deleted = 0 AND expirationTime < NOW()");
+        await (await this.getEntityManager()).query("DELETE FROM d_b_one_time_secret WHERE expirationTime < NOW()");
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Instead of running a job to mark expired OTS as deleted, such that it can then be deleted by another job, we delete them directly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-ots-del1b6fa1adb7</li>
	<li><b>🔗 URL</b> - <a href="https://mp-ots-del1b6fa1adb7.preview.gitpod-dev.com/workspaces" target="_blank">mp-ots-del1b6fa1adb7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
