### PR TITLE
[dashboards] Fix min/avg/max-over-time aggregate

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.json
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -94,14 +93,14 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"}[7d]))",
+          "expr": "avg_over_time(sum(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"})[7d])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Avg",
@@ -113,7 +112,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(min_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"}[7d]))",
+          "expr": "min_over_time(sum(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"})[7d])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Min",
@@ -125,7 +124,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(max_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"}[7d]))",
+          "expr": "max_over_time(sum(gitpod_ws_manager_mk2_workspace_phase_total{phase=\"Running\"})[7d])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Max",
@@ -175,9 +174,10 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "valueMode": "color"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -234,9 +234,10 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "valueMode": "color"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -293,7 +294,7 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 9
       },
@@ -318,7 +319,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -425,7 +426,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 65
       },
       "id": 13,
       "panels": [],
@@ -454,9 +455,9 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 17
+        "y": 66
       },
       "hiddenSeries": false,
       "id": 6,
@@ -479,7 +480,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -557,7 +558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 122
       },
       "id": 14,
       "panels": [],
@@ -604,9 +605,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 25
+        "y": 123
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -693,7 +694,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 179
       },
       "id": 15,
       "panels": [],
@@ -722,9 +723,9 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 33
+        "y": 180
       },
       "hiddenSeries": false,
       "id": 8,
@@ -853,7 +854,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 236
       },
       "id": 16,
       "panels": [],
@@ -881,9 +882,9 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 41
+        "y": 237
       },
       "hiddenSeries": false,
       "id": 9,
@@ -982,7 +983,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 293
       },
       "id": 17,
       "panels": [],
@@ -1010,9 +1011,9 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 49
+        "y": 294
       },
       "hiddenSeries": false,
       "id": 10,


### PR DESCRIPTION
## Description
Fixes min/avg/max_over_time aggregation on the Overview dashboard (in the `Stats(7d)` panel at the top), should take e.g. the `max` over the `sum` instead of the other way around, to get the max running workspace count in the past 7 days

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
