### PR TITLE
allow to redirect only for whitelisted trusted protocols

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -192,7 +192,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         try {
             const desktopLink = new URL(url);
             // allow to redirect only for whitelisted trusted protocols
-            // security: IDE-69
+            // IDE-69
             const trustedProtocols = ["vscode:", "vscode-insiders:", "jetbrains-gateway:"];
             redirect = trustedProtocols.includes(desktopLink.protocol);
         } catch (e) {

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -193,10 +193,8 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             const desktopLink = new URL(url);
             // allow to redirect only for whitelisted trusted protocols
             // security: IDE-69
-            redirect =
-                desktopLink.protocol === "vscode:" ||
-                desktopLink.protocol === "vscode-insiders:" ||
-                desktopLink.protocol === "jetbrains-gateway:";
+            const trustedProtocols = ["vscode:", "vscode-insiders:", "jetbrains-gateway:"];
+            redirect = trustedProtocols.includes(desktopLink.protocol);
         } catch (e) {
             console.error("invalid desktop link:", e);
         }

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -191,7 +191,12 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         let redirect = false;
         try {
             const desktopLink = new URL(url);
-            redirect = desktopLink.protocol !== "http:" && desktopLink.protocol !== "https:";
+            // allow to redirect only for whitelisted trusted protocols
+            // security: IDE-69
+            redirect =
+                desktopLink.protocol === "vscode:" ||
+                desktopLink.protocol === "vscode-insiders:" ||
+                desktopLink.protocol === "jetbrains-gateway:";
         } catch (e) {
             console.error("invalid desktop link:", e);
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

see IDE-69

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

fix IDE-69

## How to test
<!-- Provide steps to test this PR -->

- Ensure that VS Code Desktop, VS Code Desktop Insiders and Intellij works

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-whitelib79f1fcc25</li>
	<li><b>🔗 URL</b> - <a href="https://ak-whitelib79f1fcc25.preview.gitpod-dev.com/workspaces" target="_blank">ak-whitelib79f1fcc25.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
