### PR TITLE
[server] fix stripe customer information

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -134,6 +134,7 @@ import { JobRunner } from "./jobs/runner";
 import { DatabaseGarbageCollector } from "./jobs/database-gc";
 import { OTSGarbageCollector } from "./jobs/ots-gc";
 import { UserToTeamMigrationService } from "./migration/user-to-team-migration-service";
+import { FixStripeAttributionIds } from "./jobs/fix-stripe-job";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -362,6 +363,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
     bind(DatabaseGarbageCollector).toSelf().inSingletonScope();
     bind(OTSGarbageCollector).toSelf().inSingletonScope();
+    bind(FixStripeAttributionIds).toSelf().inSingletonScope();
     bind(JobRunner).toSelf().inSingletonScope();
 
     // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129

--- a/components/server/src/jobs/fix-stripe-job.ts
+++ b/components/server/src/jobs/fix-stripe-job.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM } from "@gitpod/gitpod-db/lib";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { StripeService } from "../user/stripe-service";
+import { Job } from "./runner";
+import { Config } from "../config";
+
+@injectable()
+export class FixStripeAttributionIds implements Job {
+    @inject(TypeORM) protected readonly typeorm: TypeORM;
+    @inject(StripeService) protected readonly stripeService: StripeService;
+    @inject(Config) protected readonly config: Config;
+
+    public readonly name = "fix-stripe-attribution-ids";
+    public readonly lockId = [this.name];
+    public frequencyMs = 300 * 60 * 1000; // every 5 hours
+
+    public async run(): Promise<void> {
+        if (!this.config.stripeSecrets) {
+            log.info("Job disabled", { name: this.name, reason: "stripeSecrets not configured" });
+            return;
+        }
+        try {
+            const c = await this.typeorm.getConnection();
+            const result = await c.query(`
+                SELECT
+                    c.stripeCustomerid, o.id as organizationId, u.id as userId
+                FROM
+                    d_b_stripe_customer c, d_b_team o, d_b_team_membership m, d_b_user u
+                WHERE
+                    o.id = m.teamId AND
+                    m.userId = u.id AND
+                    (o.name = u.name OR o.name = u.fullName) AND
+                    u._lastModified >'2023-04-15' AND
+                    c.deleted = 0 AND
+                    u.additionalData->>'$.isMigratedToTeamOnlyAttribution' = 'true' AND
+                    SUBSTRING(c.attributionId,6) = o.id
+            `);
+            log.info(`Starting update for stripe customer ids`, { numberOfCustomers: result.length });
+            let migrated = 0;
+            // iterate over result set and update the attributionid stripe attributionid
+            for (const row of result) {
+                const userId = row.userId;
+                const organizationId = row.organizationId;
+                const stripeCustomerId = row.stripeCustomerid;
+                if (
+                    await this.stripeService.updateAttributionId(
+                        stripeCustomerId,
+                        AttributionId.render({ kind: "team", teamId: organizationId }),
+                        AttributionId.render({ kind: "user", userId: userId }),
+                    )
+                ) {
+                    migrated++;
+                }
+                // wait a bit to not overload the stripe API
+                await new Promise((r) => setTimeout(r, 1000));
+            }
+
+            log.info(`Finished update for stripe customer ids`, { numberOfCustomers: result.length, migrated });
+        } catch (err) {
+            log.error("Failed to run job", err, { jobName: this.name });
+            throw err;
+        }
+    }
+}

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -16,13 +16,14 @@ import { OTSGarbageCollector } from "./ots-gc";
 import { TokenGarbageCollector } from "./token-gc";
 import { WebhookEventGarbageCollector } from "./webhook-gc";
 import { WorkspaceGarbageCollector } from "./workspace-gc";
+import { FixStripeAttributionIds } from "./fix-stripe-job";
 
 export const Job = Symbol("Job");
 
 export interface Job {
-    name: string;
-    lockId: string[];
-    frequencyMs: number;
+    get name(): string;
+    get lockId(): string[];
+    get frequencyMs(): number;
     run: () => Promise<void>;
 }
 
@@ -35,11 +36,19 @@ export class JobRunner {
     @inject(TokenGarbageCollector) protected tokenGC: TokenGarbageCollector;
     @inject(WebhookEventGarbageCollector) protected webhookGC: WebhookEventGarbageCollector;
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
+    @inject(FixStripeAttributionIds) protected fixStripeAttributionIds: FixStripeAttributionIds;
 
     public start(): DisposableCollection {
         const disposables = new DisposableCollection();
 
-        const jobs: Job[] = [this.databaseGC, this.otsGC, this.tokenGC, this.webhookGC, this.workspaceGC];
+        const jobs: Job[] = [
+            this.databaseGC,
+            this.otsGC,
+            this.tokenGC,
+            this.webhookGC,
+            this.workspaceGC,
+            this.fixStripeAttributionIds,
+        ];
 
         for (let job of jobs) {
             log.info(`Registered job ${job.name} in job runner.`, {

--- a/components/server/src/migration/user-to-team-migration-service.spec.db.ts
+++ b/components/server/src/migration/user-to-team-migration-service.spec.db.ts
@@ -13,8 +13,12 @@ import { StripeService } from "../user/stripe-service";
 const expect = chai.expect;
 
 const mockedStripe = new StripeService();
-mockedStripe.updateAttributionId = async (stripeCustomerId: string, attributionId: string) => {
-    return;
+mockedStripe.updateAttributionId = async (
+    stripeCustomerId: string,
+    attributionId: string,
+    oldAttributionId: string,
+) => {
+    return true;
 };
 testContainer.load(
     new ContainerModule((bind) => {

--- a/components/server/src/migration/user-to-team-migration-service.ts
+++ b/components/server/src/migration/user-to-team-migration-service.ts
@@ -161,7 +161,7 @@ export class UserToTeamMigrationService {
             const stripeCustomerId = stripeCustomer[0].stripeId;
             // update the metadata['attributionid'] on the stripe customer in stripe
             try {
-                await this.stripeService.updateAttributionId(stripeCustomerId, newAttribution);
+                await this.stripeService.updateAttributionId(stripeCustomerId, newAttribution, oldAttribution);
                 // delete the record from the db so it gets repopulated on next use
                 result = await conn.query("DELETE FROM d_b_stripe_customer WHERE attributionid = ?", [oldAttribution]);
                 log.info(ctx, "Migrated stripe customer data.", {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A job that iterates over already migrated users and updates the attributionid in stripe

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-352

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
