### PR TITLE
Implement deactivation of OIDC client configs – WEB-333

### DIFF
--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -268,15 +268,7 @@ func UpdateOIDCClientConfig(ctx context.Context, conn *gorm.DB, cipher Cipher, u
 	return nil
 }
 
-func ActivateClientConfig(ctx context.Context, conn *gorm.DB, id uuid.UUID) error {
-	return setClientConfigActiveFlag(ctx, conn, id, true)
-}
-
-func DeactivateClientConfig(ctx context.Context, conn *gorm.DB, id uuid.UUID) error {
-	return setClientConfigActiveFlag(ctx, conn, id, false)
-}
-
-func setClientConfigActiveFlag(ctx context.Context, conn *gorm.DB, id uuid.UUID, active bool) error {
+func SetClientConfigActiviation(ctx context.Context, conn *gorm.DB, id uuid.UUID, active bool) error {
 	config, err := GetOIDCClientConfig(ctx, conn, id)
 	if err != nil {
 		return err

--- a/components/gitpod-db/go/oidc_client_config_test.go
+++ b/components/gitpod-db/go/oidc_client_config_test.go
@@ -175,7 +175,7 @@ func TestActivateClientConfig(t *testing.T) {
 	t.Run("not found when config does not exist", func(t *testing.T) {
 		conn := dbtest.ConnectForTests(t)
 
-		err := db.ActivateClientConfig(context.Background(), conn, uuid.New())
+		err := db.SetClientConfigActiviation(context.Background(), conn, uuid.New(), true)
 		require.Error(t, err)
 		require.ErrorIs(t, err, db.ErrorNotFound)
 	})
@@ -193,14 +193,14 @@ func TestActivateClientConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, false, config.Active)
 
-		err = db.ActivateClientConfig(context.Background(), conn, configID)
+		err = db.SetClientConfigActiviation(context.Background(), conn, configID, true)
 		require.NoError(t, err)
 
 		config2, err := db.GetOIDCClientConfig(context.Background(), conn, configID)
 		require.NoError(t, err)
 		require.Equal(t, true, config2.Active)
 
-		err = db.ActivateClientConfig(context.Background(), conn, configID)
+		err = db.SetClientConfigActiviation(context.Background(), conn, configID, true)
 		require.NoError(t, err)
 	})
 
@@ -219,7 +219,7 @@ func TestActivateClientConfig(t *testing.T) {
 		config2 := configs[1]
 
 		// activate first
-		err := db.ActivateClientConfig(context.Background(), conn, config1.ID)
+		err := db.SetClientConfigActiviation(context.Background(), conn, config1.ID, true)
 		require.NoError(t, err)
 
 		config1, err = db.GetOIDCClientConfig(context.Background(), conn, config1.ID)
@@ -227,7 +227,7 @@ func TestActivateClientConfig(t *testing.T) {
 		require.Equal(t, true, config1.Active, "failed to activate config1")
 
 		// activate second
-		err = db.ActivateClientConfig(context.Background(), conn, config2.ID)
+		err = db.SetClientConfigActiviation(context.Background(), conn, config2.ID, true)
 		require.NoError(t, err)
 
 		config2, err = db.GetOIDCClientConfig(context.Background(), conn, config2.ID)

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -330,6 +330,10 @@ func (s *OIDCService) SetClientConfigActivation(ctx context.Context, req *connec
 
 	config, err := db.GetOIDCClientConfig(ctx, s.dbConn, clientConfigID)
 	if err != nil {
+		if errors.Is(err, db.ErrorNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("OIDC Client Config %s for Organization %s does not exist", clientConfigID.String(), organizationID.String()))
+		}
+
 		return nil, err
 	}
 

--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -342,20 +342,12 @@ func (s *OIDCService) SetClientConfigActivation(ctx context.Context, req *connec
 			log.Extract(ctx).WithError(err).Error("Failed to activate an unverified OIDC Client Config.")
 			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("Failed to activate an unverified OIDC Client Config %s for Organization %s", clientConfigID.String(), organizationID.String()))
 		}
-
-		err = db.ActivateClientConfig(ctx, s.dbConn, clientConfigID)
-		if err != nil {
-			log.Extract(ctx).WithError(err).Error("Failed to activate OIDC Client Config.")
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Failed to activate OIDC Client Config %s for Organization %s", clientConfigID.String(), organizationID.String()))
-		}
 	}
 
-	if !req.Msg.Activate {
-		err = db.DeactivateClientConfig(ctx, s.dbConn, clientConfigID)
-		if err != nil {
-			log.Extract(ctx).WithError(err).Error("Failed to deactivate OIDC Client Config.")
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Failed to deactivate OIDC Client Config %s for Organization %s", clientConfigID.String(), organizationID.String()))
-		}
+	err = db.SetClientConfigActiviation(ctx, s.dbConn, clientConfigID, req.Msg.Activate)
+	if err != nil {
+		log.Extract(ctx).WithError(err).Error("Failed to set OIDC Client Config activation.")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Failed to set OIDC Client Config activation (ID: %s) for Organization %s", clientConfigID.String(), organizationID.String()))
 	}
 
 	return connect.NewResponse(&v1.SetClientConfigActivationResponse{}), nil

--- a/components/public-api-server/pkg/apiv1/oidc_test.go
+++ b/components/public-api-server/pkg/apiv1/oidc_test.go
@@ -727,6 +727,18 @@ func TestOIDCService_SetClientConfigActivation_WithFeatureFlagEnabled(t *testing
 		require.NoError(t, err)
 		require.Equal(t, false, getResponse.Msg.Config.Active)
 	})
+
+	t.Run("record not found", func(t *testing.T) {
+		_, client, _ := setupOIDCService(t, withOIDCFeatureEnabled)
+
+		_, err := client.SetClientConfigActivation(context.Background(), connect.NewRequest(&v1.SetClientConfigActivationRequest{
+			Id:             uuid.NewString(),
+			OrganizationId: organizationID.String(),
+			Activate:       false,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
 }
 
 func setupOIDCService(t *testing.T, expClient experiments.Client) (*protocol.MockAPIInterface, v1connect.OIDCServiceClient, *gorm.DB) {

--- a/components/public-api-server/pkg/oidc/service.go
+++ b/components/public-api-server/pkg/oidc/service.go
@@ -196,7 +196,7 @@ func (s *Service) activateAndVerifyClientConfig(ctx context.Context, config *Cli
 	if err != nil {
 		return err
 	}
-	return db.ActivateClientConfig(ctx, s.dbConn, uuid)
+	return db.SetClientConfigActiviation(ctx, s.dbConn, uuid, true)
 }
 
 func (s *Service) markClientConfigAsVerified(ctx context.Context, config *ClientConfig) error {


### PR DESCRIPTION
This is a follow-up to #17576. 

With this change it's possible to deactivate a client config by using `SetClientConfigActivation` RPC method with `Activate: false` parameter.

## How to test
See unit test.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
