### PR TITLE
[dashboard] fix reload

### DIFF
--- a/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
@@ -7,11 +7,38 @@
 import { GitpodServer } from "@gitpod/gitpod-protocol";
 import { useMutation } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
+import { useState } from "react";
 
 export const useCreateWorkspaceMutation = () => {
-    return useMutation({
+    const [isStarting, setIsStarting] = useState(false);
+    const mutation = useMutation({
         mutationFn: async (options: GitpodServer.CreateWorkspaceOptions) => {
             return await getGitpodService().server.createWorkspace(options);
         },
+        onMutate: async (options: GitpodServer.CreateWorkspaceOptions) => {
+            setIsStarting(true);
+        },
+        onError: (error) => {
+            console.error(error);
+            setIsStarting(false);
+        },
+        onSuccess: (result) => {
+            if (result && result.createdWorkspaceId) {
+                // successfully started a workspace, wait a bit before we allow to start another one
+                setTimeout(() => {
+                    setIsStarting(false);
+                }, 4000);
+            } else {
+                setIsStarting(false);
+            }
+        },
     });
+    return {
+        createWorkspace: (options: GitpodServer.CreateWorkspaceOptions) => {
+            return mutation.mutateAsync(options);
+        },
+        isStarting,
+        error: mutation.error,
+        reset: mutation.reset,
+    };
 };

--- a/components/dashboard/src/start/start-workspace-options.ts
+++ b/components/dashboard/src/start/start-workspace-options.ts
@@ -42,8 +42,8 @@ export namespace StartWorkspaceOptions {
                 };
             }
         }
-        if (params.get(StartWorkspaceOptions.AUTOSTART) === "true") {
-            options.autostart = true;
+        if (params.get(StartWorkspaceOptions.AUTOSTART)) {
+            options.autostart = params.get(StartWorkspaceOptions.AUTOSTART) === "true";
         }
         return options;
     }

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -108,7 +108,7 @@ export class GitpodHostUrl {
     }
 
     asAccessControl(): GitpodHostUrl {
-        return this.with((url) => ({ pathname: "/integrations" }));
+        return this.with((url) => ({ pathname: "/user/integrations" }));
     }
 
     asSettings(): GitpodHostUrl {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes an endless loop that could happen when opening a context in the context fo the wrong org.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-334

## How to test
<!-- Provide steps to test this PR -->

https://se-create-ws-loop.preview.gitpod-dev.com/workspaces

1) create two orgs
2) memorize workspace options in one org
3) switch to the other org
4) use a contextURL for the memorized repo

Expected behavior is that the dashboard switched to the org the start options were remembered for and starts the workspace.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://se-create-ws-loop.preview.gitpod-dev.com/workspaces

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
