### PR TITLE
[server] remove admin-user from org on first user sign-in – WEB-303

### DIFF
--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -108,6 +108,13 @@ export class IamSessionApp {
         await this.teamDb.addMemberToTeam(user.id, organizationId);
         if (firstMember) {
             await this.teamDb.setTeamMemberRole(user.id, organizationId, "owner");
+
+            // remove the admin-user from the org
+            try {
+                await this.teamDb.removeMemberFromTeam(BUILTIN_INSTLLATION_ADMIN_USER_ID, organizationId);
+            } catch {
+                // ignore errors if membership would not exist.
+            }
         }
 
         return user;


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-303

## How to test
see unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
