### PR TITLE
SSO Setup screen showing on setup cell

### DIFF
--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -33,7 +33,15 @@ export const AppBlockingFlows: FC = ({ children }) => {
 
     // Handle dedicated setup if necessary
     if (showDedicatedSetup.showSetup) {
-        return <DedicatedSetup onComplete={() => showDedicatedSetup.markCompleted()} />;
+        return (
+            <DedicatedSetup
+                onComplete={() => {
+                    showDedicatedSetup.markCompleted();
+                    // doing a full page reload here to avoid any lingering setup-related state issues
+                    document.location.href = "/settings/git";
+                }}
+            />
+        );
     }
 
     // New user onboarding flow

--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -9,6 +9,7 @@ import { useShowDedicatedSetup } from "../dedicated-setup/use-show-dedicated-set
 import { useCurrentUser } from "../user-context";
 import { MigrationPage, useShouldSeeMigrationPage } from "../whatsnew/MigrationPage";
 import { useShowUserOnboarding } from "../onboarding/use-show-user-onboarding";
+import { useHistory } from "react-router";
 
 const UserOnboarding = lazy(() => import(/* webpackPrefetch: true */ "../onboarding/UserOnboarding"));
 const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicated-setup/DedicatedSetup"));
@@ -16,6 +17,7 @@ const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicat
 // This component handles any flows that should come after we've loaded the user/orgs, but before we render the normal app chrome.
 // Since this runs before the app is rendered, we should avoid adding any lengthy async calls that would delay the app from loading.
 export const AppBlockingFlows: FC = ({ children }) => {
+    const history = useHistory();
     const user = useCurrentUser();
     const shouldSeeMigrationPage = useShouldSeeMigrationPage();
     const showDedicatedSetup = useShowDedicatedSetup();
@@ -37,6 +39,8 @@ export const AppBlockingFlows: FC = ({ children }) => {
             <DedicatedSetup
                 onComplete={() => {
                     showDedicatedSetup.markCompleted();
+                    // keep this here to avoid flashing a different page while we reload below
+                    history.push("/settings/git");
                     // doing a full page reload here to avoid any lingering setup-related state issues
                     document.location.href = "/settings/git";
                 }}

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -10,7 +10,6 @@ import { OrgNamingStep } from "./OrgNamingStep";
 import { SSOSetupStep } from "./SSOSetupStep";
 import { useConfetti } from "../contexts/ConfettiContext";
 import { SetupCompleteStep } from "./SetupCompleteStep";
-import { useHistory } from "react-router";
 import { useOIDCClientsQuery } from "../data/oidc-clients/oidc-clients-query";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { Delayed } from "../components/Delayed";
@@ -66,7 +65,7 @@ const STEPS = {
     SSO_SETUP: "sso-setup",
     COMPLETE: "complete",
 } as const;
-type StepsValue = (typeof STEPS)[keyof typeof STEPS];
+type StepsValue = typeof STEPS[keyof typeof STEPS];
 
 type DedicatedSetupStepsProps = {
     org?: OrganizationInfo;
@@ -87,7 +86,6 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, ssoConfig, onC
     // If setup forced via params, just start at beginning
     const forceSetup = forceDedicatedSetupParam(params);
     const [step, setStep] = useState<StepsValue>(forceSetup ? STEPS.GETTING_STARTED : initialStep);
-    const history = useHistory();
     const { dropConfetti } = useConfetti();
 
     const handleSetupComplete = useCallback(() => {
@@ -105,9 +103,8 @@ const DedicatedSetupSteps: FC<DedicatedSetupStepsProps> = ({ org, ssoConfig, onC
 
     const handleEndSetup = useCallback(async () => {
         await updateUser();
-        history.push(`/settings/git?org=${org?.id}`);
         onComplete();
-    }, [history, onComplete, updateUser, org?.id]);
+    }, [onComplete, updateUser]);
 
     return (
         <>

--- a/components/dashboard/src/dedicated-setup/use-needs-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-needs-setup.ts
@@ -15,7 +15,9 @@ import { getGitpodService } from "../service/service";
 export const useNeedsSetup = () => {
     const { data: onboardingState, isLoading } = useOnboardingState();
     const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
-    let needsSetup = !isLoading && onboardingState && (onboardingState?.isCompleted ?? false) !== true;
+
+    // This needs to only be true if we've loaded the onboarding state
+    let needsSetup = !isLoading && onboardingState && onboardingState.isCompleted !== true;
 
     if (isCurrentHostExcludedFromSetup()) {
         needsSetup = false;

--- a/components/dashboard/src/dedicated-setup/use-needs-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-needs-setup.ts
@@ -15,8 +15,7 @@ import { getGitpodService } from "../service/service";
 export const useNeedsSetup = () => {
     const { data: onboardingState, isLoading } = useOnboardingState();
     const enableDedicatedOnboardingFlow = useFeatureFlag("enableDedicatedOnboardingFlow");
-
-    let needsSetup = (onboardingState?.isCompleted ?? false) !== true;
+    let needsSetup = !isLoading && onboardingState && (onboardingState?.isCompleted ?? false) !== true;
 
     if (isCurrentHostExcludedFromSetup()) {
         needsSetup = false;
@@ -38,9 +37,6 @@ const useOnboardingState = () => {
             return await getGitpodService().server.getOnboardingState();
         },
         {
-            // Cache for a bit so we can avoid having the value change before we're ready
-            staleTime: 1000 * 60 * 60 * 1, // 1h
-            cacheTime: 1000 * 60 * 60 * 1, // 1h
             // Only query if feature flag is enabled
             enabled: enableDedicatedOnboardingFlow,
         },

--- a/components/dashboard/src/dedicated-setup/use-show-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-show-dedicated-setup.ts
@@ -6,7 +6,7 @@
 
 import { useQueryParams } from "../hooks/use-query-params";
 import { useFeatureFlag } from "../data/featureflag-query";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { isCurrentHostExcludedFromSetup, useNeedsSetup } from "./use-needs-setup";
 
 const FORCE_SETUP_PARAM = "dedicated-setup";
@@ -35,13 +35,10 @@ export const useShowDedicatedSetup = () => {
 
     const markCompleted = useCallback(() => setInProgress(false), []);
 
-    // If needsOnboarding changes to true, we want to set flow as in progress
-    // This helps us not close the flow prematurely (i.e. onboardingState.completed = true but we want to show the completed page)
-    useEffect(() => {
-        if (enableDedicatedOnboardingFlow && showSetup && !inProgress) {
-            setInProgress(true);
-        }
-    }, [enableDedicatedOnboardingFlow, inProgress, showSetup]);
+    // Update to inProgress if we should show the setup flow and we aren't
+    if (enableDedicatedOnboardingFlow && showSetup && !inProgress) {
+        setInProgress(true);
+    }
 
     return {
         showSetup: inProgress,

--- a/components/dashboard/src/dedicated-setup/use-show-dedicated-setup.ts
+++ b/components/dashboard/src/dedicated-setup/use-show-dedicated-setup.ts
@@ -41,8 +41,7 @@ export const useShowDedicatedSetup = () => {
         if (enableDedicatedOnboardingFlow && showSetup && !inProgress) {
             setInProgress(true);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enableDedicatedOnboardingFlow, forceSetup, showSetup]);
+    }, [enableDedicatedOnboardingFlow, inProgress, showSetup]);
 
     return {
         showSetup: inProgress,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixing some bugs with when we show the dedicated setup flow.

* Ensure `needsSetup` is only true after we've loaded onboarding state. This was causing the setup flow to sometimes render when it shouldn't, and sometimes not render when it should.
* Removing query cache & stale times for `getOnboardingState`. This was causing issues at the end of the setup flow.
* Removed logic that sets setup flow to in progress from a useEffect to in the render. The `useEffect` wasn't running as reliably as it seemed to be setup to. This felt wrong to me at first, but because of the check against the value it changes, it won't cause render loops. Also, [this part](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) of the react docs does suggest this approach over an effect in some situations, which was enough to make me feel like I can sleep at night w/ this change 😄 .
* Shifted the redirect at the end of the flow to do a full page load to avoid any lingering setup state issues.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-374

## How to test
<!-- Provide steps to test this PR -->
To test this you need a fresh preview environment w/ dedicated emulation.

After creating your admin credential, use the link.
* You should see the setup flow
* Complete the flow, it should redirect and reload to `/git/settings` on completion.
* Navigate around, reloading the app and make sure you don't see the setup flow again.
* Bonus points for setting up git, and verifying starting a workspace works as well.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-dedicab4b73167dc</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-dedicab4b73167dc.preview.gitpod-dev.com/workspaces" target="_blank">bmh-dedicab4b73167dc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
