### PR TITLE
[supervisor] Persist bash history across workspace restarts PRD-59

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1006,8 +1006,10 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 		envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -Xmx%sm", mem)
 	}
 
-	envs["HISTFILE"] = "/workspace/.gitpod/.bash_history"
-	envs["PROMPT_COMMAND"] = "history -a"
+	if _, ok := envs["HISTFILE"]; !ok {
+		envs["HISTFILE"] = "/workspace/.gitpod/.shell_history"
+		envs["PROMPT_COMMAND"] = "history -a"
+	}
 
 	var env, envn []string
 	for nme, val := range envs {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1006,6 +1006,9 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 		envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -Xmx%sm", mem)
 	}
 
+	envs["HISTFILE"] = "/workspace/.gitpod/.bash_history"
+	envs["PROMPT_COMMAND"] = "history -a"
+
 	var env, envn []string
 	for nme, val := range envs {
 		log.WithField("envvar", nme).Debug("passing environment variable to IDE")

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,7 +21,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
-			"HISTFILE=/workspace/.gitpod/.bash_history",
+			"HISTFILE=/workspace/.gitpod/.shell_history",
 			"PROMPT_COMMAND=history -a",
 		)
 	}
@@ -90,14 +90,14 @@ func TestBuildChildProcEnv(t *testing.T) {
 			Name:  "ots",
 			Input: []string{},
 			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
-			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.bash_history",
+			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
 		{
 			Name:  "failed ots",
 			Input: []string{},
 			OTS:   `invalid json`,
-			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.bash_history",
+			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},
 	}

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,6 +21,8 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
+			"HISTFILE=/workspace/.gitpod/.bash_history",
+			"PROMPT_COMMAND=history -a",
 		)
 	}
 
@@ -85,16 +87,18 @@ func TestBuildChildProcEnv(t *testing.T) {
 			},
 		},
 		{
-			Name:        "ots",
-			Input:       []string{},
-			OTS:         `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
-			Expectation: []string{"HOME=/home/gitpod", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
+			Name:  "ots",
+			Input: []string{},
+			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
+			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.bash_history",
+				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
 		{
-			Name:        "failed ots",
-			Input:       []string{},
-			OTS:         `invalid json`,
-			Expectation: []string{"HOME=/home/gitpod", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
+			Name:  "failed ots",
+			Input: []string{},
+			OTS:   `invalid json`,
+			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.bash_history",
+				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates [PRD-59](https://linear.app/gitpod/issue/PRD-59/persisted-terminal-history)

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in your preview environment
2. execute some command in this workspace
3. restart this workspace
4. use up arrow key to check if history still in there

repeat these step in different ide, i.e. Jetbrains, ssh, vscode desktop

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-bash-history</li>
	<li><b>🔗 URL</b> - <a href="https://pd-bash-history.preview.gitpod-dev.com/workspaces" target="_blank">pd-bash-history.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
