### PR TITLE
Dedicated Setup - Avoid creating duplicate configs

### DIFF
--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -48,6 +48,12 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete }) => {
                 // Create returns the new config, update does not
                 if ("config" in response && response.config) {
                     configId = response.config.id;
+
+                    // Update our local state with the new config ID in case we created a new one
+                    // This ensures we update the correct config if we save again vs. create a new one
+                    dispatch({
+                        id: configId,
+                    });
                 }
 
                 await openOIDCStartWindow({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes a bug where duplicate sso configs could get created each time a user tries to "verify" their configuration. Tracking the newly created config's id in our local state resolves this so that subsequent attempts to verify will update the existing config vs. creating a new one each time.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-316

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
