### PR TITLE
VS Code Browser release 1.78

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: da355915c07d6bc5b965cb2a886c3c92303c2304
-  codeVersion: 1.77.3
+  codeCommit: d62456125e4cd827223752c71087aed947cc7261
+  codeVersion: 1.78.0
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2023.1.tar.gz"

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-5999c87e5c9bed5dcb7397820ef95b89ace55dab" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-3bd40c0145a7e8f2341ab2e0a83a4797ecca2519" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
 	CodeWebExtensionVersion     = "commit-a4223052a4da260954ad0d9c2e51c1f54ebda16a" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update code to `1.78.0`

Related https://github.com/gitpod-io/gitpod/issues/17351

## How to test
<!-- Provide steps to test this PR -->
- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [x] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-vscode-update-178</li>
	<li><b>🔗 URL</b> - <a href="https://jp-vscode-update-178.preview.gitpod-dev.com/workspaces" target="_blank">jp-vscode-update-178.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
