### PR TITLE
Don't wait for onboarding state to render

### DIFF
--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -9,7 +9,6 @@ import { useCheckDedicatedSetup } from "../dedicated-setup/use-check-dedicated-s
 import { useCurrentUser } from "../user-context";
 import { MigrationPage, useShouldSeeMigrationPage } from "../whatsnew/MigrationPage";
 import { useShowUserOnboarding } from "../onboarding/use-show-user-onboarding";
-import { AppLoading } from "./AppLoading";
 
 const UserOnboarding = lazy(() => import(/* webpackPrefetch: true */ "../onboarding/UserOnboarding"));
 const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicated-setup/DedicatedSetup"));
@@ -25,11 +24,6 @@ export const AppBlockingFlows: FC = ({ children }) => {
     // This shouldn't happen, but if it does don't render anything yet
     if (!user) {
         return <></>;
-    }
-
-    // Wait until we've loaded the onboarding state before rendering anything
-    if (checkDedicatedSetup.isLoading) {
-        return <AppLoading />;
     }
 
     // If orgOnlyAttribution is enabled and the user hasn't been migrated, yet, we need to show the migration page

--- a/components/dashboard/src/app/AppLoading.tsx
+++ b/components/dashboard/src/app/AppLoading.tsx
@@ -11,8 +11,8 @@ import gitpodIcon from "../icons/gitpod.svg";
 
 export const AppLoading: FunctionComponent = () => {
     return (
-        // Wait 2 seconds before showing the loading screen to avoid flashing it too quickly
-        <Delayed wait={2000}>
+        // Wait 3 seconds before showing the loading screen to avoid flashing it too quickly
+        <Delayed wait={3000}>
             <div className="flex flex-col justify-center items-center w-full h-screen space-y-4">
                 <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0"} />
                 <Heading3>Just getting a few more things ready</Heading3>

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -257,10 +257,13 @@ export const AppRoutes = () => {
                     <Route
                         path="*"
                         render={(_match) => {
-                            return isGitpodIo() ? (
-                                // delegate to our website to handle the request
-                                (window.location.host = "www.gitpod.io")
-                            ) : (
+                            // delegate to our website to handle the request
+                            if (isGitpodIo()) {
+                                window.location.host = "www.gitpod.io";
+                                return;
+                            }
+
+                            return (
                                 <div className="mt-48 text-center">
                                     <Heading1>404</Heading1>
                                     <Subheading className="mt-4">Page not found.</Subheading>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adjusts the app loading flow so we don't wait for the result of `getOnboardingState` before rendering the current route. The motivation is to avoid adding a delay for majority of users (where dedicated setup isn't required) and render right away. The tradeoff is in the case where dedicated setup is required, there may be a brief flash of the current route rendered prior to the setup flow. I've also bumped up the delay for how long we wait before rendering the `<AppLoading/>` state from 2 seconds to 3.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-297

## How to test
<!-- Provide steps to test this PR -->
It's quite difficult to reproduce scenarios that would cause the app to take longer to load, so testing that the app still loads as expected is probably the best approach. 

Testing starting workspaces is another good flow that benefits from these changes as well.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-app-lo672a85a66a</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-app-lo672a85a66a.preview.gitpod-dev.com/workspaces" target="_blank">bmh-app-lo672a85a66a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
