### PR TITLE
Touch up SSO Config changes

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -51,7 +51,6 @@ export default function ConfirmationModal(props: {
         >
             <ModalHeader>{props.title || "Confirm"}</ModalHeader>
             <ModalBody>
-                <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
                 {props.warningText && (
                     <Alert type="warning" className="mb-4">
                         <strong>{props.warningHead}</strong>
@@ -59,6 +58,7 @@ export default function ConfirmationModal(props: {
                         {props.warningText}
                     </Alert>
                 )}
+                <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
                 {isEntity(props.children) ? (
                     <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
                         <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">

--- a/components/dashboard/src/components/toasts/Toasts.tsx
+++ b/components/dashboard/src/components/toasts/Toasts.tsx
@@ -10,7 +10,7 @@ import { Portal } from "react-portal";
 import { ToastEntry, toastReducer } from "./reducer";
 import { Toast } from "./Toast";
 
-type ToastFnProps = string | (Pick<ToastEntry, "message"> & Partial<ToastEntry>);
+type ToastFnProps = ToastEntry["message"] | (Pick<ToastEntry, "message"> & Partial<ToastEntry>);
 
 const ToastContext = createContext<{
     toast: (toast: ToastFnProps, opts?: Partial<ToastEntry>) => void;
@@ -30,15 +30,23 @@ export const ToastContextProvider: FC = ({ children }) => {
     }, []);
 
     const addToast = useCallback((message: ToastFnProps, opts = {}) => {
+        // detect if message arg looks like a toast object
+        // it can also be a ReactNode
+        let isToastObj = false;
+        if (message && typeof message === "object" && message.hasOwnProperty("message")) {
+            isToastObj = true;
+        }
+
         let newToast: ToastEntry = {
-            ...(typeof message === "string"
+            ...(isToastObj
                 ? {
                       id: `${Math.random()}`,
-                      message,
+                      // @ts-ignore
+                      ...message,
                   }
                 : {
                       id: `${Math.random()}`,
-                      ...message,
+                      message,
                   }),
             ...opts,
         };

--- a/components/dashboard/src/components/toasts/reducer.ts
+++ b/components/dashboard/src/components/toasts/reducer.ts
@@ -4,9 +4,11 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { ReactNode } from "react";
+
 export type ToastEntry = {
     id: string;
-    message: string;
+    message: ReactNode;
     duration?: number;
     autoHide?: boolean;
 };

--- a/components/dashboard/src/teams/sso/ActivateConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/ActivateConfigModal.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback } from "react";
+import ConfirmationModal from "../../components/ConfirmationModal";
+import { useOIDCClientsQuery } from "../../data/oidc-clients/oidc-clients-query";
+import { useActivateOIDCClientMutation } from "../../data/oidc-clients/activate-oidc-client-mutation";
+import { useToast } from "../../components/toasts/Toasts";
+import { ModalFooterAlert } from "../../components/Modal";
+
+type Props = {
+    configId: string;
+    hasActiveConfig: boolean;
+    onClose: () => void;
+};
+export const ActivateConfigModal: FC<Props> = ({ configId, hasActiveConfig, onClose }) => {
+    const { toast } = useToast();
+    const { data } = useOIDCClientsQuery();
+    const config = (data || []).find((c) => c.id === configId);
+    const activateClient = useActivateOIDCClientMutation();
+
+    const handleActivateClient = useCallback(async () => {
+        if (!config) {
+            return;
+        }
+
+        activateClient.mutate(
+            { id: config.id },
+            {
+                onSuccess: () => {
+                    toast("Single sign-on configuration was activated.");
+                    onClose();
+                },
+                onError: (error) => {
+                    console.error(error);
+                },
+            },
+        );
+    }, [activateClient, config, onClose, toast]);
+
+    // We should already have the config in all the scenarios we show this modal. If we don't, wait for it.
+    if (!config) {
+        return null;
+    }
+
+    return (
+        <ConfirmationModal
+            title="Activate SSO configuration"
+            areYouSureText="Are you sure you want to activate the following SSO configuration?"
+            children={{
+                name: config.oidcConfig?.issuer ?? "",
+                description: config.oauth2Config?.clientId ?? "",
+            }}
+            buttonText="Activate"
+            buttonType="primary"
+            buttonLoading={activateClient.isLoading}
+            warningText={
+                hasActiveConfig
+                    ? "Activating this SSO configuration will also deactivate the currently active configuration."
+                    : ""
+            }
+            footerAlert={
+                activateClient.isError ? (
+                    <ModalFooterAlert type="danger">There was a problem activating the configuration</ModalFooterAlert>
+                ) : null
+            }
+            onClose={onClose}
+            onConfirm={handleActivateClient}
+        />
+    );
+};

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -59,7 +59,7 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
             toast(
                 <span>
                     Your SSO configuration was successfully saved.{" "}
-                    <LinkButton onClick={() => verifyClient(configId)}>Verify it</LinkButton>.
+                    <LinkButton onClick={() => verifyClient(configId)}>Verify configuration</LinkButton>.
                 </span>,
             );
         },

--- a/components/dashboard/src/teams/sso/OIDCClients.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClients.tsx
@@ -42,7 +42,7 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
             toast(
                 <span>
                     Single sign-on configuration was successfully verified.{" "}
-                    <LinkButton onClick={() => setActivateModalConfigID(configId)}>Activate configuration</LinkButton>.
+                    <LinkButton onClick={() => setActivateModalConfigID(configId)}>Activate configuration</LinkButton>
                 </span>,
             );
         },
@@ -58,8 +58,8 @@ const OIDCClientsList: FC<OIDCClientsListProps> = ({ clientConfigs }) => {
         (configId: string) => {
             toast(
                 <span>
-                    Your SSO configuration was successfully saved.{" "}
-                    <LinkButton onClick={() => verifyClient(configId)}>Verify configuration</LinkButton>.
+                    Single sign-on configuration was successfully saved.{" "}
+                    <LinkButton onClick={() => verifyClient(configId)}>Verify configuration</LinkButton>
                 </span>,
             );
         },

--- a/components/dashboard/src/teams/sso/use-verify-client.ts
+++ b/components/dashboard/src/teams/sso/use-verify-client.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useCallback } from "react";
+import { openOIDCStartWindow } from "../../provider-utils";
+import { useInvalidateOIDCClientsQuery } from "../../data/oidc-clients/oidc-clients-query";
+
+type Props = {
+    onSuccess: (configId: string) => void;
+    onError: (errorMessage: string) => void;
+};
+export const useVerifyClient = ({ onSuccess, onError }: Props) => {
+    const invalidateClients = useInvalidateOIDCClientsQuery();
+
+    return useCallback(
+        async (configId: string) => {
+            await openOIDCStartWindow({
+                verify: true,
+                configId,
+                // TODO: fix callback to not call for previous windows
+                onSuccess: async () => {
+                    invalidateClients();
+                    onSuccess(configId);
+                },
+                onError: (payload) => {
+                    let errorMessage: string;
+                    if (typeof payload === "string") {
+                        errorMessage = payload;
+                    } else {
+                        errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
+                    }
+
+                    onError(errorMessage);
+                },
+            });
+        },
+        [invalidateClients, onError, onSuccess],
+    );
+};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some followup work from #17635 

* Updating some copy
* Added clickable actions inside toast notifications for verifying and activating configs. Needed to shift some of the activate & verify logic up a few component levels for this to work right.
* Shifted the `<ConfirmationModal/>`'s `alert` to be above the warning text based on feedback.
* Made the `toast()` function (from `useToast`) accept a ReactNode for the message instead of only a string. This allows for clickable links, etc, inside of toasts. Would be good to iterate here and settle on a pattern for action buttons on toasts to be more explicit. Would also be nice to have a specific error style toast as well. cc @gtsiolis 

| Header | Header |
|--------|--------|
| <img width="404" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/2825bd73-57f9-4152-8db4-415e11412369"> | <img width="406" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/795cf464-b447-48ce-a8c3-7001a5ac81b7"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-322

## How to test
<!-- Provide steps to test this PR -->
* Create an SSO config for your org.
* Try using the verify link in the toast after you save it. You can edit/save the config to get the toast again.
* After verifying, use the Activate link in the toast. You can edit/save/verify to see the toast again if needed.
* Create a new config and use the verify/activate menu items from the list entry with a config as well. You can use the same credentials for the 2nd config w/o any problems.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-pr-1763f7234a33c</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-pr-1763f7234a33c.preview.gitpod-dev.com/workspaces" target="_blank">bmh-pr-1763f7234a33c.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
