### PR TITLE
[usage] Remove accidental debug level logging

### DIFF
--- a/components/usage/pkg/scheduler/scheduler.go
+++ b/components/usage/pkg/scheduler/scheduler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/go-redsync/redsync/v4"
 	"github.com/robfig/cron"
-	"github.com/sirupsen/logrus"
 )
 
 func New(mutex *redsync.Redsync, jobs ...JobSpec) *Scheduler {
@@ -52,7 +51,6 @@ func (c *Scheduler) Start() {
 			defer c.runningJobs.Done()
 
 			now := time.Now().UTC()
-			log.Log.Logger.SetLevel(logrus.DebugLevel)
 			logger := log.WithField("job_id", j.ID)
 
 			err := WithRefreshingMutex(ctx, c.mutex, j.ID, j.InitialLockDuration, func(ctx context.Context) error {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
