### PR TITLE
Update stripe customers during migration

### DIFF
--- a/components/gitpod-db/go/stripe_customer.go
+++ b/components/gitpod-db/go/stripe_customer.go
@@ -36,7 +36,7 @@ func CreateStripeCustomer(ctx context.Context, conn *gorm.DB, customer StripeCus
 
 	tx := conn.WithContext(ctx).Create(customer)
 	if tx.Error != nil {
-		return fmt.Errorf("failed to create StripeCustomer ID %s", customer.StripeCustomerID)
+		return fmt.Errorf("failed to create StripeCustomer ID %s: %w", customer.StripeCustomerID, tx.Error)
 	}
 
 	return nil
@@ -53,7 +53,7 @@ func GetStripeCustomer(ctx context.Context, conn *gorm.DB, stripeCustomerID stri
 			return StripeCustomer{}, fmt.Errorf("stripe customer with ID %s does not exist: %w", stripeCustomerID, ErrorNotFound)
 		}
 
-		return StripeCustomer{}, fmt.Errorf("failed to lookup stripe customer with ID %s", stripeCustomerID)
+		return StripeCustomer{}, fmt.Errorf("failed to lookup stripe customer with ID %s: %w", stripeCustomerID, err)
 	}
 
 	return customer, nil

--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -44,7 +44,6 @@ import { BlockedRepositoryDB } from "./blocked-repository-db";
 import { WebhookEventDB } from "./webhook-event-db";
 import { WebhookEventDBImpl } from "./typeorm/webhook-event-db-impl";
 import { PersonalAccessTokenDBImpl } from "./typeorm/personal-access-token-db-impl";
-import { UserToTeamMigrationService } from "./user-to-team-migration-service";
 import { Synchronizer } from "./typeorm/synchronizer";
 import { WorkspaceOrganizationIdMigration } from "./long-running-migration/workspace-organizationid-migration";
 import { LongRunningMigration, LongRunningMigrationService } from "./long-running-migration/long-running-migration";
@@ -116,7 +115,6 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
 
     // com concerns
     bind(EmailDomainFilterDB).to(EmailDomainFilterDBImpl).inSingletonScope();
-    bind(UserToTeamMigrationService).toSelf().inSingletonScope();
     bind(WorkspaceOrganizationIdMigration).toSelf().inSingletonScope();
     bind(Synchronizer).toSelf().inSingletonScope();
     bind(LinkedInProfileDBImpl).toSelf().inSingletonScope();

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -16,7 +16,7 @@
     "clean:node": "rimraf node_modules",
     "purge": "yarn clean && yarn clean:node && yarn run rimraf yarn.lock",
     "lint": "yarn tslint -p .",
-    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
+    "test": ". $(leeway run components/gitpod-db:db-test-env) && mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
     "db-test-run": "mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",
     "telepresence": "leeway run .:telepresence"

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -133,6 +133,7 @@ import { StripeService } from "./user/stripe-service";
 import { JobRunner } from "./jobs/runner";
 import { DatabaseGarbageCollector } from "./jobs/database-gc";
 import { OTSGarbageCollector } from "./jobs/ots-gc";
+import { UserToTeamMigrationService } from "./migration/user-to-team-migration-service";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -314,6 +315,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(UsageService).toService(UsageServiceImpl);
 
     bind(LinkedInService).toSelf().inSingletonScope();
+    bind(UserToTeamMigrationService).toSelf().inSingletonScope();
 
     // IAM Support
     bind(IamSessionApp).toSelf().inSingletonScope();

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -41,7 +41,7 @@ export class IamSessionApp {
                 const result = await this.doCreateSession(req);
                 res.status(200).json(result);
             } catch (error) {
-                log.error("Error creating session on behalf of IAM", error, { error });
+                log.error("Error creating session on behalf of IAM", error);
                 if (error instanceof ResponseError) {
                     res.status(error.code).json({ message: error.message });
                     return;

--- a/components/server/src/user/stripe-service.ts
+++ b/components/server/src/user/stripe-service.ts
@@ -113,6 +113,14 @@ export class StripeService {
             return this.getStripe().subscriptions.del(subscriptionId, { invoice_now: true });
         });
     }
+
+    public async updateAttributionId(stripeCustomerId: string, attributionId: string): Promise<void> {
+        await this.getStripe().customers.update(stripeCustomerId, {
+            metadata: {
+                attributionId,
+            },
+        });
+    }
 }
 
 async function reportStripeOutcome<T>(op: string, f: () => Promise<T>) {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -19,7 +19,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { ResponseError } from "vscode-ws-jsonrpc";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { UsageService } from "./usage-service";
-import { UserToTeamMigrationService } from "@gitpod/gitpod-db/lib/user-to-team-migration-service";
+import { UserToTeamMigrationService } from "../migration/user-to-team-migration-service";
 import { ConfigCatClientFactory } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 
 export interface CreateUserParams {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -200,7 +200,7 @@ import { PrebuildManager } from "../prebuilds/prebuild-manager";
 import { GitHubAppSupport } from "../github/github-app-support";
 import { GitLabAppSupport } from "../gitlab/gitlab-app-support";
 import { BitbucketAppSupport } from "../bitbucket/bitbucket-app-support";
-import { UserToTeamMigrationService } from "@gitpod/gitpod-db/lib/user-to-team-migration-service";
+import { UserToTeamMigrationService } from "../migration/user-to-team-migration-service";
 import { StripeService } from "../user/stripe-service";
 import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 import {

--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -152,7 +152,7 @@ func (s *BillingService) CreateStripeCustomer(ctx context.Context, req *v1.Creat
 	}
 
 	customer, err := s.stripeClient.CreateCustomer(ctx, stripe.CreateCustomerParams{
-		AttributuonID:        string(attributionID),
+		AttributionID:        string(attributionID),
 		Currency:             req.GetCurrency(),
 		Email:                req.GetEmail(),
 		Name:                 req.GetName(),

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -277,7 +277,7 @@ func (c *Client) GetPriceInformation(ctx context.Context, priceID string) (price
 }
 
 type CreateCustomerParams struct {
-	AttributuonID        string
+	AttributionID        string
 	Currency             string
 	Email                string
 	Name                 string
@@ -299,7 +299,7 @@ func (c *Client) CreateCustomer(ctx context.Context, params CreateCustomerParams
 				// This is also done to propagate the preference into the Customer such that we can inform them when their
 				// new subscription would use a different currency to the previous one
 				PreferredCurrencyMetadataKey:    params.Currency,
-				AttributionIDMetadataKey:        params.AttributuonID,
+				AttributionIDMetadataKey:        params.AttributionID,
 				BillingCreaterUserIDMetadataKey: params.BillingCreatorUserID,
 			},
 		},

--- a/scripts/mysql-test.sh
+++ b/scripts/mysql-test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysql -h 127.0.0.1 -P 23306 -u root -D gitpod --select-limit=200 --safe-updates --password="test"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The org-only migration needs to update the attribution id in stripe as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-351

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
