### PR TITLE
[idp] Add email to ID token

### DIFF
--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -70,6 +70,15 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 		return nil, proxy.ConvertError(err)
 	}
 
+	var email string
+	for _, id := range user.Identities {
+		if id == nil || id.Deleted || id.PrimaryEmail == "" {
+			continue
+		}
+		email = id.PrimaryEmail
+		break
+	}
+
 	if workspace.Workspace == nil {
 		log.Extract(ctx).WithError(err).Error("Server did not return a workspace.")
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("workspace not found"))
@@ -79,6 +88,9 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo := oidc.NewUserInfo()
 	userInfo.SetName(user.Name)
 	userInfo.SetSubject(subject)
+	if email != "" {
+		userInfo.SetEmail(email, false)
+	}
 
 	token, err := srv.idTokenSource.IDToken(ctx, "gitpod", req.Msg.Audience, userInfo)
 	if err != nil {

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -89,7 +89,7 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo.SetName(user.Name)
 	userInfo.SetSubject(subject)
 	if email != "" {
-		userInfo.SetEmail(email, false)
+		userInfo.SetEmail(email, true)
 	}
 
 	token, err := srv.idTokenSource.IDToken(ctx, "gitpod", req.Msg.Audience, userInfo)

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -64,7 +64,7 @@ func TestGetIDToken(t *testing.T) {
 						Identities: []*protocol.Identity{
 							nil,
 							{Deleted: true, PrimaryEmail: "nonsense@gitpod.io"},
-							{PrimaryEmail: "correct@gitpod.io"},
+							{Deleted: false, PrimaryEmail: "correct@gitpod.io"},
 						},
 					},
 					nil,

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -43,7 +43,7 @@ func TestGetIDToken(t *testing.T) {
 			TokenSource: func(t *testing.T) IDTokenSource {
 				return functionIDTokenSource(func(ctx context.Context, org string, audience []string, userInfo oidc.UserInfo) (string, error) {
 					require.Equal(t, "correct@gitpod.io", userInfo.GetEmail())
-					require.False(t, userInfo.IsEmailVerified())
+					require.True(t, userInfo.IsEmailVerified())
 
 					return "foobar", nil
 				})


### PR DESCRIPTION
## Description
This PR adds the `email` claim to the ID tokens produced by the IDP feature.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #17530 

## How to test
see unit tests or `gp idp token`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - cw-fix-17530</li>
	<li><b>🔗 URL</b> - <a href="https://cw-fix-17530.preview.gitpod-dev.com/workspaces" target="_blank">cw-fix-17530.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
