### PR TITLE
[SSO] find organizational accounts by email – WEB-346

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -600,7 +600,7 @@ export class TypeORMUserDBImpl implements UserDB {
         return blockedUsers > 0;
     }
 
-    async findOrganizationalUser(organizationId: string, email: string): Promise<MaybeUser> {
+    async findOrgOwnedUser(organizationId: string, email: string): Promise<MaybeUser> {
         const userRepo = await this.getUserRepo();
         const qBuilder = userRepo
             .createQueryBuilder("user")

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -178,7 +178,7 @@ class UserDBSpec {
     }
 
     @test(timeout(10000))
-    public async findOrganizationalUser_by_email() {
+    public async findOrgOwnedUser_by_email() {
         let orgUser = await this.db.newUser();
         orgUser.organizationId = "org1";
         orgUser.name = "Tester";
@@ -190,7 +190,7 @@ class UserDBSpec {
         });
         orgUser = await this.db.storeUser(orgUser);
 
-        const result = await this.db.findOrganizationalUser("org1", "tester@some.org");
+        const result = await this.db.findOrgOwnedUser("org1", "tester@some.org");
         expect(result, "organizational user should be found").not.to.be.undefined;
         expect(result!.identities, "should find a single identity").to.have.length(1);
     }

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -179,20 +179,23 @@ class UserDBSpec {
 
     @test(timeout(10000))
     public async findOrgOwnedUser_by_email() {
-        let orgUser = await this.db.newUser();
-        orgUser.organizationId = "org1";
-        orgUser.name = "Tester";
-        orgUser.identities.push({
+        let orgUser1 = await this.db.newUser();
+        orgUser1.organizationId = "org1";
+        orgUser1.name = "Tester";
+        orgUser1.identities.push({
             authId: "123",
             authName: "Tester",
             authProviderId: "oauth2-client-id",
             primaryEmail: "tester@some.org",
         });
-        orgUser = await this.db.storeUser(orgUser);
+        orgUser1 = await this.db.storeUser(orgUser1);
 
         const result = await this.db.findOrgOwnedUser("org1", "tester@some.org");
         expect(result, "organizational user should be found").not.to.be.undefined;
         expect(result!.identities, "should find a single identity").to.have.length(1);
+
+        const result2 = await this.db.findOrgOwnedUser("org1", "unknown@some.org");
+        expect(result2, "no user should be found").to.be.undefined;
     }
 }
 

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -176,6 +176,24 @@ class UserDBSpec {
         expect(r1).to.be.not.undefined;
         expect(r1!.name).to.be.eq("XYZ");
     }
+
+    @test(timeout(10000))
+    public async findOrganizationalUser_by_email() {
+        let orgUser = await this.db.newUser();
+        orgUser.organizationId = "org1";
+        orgUser.name = "Tester";
+        orgUser.identities.push({
+            authId: "123",
+            authName: "Tester",
+            authProviderId: "oauth2-client-id",
+            primaryEmail: "tester@some.org",
+        });
+        orgUser = await this.db.storeUser(orgUser);
+
+        const result = await this.db.findOrganizationalUser("org1", "tester@some.org");
+        expect(result, "organizational user should be found").not.to.be.undefined;
+        expect(result!.identities, "should find a single identity").to.have.length(1);
+    }
 }
 
 namespace TestData {

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -148,6 +148,8 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
     deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void>;
     countUsagesOfPhoneNumber(phoneNumber: string): Promise<number>;
     isBlockedPhoneNumber(phoneNumber: string): Promise<boolean>;
+
+    findOrganizationalUser(organizationId: string, email: string): Promise<MaybeUser>;
 }
 export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "id">;
 

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -149,7 +149,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
     countUsagesOfPhoneNumber(phoneNumber: string): Promise<number>;
     isBlockedPhoneNumber(phoneNumber: string): Promise<boolean>;
 
-    findOrganizationalUser(organizationId: string, email: string): Promise<MaybeUser>;
+    findOrgOwnedUser(organizationId: string, email: string): Promise<MaybeUser>;
 }
 export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "id">;
 

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -44,7 +44,7 @@ class TestIamSessionApp {
             }
             return undefined;
         },
-        findOrganizationalUser: async (params) => {
+        findOrgOwnedUser: async (params) => {
             if (params.email === this.knownEmail) {
                 return { id: "id-known-user" } as any;
             }

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -30,15 +30,22 @@ class TestIamSessionApp {
 
     protected cookieName = "test-session-name";
 
-    protected knownSub = "111";
+    protected knownSubjectID = "111";
+    protected knownEmail = "tester@my.org";
 
     protected userServiceMock: Partial<UserService> = {
         createUser: (params) => {
             return { id: "id-new-user" } as any;
         },
 
-        findUserForLogin: (params) => {
-            if (params.candidate?.authId === this.knownSub) {
+        findUserForLogin: async (params) => {
+            if (params.candidate?.authId === this.knownSubjectID) {
+                return { id: "id-known-user" } as any;
+            }
+            return undefined;
+        },
+        findOrganizationalUser: async (params) => {
+            if (params.email === this.knownEmail) {
                 return { id: "id-known-user" } as any;
             }
             return undefined;
@@ -141,7 +148,21 @@ class TestIamSessionApp {
 
     @test public async testSessionRequestResponsesWithSetCookie_knownUser() {
         const payload = { ...this.payload };
-        payload.claims.sub = this.knownSub;
+        payload.claims.sub = this.knownSubjectID;
+        const result = await request(this.app.create())
+            .post("/session")
+            .set("Content-Type", "application/json")
+            .send(JSON.stringify(payload));
+
+        expect(result.statusCode, JSON.stringify(result.body)).to.equal(200);
+        expect(result.body?.userId).to.equal("id-known-user");
+        expect(JSON.stringify(result.get("Set-Cookie"))).to.contain(this.cookieName);
+    }
+
+    @test public async testSessionRequestResponsesWithSetCookie_knownEmail() {
+        const payload = { ...this.payload };
+        payload.claims.sub = "random-subject-id";
+        payload.claims.email = this.knownEmail;
         const result = await request(this.app.create())
             .post("/session")
             .set("Content-Type", "application/json")

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -127,7 +127,7 @@ export class IamSessionApp {
         }
 
         // Organizational account lookup by email address
-        existingUser = await this.userService.findOrganizationalUser({
+        existingUser = await this.userService.findOrgOwnedUser({
             organizationId: payload.organizationId,
             email: payload.claims.email,
         });

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -131,6 +131,9 @@ export class IamSessionApp {
             organizationId: payload.organizationId,
             email: payload.claims.email,
         });
+        if (existingUser) {
+            log.info("Found Org-owned user by email.", { email: payload?.claims?.email });
+        }
 
         return existingUser;
     }

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -11,7 +11,7 @@ import { Authenticator } from "../auth/authenticator";
 import { UserService } from "../user/user-service";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { Identity, User } from "@gitpod/gitpod-protocol";
+import { Identity, IdentityLookup, User } from "@gitpod/gitpod-protocol";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib";
 import { ResponseError } from "vscode-ws-jsonrpc";
 
@@ -57,9 +57,8 @@ export class IamSessionApp {
 
     protected async doCreateSession(req: express.Request) {
         const payload = OIDCCreateSessionPayload.validate(req.body);
-        const existingUser = await this.userService.findUserForLogin({
-            candidate: this.mapOIDCProfileToIdentity(payload),
-        });
+
+        const existingUser = await this.findExistingOIDCUser(payload);
         const user = existingUser || (await this.createNewOIDCUser(payload));
 
         await new Promise<void>((resolve, reject) => {
@@ -77,17 +76,63 @@ export class IamSessionApp {
         };
     }
 
+    /**
+     * Maps from OIDC profile (ID token) to `Identity` which is used for the primary
+     * lookup of existing users as well as for creating new accounts.
+     */
     protected mapOIDCProfileToIdentity(payload: OIDCCreateSessionPayload): Identity {
         const {
-            claims: { sub, name, email },
+            claims: { sub, name, email, aud },
+        } = payload;
+        return {
+            authId: sub,
+            authProviderId: aud,
+            primaryEmail: email,
+            authName: name,
+        };
+    }
+
+    /**
+     * Computes search criteria to look up existing accounts in compatibility mode.
+     * The composite key `[subject, oidc-client-config-id]` was used as identifier for
+     * existing accounts before the switch to `[subject, audience/client-id]`.
+     */
+    protected mapOIDCProfileToIdentityLookup_compatibility(payload: OIDCCreateSessionPayload): IdentityLookup {
+        const {
+            claims: { sub },
             oidcClientConfigId,
         } = payload;
         return {
             authId: sub,
             authProviderId: oidcClientConfigId,
-            authName: name,
-            primaryEmail: email,
         };
+    }
+
+    protected async findExistingOIDCUser(payload: OIDCCreateSessionPayload): Promise<User | undefined> {
+        // Direct lookup
+        let existingUser = await this.userService.findUserForLogin({
+            candidate: this.mapOIDCProfileToIdentity(payload),
+        });
+        if (existingUser) {
+            return existingUser;
+        }
+
+        // Compatibility lookup
+        existingUser = await this.userService.findUserForLogin({
+            candidate: this.mapOIDCProfileToIdentityLookup_compatibility(payload),
+        });
+        if (existingUser) {
+            // TODO(at) convert legacy entry
+            return existingUser;
+        }
+
+        // Organizational account lookup by email address
+        existingUser = await this.userService.findOrganizationalUser({
+            organizationId: payload.organizationId,
+            email: payload.claims.email,
+        });
+
+        return existingUser;
     }
 
     protected async createNewOIDCUser(payload: OIDCCreateSessionPayload): Promise<User> {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -335,8 +335,8 @@ export class UserService {
         return user;
     }
 
-    async findOrganizationalUser(params: { organizationId: string; email: string }): Promise<MaybeUser> {
-        let user = await this.userDb.findOrganizationalUser(params.organizationId, params.email);
+    async findOrgOwnedUser(params: { organizationId: string; email: string }): Promise<MaybeUser> {
+        let user = await this.userDb.findOrgOwnedUser(params.organizationId, params.email);
         return user;
     }
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -5,8 +5,8 @@
  */
 
 import { injectable, inject } from "inversify";
-import { User, Identity, Token, AdditionalUserData } from "@gitpod/gitpod-protocol";
-import { BUILTIN_INSTLLATION_ADMIN_USER_ID, ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { User, Identity, Token, AdditionalUserData, IdentityLookup } from "@gitpod/gitpod-protocol";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, MaybeUser, ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
@@ -330,8 +330,13 @@ export class UserService {
         return await this.userDb.storeUser(target);
     }
 
-    async findUserForLogin(params: { candidate: Identity }) {
+    async findUserForLogin(params: { candidate: IdentityLookup }) {
         let user = await this.userDb.findUserByIdentity(params.candidate);
+        return user;
+    }
+
+    async findOrganizationalUser(params: { organizationId: string; email: string }): Promise<MaybeUser> {
+        let user = await this.userDb.findOrganizationalUser(params.organizationId, params.email);
         return user;
     }
 


### PR DESCRIPTION
First try to look up accounts by `[subjectID, audience]` as composite key, then try to lookup by email address. The scope of this lookup is limited to the Org owning the SSO configuration.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-346

## How to test
* See unit test
* Regular SSO login should still work


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
