### PR TITLE
Show usage

### DIFF
--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -74,9 +74,7 @@ export default function OrganizationSelector() {
         BillingMode.showUsageBasedBilling(userBillingMode) &&
         !user?.additionalData?.isMigratedToTeamOnlyAttribution;
 
-    const showUsageForOrg = currentOrg.data?.isOwner && orgBillingMode?.mode === "usage-based";
-
-    if (showUsageForPersonalAccount || showUsageForOrg) {
+    if (showUsageForPersonalAccount || currentOrg.data) {
         linkEntries.push({
             title: "Usage",
             customContent: <LinkEntry>Usage</LinkEntry>,

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -262,7 +262,7 @@ class TestResourceAccess {
                 name: "member - get",
                 teamRole: "member",
                 operation: "get",
-                expectation: false,
+                expectation: true,
             },
             {
                 name: "member - update",
@@ -364,7 +364,7 @@ class TestResourceAccess {
             if (!owner) {
                 throw new Error("Bad test data: expected isOwner OR teamRole to be configured!");
             }
-            const actual = await resourceGuard.canAccess({ kind: "costCenter", owner }, "get");
+            const actual = await resourceGuard.canAccess({ kind: "costCenter", owner }, t.operation);
             expect(actual).to.be.eq(
                 t.expectation,
                 `"${t.name}" expected canAccess(resource, "${t.operation}") === ${t.expectation}, but was ${actual}`,

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -191,8 +191,11 @@ export class TeamMemberResourceGuard implements ResourceAccessGuard {
                     // This is handled in the "OwnerResourceGuard"
                     return false;
                 }
+                if (operation === "get") {
+                    return owner.members.some((m) => m.userId === this.userId);
+                }
                 // TODO(gpl) We should check whether we're looking at the right team for the right CostCenter here!
-                // Only team "owners" are allowed to do anything with CostCenters
+                // Only team "owners" are allowed to write CostCenters
                 return owner.members.filter((m) => m.role === "owner").some((m) => m.userId === this.userId);
         }
         return false;

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -196,7 +196,7 @@ class TestIamSessionApp {
         expect(result.body?.message).to.equal("OIDC client config id is missing");
     }
 
-    @test.only public async testSessionRequest_createUser_removes_admin() {
+    @test public async testSessionRequest_createUser_removes_admin() {
         // assert only admin is member of the org
         await this.teamDbMock.addMemberToTeam!(BUILTIN_INSTLLATION_ADMIN_USER_ID, "test-org");
         expect(this.teamDbMock.memberships.has(BUILTIN_INSTLLATION_ADMIN_USER_ID)).to.be.true;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds the usage view to all org members (previously only owners could see usage)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-314

## How to test
<!-- Provide steps to test this PR -->
Join https://se-usage.preview.gitpod-dev.com/orgs/join?inviteId=71788c56-a3bb-4de1-913c-ca81de001327

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-usage</li>
	<li><b>🔗 URL</b> - <a href="https://se-usage.preview.gitpod-dev.com/workspaces" target="_blank">se-usage.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
