### PR TITLE
ensure dedicated setup doesn't show on prod saas

### DIFF
--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -25,7 +25,14 @@ export const useCheckDedicatedSetup = () => {
     const { data: onboardingState, isLoading } = useOnboardingState();
 
     const forceSetup = forceDedicatedSetupParam(params);
-    const needsOnboarding = forceSetup || (onboardingState && onboardingState.isCompleted !== true);
+    let needsOnboarding = forceSetup || (onboardingState && onboardingState.isCompleted !== true);
+
+    // TODO: This is a temporary safety-gurad against this flow showing up on gitpod.io
+    // We can remove this once we've ensured we're distinguishing different installation types for this
+    // Purposely not using isGitpodIo() check here to avoid disabling on preview environments too.
+    if (window.location.hostname === "gitpod.io") {
+        needsOnboarding = false;
+    }
 
     const markCompleted = useCallback(() => setInProgress(false), []);
 

--- a/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-check-dedicated-setup.ts
@@ -30,7 +30,7 @@ export const useCheckDedicatedSetup = () => {
     // TODO: This is a temporary safety-gurad against this flow showing up on gitpod.io
     // We can remove this once we've ensured we're distinguishing different installation types for this
     // Purposely not using isGitpodIo() check here to avoid disabling on preview environments too.
-    if (window.location.hostname === "gitpod.io") {
+    if (["gitpod.io", "gitpod-staging.com"].includes(window.location.hostname)) {
         needsOnboarding = false;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This ensures we don't show the dedicated setup flow on prod saas (gitpod.io). It's a bit of a hacky check atm, but wanted it in there as a safety guard while we sort out some related work around distinguishing different installation types.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-358

## How to test
<!-- Provide steps to test this PR -->
As this explicitly checks for `gitpod.io` as the host, there's not much to test other than making sure the app loads on a preview environment.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-saas-d9604327a75</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-saas-d9604327a75.preview.gitpod-dev.com/workspaces" target="_blank">bmh-saas-d9604327a75.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
