### PR TITLE
Show billing in the organization menu and the organization usage page

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -24,6 +24,8 @@ import { toRemoteURL } from "../projects/render-utils";
 import { gitpodHostUrl } from "../service/service";
 import "./react-datepicker.css";
 import { Heading1, Heading2, Subheading } from "./typography/headings";
+import { Link } from "react-router-dom";
+import { useCurrentOrg } from "../data/organizations/orgs-query";
 
 interface UsageViewProps {
     attributionId: AttributionId;
@@ -37,6 +39,7 @@ function UsageView({ attributionId }: UsageViewProps) {
     const [endDate, setEndDate] = useState(dayjs());
     const supportedClasses = useWorkspaceClasses();
     const location = useLocation();
+    const currentOrg = useCurrentOrg();
     useEffect(() => {
         const match = /#(\d{4}-\d{2}-\d{2}):(\d{4}-\d{2}-\d{2})/.exec(location.hash);
         if (match) {
@@ -246,6 +249,15 @@ function UsageView({ attributionId }: UsageViewProps) {
                                                     {usagePage.data?.creditsUsed.toLocaleString()}
                                                 </span>
                                             </div>
+                                            {currentOrg.data && currentOrg.data.isOwner && (
+                                                <div className="flex text-xs text-gray-600">
+                                                    <span className="dark:text-gray-500 text-gray-400">
+                                                        <Link to="/billing" className="gp-link">
+                                                            View Billing →
+                                                        </Link>
+                                                    </span>
+                                                </div>
+                                            )}
                                         </div>
                                     </div>
                                 )}

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -82,8 +82,15 @@ export default function OrganizationSelector() {
         });
     }
 
-    // Show settings if user is an owner of current org
+    // Show billing & settings if user is an owner of current org
     if (currentOrg.data && currentOrg.data.isOwner) {
+        linkEntries.push({
+            title: "Billing",
+            customContent: <LinkEntry>Billing</LinkEntry>,
+            active: false,
+            separator: false,
+            link: "/billing",
+        });
         linkEntries.push({
             title: "Settings",
             customContent: <LinkEntry>Settings</LinkEntry>,


### PR DESCRIPTION
## Description

This will surface a link to `/billing` in the organization menu and a link to `/billing` from `/usage` if you are an organization owner, and you are able to access billing settings for the organization.

See [relevant discussion](https://gitpod.slack.com/archives/C027AUU7BC3/p1684141795509689) (internal). Cc @jankeromnes @loujaybee @axonasif @JohannesLandgraf 

~~⚠️ Haven't tested code changes in the preview environment yet.~~

![Frame 1470](https://github.com/gitpod-io/gitpod/assets/120486/a096ef88-05fb-4942-94b4-b84b17b7ce3d)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related UX-23

## How to test
Ope

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-show-bi318aa7585a</li>
	<li><b>🔗 URL</b> - <a href="https://gt-show-bi318aa7585a.preview.gitpod-dev.com/workspaces" target="_blank">gt-show-bi318aa7585a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
