### PR TITLE
[papi] select active OIDC config for start request – WEB-316

### DIFF
--- a/components/gitpod-db/go/dbtest/oidc_client_config.go
+++ b/components/gitpod-db/go/dbtest/oidc_client_config.go
@@ -31,10 +31,12 @@ func NewOIDCClientConfig(t *testing.T, record db.OIDCClientConfig) db.OIDCClient
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	result := db.OIDCClientConfig{
-		ID:           uuid.New(),
-		Issuer:       "issuer",
-		Data:         encrypted,
-		LastModified: now,
+		ID:             uuid.New(),
+		OrganizationID: uuid.New(),
+		Issuer:         "issuer",
+		Data:           encrypted,
+		LastModified:   now,
+		Active:         false,
 	}
 
 	if record.ID != uuid.Nil {
@@ -53,6 +55,10 @@ func NewOIDCClientConfig(t *testing.T, record db.OIDCClientConfig) db.OIDCClient
 		result.Data = record.Data
 	}
 
+	if record.Active {
+		result.Active = true
+	}
+
 	return result
 }
 
@@ -66,8 +72,9 @@ func CreateOIDCClientConfigs(t *testing.T, conn *gorm.DB, entries ...db.OIDCClie
 		records = append(records, record)
 		ids = append(ids, record.ID.String())
 
-		_, err := db.CreateOIDCClientConfig(context.Background(), conn, record)
+		foo, err := db.CreateOIDCClientConfig(context.Background(), conn, record)
 		require.NoError(t, err)
+		require.NotNil(t, foo)
 	}
 
 	t.Cleanup(func() {

--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -55,11 +55,15 @@ type OIDCSpec struct {
 
 func CreateOIDCClientConfig(ctx context.Context, conn *gorm.DB, cfg OIDCClientConfig) (OIDCClientConfig, error) {
 	if cfg.ID == uuid.Nil {
-		return OIDCClientConfig{}, errors.New("id must be set")
+		return OIDCClientConfig{}, errors.New("ID must be set")
+	}
+
+	if cfg.OrganizationID == uuid.Nil {
+		return OIDCClientConfig{}, errors.New("Organization ID must be set")
 	}
 
 	if cfg.Issuer == "" {
-		return OIDCClientConfig{}, errors.New("issuer must be set")
+		return OIDCClientConfig{}, errors.New("Issuer must be set")
 	}
 
 	tx := conn.
@@ -179,15 +183,18 @@ func GetOIDCClientConfigByOrgSlug(ctx context.Context, conn *gorm.DB, slug strin
 
 	tx := conn.
 		WithContext(ctx).
-		Table((&OIDCClientConfig{}).TableName()).
-		// TODO: is there a better way to reference table names here and below?
-		Joins("JOIN d_b_team team ON team.id = d_b_oidc_client_config.organizationId").
+		Table(fmt.Sprintf("%s as config", (&OIDCClientConfig{}).TableName())).
+		Joins(fmt.Sprintf("JOIN %s AS team ON team.id = config.organizationId", (&Team{}).TableName())).
 		Where("team.slug = ?", slug).
-		Where("d_b_oidc_client_config.deleted = ?", 0).
+		Where("config.deleted = ?", 0).
+		Where("config.active = ?", 1).
 		First(&config)
 
 	if tx.Error != nil {
-		return OIDCClientConfig{}, fmt.Errorf("failed to get oidc client config by org slug (slug: %s): %v", slug, tx.Error)
+		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+			return OIDCClientConfig{}, fmt.Errorf("OIDC Client Config for Organization (slug: %s) does not exist: %w", slug, ErrorNotFound)
+		}
+		return OIDCClientConfig{}, fmt.Errorf("Failed to retrieve OIDC client config: %v", tx.Error)
 	}
 
 	return config, nil

--- a/components/gitpod-db/go/team_test.go
+++ b/components/gitpod-db/go/team_test.go
@@ -19,16 +19,18 @@ func Test_WriteRead(t *testing.T) {
 
 	team := db.Team{
 		ID:   uuid.New(),
-		Name: "Team1",
-		Slug: "team1",
+		Name: "Org 1",
+		Slug: "org-" + uuid.New().String(),
 	}
 
 	_, err := db.CreateTeam(context.Background(), conn, team)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where("slug = ?", team.Slug).Delete(&db.Team{}).Error)
+	})
 
 	candidates := []db.Team{
 		{ID: team.ID},
-		{Slug: team.Slug},
 	}
 
 	for _, read := range candidates {
@@ -45,11 +47,14 @@ func Test_GetTeamBySlug(t *testing.T) {
 	team := db.Team{
 		ID:   uuid.New(),
 		Name: "Team1",
-		Slug: "team1",
+		Slug: "org-" + uuid.New().String(),
 	}
 
 	_, err := db.CreateTeam(context.Background(), conn, team)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where("slug = ?", team.Slug).Delete(&db.Team{}).Error)
+	})
 
 	read, err := db.GetTeamBySlug(context.Background(), conn, team.Slug)
 	require.NoError(t, err)
@@ -69,11 +74,14 @@ func Test_GetTheSingleTeam(t *testing.T) {
 	team := db.Team{
 		ID:   uuid.New(),
 		Name: "Team1",
-		Slug: "team1",
+		Slug: "org-" + uuid.New().String(),
 	}
 
 	_, err = db.CreateTeam(context.Background(), conn, team)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where("slug = ?", team.Slug).Delete(&db.Team{}).Error)
+	})
 
 	read, err := db.GetTheSingleTeam(context.Background(), conn)
 	require.NoError(t, err)
@@ -84,11 +92,14 @@ func Test_GetTheSingleTeam(t *testing.T) {
 	team2 := db.Team{
 		ID:   uuid.New(),
 		Name: "Team1",
-		Slug: "team1",
+		Slug: "org-" + uuid.New().String(),
 	}
 
 	_, err = db.CreateTeam(context.Background(), conn, team2)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where("slug = ?", team.Slug).Delete(&db.Team{}).Error)
+	})
 
 	_, err = db.GetTheSingleTeam(context.Background(), conn)
 	require.Error(t, err)

--- a/components/public-api-server/pkg/oidc/service.go
+++ b/components/public-api-server/pkg/oidc/service.go
@@ -45,6 +45,7 @@ type ClientConfig struct {
 	ID             string
 	OrganizationID string
 	Issuer         string
+	Active         bool
 	OAuth2Config   *oauth2.Config
 	VerifierConfig *goidc.Config
 }
@@ -227,6 +228,7 @@ func (s *Service) convertClientConfig(ctx context.Context, dbEntry db.OIDCClient
 		ID:             dbEntry.ID.String(),
 		OrganizationID: dbEntry.OrganizationID.String(),
 		Issuer:         dbEntry.Issuer,
+		Active:         dbEntry.Active,
 		OAuth2Config: &oauth2.Config{
 			ClientID:     spec.ClientID,
 			ClientSecret: spec.ClientSecret,

--- a/components/public-api-server/pkg/oidc/service_test.go
+++ b/components/public-api-server/pkg/oidc/service_test.go
@@ -78,12 +78,14 @@ func TestGetClientConfigFromStartRequest(t *testing.T) {
 	service, dbConn := setupOIDCServiceForTests(t)
 	config, team := createConfig(t, dbConn, &ClientConfig{
 		Issuer:         issuer,
+		Active:         true,
 		VerifierConfig: &oidc.Config{},
 		OAuth2Config:   &oauth2.Config{},
 	})
 	// create second org to emulate an installation with multiple orgs
 	createConfig(t, dbConn, &ClientConfig{
 		Issuer:         issuer,
+		Active:         true,
 		VerifierConfig: &oidc.Config{},
 		OAuth2Config:   &oauth2.Config{},
 	})
@@ -143,6 +145,7 @@ func TestGetClientConfigFromStartRequestSingleOrg(t *testing.T) {
 	dbConn.Delete(&db.Team{}, "1=1")
 	config, team := createConfig(t, dbConn, &ClientConfig{
 		Issuer:         issuer,
+		Active:         true,
 		VerifierConfig: &oidc.Config{},
 		OAuth2Config:   &oauth2.Config{},
 	})
@@ -190,7 +193,7 @@ func TestGetClientConfigFromStartRequestSingleOrg(t *testing.T) {
 			if tc.ExpectedError != true {
 				require.NoError(te, err)
 				require.NotNil(te, config)
-				require.Equal(te, tc.ExpectedId, config.ID)
+				require.Equal(te, tc.ExpectedId, config.ID, "wrong config")
 			}
 		})
 	}
@@ -348,9 +351,12 @@ func createConfig(t *testing.T, dbConn *gorm.DB, config *ClientConfig) (db.OIDCC
 		ID:   orgID,
 		Name: "Org 1",
 		// creating random slug using UUID generator, because it's handy here
-		Slug: uuid.New().String(),
+		Slug: "org-" + uuid.New().String(),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbConn.Where("slug = ?", team.Slug).Delete(&db.Team{}).Error)
+	})
 
 	data, err := db.EncryptJSON(dbtest.CipherSet(t), db.OIDCSpec{
 		ClientID:     config.OAuth2Config.ClientID,
@@ -359,10 +365,18 @@ func createConfig(t *testing.T, dbConn *gorm.DB, config *ClientConfig) (db.OIDCC
 	require.NoError(t, err)
 
 	created := dbtest.CreateOIDCClientConfigs(t, dbConn, db.OIDCClientConfig{
+		ID:             uuid.New(),
 		OrganizationID: orgID,
 		Issuer:         config.Issuer,
+		Active:         false,
 		Data:           data,
-	})[0]
+	}, db.OIDCClientConfig{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		Issuer:         config.Issuer,
+		Active:         config.Active,
+		Data:           data,
+	})[1]
 
 	return created, team
 }


### PR DESCRIPTION
Ensure the single active OIDC client config is selected properly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of WEB-316

## How to test
See unit tests.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
