### PR TITLE
[registry-facade] Log handle manifest request

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -161,7 +161,7 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 			retrieved, dontCache, err = bh.retrieveFromSource(ctx, s, w, r)
 			if err != nil {
-				log.WithField("src", src.Name()).WithError(err).Error("unable to retrieve blob")
+				log.WithField("src", s.Name()).WithError(err).Error("unable to retrieve blob")
 			}
 
 			if retrieved {

--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -43,6 +43,7 @@ func (reg *Registry) handleManifest(ctx context.Context, r *http.Request) http.H
 			respondWithError(w, distv2.ErrorCodeManifestUnknown)
 		})
 	}
+	log.Infof("provider %s will handle request for %s", spname, name)
 	spec, err := sp.GetSpec(ctx, name)
 	if err != nil {
 		// treat invalid names from node-labeler as debug, not errors


### PR DESCRIPTION
## Description
Log handle manifest request

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
