### PR TITLE
[analytics plugin] allow to configure segment endpoint

### DIFF
--- a/components/proxy/plugins/analytics/analytics.go
+++ b/components/proxy/plugins/analytics/analytics.go
@@ -51,7 +51,7 @@ func (Analytics) CaddyModule() caddy.ModuleInfo {
 func (a *Analytics) Provision(ctx caddy.Context) error {
 	logger := ctx.Logger(a)
 
-	segmentEndponit, err := url.Parse(segment.DefaultEndpoint)
+	segmentEndpoint, err := resolveSegmenEndpoint()
 	if err != nil {
 		logger.Error("failed to parse segment endpoint", zap.Error(err))
 		return nil
@@ -63,11 +63,19 @@ func (a *Analytics) Provision(ctx caddy.Context) error {
 		return nil
 	}
 
-	a.segmentProxy = newSegmentProxy(segmentEndponit, errorLog)
+	a.segmentProxy = newSegmentProxy(segmentEndpoint, errorLog)
 	a.untrustedSegmentKey = os.Getenv("ANALYTICS_PLUGIN_UNTRUSTED_SEGMENT_KEY")
 	a.trustedSegmentKey = os.Getenv("ANALYTICS_PLUGIN_TRUSTED_SEGMENT_KEY")
 
 	return nil
+}
+
+func resolveSegmenEndpoint() (*url.URL, error) {
+	segmentEndpoint := os.Getenv("ANALYTICS_PLUGIN_SEGMENT_ENDPOINT")
+	if segmentEndpoint == "" {
+		segmentEndpoint = segment.DefaultEndpoint
+	}
+	return url.Parse(segmentEndpoint)
 }
 
 func newSegmentProxy(segmentEndpoint *url.URL, errorLog *log.Logger) http.Handler {

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -101,12 +101,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	var frontendDevEnabled bool
 	var trustedSegmentKey string
 	var untrustedSegmentKey string
+	var segmentEndpoint string
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.ProxyConfig != nil {
 			frontendDevEnabled = cfg.WebApp.ProxyConfig.FrontendDevEnabled
 			if cfg.WebApp.ProxyConfig.AnalyticsPlugin != nil {
 				trustedSegmentKey = cfg.WebApp.ProxyConfig.AnalyticsPlugin.TrustedSegmentKey
 				untrustedSegmentKey = cfg.WebApp.ProxyConfig.AnalyticsPlugin.UntrustedSegmentKey
+				segmentEndpoint = cfg.WebApp.ProxyConfig.AnalyticsPlugin.SegmentEndpoint
 			}
 		}
 		if cfg.WebApp != nil && cfg.WebApp.ProxyConfig != nil && cfg.WebApp.ProxyConfig.Configcat != nil && cfg.WebApp.ProxyConfig.Configcat.FromConfigMap != "" {
@@ -273,6 +275,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								}, {
 									Name:  "ANALYTICS_PLUGIN_UNTRUSTED_SEGMENT_KEY",
 									Value: untrustedSegmentKey,
+								}, {
+									Name:  "ANALYTICS_PLUGIN_SEGMENT_ENDPOINT",
+									Value: segmentEndpoint,
 								}},
 							)),
 						}},

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -295,6 +295,7 @@ type ConfigcatProxyConfig struct {
 type AnalyticsPluginConfig struct {
 	TrustedSegmentKey   string `json:"trustedSegmentKey"`
 	UntrustedSegmentKey string `json:"untrustedSegmentKey"`
+	SegmentEndpoint     string `json:"segmentEndpoint,omitempty"`
 }
 
 type PublicAPIConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

in case of dedicated we would like to stream to telemetry exporter instead

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace, check proxy logs for errors, check segment that events are still reported.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-analytic1fb6136ea</li>
	<li><b>🔗 URL</b> - <a href="https://ak-analytic1fb6136ea.preview.gitpod-dev.com/workspaces" target="_blank">ak-analytic1fb6136ea.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
