### PR TITLE
Show migration message after migration

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -21,7 +21,6 @@ const featureFlags = {
     orgGitAuthProviders: true,
     userGitAuthProviders: false,
     linkedinConnectionForOnboarding: false,
-    team_only_attribution: false,
     enableDedicatedOnboardingFlow: false,
 };
 

--- a/components/dashboard/src/whatsnew/MigrationPage.tsx
+++ b/components/dashboard/src/whatsnew/MigrationPage.tsx
@@ -4,17 +4,15 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { AdditionalUserData, User } from "@gitpod/gitpod-protocol";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { OnboardingStep } from "../onboarding/OnboardingStep";
-import { User } from "@gitpod/gitpod-protocol";
-import { getGitpodService } from "../service/service";
-import { useOrganizationsInvalidator } from "../data/organizations/orgs-query";
-import { Separator } from "../components/Separator";
-import gitpodIcon from "../icons/gitpod.svg";
 import { useContext } from "react";
-import { UserContext, useCurrentUser } from "../user-context";
+import { Separator } from "../components/Separator";
 import { Heading3 } from "../components/typography/headings";
-import { useFeatureFlag } from "../data/featureflag-query";
+import gitpodIcon from "../icons/gitpod.svg";
+import { OnboardingStep } from "../onboarding/OnboardingStep";
+import { getGitpodService } from "../service/service";
+import { UserContext, useCurrentUser } from "../user-context";
 
 namespace SkipMigration {
     const key = "skip-migration";
@@ -41,6 +39,10 @@ namespace SkipMigration {
         return !skipped.data || skipped.data.timesSkipped < 3;
     }
 
+    export function clearSkipInfo() {
+        window.localStorage.removeItem(key);
+    }
+
     export function useMarkSkipped() {
         const queryClient = useQueryClient();
         const currentSkip = useGetSkipInfo();
@@ -65,12 +67,11 @@ namespace SkipMigration {
 export function useShouldSeeMigrationPage(): boolean {
     const user = useCurrentUser();
     const isSkipped = SkipMigration.useIsSkipped();
-    const orgOnlyAttribution = useFeatureFlag("team_only_attribution");
-    return !!user && !user.additionalData?.isMigratedToTeamOnlyAttribution && orgOnlyAttribution && !isSkipped;
+    return !!user && !!user.additionalData?.shouldSeeMigrationMessage && !isSkipped;
 }
 
 export function MigrationPage() {
-    const migrateUsers = useMigrateUserMutation();
+    const markRead = useMarkMessageReadMutation();
     const user = useCurrentUser();
     const canSkip = SkipMigration.useCanSkip();
     const markSkipped = SkipMigration.useMarkSkipped();
@@ -86,19 +87,19 @@ export function MigrationPage() {
                 <div className="mt-24">
                     <OnboardingStep
                         title="It's getting easier to collaborate"
-                        subtitle="Your personal account is turned into an organization."
+                        subtitle="Your personal account has turned into an organization."
                         isValid={true}
-                        isSaving={migrateUsers.isLoading}
-                        onSubmit={migrateUsers.mutateAsync}
+                        isSaving={markRead.isLoading}
+                        onSubmit={markRead.mutateAsync}
                         onCancel={skipForNow}
-                        cancelButtonText="Ask me later"
+                        cancelButtonText="Read later"
                     >
                         <Heading3>What's different?</Heading3>
                         <p className="text-gray-500 text-base mb-4">
-                            Your personal account (<b>{user?.fullName || user?.name}</b>) is converted to an
+                            Your personal account (<b>{user?.fullName || user?.name}</b>) was converted to an
                             organization. As part of this any of your personal workspaces, projects, and configurations
-                            are moved to that organization. Additionally, after this step usage cost is always
-                            attributed to the currently selected organization, allowing for better cost control.{" "}
+                            have moved to that organization. Additionally, usage cost is now always attributed to the
+                            currently selected organization, allowing for better cost control.{" "}
                             <a className="gp-link" href="https://gitpod.io/blog/organizations">
                                 Learn more →
                             </a>
@@ -120,18 +121,19 @@ export function MigrationPage() {
     );
 }
 
-function useMigrateUserMutation() {
-    const invalidateOrgs = useOrganizationsInvalidator();
-    const { setUser } = useContext(UserContext);
+function useMarkMessageReadMutation() {
+    const { user, setUser } = useContext(UserContext);
 
     return useMutation<User, Error>({
         mutationFn: async () => {
-            const user = await getGitpodService().server.migrateLoggedInUserToOrgOnlyMode();
-            setUser(user);
-            return user;
-        },
-        onSuccess(updatedOrg) {
-            invalidateOrgs();
+            if (!user) {
+                throw new Error("No user");
+            }
+            let updatedUser = AdditionalUserData.set(user, { shouldSeeMigrationMessage: false });
+            updatedUser = await getGitpodService().server.updateLoggedInUser(updatedUser);
+            SkipMigration.clearSkipInfo();
+            setUser(updatedUser);
+            return updatedUser;
         },
     });
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -75,7 +75,6 @@ export const GitpodServer = Symbol("GitpodServer");
 export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, IDEServer {
     // User related API
     getLoggedInUser(): Promise<User>;
-    migrateLoggedInUserToOrgOnlyMode(): Promise<User>;
     updateLoggedInUser(user: Partial<User>): Promise<User>;
     sendPhoneNumberVerificationToken(phoneNumber: string): Promise<void>;
     verifyPhoneNumberVerificationToken(phoneNumber: string, token: string): Promise<boolean>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -273,8 +273,8 @@ export interface AdditionalUserData extends Partial<WorkspaceTimeoutSetting> {
     // additional user profile data
     profile?: ProfileDetails;
     // whether the user has been migrated to team attribution.
-    // a corresponding feature flag (team_only_attribution) triggers the migration.
     isMigratedToTeamOnlyAttribution?: boolean;
+    shouldSeeMigrationMessage?: boolean;
 
     // remembered workspace auto start options
     workspaceAutostartOptions?: WorkspaceAutostartOption[];

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -44,7 +44,6 @@ export function isValidFunctionName(name: string): boolean {
 
 const defaultFunctions: FunctionsConfig = {
     getLoggedInUser: { group: "default", points: 1 },
-    migrateLoggedInUserToOrgOnlyMode: { group: "default", points: 1 },
     updateLoggedInUser: { group: "default", points: 1 },
     sendPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },
     verifyPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },

--- a/components/server/src/migration/user-to-team-migration-service.spec.db.ts
+++ b/components/server/src/migration/user-to-team-migration-service.spec.db.ts
@@ -80,7 +80,7 @@ describe("Migration Service", () => {
         expect(userProjects.length, "personal projects should be migrated to the new team.").to.be.eq(0);
 
         await teamDB.removeMemberFromTeam(user.id, teams[0].id);
-        expect(await migrationService.needsMigration(user), "migrated user withoiut team needs migration").to.be.true;
+        expect(migrationService.needsMigration(user), "migrated user withoiut team needs migration").to.be.true;
         await migrationService.migrateUser(user);
         teams = await teamDB.findTeamsByUser(user.id);
         expect(teams.length, "rerunning the migration should not create a new team.").to.be.eq(1);

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -89,18 +89,12 @@ export class UserService {
         if (token) {
             await this.userDb.storeSingleToken(identity, token);
         }
-        if (
-            await this.configCatClientFactory().getValueAsync("migrate_new_users", false, {
-                user: newUser,
-            })
-        ) {
-            // org-owned users have an org and the setup user should not get one automatically
-            if (newUser.organizationId || newUser.id === BUILTIN_INSTLLATION_ADMIN_USER_ID) {
-                AdditionalUserData.set(newUser, { isMigratedToTeamOnlyAttribution: true });
-                newUser = await this.userDb.storeUser(newUser);
-            } else {
-                await this.migrationService.migrateUser(newUser);
-            }
+        // org-owned users have an org and the setup user should not get one automatically
+        if (newUser.organizationId || newUser.id === BUILTIN_INSTLLATION_ADMIN_USER_ID) {
+            AdditionalUserData.set(newUser, { isMigratedToTeamOnlyAttribution: true });
+            newUser = await this.userDb.storeUser(newUser);
+        } else {
+            newUser = await this.migrationService.migrateUser(newUser, false);
         }
 
         return newUser;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is a preparation step for running the user migration as a job and then flagging users so thex see the migration message next time they log into the product.

Also removes two feature flags, that are no longer needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-371

## How to test
<!-- Provide steps to test this PR -->

This is what I did during my test:
- signup on the preview env. As a new user you should not see the migration message.
- update the `isMigratedToTeamOnlyAttribution` flag in the DB
- reload page or religion and verifythat you now see the message as the user has been migrated a second time (also gets another org which is expected)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-migration-message</li>
	<li><b>🔗 URL</b> - <a href="https://se-migration-message.preview.gitpod-dev.com/workspaces" target="_blank">se-migration-message.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
