### PR TITLE
[server] delete duplicate auth provider

### DIFF
--- a/components/gitpod-db/src/auth-provider-entry.spec.db.ts
+++ b/components/gitpod-db/src/auth-provider-entry.spec.db.ts
@@ -104,9 +104,9 @@ export class AuthProviderEntryDBSpec {
     }
 
     @test public async findByOrgId() {
-        const ap1 = this.authProvider({ id: "1", organizationId: "O1" });
-        const ap2 = this.authProvider({ id: "2", organizationId: "O1" });
-        const ap3 = this.authProvider({ id: "3", organizationId: "O2" });
+        const ap1 = this.authProvider({ id: "1", organizationId: "O1", host: "H1" });
+        const ap2 = this.authProvider({ id: "2", organizationId: "O1", host: "H2" });
+        const ap3 = this.authProvider({ id: "3", organizationId: "O2", host: "H1" });
 
         await this.db.storeAuthProvider(ap1, false);
         await this.db.storeAuthProvider(ap2, false);

--- a/components/gitpod-db/src/typeorm/migration/1684328022688-AuthProviderUniqueHostName.ts
+++ b/components/gitpod-db/src/typeorm/migration/1684328022688-AuthProviderUniqueHostName.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AuthProviderUniqueHostName1684328022688 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // delete any duplicates
+        await queryRunner.query(`
+            DELETE FROM d_b_auth_provider_entry
+            WHERE id NOT IN (
+                SELECT id FROM (
+                    SELECT MIN(id) AS id
+                    FROM d_b_auth_provider_entry
+                    GROUP BY host
+                ) AS t
+            )
+        `);
+        // create constraint
+        await queryRunner.query(`
+            ALTER TABLE d_b_auth_provider_entry
+            ADD CONSTRAINT unique_host_by_org UNIQUE (host, organizationId)
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -33,19 +33,7 @@ export class AuthProviderService {
      */
     async getAllAuthProviders(exceptOAuthRevisions: string[] = []): Promise<AuthProviderParams[]> {
         const all = await this.authProviderDB.findAll(exceptOAuthRevisions);
-        const transformed = all.map(this.toAuthProviderParams.bind(this));
-
-        // as a precaution, let's remove duplicates
-        const unique = new Map<string, AuthProviderParams>();
-        for (const current of transformed) {
-            const duplicate = unique.get(current.host);
-            if (duplicate) {
-                log.warn(`Duplicate dynamic Auth Provider detected.`, { rawResult: all, duplicate: current.host });
-                continue;
-            }
-            unique.set(current.host, current);
-        }
-        return Array.from(unique.values());
+        return all.map((provider) => this.toAuthProviderParams(provider));
     }
 
     async getAllAuthProviderHosts(): Promise<string[]> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Stumbled over this [log message](https://cloudlogging.app.goo.gl/hExAVvtFJ1Dwu3cc7). Which is caused by two entries in d_b_auth_provider_entry with the same host. There is only this one duplicate case in the prdo DB and I don't know how it got there, but instead of always ignoring one entry we should enforce this on insert/update.

The message is logged because the actual config that is used alternates with every call. 
And since we cache by host name it gets re-created every time.

https://github.com/gitpod-io/gitpod/blob/079d31e7de2e0319a097ef391156e1be05acbe78/components/server/src/auth/host-context-provider-impl.ts#L84-L109

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
