### PR TITLE
[server] Add support for encoding AuthFlow as JWT

### DIFF
--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -105,4 +105,19 @@ export namespace AuthFlow {
             return saveSession(session);
         }
     }
+
+    export function is(obj: any): obj is AuthFlow {
+        if (obj === undefined) {
+            return false;
+        }
+        if (typeof obj !== "object") {
+            return false;
+        }
+
+        if (!("host" in obj) || !("returnTo" in obj)) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/components/server/src/auth/jwt-signin.spec.ts
+++ b/components/server/src/auth/jwt-signin.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import { SignInJWT } from "./jwt";
+import { Container } from "inversify";
+import { Config } from "../config";
+import * as crypto from "crypto";
+import * as chai from "chai";
+import { AuthFlow } from "./auth-provider";
+
+const expect = chai.expect;
+
+@suite()
+class TestSigninJWT {
+    private container: Container;
+
+    private signingKeyPair = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+    private config: Config = {
+        auth: {
+            pki: {
+                signing: toKeyPair("0001", this.signingKeyPair),
+            },
+        },
+    } as Config;
+
+    async before() {
+        this.container = new Container();
+        this.container.bind(Config).toConstantValue(this.config);
+        this.container.bind(SignInJWT).toSelf().inSingletonScope();
+    }
+
+    @test
+    async test_sign_verify() {
+        const sut = this.container.get<SignInJWT>(SignInJWT);
+
+        const flow: AuthFlow = {
+            host: "https://my.awesome.host",
+            returnTo: "https://here.is.gitpod/signin/callback",
+            overrideScopes: true,
+        };
+        const encoded = await sut.sign(flow);
+        const decoded = await sut.verify(encoded);
+
+        expect({
+            host: decoded.host,
+            returnTo: decoded.returnTo,
+            overrideScopes: decoded.overrideScopes,
+        }).to.eq(flow);
+    }
+}
+
+function toKeyPair(
+    id: string,
+    kp: crypto.KeyPairKeyObjectResult,
+): {
+    id: string;
+    privateKey: string;
+    publicKey: string;
+} {
+    return {
+        id,
+        privateKey: kp.privateKey
+            .export({
+                type: "pkcs1",
+                format: "pem",
+            })
+            .toString(),
+        publicKey: kp.publicKey
+            .export({
+                type: "pkcs1",
+                format: "pem",
+            })
+            .toString(),
+    };
+}
+
+module.exports = new TestSigninJWT();

--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -46,7 +46,6 @@ class TestAuthJWT {
 
         const subject = "user-id";
         const encoded = await sut.sign(subject, {});
-        console.log("encoded", encoded);
 
         const decoded = await verify(encoded, this.config.auth.pki.signing.publicKey, {
             algorithms: ["RS512"],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
