### PR TITLE
Fixing unstable react context values and adding lint rule

### DIFF
--- a/components/dashboard/.eslintrc.js
+++ b/components/dashboard/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
     extends: ["react-app"],
     rules: {
         "import/no-anonymous-default-export": "error",
+        "react/jsx-no-constructed-context-values": "error",
     },
 };

--- a/components/dashboard/src/admin-context.tsx
+++ b/components/dashboard/src/admin-context.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { createContext, useState } from "react";
+import React, { createContext, useMemo, useState } from "react";
 import { InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 
 const AdminContext = createContext<{
@@ -16,7 +16,10 @@ const AdminContext = createContext<{
 
 const AdminContextProvider: React.FC = ({ children }) => {
     const [adminSettings, setAdminSettings] = useState<InstallationAdminSettings>();
-    return <AdminContext.Provider value={{ adminSettings, setAdminSettings }}>{children}</AdminContext.Provider>;
+
+    const ctx = useMemo(() => ({ adminSettings, setAdminSettings }), [adminSettings]);
+
+    return <AdminContext.Provider value={ctx}>{children}</AdminContext.Provider>;
 };
 
 export { AdminContext, AdminContextProvider };

--- a/components/dashboard/src/payment-context.tsx
+++ b/components/dashboard/src/payment-context.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 
 export type Currency = "USD" | "EUR";
 
@@ -19,16 +19,15 @@ const PaymentContext = createContext<{
 const PaymentContextProvider: React.FC = ({ children }) => {
     const [currency, setCurrency] = useState<Currency>("USD");
 
-    return (
-        <PaymentContext.Provider
-            value={{
-                currency,
-                setCurrency,
-            }}
-        >
-            {children}
-        </PaymentContext.Provider>
+    const ctx = useMemo(
+        () => ({
+            currency,
+            setCurrency,
+        }),
+        [currency],
     );
+
+    return <PaymentContext.Provider value={ctx}>{children}</PaymentContext.Provider>;
 };
 
 export { PaymentContext, PaymentContextProvider };

--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -21,7 +21,10 @@ export const ProjectContext = createContext<{
 
 export const ProjectContextProvider: React.FC = ({ children }) => {
     const [project, setProject] = useState<Project>();
-    return <ProjectContext.Provider value={{ project, setProject }}>{children}</ProjectContext.Provider>;
+
+    const ctx = useMemo(() => ({ project, setProject }), [project]);
+
+    return <ProjectContext.Provider value={ctx}>{children}</ProjectContext.Provider>;
 };
 
 export function useProjectSlugs(): { projectSlug?: string; prebuildId?: string } {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes a few react Contexts that are sending unstable (change on every render) context values by wrapping them in useMemo(). This helps avoid re-renders that aren't necessary. I've also enabled a lint rule to catch these in the future.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-391

## How to test
<!-- Provide steps to test this PR -->
Verify you can login and create projects. Bonus points for setting up a subscription for your org.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
