### PR TITLE
[server] update OIDC users on sign-in (email) – WEB-370

### DIFF
--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -20,7 +20,7 @@ import * as request from "supertest";
 import * as chai from "chai";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib";
-import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
+import { TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
 const expect = chai.expect;
 
 @suite(timeout(10000))
@@ -33,6 +33,11 @@ class TestIamSessionApp {
     protected knownSubjectID = "111";
     protected knownEmail = "tester@my.org";
 
+    protected knownUser: Partial<User> = {
+        id: "id-known-user",
+        identities: [],
+    };
+
     protected userServiceMock: Partial<UserService> = {
         createUser: (params) => {
             return { id: "id-new-user" } as any;
@@ -40,13 +45,13 @@ class TestIamSessionApp {
 
         findUserForLogin: async (params) => {
             if (params.candidate?.authId === this.knownSubjectID) {
-                return { id: "id-known-user" } as any;
+                return this.knownUser as any;
             }
             return undefined;
         },
         findOrgOwnedUser: async (params) => {
             if (params.email === this.knownEmail) {
-                return { id: "id-known-user" } as any;
+                return this.knownUser as any;
             }
             return undefined;
         },

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -302,20 +302,20 @@ export class UserService {
         user.name = user.name || authUser.name || authUser.primaryEmail;
         user.avatarUrl = user.avatarUrl || authUser.avatarUrl;
         await this.onAfterUserLoad(user);
-        await this.updateUserIdentity(user, candidate, token);
+        await this.updateUserIdentity(user, candidate);
+        await this.userDb.storeSingleToken(candidate, token);
     }
 
     async onAfterUserLoad(user: User): Promise<User> {
         return user;
     }
 
-    async updateUserIdentity(user: User, candidate: Identity, token: Token) {
+    async updateUserIdentity(user: User, candidate: Identity) {
         // ensure single identity per auth provider instance
         user.identities = user.identities.filter((i) => i.authProviderId !== candidate.authProviderId);
         user.identities.push(candidate);
 
         await this.userDb.storeUser(user);
-        await this.userDb.storeSingleToken(candidate, token);
     }
 
     async deauthorize(user: User, authProviderId: string) {


### PR DESCRIPTION
Updates email address of SSO users on each sign-in.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-370

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
