### PR TITLE
Initial commit of the scrubber

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 /components/blobserve @gitpod-io/engineering-ide
 /components/common-go @gitpod-io/engineering-staff-engineers
+/components/components/scrubber @gitpod-io/engineering-staff-engineers
 /components/content-service-api @gitpod-io/engineering-workspace
 /components/content-service @gitpod-io/engineering-workspace
 /components/dashboard @gitpod-io/engineering-webapp @gtsiolis

--- a/components/scrubber/BUILD.yaml
+++ b/components/scrubber/BUILD.yaml
@@ -1,0 +1,11 @@
+packages:
+    - name: lib
+      type: go
+      srcs:
+        - go.mod
+        - go.sum
+        - "**/*.go"
+      env:
+        - CGO_ENABLED=0
+      config:
+        packaging: library

--- a/components/scrubber/README.md
+++ b/components/scrubber/README.md
@@ -1,0 +1,4 @@
+# scrubber
+Scrubber is the library we use to scrub data from PII and other sensitive information.
+
+This code is located in `components/` instead of `components/common-go/scrubber` to reduce the number of transitive depencies we're introducing to consumers of this package.

--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -4,6 +4,8 @@
 
 package scrubber
 
+import "regexp"
+
 var (
 	// RedactedFieldNames are the names of fields we'll redact
 	RedactedFieldNames = []string{
@@ -21,5 +23,11 @@ var (
 		"workspaceID",
 		"username",
 		"email",
+	}
+
+	// HashedValues are regular expressions which - when matched - cause the entire value to be hashed
+	HashedValues = map[string]*regexp.Regexp{
+		// https://www.regular-expressions.info/email.html
+		"email": regexp.MustCompile(`\A[a-z0-9!#$%&'*+/=?^_‘{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_‘{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z`),
 	}
 )

--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+var (
+	// RedactedFieldNames are the names of fields we'll redact
+	RedactedFieldNames = []string{
+		"auth_",
+		"password",
+		"token",
+		"key",
+		"jwt",
+		"secret",
+	}
+
+	// HashedFieldNames name fields whose values we'll hash
+	HashedFieldNames = []string{
+		"workspaceId",
+		"workspaceID",
+		"username",
+		"email",
+	}
+)

--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -27,7 +27,7 @@ var (
 
 	// HashedValues are regular expressions which - when matched - cause the entire value to be hashed
 	HashedValues = map[string]*regexp.Regexp{
-		// https://www.regular-expressions.info/email.html
-		"email": regexp.MustCompile(`\A[a-z0-9!#$%&'*+/=?^_‘{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_‘{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z`),
+		// https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
+		"email": regexp.MustCompile(`[a-zA-Z0-9.!#$%&'*+\/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*`),
 	}
 )

--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -19,7 +19,7 @@ var (
 
 	// HashedFieldNames name fields whose values we'll hash
 	HashedFieldNames = []string{
-		"workspaceId",
+		"contextURL",
 		"workspaceID",
 		"username",
 		"email",

--- a/components/scrubber/example_test.go
+++ b/components/scrubber/example_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestScrub(t *testing.T) {
+
+	scrubber := Default
+
+	// log.WithFieldSensitive("workspaceID", "gitpodio-gitpod-uesaddev73c").Info("hello world")
+	scrubber.KeyValue("workspaceID", "gitpodio-gitpod-uesaddev73c") // -> [scrubbed:md5:ae3e415b124cdbac878e995cad169490]
+
+	var someJSONData = json.RawMessage(`{"email": "foo@bar.com", "username": "foobar", "orgID": "112233", "desc": "the email is foo@bar.com"}`)
+	scrubber.JSON(someJSONData) // -> `{"email": "[scrubbed:md5:e2e6d7a977f2ca2b3900e22c68655b30]", "username": "[scrubbed:md5:14758f1afd44c09b7992073ccf00b43d]", "orgID": "[scrubbed:md5:cc9d7e078ba46da002aba1cf665b0acf]", "desc": "the email is [scrubbed:email]"}`
+
+	var user = User{
+		Username:  "foobar",
+		Email:     "foo@bar.com",
+		AuthToken: "112233",
+	}
+	scrubber.Struct(&user) // -> {Username: "[scrubbed:md5:14758f1afd44c09b7992073ccf00b43d]", Email: "[scrubbed:md5:e2e6d7a977f2ca2b3900e22c68655b30]", AuthToken: "[scrubbed]"}
+
+	scrubber.Value("this may be an email: foo@bar.com") // -> "this may be an email: [scrubbed:md5:e2e6d7a977f2ca2b3900e22c68655b30:email]"
+}
+
+type User struct {
+	Username  string
+	Email     string
+	AuthToken string `scrub:"redact"`
+}

--- a/components/scrubber/go.mod
+++ b/components/scrubber/go.mod
@@ -1,0 +1,5 @@
+module github.com/gitpod-io/scrubber
+
+go 1.19
+
+require github.com/google/go-cmp v0.5.9 // indirect

--- a/components/scrubber/go.mod
+++ b/components/scrubber/go.mod
@@ -1,4 +1,4 @@
-module github.com/gitpod-io/scrubber
+module github.com/gitpod-io/gitpod/components/scrubber
 
 go 1.19
 

--- a/components/scrubber/go.mod
+++ b/components/scrubber/go.mod
@@ -2,4 +2,7 @@ module github.com/gitpod-io/scrubber
 
 go 1.19
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require (
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+)

--- a/components/scrubber/go.sum
+++ b/components/scrubber/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/components/scrubber/go.sum
+++ b/components/scrubber/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/components/scrubber/sanitisation.go
+++ b/components/scrubber/sanitisation.go
@@ -9,17 +9,51 @@ import (
 	"fmt"
 )
 
+// sanitiserOption provides additional options to a sanitiser
+type SanitiserOption func(*sanitiserOptions)
+
+// SanitiseWithKeyName adds the keyname as metadata to the sanitised value
+func SanitiseWithKeyName(keyName string) SanitiserOption {
+	return func(so *sanitiserOptions) {
+		so.keyName = keyName
+	}
+}
+
+type sanitiserOptions struct {
+	keyName string
+}
+
 // Sanitiser turns a potentially sensitive value into a non-sensitive value
-type Sanitisatiser func(value string) string
+type Sanitisatiser func(value string, opts ...SanitiserOption) string
 
 // SanitiseRedact sanitises a single value by replacing it with a fixed string
-func SanitiseRedact(value string) string {
+func SanitiseRedact(value string, opts ...SanitiserOption) string {
+	options := mergeSanitiserOpts(opts)
+	if options.keyName != "" {
+		return "[redacted:" + options.keyName + "]"
+	}
 	return "[redacted]"
 }
 
 // SanitiseHash sanitises a single value by hashing it using MD5
-func SanitiseHash(value string) string {
+func SanitiseHash(value string, opts ...SanitiserOption) string {
+	options := mergeSanitiserOpts(opts)
+
 	hash := md5.New()
 	_, _ = hash.Write([]byte(value))
-	return fmt.Sprintf("[redacted:md5:%x]", hash.Sum(nil))
+
+	res := fmt.Sprintf("[redacted:md5:%x", hash.Sum(nil))
+	if options.keyName != "" {
+		res += ":" + options.keyName
+	}
+	res += "]"
+	return res
+}
+
+func mergeSanitiserOpts(opts []SanitiserOption) sanitiserOptions {
+	var res sanitiserOptions
+	for _, opt := range opts {
+		opt(&res)
+	}
+	return res
 }

--- a/components/scrubber/sanitisation.go
+++ b/components/scrubber/sanitisation.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// Sanitiser turns a potentially sensitive value into a non-sensitive value
+type Sanitisatiser func(value string) string
+
+// SanitiseRedact sanitises a single value by replacing it with a fixed string
+func SanitiseRedact(value string) string {
+	return "[redacted]"
+}
+
+// SanitiseHash sanitises a single value by hashing it using MD5
+func SanitiseHash(value string) string {
+	hash := md5.New()
+	_, _ = hash.Write([]byte(value))
+	return fmt.Sprintf("[redacted:md5:%x]", hash.Sum(nil))
+}

--- a/components/scrubber/sanitisation_test.go
+++ b/components/scrubber/sanitisation_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSanitiser(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Func        Sanitisatiser
+		Expectation string
+		Input       string
+	}{
+		{Func: SanitiseRedact, Name: "redact empty string", Expectation: "[redacted]"},
+		{Func: SanitiseRedact, Name: "redact sensitive string", Input: "foo@bar.com", Expectation: "[redacted]"},
+		{Func: SanitiseHash, Name: "hash empty string", Expectation: "[redacted:md5:d41d8cd98f00b204e9800998ecf8427e]"},
+		{Func: SanitiseHash, Name: "hash sensitive string", Input: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8]"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			act := test.Func(test.Input)
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("sanitiser mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/scrubber/sanitisation_test.go
+++ b/components/scrubber/sanitisation_test.go
@@ -14,18 +14,21 @@ func TestSanitiser(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Func        Sanitisatiser
+		Opts        []SanitiserOption
 		Expectation string
 		Input       string
 	}{
 		{Func: SanitiseRedact, Name: "redact empty string", Expectation: "[redacted]"},
 		{Func: SanitiseRedact, Name: "redact sensitive string", Input: "foo@bar.com", Expectation: "[redacted]"},
+		{Func: SanitiseRedact, Name: "redact key name", Opts: []SanitiserOption{SanitiseWithKeyName("foo")}, Input: "foo@bar.com", Expectation: "[redacted:foo]"},
 		{Func: SanitiseHash, Name: "hash empty string", Expectation: "[redacted:md5:d41d8cd98f00b204e9800998ecf8427e]"},
 		{Func: SanitiseHash, Name: "hash sensitive string", Input: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8]"},
+		{Func: SanitiseHash, Name: "hash key name", Opts: []SanitiserOption{SanitiseWithKeyName("foo")}, Input: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:foo]"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			act := test.Func(test.Input)
+			act := test.Func(test.Input, test.Opts...)
 
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
 				t.Errorf("sanitiser mismatch (-want +got):\n%s", diff)

--- a/components/scrubber/scrubber.go
+++ b/components/scrubber/scrubber.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+import (
+	"encoding/json"
+)
+
+type Scrubber interface {
+	// Value scrubs a single value, by trying to detect the kind of data it may contain.
+	// This is an entirely heuristic effort with the lowest likelihood of success. Prefer
+	// the other methods over this one. No assumptions about the structure of the data are made,
+	// e.g. that the value is a JSON string.
+	Value(value string) string
+
+	// KeyValue scrubs a key-value pair. The key is never changed, assuming that it's a hardcoded,
+	// well choosen identifier. The value however is sanitisied much like Value() would, except with the
+	// additional hint of the key name itself.
+	KeyValue(key, value string) (sanitisedValue string)
+
+	// JSON scrubs a JSON structure using a combination of KeyValue() and Value(). If the msg
+	// is not valid JSON, an error is returned.
+	JSON(msg json.RawMessage) (json.RawMessage, error)
+
+	// Struct scrubes a struct. val must be a pointer, otherwise an error is returned.
+	// By default only string and json.RawMessage fields are scrubbed.
+	// The `scrub` struct tag can be used to influnce the scrubber. The struct tag takes the following values:
+	//   - `ignore` which causes the scrubber to ignore the field
+	//   - `hash` which makes the scrubber hash the field value
+	//   - `redact` which makes the scrubber redact the field value
+	//
+	// Example:
+	//   type Example struct {
+	// 		Username      string `scrub:"ignore"`
+	//	    Password      string
+	//	    Inconspicuous string `scrub:"redact"`
+	//   }
+	//
+	Struct(val any) error
+}
+
+// Default is the default scrubber consumers of this package should use
+var Default Scrubber = scrubberImpl{}
+
+type scrubberImpl struct{}
+
+// JSON implements Scrubber
+func (scrubberImpl) JSON(msg json.RawMessage) (json.RawMessage, error) {
+	panic("unimplemented")
+}
+
+// KeyValue implements Scrubber
+func (scrubberImpl) KeyValue(key string, value string) (sanitisedValue string) {
+	panic("unimplemented")
+}
+
+// Struct implements Scrubber
+func (scrubberImpl) Struct(val any) error {
+	panic("unimplemented")
+}
+
+// Value implements Scrubber
+func (scrubberImpl) Value(value string) string {
+	panic("unimplemented")
+}

--- a/components/scrubber/scrubber.go
+++ b/components/scrubber/scrubber.go
@@ -184,7 +184,8 @@ func (s *structScrubber) Map(m reflect.Value) error {
 func (s *structScrubber) MapElem(m reflect.Value, k reflect.Value, v reflect.Value) error {
 	kind := v.Kind()
 	if kind == reflect.Interface {
-		kind = v.Elem().Kind()
+		v = v.Elem()
+		kind = v.Kind()
 	}
 	if kind == reflect.String {
 		m.SetMapIndex(k, reflect.ValueOf(s.Parent.KeyValue(k.String(), v.String())))

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package scrubber
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestValue(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Value       string
+		Expectation string
+	}{
+		{Name: "empty string"},
+		{Name: "email", Value: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email]"},
+		{Name: "email in text", Value: "The email is foo@bar.com or bar@foo.com"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			act := Default.Value(test.Value)
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("Value() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestKeyValue(t *testing.T) {
+	const testValue = "testvalue"
+	tests := []struct {
+		Key         string
+		Expectation string
+	}{
+		{Key: "email", Expectation: "[redacted:md5:e9de89b0a5e9ad6efd5e5ab543ec617c]"},
+		{Key: "token", Expectation: "[redacted]"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Key, func(t *testing.T) {
+			act := Default.KeyValue(test.Key, testValue)
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("KeyValue() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -92,7 +92,7 @@ func TestStruct(t *testing.T) {
 				},
 			},
 			Expectation: Expectation{
-				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted:md5:8ca658a5d9282ba6de6fc39825c054ab]")}},
+				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted:md5:aa7cedb94f5a9a40dc762b156272d991]")}},
 			},
 		},
 		{
@@ -163,8 +163,13 @@ func TestJSON(t *testing.T) {
 			Name:  "basic happy path",
 			Input: `{"ok": true, "email": "foo@bar.com", "workspaceID": "gitpodio-gitpod-uesaddev73c"}`,
 			Expectation: Expectation{
-				Result: `{"email":"[redacted:md5:8ca658a5d9282ba6de6fc39825c054ab]","ok":true,"workspaceID":"[redacted:md5:8ca658a5d9282ba6de6fc39825c054ab]"}`,
+				Result: `{"email":"[redacted:md5:f3ada405ce890b6f8204094deb12d8a8]","ok":true,"workspaceID":"[redacted:md5:a35538939333def8477b5c19ac694b35]"}`,
 			},
+		},
+		{
+			Name:        "analytics",
+			Input:       `{"batch":[{"event":"signup","foo":"bar","type":"track"}],"foo":"bar"}`,
+			Expectation: Expectation{Result: `{"batch":[{"event":"signup","foo":"bar","type":"track"}],"foo":"bar"}`},
 		},
 	}
 

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -5,6 +5,7 @@
 package scrubber
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -49,5 +50,21 @@ func TestKeyValue(t *testing.T) {
 				t.Errorf("KeyValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func BenchmarkKeyValue(b *testing.B) {
+	key := HashedFieldNames[rand.Intn(len(HashedFieldNames))]
+
+	for i := 0; i < b.N; i++ {
+		Default.KeyValue(key, "value")
+	}
+}
+
+func BenchmarkValue(b *testing.B) {
+	const input = "This text contains {\"json\":\"data\"}, a workspace ID gitpodio-gitpod-uesaddev73c and an email foo@bar.com"
+
+	for i := 0; i < b.N; i++ {
+		Default.Value(input)
 	}
 }

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -18,7 +18,7 @@ func TestValue(t *testing.T) {
 	}{
 		{Name: "empty string"},
 		{Name: "email", Value: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email]"},
-		{Name: "email in text", Value: "The email is foo@bar.com or bar@foo.com"},
+		{Name: "email in text", Value: "The email is foo@bar.com or bar@foo.com", Expectation: "The email is [redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email] or [redacted:md5:dc8a42aba3651b0b1f088ef928ff3b1d:email]"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
This PR prepares the interface for a new `scrubber` library which we'd use to remove sensitive information at the application level.

See the [design doc](https://www.notion.so/gitpod/Data-Sanitisation-4747f7941ed54b28b2459bab5220febd) for more information.

This library can be imported using `github.com/gitpod-io/gitpod/components/scrubber` as import path. 

>**Note**: Importing this library from outside this repo will download the entire Gitpod repo, a fairly slow operation.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
