### PR TITLE
[public-api] refine mapping of json rpc error codes

### DIFF
--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -43,15 +43,28 @@ func categorizeRPCError(err error) *connect.Error {
 		// components/gitpod-protocol/src/messaging/error.ts
 		case 409:
 			return connect.NewError(connect.CodeAlreadyExists, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts - SETUP_REQUIRED (no user)
+		case 410:
+			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts - NEEDS_VERIFICATION (no user)
+		case 411:
+			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
+		case 429:
+			return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(rpcErr.Message))
 		// components/gitpod-messagebus/src/jsonrpc-server.ts#47
 		case -32603:
 			return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
 		case 470:
 			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
-
-		default:
-			return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts - INVALID_VALUE (no user)
+		case 650:
+			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(rpcErr.Message))
 		}
+		// components/gitpod-protocol/src/messaging/error.ts - user errors
+		if rpcErr.Code >= 400 && rpcErr.Code < 500 {
+			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(rpcErr.Message))
+		}
+		return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
 	}
 
 	if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- map 4xx and 650 codes as invalid argument (client errors)
- map 401, 411 related to unauthedicated and permission denied
- map 429 to resource exhausted

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

See https://gitpod.slack.com/archives/C03QM0ZHF5Z/p1683700223165729

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
