### PR TITLE
[ws-manager-mk2] Cleanup and fail workspaces when node disappears

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -155,7 +155,7 @@ func (s *WorkspaceStatus) SetCondition(cond metav1.Condition) {
 	s.Conditions = wsk8s.AddUniqueCondition(s.Conditions, cond)
 }
 
-// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;EverReady;BackupComplete;BackupFailure
+// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;EverReady;BackupComplete;BackupFailure;Refresh;NodeDisappeared
 type WorkspaceCondition string
 
 const (
@@ -200,6 +200,9 @@ const (
 
 	// Refresh is used to ensure that we operate on the latest version of the workspace
 	WorkspaceConditionRefresh WorkspaceCondition = "Refresh"
+
+	// NodeDisappeared is true if the workspace's node disappeared before the workspace was stopped
+	WorkspaceConditionNodeDisappeared WorkspaceCondition = "NodeDisappeared"
 )
 
 func NewWorkspaceConditionDeployed() metav1.Condition {
@@ -315,6 +318,14 @@ func NewWorkspaceConditionBackupFailure(message string) metav1.Condition {
 func NewWorkspaceConditionRefresh() metav1.Condition {
 	return metav1.Condition{
 		Type:               string(WorkspaceConditionRefresh),
+		LastTransitionTime: metav1.Now(),
+		Status:             metav1.ConditionTrue,
+	}
+}
+
+func NewWorkspaceConditionNodeDisappeared() metav1.Condition {
+	return metav1.Condition{
+		Type:               string(WorkspaceConditionNodeDisappeared),
 		LastTransitionTime: metav1.Now(),
 		Status:             metav1.ConditionTrue,
 	}

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -260,6 +260,10 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			return ctrl.Result{Requeue: true}, err
 		}
 
+	// if the node disappeared, delete the pod.
+	case wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionNodeDisappeared)) && !isPodBeingDeleted(pod):
+		return r.deleteWorkspacePod(ctx, pod, "node disappeared")
+
 	// if the workspace timed out, delete it
 	case wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionTimeout)) && !isPodBeingDeleted(pod):
 		return r.deleteWorkspacePod(ctx, pod, "timed out")


### PR DESCRIPTION
## Description

Detect when a node disappears, and stop any workspaces on that node. If any of those workspaces did not finish disposal, consider their backup to have failed, and mark the workspace as failed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-177

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
