### PR TITLE
[server] Delete webhook events directly

### DIFF
--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -52,19 +52,16 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         return query.getMany();
     }
 
-    public async deleteOldEvents(ageInDays: number, limit?: number): Promise<void> {
+    public async deleteOldEvents(ageInDays: number, limit: number): Promise<void> {
         const repo = await this.getRepo();
         const d = new Date();
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
-        const query = repo
+        await repo
             .createQueryBuilder()
-            .update()
-            .set({ deleted: true })
-            .where("creationTime <= :expirationDate", { expirationDate });
-        if (typeof limit === "number") {
-            query.limit(limit);
-        }
-        await query.execute();
+            .where("creationTime <= :expirationDate", { expirationDate })
+            .limit(limit)
+            .delete()
+            .execute();
     }
 }

--- a/components/gitpod-db/src/webhook-event-db.spec.db.ts
+++ b/components/gitpod-db/src/webhook-event-db.spec.db.ts
@@ -64,9 +64,8 @@ export class WebhookEventDBSpec {
 
         await this.db.deleteOldEvents(0, 1);
 
-        const event = (await this.db.findByCloneUrl(cloneUrl))[0];
-        expect(event, "should be found").to.be.not.undefined;
-        expect((event as DBWebhookEvent).deleted, "should be marked as deleted").to.be.true;
+        const events = await this.db.findByCloneUrl(cloneUrl);
+        expect(events.length).to.be.eq(0);
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Instead of deleting through marking the webhook events as deleted, such that they are eventually GCed by the DB deleter, we delete them directly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-delete-b5e8963a85</li>
	<li><b>🔗 URL</b> - <a href="https://mp-delete-b5e8963a85.preview.gitpod-dev.com/workspaces" target="_blank">mp-delete-b5e8963a85.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
