### PR TITLE
Add dropdown2 shadow

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -136,7 +136,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                 className={
                     "h-16 bg-gray-100 dark:bg-gray-800 flex items-center px-2 " +
                     (showDropDown
-                        ? "rounded-t-lg"
+                        ? "rounded-t-lg drop-shadow-xl"
                         : "rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer")
                 }
                 onClick={toggleDropDown}
@@ -149,7 +149,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
             </div>
             {showDropDown && (
                 <>
-                    <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 max-h-72 overflow-auto rounded-b-lg mt-3 z-50 p-2">
+                    <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 max-h-72 overflow-auto rounded-b-lg mt-3 z-50 p-2 drop-shadow-xl">
                         {!props.disableSearch && (
                             <div className="h-12">
                                 <input


### PR DESCRIPTION
## Description

Follow-up from https://github.com/gitpod-io/gitpod/pull/17679, attempting to add elevation (shadow) on the Dropdown2 component.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1684509958522479?thread_ts=1684508765.327739&cid=C01KPEPQYE6) (internal). Cc @selfcontained 

⚠️ Haven't tested code changes in a preview environment.

![Frame 1522](https://github.com/gitpod-io/gitpod/assets/120486/96833f1b-6386-41dc-ab81-d046fa51d45b)

## How to test

Go to `/new` and notice the shadow on the opened dropdown. 😎

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
