### PR TITLE
[gha] update IDE github action to default use ws-manager-mk2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,6 +414,7 @@ jobs:
             TEST_BUILD_ID: ${{ github.run_id }}
             TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
+            WS_MANAGER_MK2: ${{ needs.configuration.outputs.with_ws_manager_mk2 != 'false' }}
         run: |
             set -euo pipefail
 

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -8,6 +8,11 @@ on:
             version:
                 required: true
                 description: "The version of Gitpod to install"
+            wsman_mk2:
+                required: false
+                type: boolean
+                default: true
+                description: "Run tests against ws-manager-mk2"
             skip_deploy:
                 required: false
                 description: "Skip deploy preview environment (debug only)"
@@ -83,6 +88,7 @@ jobs:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
+                  wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -134,6 +140,8 @@ jobs:
                   JETBRAINS_TESTS="$IDE_TESTS_DIR/jetbrains"
                   VSCODE_TESTS="$IDE_TESTS_DIR/vscode"
                   SSH_TESTS="$IDE_TESTS_DIR/ssh"
+
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -106,6 +106,7 @@ jobs:
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
                       - [x] latest-ide-version=${{ contains(inputs.pluginId, 'latest') }}
+                      - [x] with-ws-manager-mk2
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -67,6 +67,7 @@ jobs:
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
                       - [x] latest-ide-version=false
+                      - [x] with-ws-manager-mk2
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_
                   commit-message: "[JetBrains] Update IDE images to new build version"

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -15,7 +15,12 @@ on:
             infrastructure_provider:
                 description: "The infrastructure provider to use. Valid options: harvester, gcp"
                 required: false
-                default: harvester
+                default: gcp
+            wsman_mk2:
+                required: false
+                type: boolean
+                default: true
+                description: "Run tests against ws-manager-mk2"
 
 jobs:
     configuration:
@@ -71,6 +76,7 @@ jobs:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
+                  wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -117,6 +123,8 @@ jobs:
                   args+=( "-timeout=60m" )
 
                   TESTS_DIR="$GITHUB_WORKSPACE/test/tests/smoke-test"
+
+                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[gh-action] update IDE github action to default use ws-manager-mk2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-update-template</li>
	<li><b>🔗 URL</b> - <a href="https://pd-update-template.preview.gitpod-dev.com/workspaces" target="_blank">pd-update-template.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace

</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=ssh
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
