### PR TITLE
[ws-proxy] don't hit blobserve with web sockets

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -751,7 +751,16 @@ func (t *blobserveTransport) DoRoundTrip(req *http.Request) (resp *http.Response
 	return resp, err
 }
 
+func isWebSocketUpgrade(req *http.Request) bool {
+	return strings.EqualFold(req.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(req.Header.Get("Connection")), "upgrade")
+}
+
 func (t *blobserveTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if isWebSocketUpgrade(req) {
+		return nil, xerrors.Errorf("blobserve: websocket not supported")
+	}
+
 	image := t.resolveImage(t, req)
 
 	resp, err = t.DoRoundTrip(req)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

instead fallback directly to workspace without additional remote request

Discovered as part of instrumenting http metrics in ws-proxy: https://github.com/gitpod-io/gitpod/pull/17294

There are more 404 errors but they are unfortunately how VS Code bundle source maps for 3rd party extensions. Maybe we can server source maps always from sources. It is out of scope of this PR though.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace
- Check that VS Code is still working, file explorer, extensions

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-ws-prox9086f3011a</li>
	<li><b>🔗 URL</b> - <a href="https://ak-ws-prox9086f3011a.preview.gitpod-dev.com/workspaces" target="_blank">ak-ws-prox9086f3011a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
