### PR TITLE
[wsman-mk2] Log workspace startup time

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -131,7 +131,9 @@ func (m *controllerMetrics) recordWorkspaceStartupTime(log *logr.Logger, ws *wor
 		log.Error(err, "could not record workspace startup time", "type", tpe, "class", class)
 	}
 
-	hist.Observe(float64(time.Since(ws.CreationTimestamp.Time).Seconds()))
+	duration := time.Since(ws.CreationTimestamp.Time)
+	log.Info("workspace startup time", "ws", ws.Name, "duration", duration)
+	hist.Observe(float64(duration.Seconds()))
 }
 
 func (m *controllerMetrics) countWorkspaceStartFailures(log *logr.Logger, ws *workspacev1.Workspace) {


### PR DESCRIPTION
## Description
Log workspace startup time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-152

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
