### PR TITLE
Add CDE Universe user menu link

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -98,9 +98,14 @@ export default function Menu() {
                                     </li>
                                 )}
                                 {isGitpodIo() && (
-                                    <li className="cursor-pointer">
-                                        <PillMenuItem name="Feedback" onClick={handleFeedbackFormClick} />
-                                    </li>
+                                    <>
+                                        <li className="cursor-pointer">
+                                            <PillMenuItem name="🪐 CDE Universe ↗" link="https://cdeuniverse.com/" />
+                                        </li>
+                                        <li className="cursor-pointer">
+                                            <PillMenuItem name="Feedback" onClick={handleFeedbackFormClick} />
+                                        </li>
+                                    </>
                                 )}
                             </ul>
                         </nav>


### PR DESCRIPTION
## Description

This will add CDE Universe as a user menu link.

| BEFORE | AFTER |
|-|-|
| <img width="1104" alt="Frame 1447" src="https://user-images.githubusercontent.com/120486/236265959-962540c7-34bd-49be-901a-b16728e4ff0d.png"> | <img width="1104" alt="Frame 1446" src="https://user-images.githubusercontent.com/120486/236265967-9f964bc0-2c06-4de0-8071-89e17ee01ce5.png"> |

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-add-cde5f12029bdc</li>
	<li><b>🔗 URL</b> - <a href="https://gt-add-cde5f12029bdc.preview.gitpod-dev.com/workspaces" target="_blank">gt-add-cde5f12029bdc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
