### PR TITLE
[server] Delete webhook events directly

### DIFF
--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -57,11 +57,14 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         const d = new Date();
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
-        await repo
+        const query = await repo
             .createQueryBuilder()
             .limit(limit)
             .where("creationTime <= :expirationDate", { expirationDate })
-            .delete();
+            .delete()
+            .getQuery();
+
+        console.log(query);
 
         return;
     }

--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -52,19 +52,17 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         return query.getMany();
     }
 
-    public async deleteOldEvents(ageInDays: number, limit?: number): Promise<void> {
+    public async deleteOldEvents(ageInDays: number, limit: number): Promise<void> {
         const repo = await this.getRepo();
         const d = new Date();
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
-        const query = repo
+        await repo
             .createQueryBuilder()
-            .update()
-            .set({ deleted: true })
-            .where("creationTime <= :expirationDate", { expirationDate });
-        if (typeof limit === "number") {
-            query.limit(limit);
-        }
-        await query.execute();
+            .limit(limit)
+            .where("creationTime <= :expirationDate", { expirationDate })
+            .delete();
+
+        return;
     }
 }

--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -57,17 +57,7 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         const d = new Date();
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
-        await repo.query(
-            `DELETE FROM d_b_webhook_event
-                WHERE id IN (
-                SELECT id FROM (
-                    SELECT id FROM d_b_webhook_event
-                    WHERE creationTime <= ?
-                    LIMIT ?
-                ) AS selection
-            )`,
-            [expirationDate, limit],
-        );
+        await repo.query(`DELETE FROM d_b_webhook_event WHERE creationTime <= ? LIMIT ?`, [expirationDate, limit]);
 
         return;
     }

--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -57,14 +57,17 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         const d = new Date();
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
-        const query = await repo
-            .createQueryBuilder()
-            .limit(limit)
-            .where("creationTime <= :expirationDate", { expirationDate })
-            .delete()
-            .getQuery();
-
-        console.log(query);
+        await repo.query(
+            `DELETE FROM d_b_webhook_event
+                WHERE id IN (
+                SELECT id FROM (
+                    SELECT id FROM d_b_webhook_event
+                    WHERE creationTime <= ?
+                    LIMIT ?
+                ) AS selection
+            )`,
+            [expirationDate, limit],
+        );
 
         return;
     }

--- a/components/gitpod-db/src/webhook-event-db.spec.db.ts
+++ b/components/gitpod-db/src/webhook-event-db.spec.db.ts
@@ -64,9 +64,8 @@ export class WebhookEventDBSpec {
 
         await this.db.deleteOldEvents(0, 1);
 
-        const event = (await this.db.findByCloneUrl(cloneUrl))[0];
-        expect(event, "should be found").to.be.not.undefined;
-        expect((event as DBWebhookEvent).deleted, "should be marked as deleted").to.be.true;
+        const events = await this.db.findByCloneUrl(cloneUrl);
+        expect(events.length).to.be.eq(0);
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
