### PR TITLE
[server] Migrate snapshots jobs WEB-225

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -134,6 +134,7 @@ import { JobRunner } from "./jobs/runner";
 import { DatabaseGarbageCollector } from "./jobs/database-gc";
 import { OTSGarbageCollector } from "./jobs/ots-gc";
 import { UserToTeamMigrationService } from "./migration/user-to-team-migration-service";
+import { SnapshotsJob } from "./jobs/snapshots";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -362,6 +363,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
     bind(DatabaseGarbageCollector).toSelf().inSingletonScope();
     bind(OTSGarbageCollector).toSelf().inSingletonScope();
+    bind(SnapshotsJob).toSelf().inSingletonScope();
     bind(JobRunner).toSelf().inSingletonScope();
 
     // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -16,6 +16,7 @@ import { OTSGarbageCollector } from "./ots-gc";
 import { TokenGarbageCollector } from "./token-gc";
 import { WebhookEventGarbageCollector } from "./webhook-gc";
 import { WorkspaceGarbageCollector } from "./workspace-gc";
+import { SnapshotsJob } from "./snapshots";
 
 export const Job = Symbol("Job");
 
@@ -35,11 +36,19 @@ export class JobRunner {
     @inject(TokenGarbageCollector) protected tokenGC: TokenGarbageCollector;
     @inject(WebhookEventGarbageCollector) protected webhookGC: WebhookEventGarbageCollector;
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
+    @inject(SnapshotsJob) protected snapshotsJob: SnapshotsJob;
 
     public start(): DisposableCollection {
         const disposables = new DisposableCollection();
 
-        const jobs: Job[] = [this.databaseGC, this.otsGC, this.tokenGC, this.webhookGC, this.workspaceGC];
+        const jobs: Job[] = [
+            this.databaseGC,
+            this.otsGC,
+            this.tokenGC,
+            this.webhookGC,
+            this.workspaceGC,
+            this.snapshotsJob,
+        ];
 
         for (let job of jobs) {
             log.info(`Registered job ${job.name} in job runner.`, {

--- a/components/server/src/jobs/snapshots.ts
+++ b/components/server/src/jobs/snapshots.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Job } from "./runner";
+import { StorageClient } from "../storage/storage-client";
+import { Snapshot } from "@gitpod/gitpod-protocol";
+import { Config } from "../config";
+
+const SNAPSHOT_TIMEOUT_SECONDS = 60 * 30;
+const SNAPSHOT_POLL_INTERVAL_SECONDS = 5;
+
+@injectable()
+export class SnapshotsJob implements Job {
+    @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
+    @inject(StorageClient) protected readonly storageClient: StorageClient;
+    @inject(Config) protected readonly config: Config;
+
+    public name = "snapshots";
+    public lockId = ["snapshots"];
+    public frequencyMs = 5 * 60 * 1000; // every 5 minutes
+
+    public async run(): Promise<void> {
+        if (this.config.completeSnapshotJob?.disabled) {
+            log.info("snapshots: Snapshot completion job is disabled.");
+            return;
+        }
+
+        log.info("snapshots: we're leading the quorum. picking up pending snapshots and driving them home.");
+        const step = 50; // make sure we're not flooding ourselves
+        const { snapshots: pendingSnapshots, total } = await this.workspaceDb.findSnapshotsWithState(
+            "pending",
+            0,
+            step,
+        );
+        if (total > step) {
+            log.warn("snapshots: looks like we have more pending snapshots then we can handle!");
+        }
+
+        for (const snapshot of pendingSnapshots) {
+            const workspace = await this.workspaceDb.findById(snapshot.originalWorkspaceId);
+            if (!workspace) {
+                log.error(
+                    { workspaceId: snapshot.originalWorkspaceId },
+                    `snapshots: unable to find workspace for snapshot`,
+                    { snapshotId: snapshot.id },
+                );
+                continue;
+            }
+
+            this.driveSnapshot({ workspaceOwner: workspace.ownerId, snapshot }).catch((err) =>
+                log.error("driveSnapshot", err),
+            );
+        }
+    }
+
+    protected async driveSnapshot(opts: { workspaceOwner: string; snapshot: Snapshot }): Promise<void> {
+        if (opts.snapshot.state === "available") {
+            return;
+        }
+        if (opts.snapshot.state === "error") {
+            throw new Error(`snapshot error: ${opts.snapshot.message}`);
+        }
+
+        const { id: snapshotId, bucketId, originalWorkspaceId, creationTime } = opts.snapshot;
+        const start = new Date(creationTime).getTime();
+        while (start + SNAPSHOT_TIMEOUT_SECONDS * 1000 > Date.now()) {
+            await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_POLL_INTERVAL_SECONDS * 1000));
+
+            // did somebody else complete that snapshot?
+            const snapshot = await this.workspaceDb.findSnapshotById(snapshotId);
+            if (!snapshot) {
+                throw new Error(`no snapshot with id '${snapshotId}' found.`);
+            }
+            if (snapshot.state === "available") {
+                return;
+            }
+            if (snapshot.state === "error") {
+                throw new Error(`snapshot error: ${snapshot.message}`);
+            }
+
+            // pending: check if the snapshot is there
+            const exists = await this.storageClient.workspaceSnapshotExists(
+                opts.workspaceOwner,
+                originalWorkspaceId,
+                bucketId,
+            );
+            if (exists) {
+                await this.workspaceDb.updateSnapshot({
+                    id: snapshotId,
+                    state: "available",
+                    availableTime: new Date().toISOString(),
+                });
+                return;
+            }
+        }
+
+        // took too long
+        const message = `snapshot timed out after taking longer than ${SNAPSHOT_TIMEOUT_SECONDS}s.`;
+        await this.workspaceDb.updateSnapshot({
+            id: snapshotId,
+            state: "error",
+            message,
+        });
+        throw new Error(message);
+    }
+}

--- a/components/server/src/jobs/snapshots.ts
+++ b/components/server/src/jobs/snapshots.ts
@@ -8,17 +8,13 @@ import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { inject, injectable } from "inversify";
 import { Job } from "./runner";
-import { StorageClient } from "../storage/storage-client";
-import { Snapshot } from "@gitpod/gitpod-protocol";
 import { Config } from "../config";
-
-const SNAPSHOT_TIMEOUT_SECONDS = 60 * 30;
-const SNAPSHOT_POLL_INTERVAL_SECONDS = 5;
+import { SnapshotService } from "../workspace/snapshot-service";
 
 @injectable()
 export class SnapshotsJob implements Job {
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
-    @inject(StorageClient) protected readonly storageClient: StorageClient;
+    @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
     @inject(Config) protected readonly config: Config;
 
     public name = "snapshots";
@@ -53,60 +49,9 @@ export class SnapshotsJob implements Job {
                 continue;
             }
 
-            this.driveSnapshot({ workspaceOwner: workspace.ownerId, snapshot }).catch((err) =>
-                log.error("driveSnapshot", err),
-            );
+            this.snapshotService
+                .driveSnapshot({ workspaceOwner: workspace.ownerId, snapshot })
+                .catch((err) => log.error("driveSnapshot", err));
         }
-    }
-
-    protected async driveSnapshot(opts: { workspaceOwner: string; snapshot: Snapshot }): Promise<void> {
-        if (opts.snapshot.state === "available") {
-            return;
-        }
-        if (opts.snapshot.state === "error") {
-            throw new Error(`snapshot error: ${opts.snapshot.message}`);
-        }
-
-        const { id: snapshotId, bucketId, originalWorkspaceId, creationTime } = opts.snapshot;
-        const start = new Date(creationTime).getTime();
-        while (start + SNAPSHOT_TIMEOUT_SECONDS * 1000 > Date.now()) {
-            await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_POLL_INTERVAL_SECONDS * 1000));
-
-            // did somebody else complete that snapshot?
-            const snapshot = await this.workspaceDb.findSnapshotById(snapshotId);
-            if (!snapshot) {
-                throw new Error(`no snapshot with id '${snapshotId}' found.`);
-            }
-            if (snapshot.state === "available") {
-                return;
-            }
-            if (snapshot.state === "error") {
-                throw new Error(`snapshot error: ${snapshot.message}`);
-            }
-
-            // pending: check if the snapshot is there
-            const exists = await this.storageClient.workspaceSnapshotExists(
-                opts.workspaceOwner,
-                originalWorkspaceId,
-                bucketId,
-            );
-            if (exists) {
-                await this.workspaceDb.updateSnapshot({
-                    id: snapshotId,
-                    state: "available",
-                    availableTime: new Date().toISOString(),
-                });
-                return;
-            }
-        }
-
-        // took too long
-        const message = `snapshot timed out after taking longer than ${SNAPSHOT_TIMEOUT_SECONDS}s.`;
-        await this.workspaceDb.updateSnapshot({
-            id: snapshotId,
-            state: "error",
-            message,
-        });
-        throw new Error(message);
     }
 }

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -306,9 +306,6 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         // Start periodic jobs
         this.jobRunner.start();
 
-        // Start long running migrations
-        this.startLongRunningMigrations().catch((err) => log.error("long running migrations errored", err));
-
         this.app = app;
 
         log.info("server initialized.");

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -306,11 +306,8 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         // Start periodic jobs
         this.jobRunner.start();
 
-        if (!this.config.completeSnapshotJob?.disabled) {
-            // Start Snapshot Service
-            log.info("Starting snapshot completion job...");
-            await this.snapshotService.start();
-        }
+        // Start long running migrations
+        this.startLongRunningMigrations().catch((err) => log.error("long running migrations errored", err));
 
         this.app = app;
 

--- a/components/server/src/workspace/snapshot-service.ts
+++ b/components/server/src/workspace/snapshot-service.ts
@@ -7,72 +7,15 @@
 import { inject, injectable } from "inversify";
 import { v4 as uuidv4 } from "uuid";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
-import { Disposable, GitpodServer, Snapshot } from "@gitpod/gitpod-protocol";
-import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { GitpodServer, Snapshot } from "@gitpod/gitpod-protocol";
 import { StorageClient } from "../storage/storage-client";
 import { ConsensusLeaderQorum } from "../consensus/consensus-leader-quorum";
 
-const SNAPSHOT_TIMEOUT_SECONDS = 60 * 30;
-const SNAPSHOT_POLL_INTERVAL_SECONDS = 5;
-const SNAPSHOT_DB_POLL_INTERVAL_SECONDS = 60 * 5;
-
-export interface WaitForSnapshotOptions {
-    workspaceOwner: string;
-    snapshot: Snapshot;
-}
-
-/**
- * SnapshotService hosts all code that's necessary to create snapshots and drive them to completion.
- * To guarantee every snapshot reacheds an end state ('error' or 'available') it regularly polls the DB to pick up and drive those as well.
- */
 @injectable()
 export class SnapshotService {
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
     @inject(StorageClient) protected readonly storageClient: StorageClient;
     @inject(ConsensusLeaderQorum) protected readonly leaderQuorum: ConsensusLeaderQorum;
-
-    protected readonly runningSnapshots: Map<string, Promise<void>> = new Map();
-
-    public async start(): Promise<Disposable> {
-        return repeat(
-            () => this.pickupAndDriveFromDbIfWeAreLeader().catch(log.error),
-            SNAPSHOT_DB_POLL_INTERVAL_SECONDS * 1000,
-        );
-    }
-
-    public async pickupAndDriveFromDbIfWeAreLeader() {
-        if (!(await this.leaderQuorum.areWeLeader())) {
-            return;
-        }
-
-        log.info("snapshots: we're leading the quorum. picking up pending snapshots and driving them home.");
-        const step = 50; // make sure we're not flooding ourselves
-        const { snapshots: pendingSnapshots, total } = await this.workspaceDb.findSnapshotsWithState(
-            "pending",
-            0,
-            step,
-        );
-        if (total > step) {
-            log.warn("snapshots: looks like we have more pending snapshots then we can handle!");
-        }
-
-        for (const snapshot of pendingSnapshots) {
-            const workspace = await this.workspaceDb.findById(snapshot.originalWorkspaceId);
-            if (!workspace) {
-                log.error(
-                    { workspaceId: snapshot.originalWorkspaceId },
-                    `snapshots: unable to find workspace for snapshot`,
-                    { snapshotId: snapshot.id },
-                );
-                continue;
-            }
-
-            this.driveSnapshotCached({ workspaceOwner: workspace.ownerId, snapshot }).catch((err) => {
-                /** ignore */
-            });
-        }
-    }
 
     public async createSnapshot(options: GitpodServer.TakeSnapshotOptions, snapshotUrl: string): Promise<Snapshot> {
         const id = uuidv4();
@@ -83,73 +26,5 @@ export class SnapshotService {
             bucketId: snapshotUrl,
             originalWorkspaceId: options.workspaceId,
         });
-    }
-
-    public async waitForSnapshot(opts: WaitForSnapshotOptions): Promise<void> {
-        return await this.driveSnapshotCached(opts);
-    }
-
-    protected async driveSnapshotCached(opts: WaitForSnapshotOptions): Promise<void> {
-        const running = this.runningSnapshots.get(opts.snapshot.id);
-        if (running) {
-            return running;
-        }
-
-        const started = this.driveSnapshot(opts)
-            .finally(() => this.runningSnapshots.delete(opts.snapshot.id))
-            .catch((err) => log.error("driveSnapshot", err));
-        this.runningSnapshots.set(opts.snapshot.id, started);
-        return started;
-    }
-
-    protected async driveSnapshot(opts: WaitForSnapshotOptions): Promise<void> {
-        if (opts.snapshot.state === "available") {
-            return;
-        }
-        if (opts.snapshot.state === "error") {
-            throw new Error(`snapshot error: ${opts.snapshot.message}`);
-        }
-
-        const { id: snapshotId, bucketId, originalWorkspaceId, creationTime } = opts.snapshot;
-        const start = new Date(creationTime).getTime();
-        while (start + SNAPSHOT_TIMEOUT_SECONDS * 1000 > Date.now()) {
-            await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_POLL_INTERVAL_SECONDS * 1000));
-
-            // did somebody else complete that snapshot?
-            const snapshot = await this.workspaceDb.findSnapshotById(snapshotId);
-            if (!snapshot) {
-                throw new Error(`no snapshot with id '${snapshotId}' found.`);
-            }
-            if (snapshot.state === "available") {
-                return;
-            }
-            if (snapshot.state === "error") {
-                throw new Error(`snapshot error: ${snapshot.message}`);
-            }
-
-            // pending: check if the snapshot is there
-            const exists = await this.storageClient.workspaceSnapshotExists(
-                opts.workspaceOwner,
-                originalWorkspaceId,
-                bucketId,
-            );
-            if (exists) {
-                await this.workspaceDb.updateSnapshot({
-                    id: snapshotId,
-                    state: "available",
-                    availableTime: new Date().toISOString(),
-                });
-                return;
-            }
-        }
-
-        // took too long
-        const message = `snapshot timed out after taking longer than ${SNAPSHOT_TIMEOUT_SECONDS}s.`;
-        await this.workspaceDb.updateSnapshot({
-            id: snapshotId,
-            state: "error",
-            message,
-        });
-        throw new Error(message);
     }
 }

--- a/components/server/src/workspace/snapshot-service.ts
+++ b/components/server/src/workspace/snapshot-service.ts
@@ -9,7 +9,6 @@ import { v4 as uuidv4 } from "uuid";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { GitpodServer, Snapshot } from "@gitpod/gitpod-protocol";
 import { StorageClient } from "../storage/storage-client";
-import { ConsensusLeaderQorum } from "../consensus/consensus-leader-quorum";
 
 export interface WaitForSnapshotOptions {
     workspaceOwner: string;
@@ -23,7 +22,6 @@ const SNAPSHOT_POLL_INTERVAL_SECONDS = 5;
 export class SnapshotService {
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
     @inject(StorageClient) protected readonly storageClient: StorageClient;
-    @inject(ConsensusLeaderQorum) protected readonly leaderQuorum: ConsensusLeaderQorum;
 
     public async createSnapshot(options: GitpodServer.TakeSnapshotOptions, snapshotUrl: string): Promise<Snapshot> {
         const id = uuidv4();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Migrate snapshot job to Redis and our new jobs wrapper.

This is the final piece, which unblocks removal of Messagebus leadership election

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-cb5b78d460</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-cb5b78d460.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-cb5b78d460.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
