### PR TITLE
At/testing-ff

### DIFF
--- a/components/gitpod-protocol/src/experiments/configcat-server.ts
+++ b/components/gitpod-protocol/src/experiments/configcat-server.ts
@@ -33,7 +33,7 @@ export function getExperimentsClientForBackend(): Client {
     const configCatClient = configcat.createClient(sdkKey, {
         pollIntervalSeconds: 3 * 60, // 3 minutes
         requestTimeoutMs: 2000,
-        logger: configcat.createConsoleLogger(LogLevel.Error),
+        logger: configcat.createConsoleLogger(LogLevel.Debug),
         maxInitWaitTimeSeconds: 0,
         baseUrl: process.env.CONFIGCAT_BASE_URL,
     });

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1312,7 +1312,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 log.info({ userId: this.user.id }, "Updating workspace without orgId.");
                 const userOrg = await this.userToTeamMigrationService.getUserOrganization(this.user);
                 const latestInstance = await this.workspaceDb.trace({}).findCurrentInstance(workspace.id);
-                this.userToTeamMigrationService.updateWorkspacesOrganizationId(
+                await this.userToTeamMigrationService.updateWorkspacesOrganizationId(
                     [{ workspace, latestInstance }],
                     userOrg.id,
                 );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-testing-ff</li>
	<li><b>🔗 URL</b> - <a href="https://at-testing-ff.preview.gitpod-dev.com/workspaces" target="_blank">at-testing-ff.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
