### PR TITLE
Display active state on org sso configs

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -15,6 +15,7 @@ export default function ConfirmationModal(props: {
     children?: Entity | React.ReactChild[] | React.ReactChild;
     buttonText?: string;
     buttonDisabled?: boolean;
+    buttonLoading?: boolean;
     visible?: boolean;
     warningHead?: string;
     warningText?: string;
@@ -27,7 +28,13 @@ export default function ConfirmationModal(props: {
         <Button type="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>
             Cancel
         </Button>,
-        <Button type="danger" className="ml-2" onClick={props.onConfirm} disabled={props.buttonDisabled}>
+        <Button
+            type="danger"
+            className="ml-2"
+            onClick={props.onConfirm}
+            disabled={props.buttonDisabled}
+            loading={props.buttonLoading}
+        >
             {props.buttonText || "Yes, I'm Sure"}
         </Button>,
     ];

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -5,39 +5,25 @@
  */
 
 import Alert from "./Alert";
-import Modal from "./Modal";
-import { useRef, useEffect } from "react";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "./Modal";
+import { useRef, useEffect, ReactNode } from "react";
 import { Button } from "./Button";
 
 export default function ConfirmationModal(props: {
     title?: string;
     areYouSureText?: string;
-    children?: Entity | React.ReactChild[] | React.ReactChild;
+    children?: Entity | ReactNode;
     buttonText?: string;
     buttonDisabled?: boolean;
     buttonLoading?: boolean;
     visible?: boolean;
     warningHead?: string;
     warningText?: string;
+    footerAlert?: ReactNode;
     onClose: () => void;
     onConfirm: () => void;
 }) {
     const cancelButtonRef = useRef<HTMLButtonElement>(null);
-
-    const buttons = [
-        <Button type="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>
-            Cancel
-        </Button>,
-        <Button
-            type="danger"
-            className="ml-2"
-            onClick={props.onConfirm}
-            disabled={props.buttonDisabled}
-            loading={props.buttonLoading}
-        >
-            {props.buttonText || "Yes, I'm Sure"}
-        </Button>,
-    ];
 
     const buttonDisabled = useRef(props.buttonDisabled);
     useEffect(() => {
@@ -47,8 +33,6 @@ export default function ConfirmationModal(props: {
 
     return (
         <Modal
-            title={props.title || "Confirm"}
-            buttons={buttons}
             visible={props.visible === undefined ? true : props.visible}
             onClose={props.onClose}
             onEnter={() => {
@@ -63,24 +47,43 @@ export default function ConfirmationModal(props: {
                 return true;
             }}
         >
-            <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
-            {props.warningText && (
-                <Alert type="warning" className="mb-4">
-                    <strong>{props.warningHead}</strong>
-                    {props.warningHead ? ": " : ""}
-                    {props.warningText}
-                </Alert>
-            )}
-            {isEntity(props.children) ? (
-                <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
-                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
-                    {props.children.description && (
-                        <p className="text-gray-500 truncate">{props.children.description}</p>
-                    )}
-                </div>
-            ) : (
-                props.children
-            )}
+            <ModalHeader>{props.title || "Confirm"}</ModalHeader>
+            <ModalBody>
+                <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
+                {props.warningText && (
+                    <Alert type="warning" className="mb-4">
+                        <strong>{props.warningHead}</strong>
+                        {props.warningHead ? ": " : ""}
+                        {props.warningText}
+                    </Alert>
+                )}
+                {isEntity(props.children) ? (
+                    <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
+                        <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">
+                            {props.children.name}
+                        </p>
+                        {props.children.description && (
+                            <p className="text-gray-500 truncate">{props.children.description}</p>
+                        )}
+                    </div>
+                ) : (
+                    props.children
+                )}
+            </ModalBody>
+            <ModalFooter alert={props.footerAlert}>
+                <Button type="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>
+                    Cancel
+                </Button>
+                <Button
+                    type="danger"
+                    className="ml-2"
+                    onClick={props.onConfirm}
+                    disabled={props.buttonDisabled}
+                    loading={props.buttonLoading}
+                >
+                    {props.buttonText || "Yes, I'm Sure"}
+                </Button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/components/EmptyMessage.tsx
+++ b/components/dashboard/src/components/EmptyMessage.tsx
@@ -10,7 +10,7 @@ import { Button } from "./Button";
 import { Heading2, Subheading } from "./typography/headings";
 
 type Props = {
-    title: ReactNode;
+    title?: ReactNode;
     subtitle?: ReactNode;
     buttonText?: string;
     onClick?: () => void;
@@ -28,8 +28,8 @@ export const EmptyMessage: FC<Props> = ({ title, subtitle, buttonText, onClick, 
             )}
         >
             <div className="flex flex-col justify-center items-center text-center space-y-4">
-                <Heading2 color="light">{title}</Heading2>
-                <Subheading className="max-w-md">{subtitle}</Subheading>
+                {title && <Heading2 color="light">{title}</Heading2>}
+                {subtitle && <Subheading className="max-w-md">{subtitle}</Subheading>}
                 {buttonText && <Button onClick={handleClick}>{buttonText}</Button>}
             </div>
         </div>

--- a/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
@@ -9,6 +9,7 @@ import { FC, useCallback, useReducer } from "react";
 import { Button } from "../../components/Button";
 import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
 import { ssoConfigReducer, isValid, useSaveSSOConfig, SSOConfigForm } from "./SSOConfigForm";
+import Alert from "../../components/Alert";
 
 type Props = {
     clientConfig?: OIDCClientConfig;
@@ -50,12 +51,13 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
                 return false;
             }}
         >
-            <ModalHeader>{isNew ? "New OIDC Client" : "OIDC Client"}</ModalHeader>
+            <ModalHeader>{isNew ? "New SSO Configuration" : "Edit SSO Configuration"}</ModalHeader>
             <ModalBody>
-                <div className="flex flex-col">
-                    <span className="text-gray-500">Enter this information from your OIDC service.</span>
-                </div>
-
+                {clientConfig?.active && (
+                    <Alert type="message" className="mb-4">
+                        Please be careful! Your are editing an active SSO configuration.
+                    </Alert>
+                )}
                 <SSOConfigForm config={ssoConfig} onChange={dispatch} />
             </ModalBody>
             <ModalFooter alert={error ? <SaveErrorAlert error={error} /> : null}>
@@ -63,7 +65,7 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
                     Cancel
                 </Button>
                 <Button onClick={saveConfig} disabled={!configIsValid} loading={isLoading}>
-                    Save
+                    {isNew ? "Create" : "Save"}
                 </Button>
             </ModalFooter>
         </Modal>

--- a/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
@@ -54,8 +54,9 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onClose }) => {
             <ModalHeader>{isNew ? "New SSO Configuration" : "Edit SSO Configuration"}</ModalHeader>
             <ModalBody>
                 {clientConfig?.active && (
-                    <Alert type="message" className="mb-4">
-                        Please be careful! Your are editing an active SSO configuration.
+                    <Alert type="warning" className="mb-4">
+                        Warning, you are editing an active SSO configuration. A misconfiguration may prevent any user
+                        from logging in.
                     </Alert>
                 )}
                 <SSOConfigForm config={ssoConfig} onChange={dispatch} />

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -29,7 +29,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 separator: true,
             },
             {
-                title: "Login",
+                title: "Log in",
                 onClick: () => {
                     window.location.href = gitpodHostUrl
                         .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -32,7 +32,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 separator: true,
             },
             {
-                title: "Verify",
+                title: "Login",
                 onClick: () => {
                     window.location.href = gitpodHostUrl
                         .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })
@@ -74,7 +74,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
 
     return (
         <>
-            <Item key={clientConfig.id}>
+            <Item>
                 <ItemFieldIcon>
                     <div
                         className={
@@ -87,10 +87,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 </ItemFieldIcon>
                 <ItemField className="flex flex-col flex-grow">
                     <span className="font-medium truncate overflow-ellipsis">{clientConfig.oidcConfig?.issuer}</span>
-                    {/* TODO: Address overflow here, these can be quite long */}
-                    <span className="text-sm text-gray-500 truncate overflow-ellipsis">
-                        {clientConfig.oauth2Config?.clientId}
-                    </span>
+                    <span className="text-sm text-gray-500 break-all">{clientConfig.oauth2Config?.clientId}</span>
                 </ItemField>
                 <ItemFieldContextMenu menuEntries={menuEntries} />
             </Item>

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -8,7 +8,7 @@ import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/
 import { FC, useCallback, useMemo, useState } from "react";
 import ConfirmationModal from "../../components/ConfirmationModal";
 import { ContextMenuEntry } from "../../components/ContextMenu";
-import { Item, ItemField, ItemFieldContextMenu } from "../../components/ItemsList";
+import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon } from "../../components/ItemsList";
 import { useDeleteOIDCClientMutation } from "../../data/oidc-clients/delete-oidc-client-mutation";
 import { gitpodHostUrl } from "../../service/service";
 import { OIDCClientConfigModal } from "./OIDCClientConfigModal";
@@ -29,7 +29,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 separator: true,
             },
             {
-                title: "Log in",
+                title: "Login",
                 onClick: () => {
                     window.location.href = gitpodHostUrl
                         .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })
@@ -37,6 +37,19 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 },
                 separator: true,
             },
+            ...(!clientConfig.active
+                ? [
+                      {
+                          title: "Activate",
+                          onClick: () => {
+                              window.location.href = gitpodHostUrl
+                                  .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}&activate=true` })
+                                  .toString();
+                          },
+                          separator: true,
+                      },
+                  ]
+                : []),
             {
                 title: "Remove",
                 customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
@@ -58,6 +71,16 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
     return (
         <>
             <Item key={clientConfig.id}>
+                <ItemFieldIcon>
+                    <div
+                        className={
+                            "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                            (clientConfig.active ? "bg-green-500" : "bg-gray-400")
+                        }
+                    >
+                        &nbsp;
+                    </div>
+                </ItemFieldIcon>
                 <ItemField className="flex flex-col flex-grow">
                     <span className="font-medium truncate overflow-ellipsis">{clientConfig.oidcConfig?.issuer}</span>
                     <span className="text-sm text-gray-500 truncate overflow-ellipsis">{clientConfig.id}</span>

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -13,6 +13,7 @@ import { useDeleteOIDCClientMutation } from "../../data/oidc-clients/delete-oidc
 import { gitpodHostUrl } from "../../service/service";
 import { OIDCClientConfigModal } from "./OIDCClientConfigModal";
 import { useToast } from "../../components/toasts/Toasts";
+import { ModalFooterAlert } from "../../components/Modal";
 
 type Props = {
     clientConfig: OIDCClientConfig;
@@ -104,11 +105,16 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                     buttonText="Remove"
                     buttonLoading={deleteOIDCClient.isLoading}
                     warningText={
-                        deleteOIDCClient.isError
-                            ? "There was a problem deleting the configuration"
-                            : clientConfig.active
+                        clientConfig.active
                             ? "Warning, you are about to remove the active SSO configuration. If you continue, SSO will be disabled for your organization and no one, including yourself, will be able to log in."
                             : ""
+                    }
+                    footerAlert={
+                        deleteOIDCClient.isError ? (
+                            <ModalFooterAlert type="danger">
+                                There was a problem deleting the configuration
+                            </ModalFooterAlert>
+                        ) : null
                     }
                     onClose={() => setShowDeleteConfirmation(false)}
                     onConfirm={deleteClient}

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -31,15 +31,6 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig }) => {
                 onClick: () => setShowEditModal(true),
                 separator: true,
             },
-            {
-                title: "Login",
-                onClick: () => {
-                    window.location.href = gitpodHostUrl
-                        .with({ pathname: `/iam/oidc/start`, search: `id=${clientConfig.id}` })
-                        .toString();
-                },
-                separator: true,
-            },
             ...(!clientConfig.active
                 ? [
                       {

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -40,14 +40,14 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
 
             <div className="flex flex-col space-y-2 md:flex-row md:items-start md:justify-between md:space-y-0">
                 <div>
-                    <Heading2>OpenID Connect clients</Heading2>
-                    <Subheading>Configure single sign-on for your organization.</Subheading>
+                    <Heading2>SSO Configurations</Heading2>
+                    <Subheading>Configure OpenID Connect single sign-on for your organization.</Subheading>
                 </div>
 
                 {clientConfigs.length !== 0 ? (
                     <div className="">
                         <Button className="whitespace-nowrap" onClick={onCreate}>
-                            New OIDC Client
+                            New Configuration
                         </Button>
                     </div>
                 ) : null}
@@ -55,9 +55,8 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
 
             {clientConfigs.length === 0 ? (
                 <EmptyMessage
-                    title="No OIDC providers"
-                    subtitle="Enable single sign-on for your organization using an external identity provider (IdP) service that supports the OpenID Connect (OIDC) standard, such as Google."
-                    buttonText="New OIDC Client"
+                    subtitle="Enable single sign-on for your organization using an external identity provider (IdP) service that supports the OpenID Connect (OIDC) standard, such as Google or Okta."
+                    buttonText="New Configuration"
                     onClick={onCreate}
                 />
             ) : (

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -8,7 +8,7 @@ import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/
 import { FC, useCallback, useState } from "react";
 import { Button } from "../../components/Button";
 import { EmptyMessage } from "../../components/EmptyMessage";
-import { Item, ItemField, ItemsList } from "../../components/ItemsList";
+import { Item, ItemField, ItemFieldIcon, ItemsList } from "../../components/ItemsList";
 import { SpinnerLoader } from "../../components/Loader";
 import { Heading2, Subheading } from "../../components/typography/headings";
 import { useOIDCClientsQuery } from "../../data/oidc-clients/oidc-clients-query";
@@ -63,9 +63,8 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
             ) : (
                 <ItemsList className="pt-6">
                     <Item header={true}>
-                        <ItemField className="flex flex-col">
-                            <span>Issuer URL</span>
-                        </ItemField>
+                        <ItemFieldIcon />
+                        <ItemField>Issuer URL</ItemField>
                     </Item>
                     {clientConfigs.map((cc) => (
                         <OIDCClientListItem key={cc.id} clientConfig={cc} />

--- a/components/public-api/go/experimental/v1/oidc.pb.go
+++ b/components/public-api/go/experimental/v1/oidc.pb.go
@@ -56,7 +56,7 @@ type OIDCClientConfig struct {
 	// Whether this config can be used for sign-ins.
 	// Defaults to false.
 	// Optional.
-	Active bool `protobuf:"varint,9,opt,name=active,proto3" json:"active,omitempty"`
+	Active bool `protobuf:"varint,9,opt,name=active,proto3" json:"active"`
 }
 
 func (x *OIDCClientConfig) Reset() {

--- a/components/public-api/go/experimental/v1/oidc.pb.go
+++ b/components/public-api/go/experimental/v1/oidc.pb.go
@@ -56,7 +56,7 @@ type OIDCClientConfig struct {
 	// Whether this config can be used for sign-ins.
 	// Defaults to false.
 	// Optional.
-	Active bool `protobuf:"varint,9,opt,name=active,proto3" json:"active"`
+	Active bool `protobuf:"varint,9,opt,name=active,proto3" json:"active,omitempty"`
 }
 
 func (x *OIDCClientConfig) Reset() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This updates the Org Settings SSO section to show if a config is active or not. It also adds an Activate link in the menu if the config isn't active already. This will go through the Log In flow and result in an activated sso config. 

There is some work associated with WEB-322 around a future iteration of the SSO Config page for nuances w/ activating/deactivating an SSO config that we can work on following this change.

![image](https://user-images.githubusercontent.com/367275/236910095-17c935ec-56bd-4aa6-9ece-565634b63d4f.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-313

## How to test
<!-- Provide steps to test this PR -->
* Create an Org in the preview environment.
* Under Settings => SSO - create a new SSO config.
* It should show up int he list as inactive (gray circle).
* If you have a valid config that works, you can click the Activate item in the menu. This will send you through the Log in flow w/ the SSO provider. 
* You'll need to logout, and back in with your first account that has org admin access.
* Verify the SSO Config is "active" (green circle).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-sso-co094769b0b4</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-sso-co094769b0b4.preview.gitpod-dev.com/workspaces" target="_blank">bmh-sso-co094769b0b4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
