### PR TITLE
Admin user sign-in: redirect to /settings – WEB-304

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -161,9 +161,10 @@ export class UserController {
                     });
                 });
 
-                // Redirect the user to create a new Organization
-                // We'll want to be more specific about the redirect based on the cell information in the future.
-                res.redirect("/orgs/new", 307);
+                // Redirect the admin-user to the Org Settings page.
+                // The dashboard is expected to render the Onboading flow instead of the regular view,
+                // but if the browser is reloaded after completion of the flow, it should be fine to see the settings.
+                res.redirect("/settings", 307);
             } catch (e) {
                 log.error("Failed to sign-in as admin with OTS Token", e);
 


### PR DESCRIPTION


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-304


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
