### PR TITLE
Add filter on variables list

### DIFF
--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -14,6 +14,7 @@ import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { EnvironmentVariableEntry } from "./EnvironmentVariableEntry";
 import { Button } from "../components/Button";
 import { Heading2, Subheading } from "../components/typography/headings";
+import EnvironmentVariablesSearchBar from "./EnvironmentVariablesSearchBar";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -144,6 +145,8 @@ function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
 }
 
 export default function EnvVars() {
+    const [searchTerm, setSearchTerm] = useState("");
+    let allEnvVars: UserEnvVarValue[];
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
     const [currentEnvVar, setCurrentEnvVar] = useState({
         name: "",
@@ -156,7 +159,20 @@ export default function EnvVars() {
         await getGitpodService()
             .server.getAllEnvVars()
             .then((r) => setEnvVars(r.sort(sortEnvVars)));
+            allEnvVars = envVars;
     };
+
+    useEffect(() => {
+        const lowerSearchTerm = searchTerm.toLowerCase();
+
+        if(lowerSearchTerm[0] === "/"){
+            setEnvVars(allEnvVars.filter((envVar) => envVar.repositoryPattern.includes(lowerSearchTerm)));
+        }
+        else{
+            setEnvVars(allEnvVars.filter((envVar) => envVar.name.includes(lowerSearchTerm)));
+        }
+
+    }, [searchTerm]);
 
     useEffect(() => {
         update();
@@ -237,6 +253,7 @@ export default function EnvVars() {
                 </div>
                 {envVars.length !== 0 ? (
                     <div className="mt-3 flex mt-0">
+                        <EnvironmentVariablesSearchBar searchTerm={searchTerm} onSearchTermUpdated={setSearchTerm} />
                         <button onClick={add} className="ml-2">
                             New Variable
                         </button>

--- a/components/dashboard/src/user-settings/EnvironmentVariablesSearchBar.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariablesSearchBar.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import search from "../icons/search.svg";
+
+type EnvironmentVariablesSearchBarProps = {
+    searchTerm: string;
+    onSearchTermUpdated(s: string): void;
+};
+
+const EnvironmentVariablesSearchBar: FC<EnvironmentVariablesSearchBarProps> = ({ searchTerm, onSearchTermUpdated }) => {
+    return (
+        <div className="app-container py-2 flex">
+            <div className="flex relative h-10 my-auto">
+                <img src={search} title="Search" className="filter-grayscale absolute top-3 left-3" alt="search icon" />
+                <input
+                    type="search"
+                    className="w-128 pl-9 border-0"
+                    placeholder="use '/' to filter using repo name"
+                    value={searchTerm}
+                    onChange={(v) => {
+                        onSearchTermUpdated(v.target.value);
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default EnvironmentVariablesSearchBar;


### PR DESCRIPTION
## Description

Pick up changes from the https://github.com/gitpod-io/gitpod/labels/community-contribution in https://github.com/gitpod-io/gitpod/pull/17373. Cc @RayAsh37

For more context, see **[relevant section](https://www.notion.so/gitpod/How-we-develop-e8ce7e562478458a9223eb9b797415b2?pvs=4#ef8b432a56b6425db16039d603ac97f4)** in How we develop.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/17158

## How to test

// TODO

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
