### PR TITLE
[server] Use JWTs for Sign-in flow state WEB-365

### DIFF
--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -6,8 +6,6 @@
 
 import * as express from "express";
 import { AuthProviderInfo, User, OAuth2Config, AuthProviderEntry } from "@gitpod/gitpod-protocol";
-import { saveSession } from "../express-util";
-import { Session } from "../express";
 
 import { UserEnvVarValue } from "@gitpod/gitpod-protocol";
 

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -84,7 +84,7 @@ export interface AuthProvider {
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scopes?: string[],
     ): void;
     refreshToken?(user: User): Promise<void>;

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -96,22 +96,6 @@ export interface AuthFlow {
     readonly overrideScopes?: boolean;
 }
 export namespace AuthFlow {
-    export function get(session: Session | undefined): AuthFlow | undefined {
-        if (session) {
-            return session.authFlow;
-        }
-    }
-    export async function attach(session: Session, authFlow: AuthFlow): Promise<void> {
-        session.authFlow = authFlow;
-        return saveSession(session);
-    }
-    export async function clear(session: Session | undefined) {
-        if (session) {
-            session.authFlow = undefined;
-            return saveSession(session);
-        }
-    }
-
     export function is(obj: any): obj is AuthFlow {
         if (obj === undefined) {
             return false;

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -80,7 +80,13 @@ export interface AuthProvider {
     readonly info: AuthProviderInfo;
     readonly authCallbackPath: string;
     callback(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void>;
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scopes?: string[]): void;
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scopes?: string[],
+    ): void;
     refreshToken?(user: User): Promise<void>;
 }
 

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -142,13 +142,13 @@ export class Authenticator {
             return;
         }
 
-        // prepare session
-        await AuthFlow.attach(req.session, {
+        const flow: AuthFlow = {
             host,
             returnTo,
-        });
+        };
+
         // authenticate user
-        authProvider.authorize(req, res, next);
+        authProvider.authorize(req, res, next, flow);
     }
     protected async isInSetupMode() {
         const hasAnyStaticProviders = this.hostContextProvider
@@ -256,7 +256,7 @@ export class Authenticator {
         }
 
         // prepare session
-        await AuthFlow.attach(req.session, { host, returnTo, overrideScopes: override });
+        const flow: AuthFlow = { host, returnTo, overrideScopes: override };
         let wantedScopes = scopes
             .split(",")
             .map((s) => s.trim())
@@ -281,7 +281,7 @@ export class Authenticator {
             { sessionId: req.sessionID },
             `(doAuthorize) wanted scopes (${override ? "overriding" : "merging"}): ${wantedScopes.join(",")}`,
         );
-        authProvider.authorize(req, res, next, wantedScopes);
+        authProvider.authorize(req, res, next, flow, wantedScopes);
     }
     protected mergeScopes(a: string[], b: string[]) {
         const set = new Set(a);

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -148,15 +148,13 @@ export abstract class GenericAuthProvider implements AuthProvider {
 
     protected abstract readAuthUserSetup(accessToken: string, tokenResponse: object): Promise<AuthUserSetup>;
 
-    async authorize(
+    authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scope?: string[],
     ) {
-        const state = await this.signInJWT.sign(flow, 5 * 60);
-
         const handler = passport.authenticate(this.getStrategy() as any, {
             ...this.defaultStrategyOptions,
             ...{ state, scope },

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -504,7 +504,7 @@ export abstract class GenericAuthProvider implements AuthProvider {
         const { strategyName } = this;
         const clientInfo = getRequestingClientInfo(req);
         const authProviderId = this.authProviderId;
-        const authFlow = AuthFlow.get(req.session)!; // asserted in `callback` allready
+        const authFlow = await this.parseState((req.query.state as string) || "");
         const defaultLogPayload = { authFlow, clientInfo, authProviderId };
         let currentGitpodUser: User | undefined = User.is(req.user) ? req.user : undefined;
         let candidate: Identity;

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -317,8 +317,6 @@ export abstract class GenericAuthProvider implements AuthProvider {
 
         if (callbackError) {
             // e.g. "access_denied"
-            // Clean up the session
-            await AuthFlow.clear(request.session);
 
             increaseLoginCounter("failed", this.host);
             return this.sendCompletionRedirectWithError(response, {
@@ -363,8 +361,6 @@ export abstract class GenericAuthProvider implements AuthProvider {
         });
 
         if (err) {
-            await AuthFlow.clear(request.session);
-
             if (SelectAccountException.is(err)) {
                 return this.sendCompletionRedirectWithError(response, err.payload);
             }

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -513,10 +513,18 @@ export abstract class GenericAuthProvider implements AuthProvider {
         let currentGitpodUser: User | undefined = User.is(req.user) ? req.user : undefined;
         let candidate: Identity;
 
+        let authFlow: AuthFlow;
         try {
-            const authFlow = await this.parseState((req.query.state as string) || "");
-            const defaultLogPayload = { authFlow, clientInfo, authProviderId };
+            authFlow = await this.parseState((req.query.state as string) || "");
+        } catch (err) {
+            log.error(`(${strategyName}) Failed to extract auth flow from state`, err);
+            done(err, undefined);
+            return;
+        }
 
+        const defaultLogPayload = { authFlow, clientInfo, authProviderId };
+
+        try {
             const tokenResponseObject = this.ensureIsObject(tokenResponse);
             const { authUser, currentScopes, envVars } = await this.readAuthUserSetup(accessToken, tokenResponseObject);
             const { authName, primaryEmail } = authUser;

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -148,27 +148,21 @@ export abstract class GenericAuthProvider implements AuthProvider {
 
     protected abstract readAuthUserSetup(accessToken: string, tokenResponse: object): Promise<AuthUserSetup>;
 
-    authorize(
+    async authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
         flow: AuthFlow,
         scope?: string[],
-    ): void {
-        this.signInJWT
-            .sign(flow, 5 * 60)
-            .then((state) => {
-                const handler = passport.authenticate(this.getStrategy() as any, {
-                    ...this.defaultStrategyOptions,
-                    ...{ state, scope },
-                });
+    ) {
+        const state = await this.signInJWT.sign(flow, 5 * 60);
 
-                handler(req, res, next);
-            })
-            .catch((err) => {
-                res.status(500);
-                res.send("Failed to encode sign-in state.");
-            });
+        const handler = passport.authenticate(this.getStrategy() as any, {
+            ...this.defaultStrategyOptions,
+            ...{ state, scope },
+        });
+
+        handler(req, res, next);
     }
 
     protected getStrategy() {

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -48,9 +48,6 @@ export class LoginCompletionHandler {
                 });
             });
         } catch (err) {
-            // Clean up the session & avoid loops
-            await AuthFlow.clear(request.session);
-
             if (authHost) {
                 increaseLoginCounter("failed", authHost);
             }
@@ -78,9 +75,6 @@ export class LoginCompletionHandler {
         if (authHost) {
             await this.updateAuthProviderAsVerified(authHost, user);
         }
-
-        // Clean up the session & avoid loops
-        await AuthFlow.clear(request.session);
 
         if (authHost) {
             increaseLoginCounter("succeeded", authHost);

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -9,7 +9,6 @@ import * as express from "express";
 import { User } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
-import { AuthFlow } from "./auth-provider";
 import { HostContextProvider } from "./host-context-provider";
 import { AuthProviderService } from "./auth-provider-service";
 import { increaseLoginCounter, reportJWTCookieIssued } from "../prometheus-metrics";

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -8,7 +8,7 @@ import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as express from "express";
 import { inject, injectable } from "inversify";
-import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
+import { AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
 import { BitbucketServerOAuthScopes } from "./bitbucket-server-oauth-scopes";
 import { BitbucketServerApi } from "./bitbucket-server-api";
@@ -49,14 +49,14 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    async authorize(
+    authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scope?: string[],
     ) {
-        await super.authorize(req, res, next, flow, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
+        super.authorize(req, res, next, state, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
     }
 
     protected async readAuthUserSetup(accessToken: string, _tokenResponse: object) {

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -49,14 +49,14 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    authorize(
+    async authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
         flow: AuthFlow,
         scope?: string[],
-    ): void {
-        super.authorize(req, res, next, flow, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
+    ) {
+        await super.authorize(req, res, next, flow, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
     }
 
     protected async readAuthUserSetup(accessToken: string, _tokenResponse: object) {

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -8,7 +8,7 @@ import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as express from "express";
 import { inject, injectable } from "inversify";
-import { AuthUserSetup } from "../auth/auth-provider";
+import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
 import { BitbucketServerOAuthScopes } from "./bitbucket-server-oauth-scopes";
 import { BitbucketServerApi } from "./bitbucket-server-api";
@@ -49,8 +49,14 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scope?: string[],
+    ): void {
+        super.authorize(req, res, next, flow, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
     }
 
     protected async readAuthUserSetup(accessToken: string, _tokenResponse: object) {

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -47,14 +47,14 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    authorize(
+    async authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
         flow: AuthFlow,
         scope?: string[],
-    ): void {
-        super.authorize(req, res, next, flow, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
+    ) {
+        await super.authorize(req, res, next, flow, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
     }
 
     protected get baseURL() {

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -9,7 +9,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Bitbucket } from "bitbucket";
 import * as express from "express";
 import { injectable } from "inversify";
-import { AuthUserSetup } from "../auth/auth-provider";
+import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
 import { BitbucketOAuthScopes } from "./bitbucket-oauth-scopes";
 
@@ -47,8 +47,14 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scope?: string[],
+    ): void {
+        super.authorize(req, res, next, flow, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
     }
 
     protected get baseURL() {

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -9,7 +9,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Bitbucket } from "bitbucket";
 import * as express from "express";
 import { injectable } from "inversify";
-import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
+import { AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
 import { BitbucketOAuthScopes } from "./bitbucket-oauth-scopes";
 
@@ -47,14 +47,14 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
         return "x-token-auth";
     }
 
-    async authorize(
+    authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scope?: string[],
     ) {
-        await super.authorize(req, res, next, flow, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
+        super.authorize(req, res, next, state, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
     }
 
     protected get baseURL() {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -109,7 +109,7 @@ import { APIUserService } from "./api/user";
 import { APITeamsService } from "./api/teams";
 import { API } from "./api/server";
 import { LinkedInService } from "./linkedin-service";
-import { AuthJWT } from "./auth/jwt";
+import { AuthJWT, SignInJWT } from "./auth/jwt";
 import { SnapshotService } from "./workspace/snapshot-service";
 import { APIWorkspacesService } from "./api/workspaces";
 import { PrebuildManager } from "./prebuilds/prebuild-manager";
@@ -333,6 +333,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(API).toSelf().inSingletonScope();
 
     bind(AuthJWT).toSelf().inSingletonScope();
+    bind(SignInJWT).toSelf().inSingletonScope();
 
     bind(PrebuildManager).toSelf().inSingletonScope();
     bind(IPrefixContextParser).to(StartPrebuildContextParser).inSingletonScope();

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -11,7 +11,7 @@ import { Strategy as DummyStrategy } from "passport-dummy";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { ResponseError } from "vscode-jsonrpc";
 import { Authenticator } from "../auth/authenticator";
-import { AuthFlow, AuthProvider } from "../auth/auth-provider";
+import { AuthProvider } from "../auth/auth-provider";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { DevData } from "./dev-data";
 
@@ -61,7 +61,7 @@ class DummyAuthProvider implements AuthProvider {
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scopes: string[],
     ): void {
         throw new Error("Method not implemented.");

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -11,7 +11,7 @@ import { Strategy as DummyStrategy } from "passport-dummy";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { ResponseError } from "vscode-jsonrpc";
 import { Authenticator } from "../auth/authenticator";
-import { AuthProvider } from "../auth/auth-provider";
+import { AuthFlow, AuthProvider } from "../auth/auth-provider";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { DevData } from "./dev-data";
 
@@ -57,7 +57,13 @@ class DummyAuthProvider implements AuthProvider {
     authenticate(req: express.Request, res: express.Response, next: express.NextFunction): void {
         throw new Error("Method not implemented.");
     }
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scopes: string[]): void {
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scopes: string[],
+    ): void {
         throw new Error("Method not implemented.");
     }
 }

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -9,7 +9,7 @@ import * as express from "express";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitHubScope } from "./scopes";
-import { AuthUserSetup } from "../auth/auth-provider";
+import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
 import { Octokit } from "@octokit/rest";
 import { GitHubApiError } from "./api";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
@@ -45,8 +45,14 @@ export class GitHubAuthProvider extends GenericAuthProvider {
         };
     }
 
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : GitHubScope.Requirements.DEFAULT);
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scope?: string[],
+    ): void {
+        super.authorize(req, res, next, flow, scope ? scope : GitHubScope.Requirements.DEFAULT);
     }
 
     /**

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -45,14 +45,14 @@ export class GitHubAuthProvider extends GenericAuthProvider {
         };
     }
 
-    authorize(
+    async authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
         flow: AuthFlow,
         scope?: string[],
-    ): void {
-        super.authorize(req, res, next, flow, scope ? scope : GitHubScope.Requirements.DEFAULT);
+    ) {
+        await super.authorize(req, res, next, flow, scope ? scope : GitHubScope.Requirements.DEFAULT);
     }
 
     /**

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -9,7 +9,7 @@ import * as express from "express";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitHubScope } from "./scopes";
-import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
+import { AuthUserSetup } from "../auth/auth-provider";
 import { Octokit } from "@octokit/rest";
 import { GitHubApiError } from "./api";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
@@ -45,14 +45,14 @@ export class GitHubAuthProvider extends GenericAuthProvider {
         };
     }
 
-    async authorize(
+    authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scope?: string[],
     ) {
-        await super.authorize(req, res, next, flow, scope ? scope : GitHubScope.Requirements.DEFAULT);
+        super.authorize(req, res, next, state, scope ? scope : GitHubScope.Requirements.DEFAULT);
     }
 
     /**

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -12,7 +12,7 @@ import { GitLabScope } from "./scopes";
 import { UnconfirmedUserException } from "../auth/errors";
 import { GitLab } from "./api";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
-import { AuthUserSetup } from "../auth/auth-provider";
+import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
 import { oauthUrls } from "./gitlab-urls";
 
 @injectable()
@@ -46,8 +46,14 @@ export class GitLabAuthProvider extends GenericAuthProvider {
         };
     }
 
-    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : GitLabScope.Requirements.DEFAULT);
+    authorize(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+        flow: AuthFlow,
+        scope?: string[],
+    ): void {
+        super.authorize(req, res, next, flow, scope ? scope : GitLabScope.Requirements.DEFAULT);
     }
 
     protected get baseURL() {

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -46,14 +46,14 @@ export class GitLabAuthProvider extends GenericAuthProvider {
         };
     }
 
-    authorize(
+    async authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
         flow: AuthFlow,
         scope?: string[],
-    ): void {
-        super.authorize(req, res, next, flow, scope ? scope : GitLabScope.Requirements.DEFAULT);
+    ) {
+        await super.authorize(req, res, next, flow, scope ? scope : GitLabScope.Requirements.DEFAULT);
     }
 
     protected get baseURL() {

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -12,7 +12,7 @@ import { GitLabScope } from "./scopes";
 import { UnconfirmedUserException } from "../auth/errors";
 import { GitLab } from "./api";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";
-import { AuthFlow, AuthUserSetup } from "../auth/auth-provider";
+import { AuthUserSetup } from "../auth/auth-provider";
 import { oauthUrls } from "./gitlab-urls";
 
 @injectable()
@@ -46,14 +46,14 @@ export class GitLabAuthProvider extends GenericAuthProvider {
         };
     }
 
-    async authorize(
+    authorize(
         req: express.Request,
         res: express.Response,
         next: express.NextFunction,
-        flow: AuthFlow,
+        state: string,
         scope?: string[],
     ) {
-        await super.authorize(req, res, next, flow, scope ? scope : GitLabScope.Requirements.DEFAULT);
+        super.authorize(req, res, next, state, scope ? scope : GitLabScope.Requirements.DEFAULT);
     }
 
     protected get baseURL() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Stops using session storage to store the AuthFlow
* Instead, uses a signed JWT as part of the sign-in dance attached to the `state` param
* The `state` param is echoed back to us by the auth provider, and we extract our information from it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of WEB-365

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Sign-in with different providers, observe sign-in works

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-70f37720f6</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-70f37720f6.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-70f37720f6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
