### PR TITLE
[server] mark admin as migrated

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1683183008878-AdminUserMigrated.ts
+++ b/components/gitpod-db/src/typeorm/migration/1683183008878-AdminUserMigrated.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "../../user-db";
+
+export class AdminUserMigrated1683183008878 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE d_b_user SET additionalData = JSON_UNQUOTE(
+                JSON_SET(
+                    additionalData,
+                    '$.isMigratedToTeamOnlyAttribution',
+                    CAST('true' AS JSON)
+                )) WHERE id = '${BUILTIN_INSTLLATION_ADMIN_USER_ID}'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // intentionally left blank, because we don't revert migrations
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

mark admin as migrated

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-296

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-migrate-admin</li>
	<li><b>🔗 URL</b> - <a href="https://se-migrate-admin.preview.gitpod-dev.com/workspaces" target="_blank">se-migrate-admin.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
