### PR TITLE
Fix new workspace class element overflow

### DIFF
--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -86,12 +86,12 @@ function WorkspaceClassDropDownElementSelected(props: { wsClass?: SupportedWorks
                 <img className="w-8 filter-grayscale self-center" src={WorkspaceClass} alt="logo" />
             </div>
             <div className="flex-col ml-1 mt-1 flex-grow">
-                <div className="text-gray-700 dark:text-gray-300 font-semibold">
-                    {title} <span className="text-gray-300 dark:text-gray-600 font-normal">&middot;</span>{" "}
-                    <span className="text-gray-400 dark:text-gray-500 font-normal">{c?.description}</span>
-                </div>
+                <div className="text-gray-700 dark:text-gray-300 font-semibold truncate w-80">{title}</div>
                 <div className="flex text-xs text-gray-500 dark:text-gray-400">
-                    <div className="font-semibold">Class</div>
+                    <div className="font-semibold">
+                        Class <span className="text-gray-300 dark:text-gray-600 font-normal">&middot;</span>{" "}
+                        <span className="text-gray-500 dark:text-gray-400 font-normal">{c?.description}</span>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description

Minor follow-up fix from https://github.com/gitpod-io/gitpod/pull/17622. Cc @easyCZ 

This will move the class description on the second line to scale better, following the editor metadata (Desktop, Browser). Similarly, we can later use that element for surfacing context metadata.

~~⚠️ Haven't tested code changes in a preview environment.~~

| BEFORE | AFTER |
|-|-|
| <img width="501" alt="Frame 1500" src="https://github.com/gitpod-io/gitpod/assets/120486/d3fd9e94-4a1e-4c7f-9f95-38dd27a0753d"> | <img width="501" alt="Frame 1501" src="https://github.com/gitpod-io/gitpod/assets/120486/0826e90d-86d8-4cfe-8d04-1ef646d01ddf"> |

## How to test
Try opening a workspace in /new, changing the default editor in user /preferences, or going through the user onboarding and notice that the new UX for selecting workspace class does not overflow. 🌊 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-fix-cla6df90eb333</li>
	<li><b>🔗 URL</b> - <a href="https://gt-fix-cla6df90eb333.preview.gitpod-dev.com/workspaces" target="_blank">gt-fix-cla6df90eb333.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
