### PR TITLE
Use getOnboardingState api for dedicated setup flow

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -13,6 +13,7 @@ import { useUserLoader } from "./hooks/use-user-loader";
 import { Login } from "./Login";
 import { AppBlockingFlows } from "./app/AppBlockingFlows";
 import { useHistory } from "react-router";
+import { useCheckDedicatedSetup } from "./dedicated-setup/use-check-dedicated-setup";
 
 // Wrap the App in an ErrorBoundary to catch User/Org loading errors
 // This will also catch any errors that happen to bubble all the way up to the top
@@ -24,6 +25,8 @@ export const StartWorkspaceModalKeyBinding = `${/(Mac|iPhone|iPod|iPad)/i.test(n
 
 // Top level Dashboard App component
 const App: FC = () => {
+    // Fire this query off as early as possible
+    useCheckDedicatedSetup();
     const { user, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
     const history = useHistory();

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -13,7 +13,6 @@ import { useUserLoader } from "./hooks/use-user-loader";
 import { Login } from "./Login";
 import { AppBlockingFlows } from "./app/AppBlockingFlows";
 import { useHistory } from "react-router";
-import { useCheckDedicatedSetup } from "./dedicated-setup/use-check-dedicated-setup";
 
 // Wrap the App in an ErrorBoundary to catch User/Org loading errors
 // This will also catch any errors that happen to bubble all the way up to the top
@@ -25,8 +24,6 @@ export const StartWorkspaceModalKeyBinding = `${/(Mac|iPhone|iPod|iPad)/i.test(n
 
 // Top level Dashboard App component
 const App: FC = () => {
-    // Fire this query off as early as possible
-    useCheckDedicatedSetup();
     const { user, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
     const history = useHistory();

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -65,8 +65,8 @@ const App: FC = () => {
         <Suspense fallback={<AppLoading />}>
             {/* Any required onboarding flows will be handled here before rendering the main app layout & routes */}
             <AppBlockingFlows>
-                {/* Use org id, or user id (for personal account) as key to force re-render on org change */}
-                <AppRoutes key={currentOrgQuery?.data?.id ?? user.id} />
+                {/* Use org id *and* user id as key to force re-render on org *or* user changes. */}
+                <AppRoutes key={`${currentOrgQuery?.data?.id ?? "no-org"}-${user.id}`} />
             </AppBlockingFlows>
         </Suspense>
     );

--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -29,7 +29,6 @@ export const AppBlockingFlows: FC = ({ children }) => {
 
     // Wait until we've loaded the onboarding state before rendering anything
     if (checkDedicatedSetup.isLoading) {
-        console.log("waiting on checkDedicatedSetup.isLoading", checkDedicatedSetup.isLoading);
         return <AppLoading />;
     }
 

--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -29,6 +29,7 @@ export const AppBlockingFlows: FC = ({ children }) => {
 
     // Wait until we've loaded the onboarding state before rendering anything
     if (checkDedicatedSetup.isLoading) {
+        console.log("waiting on checkDedicatedSetup.isLoading", checkDedicatedSetup.isLoading);
         return <AppLoading />;
     }
 

--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -9,6 +9,7 @@ import { useCheckDedicatedSetup } from "../dedicated-setup/use-check-dedicated-s
 import { useCurrentUser } from "../user-context";
 import { MigrationPage, useShouldSeeMigrationPage } from "../whatsnew/MigrationPage";
 import { useShowUserOnboarding } from "../onboarding/use-show-user-onboarding";
+import { AppLoading } from "./AppLoading";
 
 const UserOnboarding = lazy(() => import(/* webpackPrefetch: true */ "../onboarding/UserOnboarding"));
 const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicated-setup/DedicatedSetup"));
@@ -26,13 +27,18 @@ export const AppBlockingFlows: FC = ({ children }) => {
         return <></>;
     }
 
+    // Wait until we've loaded the onboarding state before rendering anything
+    if (checkDedicatedSetup.isLoading) {
+        return <AppLoading />;
+    }
+
     // If orgOnlyAttribution is enabled and the user hasn't been migrated, yet, we need to show the migration page
     if (shouldSeeMigrationPage) {
         return <MigrationPage />;
     }
 
     // Handle dedicated onboarding if necessary
-    if (!checkDedicatedSetup.isLoading && checkDedicatedSetup.needsOnboarding) {
+    if (checkDedicatedSetup.showOnboarding) {
         return <DedicatedSetup />;
     }
 

--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -40,7 +40,7 @@ export const AppBlockingFlows: FC = ({ children }) => {
 
     // Handle dedicated onboarding if necessary
     if (checkDedicatedSetup.showOnboarding) {
-        return <DedicatedSetup />;
+        return <DedicatedSetup onComplete={() => checkDedicatedSetup.markCompleted()} />;
     }
 
     // New user onboarding flow

--- a/components/dashboard/src/data/oidc-clients/oidc-clients-query.ts
+++ b/components/dashboard/src/data/oidc-clients/oidc-clients-query.ts
@@ -25,7 +25,7 @@ export const useOIDCClientsQuery = () => {
 
             return clientConfigs;
         },
-        enabled: !isLoading,
+        enabled: !isLoading && !!organization,
     });
 };
 

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -92,7 +92,8 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
         orgId = orgIdParam;
     }
     let org = orgs.data.find((org) => org.id === orgId);
-    if (!org && user?.additionalData?.isMigratedToTeamOnlyAttribution) {
+    // TODO: Figure out how to handle this...
+    if (!org && (user?.additionalData?.isMigratedToTeamOnlyAttribution || true)) {
         // if the user is migrated to team-only attribution, we return the first org
         org = orgs.data[0];
     }

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -92,8 +92,7 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
         orgId = orgIdParam;
     }
     let org = orgs.data.find((org) => org.id === orgId);
-    // TODO: Figure out how to handle this...
-    if (!org && (user?.additionalData?.isMigratedToTeamOnlyAttribution || true)) {
+    if (!org && user?.additionalData?.isMigratedToTeamOnlyAttribution) {
         // if the user is migrated to team-only attribution, we return the first org
         org = orgs.data[0];
     }

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -17,6 +17,7 @@ import { Delayed } from "../components/Delayed";
 import { SpinnerLoader } from "../components/Loader";
 import { OrganizationInfo } from "../data/organizations/orgs-query";
 import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_pb";
+import { useCheckDedicatedSetup } from "./use-check-dedicated-setup";
 
 const DedicatedSetup: FC = () => {
     const currentOrg = useCurrentOrg();
@@ -63,6 +64,7 @@ type DedicatedSetupStepsProps = {
     config?: OIDCClientConfig;
 };
 const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
+    const { markCompleted } = useCheckDedicatedSetup();
     const { dropConfetti } = useConfetti();
     const history = useHistory();
 
@@ -78,8 +80,9 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
     }, [dropConfetti]);
 
     const handleEndSetup = useCallback(() => {
+        markCompleted();
         history.push("/settings/git");
-    }, [history]);
+    }, [history, markCompleted]);
 
     return (
         <>

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -72,6 +72,7 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config, onComp
     const { dropConfetti } = useConfetti();
     const history = useHistory();
     const client = useQueryClient();
+    const { isLoading: ssoConfigsLoading } = useOIDCClientsQuery();
 
     // If we have an org w/ a name, we can skip the first step and go to sso setup
     const initialStep = org && org.name ? STEPS.SSO_SETUP : STEPS.GETTING_STARTED;
@@ -94,7 +95,14 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config, onComp
         <>
             {step === STEPS.GETTING_STARTED && <GettingStartedStep onComplete={() => setStep(STEPS.ORG_NAMING)} />}
             {step === STEPS.ORG_NAMING && <OrgNamingStep onComplete={() => setStep(STEPS.SSO_SETUP)} />}
-            {step === STEPS.SSO_SETUP && <SSOSetupStep config={config} onComplete={handleSetupComplete} />}
+            {step === STEPS.SSO_SETUP &&
+                (ssoConfigsLoading ? (
+                    <Delayed>
+                        <SpinnerLoader />
+                    </Delayed>
+                ) : (
+                    <SSOSetupStep config={config} onComplete={handleSetupComplete} />
+                ))}
             {step === STEPS.COMPLETE && <SetupCompleteStep onComplete={handleEndSetup} />}
         </>
     );

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -17,9 +17,11 @@ import { Delayed } from "../components/Delayed";
 import { SpinnerLoader } from "../components/Loader";
 import { OrganizationInfo } from "../data/organizations/orgs-query";
 import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_pb";
-import { useCheckDedicatedSetup } from "./use-check-dedicated-setup";
 
-const DedicatedSetup: FC = () => {
+type Props = {
+    onComplete: () => void;
+};
+const DedicatedSetup: FC<Props> = ({ onComplete }) => {
     const currentOrg = useCurrentOrg();
     const oidcClients = useOIDCClientsQuery();
     console.log("currentOrg", currentOrg);
@@ -46,7 +48,7 @@ const DedicatedSetup: FC = () => {
     }
 
     // Delay rendering until we have data so we can default to the correct step
-    return <DedicatedSetupSteps org={currentOrg.data} config={ssoConfig} />;
+    return <DedicatedSetupSteps org={currentOrg.data} config={ssoConfig} onComplete={onComplete} />;
 };
 
 export default DedicatedSetup;
@@ -62,10 +64,10 @@ type StepsValue = typeof STEPS[keyof typeof STEPS];
 type DedicatedSetupStepsProps = {
     org?: OrganizationInfo;
     config?: OIDCClientConfig;
+    onComplete: () => void;
 };
-const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
+const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config, onComplete }) => {
     console.log("steps org", org);
-    const { markCompleted } = useCheckDedicatedSetup();
     const { dropConfetti } = useConfetti();
     const history = useHistory();
 
@@ -81,9 +83,9 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
     }, [dropConfetti]);
 
     const handleEndSetup = useCallback(() => {
-        markCompleted();
         history.push("/settings/git");
-    }, [history, markCompleted]);
+        onComplete();
+    }, [history, onComplete]);
 
     return (
         <>

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -22,7 +22,7 @@ import { useCheckDedicatedSetup } from "./use-check-dedicated-setup";
 const DedicatedSetup: FC = () => {
     const currentOrg = useCurrentOrg();
     const oidcClients = useOIDCClientsQuery();
-
+    console.log("currentOrg", currentOrg);
     // if a config already exists, select first active, or first config
     const ssoConfig = useMemo(() => {
         if (!oidcClients.data) {
@@ -37,7 +37,7 @@ const DedicatedSetup: FC = () => {
         return oidcClients.data?.[0];
     }, [oidcClients.data]);
 
-    if (currentOrg.isLoading || oidcClients.isLoading) {
+    if (currentOrg.isLoading) {
         return (
             <Delayed>
                 <SpinnerLoader />
@@ -64,6 +64,7 @@ type DedicatedSetupStepsProps = {
     config?: OIDCClientConfig;
 };
 const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
+    console.log("steps org", org);
     const { markCompleted } = useCheckDedicatedSetup();
     const { dropConfetti } = useConfetti();
     const history = useHistory();

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -17,6 +17,7 @@ import { Delayed } from "../components/Delayed";
 import { SpinnerLoader } from "../components/Loader";
 import { OrganizationInfo } from "../data/organizations/orgs-query";
 import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_pb";
+import { useQueryClient } from "@tanstack/react-query";
 
 type Props = {
     onComplete: () => void;
@@ -70,6 +71,7 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config, onComp
     console.log("steps org", org);
     const { dropConfetti } = useConfetti();
     const history = useHistory();
+    const client = useQueryClient();
 
     // If we have an org w/ a name, we can skip the first step and go to sso setup
     const initialStep = org && org.name ? STEPS.SSO_SETUP : STEPS.GETTING_STARTED;
@@ -85,7 +87,8 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config, onComp
     const handleEndSetup = useCallback(() => {
         history.push("/settings/git");
         onComplete();
-    }, [history, onComplete]);
+        client.resetQueries();
+    }, [client, history, onComplete]);
 
     return (
         <>

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -66,7 +66,7 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, config }) => {
     const { dropConfetti } = useConfetti();
     const history = useHistory();
 
-    // If we have an org name, we can skip the first step
+    // If we have an org w/ a name, we can skip the first step and go to sso setup
     const initialStep = org && org.name ? STEPS.SSO_SETUP : STEPS.GETTING_STARTED;
     const [step, setStep] = useState<StepsValue>(initialStep);
 

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -28,7 +28,16 @@ export const OrgNamingStep: FC<Props> = ({ onComplete }) => {
         if (org.data) {
             updateOrg.mutate({ name: orgName }, { onSuccess: onComplete });
         } else {
-            createOrg.mutate({ name: orgName }, { onSuccess: onComplete });
+            createOrg.mutate(
+                { name: orgName },
+                {
+                    onSuccess: (newOrg) => {
+                        // Need to manually set active-org here so it's returned via subsequent useCurrentOrg() calls
+                        localStorage.setItem("active-org", newOrg.id);
+                        onComplete();
+                    },
+                },
+            );
         }
     }, [createOrg, onComplete, org.data, orgName, updateOrg]);
 

--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useContext, useReducer, useState } from "react";
+import { FC, useCallback, useReducer, useState } from "react";
 import { Button } from "../components/Button";
 import { Heading1, Subheading } from "../components/typography/headings";
 import { SetupLayout } from "./SetupLayout";
@@ -14,15 +14,12 @@ import { SSOConfigForm, isValid, ssoConfigReducer, useSaveSSOConfig } from "../t
 import Alert from "../components/Alert";
 import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_pb";
 import { openOIDCStartWindow } from "../provider-utils";
-import { getGitpodService } from "../service/service";
-import { UserContext } from "../user-context";
 
 type Props = {
     config?: OIDCClientConfig;
     onComplete: () => void;
 };
 export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
-    const { setUser } = useContext(UserContext);
     const [ssoLoginError, setSSOLoginError] = useState("");
 
     const [ssoConfig, dispatch] = useReducer(ssoConfigReducer, {
@@ -34,12 +31,6 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
     const configIsValid = isValid(ssoConfig);
 
     const { save, isLoading, isError, error } = useSaveSSOConfig();
-
-    const updateUser = useCallback(async () => {
-        await getGitpodService().reconnect();
-        const user = await getGitpodService().server.getLoggedInUser();
-        setUser(user);
-    }, [setUser]);
 
     const handleVerify = useCallback(async () => {
         try {
@@ -56,7 +47,6 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
                 activate: true,
                 configId: configId,
                 onSuccess: async () => {
-                    await updateUser();
                     onComplete();
                 },
                 onError: (payload) => {
@@ -72,7 +62,7 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
         } catch (e) {
             console.error(e);
         }
-    }, [onComplete, save, ssoConfig, updateUser]);
+    }, [onComplete, save, ssoConfig]);
 
     return (
         <SetupLayout showOrg>

--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -37,7 +37,7 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
 
     const updateUser = useCallback(async () => {
         await getGitpodService().reconnect();
-        const [user] = await Promise.all([getGitpodService().server.getLoggedInUser()]);
+        const user = await getGitpodService().server.getLoggedInUser();
         setUser(user);
     }, [setUser]);
 

--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -90,7 +90,7 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
                 <Subheading>
                     {/* TODO: Find what link we want to use here */}
                     Enable single sign-on for your organization using the OpenID Connect (OIDC) standard.{" "}
-                    <a href="https://gitpod.io" target="_blank" rel="noreferrer noopener">
+                    <a href="https://gitpod.io" target="_blank" rel="noreferrer noopener" className="gp-link">
                         Learn more
                     </a>
                 </Subheading>

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -33,13 +33,13 @@ export const useCheckDedicatedSetup = () => {
     // If needsOnboarding changes to true, we want to set flow as in progress
     // This helps us not close the flow prematurely (i.e. onboardingState.completed = true but we want to show the completed page)
     useEffect(() => {
-        if (needsOnboarding && !inProgress) {
+        if (enableDedicatedOnboardingFlow && needsOnboarding && !inProgress) {
             setInProgress(true);
         }
-    }, [forceSetup, inProgress, needsOnboarding, onboardingState?.isCompleted]);
+    }, [enableDedicatedOnboardingFlow, forceSetup, inProgress, needsOnboarding]);
 
     return {
-        showOnboarding: enableDedicatedOnboardingFlow && inProgress,
+        showOnboarding: inProgress,
         isLoading: enableDedicatedOnboardingFlow && isLoading,
         markCompleted,
     };

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -23,7 +23,6 @@ export const useCheckDedicatedSetup = () => {
     const params = useQueryParams();
 
     const { data: onboardingState, isLoading } = useOnboardingState();
-    console.log("onboardingState", onboardingState);
 
     const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
     const needsOnboarding = forceSetup || (onboardingState && onboardingState.isCompleted !== true);
@@ -36,7 +35,8 @@ export const useCheckDedicatedSetup = () => {
         if (enableDedicatedOnboardingFlow && needsOnboarding && !inProgress) {
             setInProgress(true);
         }
-    }, [enableDedicatedOnboardingFlow, forceSetup, inProgress, needsOnboarding]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enableDedicatedOnboardingFlow, forceSetup, needsOnboarding]);
 
     return {
         showOnboarding: inProgress,

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -17,46 +17,60 @@ const FORCE_SETUP_PARAM_VALUE = "force";
 export const useCheckDedicatedSetup = () => {
     // track if user has finished onboarding so we avoid showing the onboarding
     // again in case onboarding state doesn't updated right away
-    const [loading, setLoading] = useState(true);
-    const [areShowing, setAreShowing] = useState(false);
+    // const [loading, setLoading] = useState(true);
+    // const [areShowing, setAreShowing] = useState(false);
+    const [inProgress, setInProgress] = useState(false);
     const [hasCompleted, setHasCompleted] = useState(false);
 
     const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
     const params = useQueryParams();
 
-    // const { data: onboardingState, isLoading } = useOnboardingState();
+    const { data: onboardingState, isLoading } = useOnboardingState();
     // console.log("enableDedicatedOnboardingFlow", enableDedicatedOnboardingFlow);
 
-    // const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
+    const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
+    const needsOnboarding = forceSetup || onboardingState?.isCompleted !== true;
 
-    const markCompleted = useCallback(() => setHasCompleted(true), []);
+    // const markInProgress = useCallback(() => setHasCompleted(true), []);
+    // const markCompleted = useCallback(() => setHasCompleted(true), []);
+    const markCompleted = useCallback(() => setInProgress(false), []);
+
+    // If needsOnboarding changes to true, we want to set flow as in progress
+    // This helps us not close the flow prematurely (i.e. onboardingState.completed = true but we want to show the completed page)
+    useEffect(() => {
+        if (needsOnboarding && !inProgress) {
+            setInProgress(true);
+        }
+    }, [inProgress, needsOnboarding]);
 
     // We want to check once up front if we need to show the setup flow
     // Once we've decided, we don't want to rely on derived state to determine it anymore
     // so we can avoid any flashing of the setup flow as it progresses and we need to do things
     // like re-fetch orgs after creation, or update signed in user
-    useEffect(() => {
-        getGitpodService()
-            .server.getOnboardingState()
-            .then((state) => {
-                console.log("getOnboardingState", state, enableDedicatedOnboardingFlow);
-                const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
-                const needsOnboarding = state.isCompleted !== true;
-                setAreShowing(enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding));
-                setLoading(false);
-            });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    // useEffect(() => {
+    //     console.log("running getOnboardingState effect");
+    //     getGitpodService()
+    //         .server.getOnboardingState()
+    //         .then((state) => {
+    //             console.log("getOnboardingState", state, enableDedicatedOnboardingFlow);
+    //             const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
+    //             const needsOnboarding = state.isCompleted !== true;
+    //             setAreShowing(enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding));
+    //             setLoading(false);
+    //         });
+    //     // eslint-disable-next-line react-hooks/exhaustive-deps
+    // }, []);
 
     return {
         // Feature flag must be on
         // Either setup forced via query param, or onboarding state is not completed
         // Also don't show if we've marked it as completed (user finished last step)
-        // showOnboarding: enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding) && !hasCompleted,
-        showOnboarding: areShowing && !hasCompleted,
-        // isLoading: enableDedicatedOnboardingFlow && isLoading,
-        isLoading: loading,
+        showOnboarding: enableDedicatedOnboardingFlow && inProgress,
+        // showOnboarding: areShowing && !hasCompleted,
+        isLoading: enableDedicatedOnboardingFlow && isLoading,
+        // isLoading: loading,
         markCompleted,
+        // markInProgress,
     };
 };
 
@@ -69,9 +83,9 @@ export const useOnboardingState = () => {
             return getGitpodService().server.getOnboardingState();
         },
         {
-            // // TODO: determine if this is helpful to cache longer
-            // staleTime: 1000 * 60 * 60 * 1, // 1h
-            // cacheTime: 1000 * 60 * 60 * 1, // 1h
+            // Cache for a bit so we can avoid having the value change before we're ready
+            staleTime: 1000 * 60 * 60 * 1, // 1h
+            cacheTime: 1000 * 60 * 60 * 1, // 1h
             // Only query if feature flag is enabled
             enabled: enableDedicatedOnboardingFlow,
         },

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -17,22 +17,17 @@ const FORCE_SETUP_PARAM_VALUE = "force";
 export const useCheckDedicatedSetup = () => {
     // track if user has finished onboarding so we avoid showing the onboarding
     // again in case onboarding state doesn't updated right away
-    // const [loading, setLoading] = useState(true);
-    // const [areShowing, setAreShowing] = useState(false);
     const [inProgress, setInProgress] = useState(false);
-    const [hasCompleted, setHasCompleted] = useState(false);
 
     const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
     const params = useQueryParams();
 
     const { data: onboardingState, isLoading } = useOnboardingState();
-    // console.log("enableDedicatedOnboardingFlow", enableDedicatedOnboardingFlow);
+    console.log("onboardingState", onboardingState);
 
     const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
-    const needsOnboarding = forceSetup || onboardingState?.isCompleted !== true;
+    const needsOnboarding = forceSetup || (onboardingState && onboardingState.isCompleted !== true);
 
-    // const markInProgress = useCallback(() => setHasCompleted(true), []);
-    // const markCompleted = useCallback(() => setHasCompleted(true), []);
     const markCompleted = useCallback(() => setInProgress(false), []);
 
     // If needsOnboarding changes to true, we want to set flow as in progress
@@ -41,36 +36,12 @@ export const useCheckDedicatedSetup = () => {
         if (needsOnboarding && !inProgress) {
             setInProgress(true);
         }
-    }, [inProgress, needsOnboarding]);
-
-    // We want to check once up front if we need to show the setup flow
-    // Once we've decided, we don't want to rely on derived state to determine it anymore
-    // so we can avoid any flashing of the setup flow as it progresses and we need to do things
-    // like re-fetch orgs after creation, or update signed in user
-    // useEffect(() => {
-    //     console.log("running getOnboardingState effect");
-    //     getGitpodService()
-    //         .server.getOnboardingState()
-    //         .then((state) => {
-    //             console.log("getOnboardingState", state, enableDedicatedOnboardingFlow);
-    //             const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
-    //             const needsOnboarding = state.isCompleted !== true;
-    //             setAreShowing(enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding));
-    //             setLoading(false);
-    //         });
-    //     // eslint-disable-next-line react-hooks/exhaustive-deps
-    // }, []);
+    }, [forceSetup, inProgress, needsOnboarding, onboardingState?.isCompleted]);
 
     return {
-        // Feature flag must be on
-        // Either setup forced via query param, or onboarding state is not completed
-        // Also don't show if we've marked it as completed (user finished last step)
         showOnboarding: enableDedicatedOnboardingFlow && inProgress,
-        // showOnboarding: areShowing && !hasCompleted,
         isLoading: enableDedicatedOnboardingFlow && isLoading,
-        // isLoading: loading,
         markCompleted,
-        // markInProgress,
     };
 };
 

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -47,9 +47,9 @@ export const useOnboardingState = () => {
             return getGitpodService().server.getOnboardingState();
         },
         {
-            // TODO: determine if this is helpful to cache longer
-            staleTime: 1000 * 60 * 60 * 1, // 1h
-            cacheTime: 1000 * 60 * 60 * 1, // 1h
+            // // TODO: determine if this is helpful to cache longer
+            // staleTime: 1000 * 60 * 60 * 1, // 1h
+            // cacheTime: 1000 * 60 * 60 * 1, // 1h
             // Only query if feature flag is enabled
             enabled: enableDedicatedOnboardingFlow,
         },

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -4,20 +4,44 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { useQuery } from "@tanstack/react-query";
 import { useQueryParams } from "../hooks/use-query-params";
+import { getGitpodService } from "../service/service";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 const FORCE_SETUP_PARAM = "dedicated-setup";
 const FORCE_SETUP_PARAM_VALUE = "force";
 
 export const useCheckDedicatedSetup = () => {
     const params = useQueryParams();
+    const { data: onboardingState, isLoading } = useOnboardingState();
+    const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
 
     const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
+    const needsOnboarding = onboardingState?.isCompleted !== true;
 
-    // For now to aid dev only show if query param is set
-    // TODO: update this once a new backend method is ready that will let us know if dedicated setup is needed
     return {
-        needsOnboarding: forceSetup,
-        isLoading: false,
+        // Feature flag must be on
+        // Either setup forced via query param, or onboarding state is not completed
+        showOnboarding: enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding),
+        isLoading,
     };
+};
+
+export const useOnboardingState = () => {
+    const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
+
+    return useQuery(
+        ["onboarding-state"],
+        async () => {
+            return getGitpodService().server.getOnboardingState();
+        },
+        {
+            // TODO: determine if this is helpful to cache longer
+            staleTime: 1000 * 60 * 60 * 1, // 1h
+            cacheTime: 1000 * 60 * 60 * 1, // 1h
+            // Only query if feature flag is enabled
+            enabled: enableDedicatedOnboardingFlow,
+        },
+    );
 };

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -20,6 +20,8 @@ export const useCheckDedicatedSetup = () => {
     const params = useQueryParams();
     const { data: onboardingState, isLoading } = useOnboardingState();
     const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
+    console.log("enableDedicatedOnboardingFlow", enableDedicatedOnboardingFlow);
+    console.log("onboardingState", onboardingState);
 
     const forceSetup = params.get(FORCE_SETUP_PARAM) === FORCE_SETUP_PARAM_VALUE;
     const needsOnboarding = onboardingState?.isCompleted !== true;
@@ -31,7 +33,7 @@ export const useCheckDedicatedSetup = () => {
         // Either setup forced via query param, or onboarding state is not completed
         // Also don't show if we've marked it as completed (user finished last step)
         showOnboarding: enableDedicatedOnboardingFlow && (forceSetup || needsOnboarding) && !hasCompleted,
-        isLoading,
+        isLoading: enableDedicatedOnboardingFlow && isLoading,
         markCompleted,
     };
 };

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -5,7 +5,8 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import React, { createContext, useState, useContext, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import React, { createContext, useState, useContext, useMemo, useCallback } from "react";
 
 const UserContext = createContext<{
     user?: User;
@@ -17,8 +18,20 @@ const UserContext = createContext<{
 const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
 
+    const client = useQueryClient();
+
+    const doSetUser = useCallback(
+        (updatedUser: User) => {
+            if (user?.id !== updatedUser.id) {
+                client.clear();
+            }
+            setUser(updatedUser);
+        },
+        [user?.id, setUser, client],
+    );
+
     // Wrap value in useMemo to avoid unnecessary re-renders
-    const ctxValue = useMemo(() => ({ user, setUser }), [user, setUser]);
+    const ctxValue = useMemo(() => ({ user, setUser: doSetUser }), [user, doSetUser]);
 
     return <UserContext.Provider value={ctxValue}>{children}</UserContext.Provider>;
 };

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -384,6 +384,7 @@ export class TeamDBImpl implements TeamDB {
         const result = await repo.query(
             `select org.id from d_b_team as org inner join d_b_oidc_client_config as oidc on org.id = oidc.organizationId
                 where oidc.active = 1
+                and oidc.deleted = 0
                 and org.deleted = 0
                 and org.markedDeleted = 0
                 limit 1;`,

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4009,13 +4009,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         // A shortcut for gitpod.io, but also for Dedicated PoC.
         // This is controlled by feature flag (per Gitpod host.)
-        if (!this.enableDedicatedOnboardingFlow) {
-            console.log("enableDedicatedOnboardingFlow is disabled, return isCompleted:true");
-            return {
-                isCompleted: true,
-                hasAnyOrg: true,
-            };
-        }
+        // TODO: figure out how to enable this feature flag check w/o it having a lag (comes back false, then true, relies on UI making multiple calls to get the correct value)
+        // if (!this.enableDedicatedOnboardingFlow) {
+        //     console.log("enableDedicatedOnboardingFlow is disabled, return isCompleted:true");
+        //     return {
+        //         isCompleted: true,
+        //         hasAnyOrg: true,
+        //     };
+        // }
 
         // Optimized check for completed setup
         const hasAnyOrgWithActiveSSO = await this.teamDB.hasAnyOrgWithActiveSSO();

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4007,17 +4007,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getOnboardingState(ctx: TraceContext): Promise<GitpodServer.OnboardingState> {
         this.checkAndBlockUser("getOnboardingState");
 
-        // A shortcut for gitpod.io, but also for Dedicated PoC.
-        // This is controlled by feature flag (per Gitpod host.)
-        // TODO: figure out how to enable this feature flag check w/o it having a lag (comes back false, then true, relies on UI making multiple calls to get the correct value)
-        // if (!this.enableDedicatedOnboardingFlow) {
-        //     console.log("enableDedicatedOnboardingFlow is disabled, return isCompleted:true");
-        //     return {
-        //         isCompleted: true,
-        //         hasAnyOrg: true,
-        //     };
-        // }
-
         // Optimized check for completed setup
         const hasAnyOrgWithActiveSSO = await this.teamDB.hasAnyOrgWithActiveSSO();
         if (hasAnyOrgWithActiveSSO) {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4004,18 +4004,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
     }
 
-    protected _getOnboardingState: GitpodServer.OnboardingState | undefined;
-
     async getOnboardingState(ctx: TraceContext): Promise<GitpodServer.OnboardingState> {
         this.checkAndBlockUser("getOnboardingState");
-
-        if (this._getOnboardingState) {
-            return this._getOnboardingState;
-        }
 
         // A shortcut for gitpod.io, but also for Dedicated PoC.
         // This is controlled by feature flag (per Gitpod host.)
         if (!this.enableDedicatedOnboardingFlow) {
+            console.log("enableDedicatedOnboardingFlow is disabled, return isCompleted:true");
             return {
                 isCompleted: true,
                 hasAnyOrg: true,
@@ -4025,12 +4020,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         // Optimized check for completed setup
         const hasAnyOrgWithActiveSSO = await this.teamDB.hasAnyOrgWithActiveSSO();
         if (hasAnyOrgWithActiveSSO) {
-            // Let's cache the state at least per connection.
-            this._getOnboardingState = {
+            return {
                 isCompleted: true,
                 hasAnyOrg: true,
             };
-            return this._getOnboardingState;
         }
 
         // Find useful details about the state of the Gitpod installation.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Hooks up the new `getOnboardingState()` api to our check for showing the dedicated setup. I had to add a bit of client-side state tracking for when we show/complete the setup flow. I also made a couple other changes.

* Filtering out deleted oidc clients from `hasAnyOrgWithActiveSSO()`
* Removing the caching and ff check in `getOnboardingState()`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-245

## How to test
<!-- Provide steps to test this PR -->
* Try and login to the preview env with your gitpod.io email: https://bmh-dedica741b327561.preview.gitpod-dev.com/workspaces
* If you're an admin/owner of the org, you can also force the setup flow manually by adding `?dedicated-setup=force` to the url and reload.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-dedica741b327561</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-dedica741b327561.preview.gitpod-dev.com/workspaces" target="_blank">bmh-dedica741b327561.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
