### PR TITLE
[server] Move update user implementation to UserService

### DIFF
--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -100,6 +100,8 @@ func (s *OIDCService) CreateClientConfig(ctx context.Context, req *connect.Reque
 		return nil, status.Errorf(codes.Internal, "Failed to store OIDC client config.")
 	}
 
+	// foo
+
 	log.AddFields(ctx, log.OIDCClientConfigID(created.ID.String()))
 
 	converted, err := dbOIDCClientConfigToAPI(created, s.cipher)

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -100,8 +100,6 @@ func (s *OIDCService) CreateClientConfig(ctx context.Context, req *connect.Reque
 		return nil, status.Errorf(codes.Internal, "Failed to store OIDC client config.")
 	}
 
-	// foo
-
 	log.AddFields(ctx, log.OIDCClientConfigID(created.ID.String()))
 
 	converted, err := dbOIDCClientConfigToAPI(created, s.cipher)

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -22,8 +22,6 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { UsageService } from "./usage-service";
 import { UserToTeamMigrationService } from "@gitpod/gitpod-db/lib/user-to-team-migration-service";
 import { ConfigCatClientFactory } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { use } from "chai";
 
 export interface FindUserByIdentityStrResult {
     user: User;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This better co-locates the logic in the service, and allows us to re-use the logic in other places, or when migrating to gRPC

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
