### PR TITLE
[usage] Scheduler with mutex by default

### DIFF
--- a/components/usage/pkg/scheduler/job.go
+++ b/components/usage/pkg/scheduler/job.go
@@ -4,13 +4,6 @@
 
 package scheduler
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/robfig/cron"
-)
-
 type Job interface {
 	Run() error
 }
@@ -19,17 +12,4 @@ type JobFunc func() error
 
 func (f JobFunc) Run() error {
 	return f()
-}
-
-func NewPeriodicJobSpec(period time.Duration, id string, job Job) (JobSpec, error) {
-	parsed, err := cron.Parse(fmt.Sprintf("@every %s", period.String()))
-	if err != nil {
-		return JobSpec{}, fmt.Errorf("failed to parse period into schedule: %w", err)
-	}
-
-	return JobSpec{
-		Job:      job,
-		ID:       id,
-		Schedule: parsed,
-	}, nil
 }

--- a/components/usage/pkg/scheduler/ledger_job.go
+++ b/components/usage/pkg/scheduler/ledger_job.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
-	"github.com/go-redsync/redsync/v4"
 	"github.com/robfig/cron"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -32,22 +31,13 @@ func NewLedgerTriggerJobSpec(schedule time.Duration, job Job) (JobSpec, error) {
 
 type ClientsConstructor func() (v1.UsageServiceClient, v1.BillingServiceClient, error)
 
-func NewLedgerTrigger(clientConstructor ClientsConstructor, sync *redsync.Redsync, mutexExpiry time.Duration) *LedgerJob {
+func NewLedgerTrigger(clientConstructor ClientsConstructor) *LedgerJob {
 	return &LedgerJob{
-		sync:               sync,
-		mutexDuration:      mutexExpiry,
 		clientsConstructor: clientConstructor,
 	}
 }
 
 type LedgerJob struct {
-	sync *redsync.Redsync
-
-	// mutexDuration configures for how a mutex on the ledger should hold initially
-	// it will be automatically extend for this duration if the job does not complete
-	// within the initial alloted time period
-	mutexDuration time.Duration
-
 	clientsConstructor ClientsConstructor
 }
 

--- a/components/usage/pkg/scheduler/ledger_job.go
+++ b/components/usage/pkg/scheduler/ledger_job.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func NewLedgerTriggerJobSpec(schedule time.Duration, job Job) (JobSpec, error) {
+func NewLedgerTriggerJob(schedule time.Duration, job Job) (JobSpec, error) {
 	parsed, err := cron.Parse(fmt.Sprintf("@every %s", schedule.String()))
 	if err != nil {
 		return JobSpec{}, fmt.Errorf("failed to parse period into schedule: %w", err)

--- a/components/usage/pkg/scheduler/reset_usage_job.go
+++ b/components/usage/pkg/scheduler/reset_usage_job.go
@@ -11,15 +11,12 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
-	"github.com/go-redsync/redsync/v4"
 	"github.com/robfig/cron"
 )
 
-func NewResetUsageJobSpec(schedule time.Duration, clientsConstructor ClientsConstructor, sync *redsync.Redsync, mutexExpiry time.Duration) (JobSpec, error) {
+func NewResetUsageJobSpec(schedule time.Duration, clientsConstructor ClientsConstructor) (JobSpec, error) {
 	job := &ResetUsageJobSpec{
 		clientsConstructor: clientsConstructor,
-		sync:               sync,
-		mutexDuration:      mutexExpiry,
 	}
 
 	parsed, err := cron.Parse(fmt.Sprintf("@every %s", schedule.String()))
@@ -38,13 +35,6 @@ func NewResetUsageJobSpec(schedule time.Duration, clientsConstructor ClientsCons
 
 type ResetUsageJobSpec struct {
 	clientsConstructor ClientsConstructor
-
-	sync *redsync.Redsync
-
-	// mutexDuration configures for how a mutex on the ledger should hold initially
-	// it will be automatically extend for this duration if the job does not complete
-	// within the initial alloted time period
-	mutexDuration time.Duration
 }
 
 func (j *ResetUsageJobSpec) Run() (err error) {

--- a/components/usage/pkg/scheduler/reset_usage_job.go
+++ b/components/usage/pkg/scheduler/reset_usage_job.go
@@ -6,22 +6,34 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 	"github.com/go-redsync/redsync/v4"
+	"github.com/robfig/cron"
 )
 
 func NewResetUsageJobSpec(schedule time.Duration, clientsConstructor ClientsConstructor, sync *redsync.Redsync, mutexExpiry time.Duration) (JobSpec, error) {
-	spec := &ResetUsageJobSpec{
+	job := &ResetUsageJobSpec{
 		clientsConstructor: clientsConstructor,
 		sync:               sync,
 		mutexDuration:      mutexExpiry,
 	}
-	return NewPeriodicJobSpec(schedule, "reset_usage", spec)
+
+	parsed, err := cron.Parse(fmt.Sprintf("@every %s", schedule.String()))
+	if err != nil {
+		return JobSpec{}, fmt.Errorf("failed to parse period into schedule: %w", err)
+	}
+
+	return JobSpec{
+		Job:                 job,
+		ID:                  "reset_usage",
+		Schedule:            parsed,
+		InitialLockDuration: schedule,
+	}, nil
+
 }
 
 type ResetUsageJobSpec struct {
@@ -38,25 +50,16 @@ type ResetUsageJobSpec struct {
 func (j *ResetUsageJobSpec) Run() (err error) {
 	ctx := context.Background()
 
-	runErr := WithRefreshingMutex(ctx, j.sync, "reset-usage", j.mutexDuration, func(ctx context.Context) error {
-		log.Info("Running reset usage job.")
-		usageClient, _, err := j.clientsConstructor()
-		if err != nil {
-			return fmt.Errorf("Failed to construct reset usage job clients: %w", err)
-		}
-
-		_, err = usageClient.ResetUsage(ctx, &v1.ResetUsageRequest{})
-		if err != nil {
-			return fmt.Errorf("failed to reset usage: %w", err)
-		}
-
-		return nil
-	})
-
-	if errors.Is(runErr, redsync.ErrFailed) {
-		log.Info("Ledger job did not acquire mutex, another job must be running already.")
-		return nil
+	log.Info("Running reset usage job.")
+	usageClient, _, err := j.clientsConstructor()
+	if err != nil {
+		return fmt.Errorf("Failed to construct reset usage job clients: %w", err)
 	}
 
-	return runErr
+	_, err = usageClient.ResetUsage(ctx, &v1.ResetUsageRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to reset usage: %w", err)
+	}
+
+	return nil
 }

--- a/components/usage/pkg/scheduler/reset_usage_job.go
+++ b/components/usage/pkg/scheduler/reset_usage_job.go
@@ -14,7 +14,7 @@ import (
 	"github.com/robfig/cron"
 )
 
-func NewResetUsageJobSpec(schedule time.Duration, clientsConstructor ClientsConstructor) (JobSpec, error) {
+func NewResetUsageJob(schedule time.Duration, clientsConstructor ClientsConstructor) (JobSpec, error) {
 	job := &ResetUsageJobSpec{
 		clientsConstructor: clientsConstructor,
 	}

--- a/components/usage/pkg/scheduler/scheduler.go
+++ b/components/usage/pkg/scheduler/scheduler.go
@@ -5,10 +5,14 @@
 package scheduler
 
 import (
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/robfig/cron"
+	"context"
+	"errors"
 	"sync"
 	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/go-redsync/redsync/v4"
+	"github.com/robfig/cron"
 )
 
 func New(jobs ...JobSpec) *Scheduler {
@@ -22,14 +26,16 @@ func New(jobs ...JobSpec) *Scheduler {
 type Scheduler struct {
 	specs       []JobSpec
 	runningJobs sync.WaitGroup
+	mutex       *redsync.Redsync
 
 	cron *cron.Cron
 }
 
 type JobSpec struct {
-	Job      Job
-	ID       string
-	Schedule cron.Schedule
+	Job                 Job
+	ID                  string
+	Schedule            cron.Schedule
+	InitialLockDuration time.Duration
 }
 
 func (c *Scheduler) Start() {
@@ -39,24 +45,40 @@ func (c *Scheduler) Start() {
 		// need to re-assign job to avoid pointing to a different job spec once the `cron.FuncJob` executes.
 		j := job
 		c.cron.Schedule(job.Schedule, cron.FuncJob(func() {
+			ctx := context.Background()
 			c.runningJobs.Add(1)
 			defer c.runningJobs.Done()
 
 			now := time.Now().UTC()
 			logger := log.WithField("job_id", j.ID)
 
-			logger.Infof("Starting scheduled job %s", j.ID)
-			reportJobStarted(j.ID)
+			err := WithRefreshingMutex(ctx, c.mutex, job.ID, job.InitialLockDuration, func(ctx context.Context) error {
+				logger.Infof("Starting scheduled job %s", j.ID)
+				reportJobStarted(j.ID)
+				jobErr := j.Job.Run()
+				reportJobCompleted(j.ID, time.Since(now), jobErr)
 
-			err := j.Job.Run()
-			defer func() {
-				reportJobCompleted(j.ID, time.Since(now), err)
-			}()
+				if jobErr != nil {
+					// We don't propagate the job erros outside of run mutex context deliberately
+					// to contain each job errors
+					logger.WithError(jobErr).Errorf("Scheduled job %s failed.", job.ID)
+					return nil
+				}
+
+				logger.Infof("Scheduled job %s completed succesfully.", job.ID)
+				return jobErr
+			})
 			if err != nil {
-				logger.WithError(err).Errorf("Scheduled job %s failed.", job.ID)
+				if errors.Is(err, redsync.ErrFailed) {
+					logger.WithError(err).Info("Failed to acquire lock, another instance holds the lock already.")
+					return
+				}
+
+				logger.WithError(err).Error("Failed to execute job inside a mutex.")
 				return
 			}
-			logger.Infof("Scheduled job %s completed succesfully.", job.ID)
+
+			logger.Debug("Succesfully obtained mutex and executed job.")
 		}))
 	}
 

--- a/components/usage/pkg/scheduler/scheduler_test.go
+++ b/components/usage/pkg/scheduler/scheduler_test.go
@@ -5,31 +5,45 @@
 package scheduler
 
 import (
-	"github.com/robfig/cron"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis"
+	"github.com/go-redsync/redsync/v4"
+	"github.com/go-redsync/redsync/v4/redis/goredis"
+	"github.com/robfig/cron"
+	"github.com/stretchr/testify/require"
 )
 
-func TestScheduler(t *testing.T) {
+func TestScheduler_StopsAll(t *testing.T) {
+	red := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: red.Addr()})
+
+	pool := goredis.NewPool(client)
+	rs := redsync.New(pool)
+
 	firstRan := false
 	secondRan := false
 	s := New(
+		rs,
 		JobSpec{
 			Job: JobFunc(func() error {
 				firstRan = true
 				return nil
 			}),
-			ID:       "first",
-			Schedule: cron.ConstantDelaySchedule{Delay: time.Second},
+			ID:                  "first",
+			Schedule:            cron.ConstantDelaySchedule{Delay: time.Second},
+			InitialLockDuration: time.Second,
 		},
 		JobSpec{
 			Job: JobFunc(func() error {
 				secondRan = true
 				return nil
 			}),
-			ID:       "second",
-			Schedule: cron.ConstantDelaySchedule{Delay: time.Second},
+			ID:                  "second",
+			Schedule:            cron.ConstantDelaySchedule{Delay: time.Second},
+			InitialLockDuration: time.Second,
 		},
 	)
 	s.Start()

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -145,7 +145,7 @@ func Start(cfg Config, version string) error {
 		}
 
 		jobSpec, err := scheduler.NewLedgerTriggerJobSpec(schedule,
-			scheduler.NewLedgerTrigger(jobClientsConstructor, redsyncPool, 30*time.Second),
+			scheduler.NewLedgerTrigger(jobClientsConstructor),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to setup ledger trigger job: %w", err)
@@ -163,7 +163,7 @@ func Start(cfg Config, version string) error {
 			return fmt.Errorf("failed to parse reset usage schedule as duration: %w", err)
 		}
 
-		spec, err := scheduler.NewResetUsageJobSpec(schedule, jobClientsConstructor, redsyncPool, 30*time.Second)
+		spec, err := scheduler.NewResetUsageJobSpec(schedule, jobClientsConstructor)
 		if err != nil {
 			return fmt.Errorf("failed to setup reset usage job: %w", err)
 		}
@@ -171,7 +171,7 @@ func Start(cfg Config, version string) error {
 		schedulerJobSpecs = append(schedulerJobSpecs, spec)
 	}
 
-	sched := scheduler.New(schedulerJobSpecs...)
+	sched := scheduler.New(redsyncPool, schedulerJobSpecs...)
 	sched.Start()
 	defer sched.Stop()
 

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -144,7 +144,7 @@ func Start(cfg Config, version string) error {
 			return fmt.Errorf("failed to parse schedule duration: %w", err)
 		}
 
-		jobSpec, err := scheduler.NewLedgerTriggerJobSpec(schedule,
+		jobSpec, err := scheduler.NewLedgerTriggerJob(schedule,
 			scheduler.NewLedgerTrigger(jobClientsConstructor),
 		)
 		if err != nil {
@@ -163,7 +163,7 @@ func Start(cfg Config, version string) error {
 			return fmt.Errorf("failed to parse reset usage schedule as duration: %w", err)
 		}
 
-		spec, err := scheduler.NewResetUsageJobSpec(schedule, jobClientsConstructor)
+		spec, err := scheduler.NewResetUsageJob(schedule, jobClientsConstructor)
 		if err != nil {
 			return fmt.Errorf("failed to setup reset usage job: %w", err)
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to https://github.com/gitpod-io/gitpod/pull/17167

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
