### PR TITLE
[server] immediately run jobs

### DIFF
--- a/components/server/src/jobs/fix-stripe-job.ts
+++ b/components/server/src/jobs/fix-stripe-job.ts
@@ -50,14 +50,18 @@ export class FixStripeAttributionIds implements Job {
                 const userId = row.userId;
                 const organizationId = row.organizationId;
                 const stripeCustomerId = row.stripeCustomerid;
-                if (
-                    await this.stripeService.updateAttributionId(
-                        stripeCustomerId,
-                        AttributionId.render({ kind: "team", teamId: organizationId }),
-                        AttributionId.render({ kind: "user", userId: userId }),
-                    )
-                ) {
-                    migrated++;
+                try {
+                    if (
+                        await this.stripeService.updateAttributionId(
+                            stripeCustomerId,
+                            AttributionId.render({ kind: "team", teamId: organizationId }),
+                            AttributionId.render({ kind: "user", userId: userId }),
+                        )
+                    ) {
+                        migrated++;
+                    }
+                } catch (err) {
+                    log.error("Failed to update stripe customer", err, { userId, organizationId, stripeCustomerId });
                 }
                 // wait a bit to not overload the stripe API
                 await new Promise((r) => setTimeout(r, 1000));

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -56,6 +56,8 @@ export class JobRunner {
                 frequencyMs: job.frequencyMs,
                 redisLockId: job.lockId,
             });
+            // immediately run the job once
+            this.run(job);
             disposables.push(repeat(() => this.run(job), job.frequencyMs));
         }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The job runner schedules jobs using `repeat` which lets it wait the `frequencyMs` before running it the first time. This change will run all jobs on start and subsequently every `frequencyMs`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
