### PR TITLE
[server] admin access guard

### DIFF
--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -9,6 +9,7 @@ import {
     GitpodToken,
     PrebuiltWorkspace,
     Repository,
+    Role,
     Snapshot,
     Team,
     TeamMemberInfo,
@@ -598,5 +599,12 @@ export class RepositoryResourceGuard implements ResourceAccessGuard {
             }),
         );
         return result.every((b) => b);
+    }
+}
+
+export class AdminResourceGuard implements ResourceAccessGuard {
+    constructor(protected readonly user: User) {}
+    async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
+        return (this.user.rolesOrPermissions || []).includes(Role.ADMIN.name);
     }
 }

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -34,6 +34,7 @@ import {
     TeamMemberResourceGuard,
     WithResourceAccessGuard,
     RepositoryResourceGuard,
+    AdminResourceGuard,
 } from "../auth/resource-access";
 import { clientIp, takeFirst } from "../express-util";
 import {
@@ -232,6 +233,7 @@ export class WebsocketConnectionManager implements ConnectionHandler {
                 new TeamMemberResourceGuard(user.id),
                 new SharedWorkspaceAccessGuard(),
                 new RepositoryResourceGuard(user, this.hostContextProvider),
+                new AdminResourceGuard(user),
             ]);
         } else {
             resourceGuard = { canAccess: async () => false };

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -20,6 +20,7 @@ import {
     OwnerResourceGuard,
     TeamMemberResourceGuard,
     RepositoryResourceGuard,
+    AdminResourceGuard,
 } from "../auth/resource-access";
 import { DBWithTracing, TracedWorkspaceDB } from "@gitpod/gitpod-db/lib/traced-db";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
@@ -225,6 +226,7 @@ export class HeadlessLogController {
             new OwnerResourceGuard(user.id),
             new TeamMemberResourceGuard(user.id),
             new RepositoryResourceGuard(user, this.hostContextProvider),
+            new AdminResourceGuard(user),
         ]);
         if (!(await resourceGuard.canAccess({ kind: "workspaceLog", subject: workspace, teamMembers }, "get"))) {
             res.sendStatus(403);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In WEB-349 we fail to update the usage limit for orgs, because the `adminSetUsageLimit` method delegates to`findStripeSubscriptionId`, which in turn checks if the current user has access. I believe instead of introducing parallel code for every admin function we should be able to use regular code paths and have admins being respected in the authorization.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-349

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-adminguard</li>
	<li><b>🔗 URL</b> - <a href="https://se-adminguard.preview.gitpod-dev.com/workspaces" target="_blank">se-adminguard.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
