### PR TITLE
[JetBrains] Update Platform Version from JetBrains Gateway Plugin (EAP)

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -1,10 +1,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=231.9011
-pluginUntilBuild=231.*
+pluginSinceBuild=232.5150
+pluginUntilBuild=232.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2023.1
+pluginVerifierIdeVersions=2023.2
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=231.9011-EAP-CANDIDATE-SNAPSHOT
+platformVersion=232.5150-EAP-CANDIDATE-SNAPSHOT
 

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.common
+
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodConnectionProvider
+import javax.swing.JComponent
+
+interface GitpodConnectionHandleFactory {
+    fun createGitpodConnectionHandle(
+            lifetime: Lifetime,
+            component: JComponent,
+            params: GitpodConnectionProvider.ConnectParams
+    ): GatewayConnectionHandle
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.latest
+
+import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
+import com.jetbrains.gateway.api.CustomConnectionFrameContext
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
+import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
+import javax.swing.JComponent
+
+class GitpodConnectionHandle(
+        lifetime: Lifetime,
+        private val component: JComponent,
+        private val params: ConnectParams
+) : GatewayConnectionHandle(lifetime) {
+    override fun customComponentProvider(lifetime: Lifetime) = object : CustomConnectionFrameComponentProvider {
+        override val closeConfirmationText = "Disconnect from ${getTitle()}?"
+        override fun createComponent(context: CustomConnectionFrameContext) = component
+    }
+
+    override fun getTitle(): String {
+        return params.title
+    }
+
+    override fun hideToTrayOnStart(): Boolean {
+        return false
+    }
+}
+
+class LatestGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
+    override fun createGitpodConnectionHandle(
+            lifetime: Lifetime,
+            component: JComponent,
+            params: ConnectParams
+    ): GatewayConnectionHandle {
+        return GitpodConnectionHandle(lifetime, component, params)
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.stable
+
+import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
+import com.jetbrains.gateway.api.CustomConnectionFrameContext
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
+import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
+import javax.swing.JComponent
+
+class GitpodConnectionHandle(
+        lifetime: Lifetime,
+        private val component: JComponent,
+        private val params: ConnectParams
+) : GatewayConnectionHandle(lifetime) {
+    override fun customComponentProvider() = object : CustomConnectionFrameComponentProvider {
+        override val closeConfirmationText = "Disconnect from ${getTitle()}?"
+        override fun createComponent(context: CustomConnectionFrameContext) = component
+    }
+
+    override fun getTitle(): String {
+        return params.title
+    }
+
+    override fun hideToTrayOnStart(): Boolean {
+        return false
+    }
+}
+
+class StableGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
+    override fun createGitpodConnectionHandle(
+            lifetime: Lifetime,
+            component: JComponent,
+            params: ConnectParams
+    ): GatewayConnectionHandle {
+        return GitpodConnectionHandle(lifetime, component, params)
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -4,6 +4,10 @@
  See License.AGPL.txt in the project root for license information.
 -->
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory"
+                            serviceImplementation="io.gitpod.jetbrains.gateway.latest.LatestGitpodConnectionHandleFactory"/>
+    </extensions>
     <extensions defaultExtensionNs="com.jetbrains">
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -4,6 +4,10 @@
  See License.AGPL.txt in the project root for license information.
 -->
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory"
+                            serviceImplementation="io.gitpod.jetbrains.gateway.stable.StableGitpodConnectionHandleFactory"/>
+    </extensions>
     <extensions defaultExtensionNs="com.jetbrains">
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Description
This PR updates the Platform Version from JetBrains Gateway Plugin (EAP) to the latest version.

## How to test

Merge if tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. Ensure you have the Gateway installed from [JetBrains Toolbox App](https://www.jetbrains.com/toolbox-app/) and have it up-to-date.
  - You should use Gateway version corresponding to plugin qualifier, i.e. for stable plugin test with released, for latest test with EAP.
  - It could be that a new Gateway is not published for the given SDK yet then wait for it to be published. You can check the build version in the About dialog.
2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
  - You can also uninstall current Gitpod plugin, configure dev channel using https://plugins.jetbrains.com/plugins/list?channel=dev&pluginId=18438-gitpod-gateway and restart GW to test that the proper version is detected and installed.
3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
</details>

## Release Notes
```release-note
NONE
```

## Werft options:
- [x] /werft publish-to-jb-marketplace
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=true
- [x] with-ws-manager-mk2

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._