### PR TITLE
[loadgen] update docs to support ws-manager-mk2

### DIFF
--- a/dev/loadgen/README.md
+++ b/dev/loadgen/README.md
@@ -14,11 +14,11 @@ You can find a short explanation of this tool in this [loom video](https://www.l
   ```
 - Fetch the TLS config from ws-manager
   ```console
-  gpctl clusters get-tls-config
+  gpctl clusters get-tls-config --secretName ws-manager-mk2-client-tls
   ```
 - Port-forward ws-manager
   ```console
-  while true; do kubectl port-forward deployment/ws-manager 12001:8080; done
+  while true; do kubectl port-forward deployment/ws-manager-mk2 12001:8080; done
   ```
 - Compile loadgen
   ```console
@@ -27,7 +27,7 @@ You can find a short explanation of this tool in this [loom video](https://www.l
   ```
 - Now you can start the benchmark with loadgen. If you want to keep the workspaces around after testing, add `--interactive`. Loadgen will then ask you before taking any destructive action. If you do not specify `--interative` loadgen will wait 2 minutes before workspaces are deleted. The config file located at the `./dev/loadgen/configs` folder.
   ```console
-  ./loadgen benchmark [config-file] --host localhost:12001 --tls ./wsman-tls --interactive
+  ./loadgen benchmark ./configs/prod-benchmark.yaml --host localhost:12001 --tls ./wsman-tls --interactive
   ```
 
 In order to configure the benchmark, you can use the configuration file


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
update docs to support ws-manager-mk2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Loadgen against a preview environment, if desired.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
