### PR TITLE
Auth window message success handlers running more than once

### DIFF
--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -52,7 +52,8 @@ interface OpenAuthorizeWindowParams extends WindowMessageHandler {
 
 async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
     const { login, host, scopes, overrideScopes } = params;
-    let search = "message=success";
+    const successKey = getUniqueSuccessKey();
+    let search = `message=${successKey}`;
     const redirectURL = getSafeURLRedirect();
     if (redirectURL) {
         search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`;
@@ -77,7 +78,7 @@ async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
 
     openModalWindow(url);
 
-    attachMessageListener(params);
+    attachMessageListener(successKey, params);
 }
 
 function openModalWindow(url: string) {
@@ -94,9 +95,12 @@ function openModalWindow(url: string) {
     );
 }
 
-function attachMessageListener({ onSuccess, onError }: WindowMessageHandler) {
+function attachMessageListener(successKey: string, { onSuccess, onError }: WindowMessageHandler) {
     const eventListener = (event: MessageEvent) => {
-        // todo: check event.origin
+        // TODO: check w/ why we didn't do this already
+        if (event?.origin !== document.location.origin) {
+            return;
+        }
 
         const killAuthWindow = () => {
             window.removeEventListener("message", eventListener);
@@ -107,7 +111,7 @@ function attachMessageListener({ onSuccess, onError }: WindowMessageHandler) {
             }
         };
 
-        if (typeof event.data === "string" && event.data.startsWith("success")) {
+        if (typeof event.data === "string" && event.data.startsWith(successKey)) {
             killAuthWindow();
             onSuccess && onSuccess(event.data);
         }
@@ -138,7 +142,8 @@ interface OpenOIDCStartWindowParams extends WindowMessageHandler {
 
 async function openOIDCStartWindow(params: OpenOIDCStartWindowParams) {
     const { orgSlug, configId, activate = false, verify = false } = params;
-    let search = "message=success";
+    const successKey = getUniqueSuccessKey();
+    let search = `message=${successKey}`;
     const redirectURL = getSafeURLRedirect();
     if (redirectURL) {
         search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`;
@@ -166,7 +171,7 @@ async function openOIDCStartWindow(params: OpenOIDCStartWindowParams) {
 
     openModalWindow(url);
 
-    attachMessageListener(params);
+    attachMessageListener(successKey, params);
 }
 const getSafeURLRedirect = (source?: string) => {
     const returnToURL: string | null = new URLSearchParams(source ? source : window.location.search).get("returnTo");
@@ -180,6 +185,12 @@ const getSafeURLRedirect = (source?: string) => {
             return returnToURL;
         }
     }
+};
+
+// Used to ensure each callback is handled uniquely
+let counter = 0;
+const getUniqueSuccessKey = () => {
+    return `success:${counter++}`;
 };
 
 export { iconForAuthProvider, simplifyProviderName, openAuthorizeWindow, getSafeURLRedirect, openOIDCStartWindow };

--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -97,7 +97,6 @@ function openModalWindow(url: string) {
 
 function attachMessageListener(successKey: string, { onSuccess, onError }: WindowMessageHandler) {
     const eventListener = (event: MessageEvent) => {
-        // TODO: check w/ why we didn't do this already
         if (event?.origin !== document.location.origin) {
             return;
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes an issue where the onSuccess callback to the auth popup flows sometimes run when they shouldn't. This can happen if any unsuccessful flows (user closed popup) precede a successful one. The successful one will then trigger all other ones to fire their onSuccess as well.

Adds a unique key for each popup auth flow so we can correlate the callbacks to the right success handlers. We were already passing a `message=success` param throughout the flow, and validating the `success` value. I've built onto that making the value we pass through the flow, and check at the end unique. This will prevent scenarios where multiple previously opened flows that never finished may all have their success callbacks fired as soon as a successful flow completes.

I've also added a check against the window message `event.origin` matching the current origin.

## Risk
I'd label this as high risk because it touches code related to the auth flows, Login included. We should be able to easily test the functionality though. I've run through the different auth scenarios below pretty heavily to test things out.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-389

## How to test
<!-- Provide steps to test this PR -->
Since this code touches auth flows, we should test the following:

* Login with GitHub (or any public provider)
* Setup SSO (verify & activate flows work)
* Login with SSO
* Setup Git Provider (activate flow works)

To verify it solves the problem of one success firing unrelated callbacks, do the following:
* Create an invalid SSO config against a valid issuer url, like `https://accounts.google.com`.
* Try and verify it - it should render an error page from the google auth flow.
* Launch another verify flow for good measure (now we've queued up 2 success callbacks that should never fire).
* Create a valid SSO or update your existing one to use valid credentials.
* Verify it - it should finish successfully.
* You should see **1** toast, not **3**.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-oidc-fc5f5d72988</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-oidc-fc5f5d72988.preview.gitpod-dev.com/workspaces" target="_blank">bmh-oidc-fc5f5d72988.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
