### PR TITLE
[ws-manager-mk2] Refactor lastActivity

### DIFF
--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(wsReconciler.SetupWithManager(k8sManager)).To(Succeed())
 
-	wsActivity = &activity.WorkspaceActivity{}
+	wsActivity = activity.NewWorkspaceActivity()
 	timeoutReconciler, err := NewTimeoutReconciler(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("workspace"), conf, wsActivity, maintenance)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(timeoutReconciler.SetupWithManager(k8sManager)).To(Succeed())

--- a/components/ws-manager-mk2/controllers/timeout_controller_test.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller_test.go
@@ -36,7 +36,7 @@ var _ = Describe("TimeoutController", func() {
 			// Use a fake client instead of the envtest's k8s client, such that we can add objects
 			// with custom CreationTimestamps and check timeout logic.
 			fakeClient = fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).Build()
-			r, err = NewTimeoutReconciler(fakeClient, record.NewFakeRecorder(100), conf, &activity.WorkspaceActivity{}, &fakeMaintenance{enabled: false})
+			r, err = NewTimeoutReconciler(fakeClient, record.NewFakeRecorder(100), conf, activity.NewWorkspaceActivity(), &fakeMaintenance{enabled: false})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -79,10 +79,9 @@ var _ = Describe("TimeoutController", func() {
 				// Set controller (re)start time.
 				if tc.controllerRestart.IsZero() {
 					// Bit arbitrary, but default to the controller running for ~2 days.
-					r.ctrlStartTime = now.Add(-48 * time.Hour)
-
+					r.activity.ManagerStartedAt = now.Add(-48 * time.Hour)
 				} else {
-					r.ctrlStartTime = tc.controllerRestart
+					r.activity.ManagerStartedAt = tc.controllerRestart
 				}
 
 				// Run the timeout controller for this workspace.
@@ -197,7 +196,7 @@ var _ = Describe("TimeoutController", func() {
 		var r *TimeoutReconciler
 		BeforeEach(func() {
 			var err error
-			r, err = NewTimeoutReconciler(k8sClient, record.NewFakeRecorder(100), newTestConfig(), &activity.WorkspaceActivity{}, &fakeMaintenance{enabled: false})
+			r, err = NewTimeoutReconciler(k8sClient, record.NewFakeRecorder(100), newTestConfig(), activity.NewWorkspaceActivity(), &fakeMaintenance{enabled: false})
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -147,7 +147,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	activity := &activity.WorkspaceActivity{}
+	activity := activity.NewWorkspaceActivity()
 	timeoutReconciler, err := controllers.NewTimeoutReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), cfg.Manager, activity, maintenanceReconciler)
 	if err != nil {
 		setupLog.Error(err, "unable to create timeout controller", "controller", "Timeout")

--- a/components/ws-manager-mk2/pkg/activity/activity.go
+++ b/components/ws-manager-mk2/pkg/activity/activity.go
@@ -7,23 +7,42 @@ package activity
 import (
 	"sync"
 	"time"
+
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 )
 
 // WorkspaceActivity is used to track the last user activity per workspace. This is
 // stored in memory instead of on the Workspace resource to limit load on the k8s API,
 // as this value will update often for each workspace.
 type WorkspaceActivity struct {
-	m sync.Map
+	ManagerStartedAt time.Time
+	m                sync.Map
+}
+
+func NewWorkspaceActivity() *WorkspaceActivity {
+	return &WorkspaceActivity{
+		ManagerStartedAt: time.Now().UTC(),
+	}
 }
 
 func (w *WorkspaceActivity) Store(workspaceId string, lastActivity time.Time) {
 	w.m.Store(workspaceId, &lastActivity)
 }
 
-func (w *WorkspaceActivity) GetLastActivity(workspaceId string) *time.Time {
-	lastActivity, ok := w.m.Load(workspaceId)
+func (w *WorkspaceActivity) GetLastActivity(ws *workspacev1.Workspace) *time.Time {
+	lastActivity, ok := w.m.Load(ws.Name)
 	if ok {
 		return lastActivity.(*time.Time)
 	}
+
+	// In case we don't have a record of the workspace's last activity, check for the FirstUserActivity condition
+	// to see if the lastActivity got lost on a manager restart.
+	if wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFirstUserActivity)) {
+		// Manager was restarted, consider the workspace's last activity to be the time the manager restarted.
+		return &w.ManagerStartedAt
+	}
+
+	// If the FirstUserActivity condition isn't present we know that the workspace has never had user activity.
 	return nil
 }

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -424,7 +424,7 @@ func (wsm *WorkspaceManagerServer) DescribeWorkspace(ctx context.Context, req *w
 		Status: wsm.extractWorkspaceStatus(&ws),
 	}
 
-	lastActivity := wsm.activity.GetLastActivity(req.Id)
+	lastActivity := wsm.activity.GetLastActivity(&ws)
 	if lastActivity != nil {
 		result.LastActivity = lastActivity.UTC().Format(time.RFC3339Nano)
 	}
@@ -1417,7 +1417,7 @@ func (wav *workspaceActivityVec) getWorkspaceActivityCounts() (active, notActive
 			continue
 		}
 
-		hasActivity := wav.activity.GetLastActivity(ws.Name) != nil
+		hasActivity := wav.activity.GetLastActivity(&ws) != nil
 		if hasActivity {
 			active++
 		} else {


### PR DESCRIPTION
## Description
Moves the lastActivity logic that takes into account a controller restart from `timeout_controller` to `WorkspaceActivity`, such that e.g. the workspace activity metric also considers workspaces with no stored `lastActivity` timestamp as active after a restart (but only when the `FirstUserActivity` condition is present, otherwise we know no activity was recorded yet before the restart either). 

Previously the metrics would show a high amount of inactive workspaces after restarting the pod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-161

## How to test
<!-- Provide steps to test this PR -->

Run the ws-manager-mk2 unit tests.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
