### PR TITLE
Correctly infer branch names for SSO users

### DIFF
--- a/components/server/src/workspace/context-parser.spec.ts
+++ b/components/server/src/workspace/context-parser.spec.ts
@@ -45,7 +45,7 @@ class TestIssueContexts {
         const issueTitle = "This is a really long issue title that goes beyond 30 characters";
         const issueNr = 3;
         const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
-        expect(result.length).to.be.at.most(30 + `-${issueNr}`.length);
+        expect(result.length).to.be.at.most(IssueContexts.maxBaseBranchLength + `-${issueNr}`.length);
     }
 
     @test

--- a/components/server/src/workspace/context-parser.spec.ts
+++ b/components/server/src/workspace/context-parser.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import "reflect-metadata";
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import { IssueContexts } from "./context-parser";
+import { User } from "@gitpod/gitpod-protocol";
+const expect = chai.expect;
+
+const baseUserInfo: User = {
+    id: "1",
+    creationDate: "today :)",
+    identities: [],
+    name: "John Doe",
+};
+
+@suite
+class TestIssueContexts {
+    @test
+    public testSanitizeAndFormatBranchName() {
+        const user: User = { ...baseUserInfo };
+        const issueTitle = "Issue Title With Special Characters like * ? @ {";
+        const issueNr = 1;
+        const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
+        expect(result).to.equal("johndoe/issue-title-with-special-characters-like-1");
+    }
+
+    @test
+    public testHandleNonAlphanumericCharactersInUserName() {
+        const user: User = { name: "John*Doe", ...baseUserInfo };
+        const issueTitle = "Simple Issue Title";
+        const issueNr = 2;
+        const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
+        expect(result).to.equal("john-doe/simple-issue-title-2");
+    }
+
+    @test
+    public testHandleBranchNameLongerThan30Characters() {
+        const user: User = { ...baseUserInfo };
+        const issueTitle = "This is a really long issue title that goes beyond 30 characters";
+        const issueNr = 3;
+        const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
+        expect(result.length).to.be.at.most(30);
+    }
+
+    @test
+    public testHandleEmptyIssueTitle() {
+        const user: User = { ...baseUserInfo };
+        const issueTitle = "";
+        const issueNr = 4;
+        const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
+        expect(result).to.equal("johndoe/-4");
+    }
+}
+
+module.exports = new TestIssueContexts();

--- a/components/server/src/workspace/context-parser.spec.ts
+++ b/components/server/src/workspace/context-parser.spec.ts
@@ -27,7 +27,7 @@ class TestIssueContexts {
         const issueTitle = "Issue Title With Special Characters like * ? @ {";
         const issueNr = 1;
         const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
-        expect(result).to.equal("johndoe/issue-title-with-special-characters-like-1");
+        expect(result).to.equal("john-doe/issue-title-with-special-1");
     }
 
     @test
@@ -45,7 +45,7 @@ class TestIssueContexts {
         const issueTitle = "This is a really long issue title that goes beyond 30 characters";
         const issueNr = 3;
         const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
-        expect(result.length).to.be.at.most(30);
+        expect(result.length).to.be.at.most(30 + `-${issueNr}`.length);
     }
 
     @test
@@ -54,7 +54,7 @@ class TestIssueContexts {
         const issueTitle = "";
         const issueNr = 4;
         const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
-        expect(result).to.equal("johndoe/-4");
+        expect(result).to.equal("johndoe/4");
     }
 }
 

--- a/components/server/src/workspace/context-parser.spec.ts
+++ b/components/server/src/workspace/context-parser.spec.ts
@@ -54,7 +54,7 @@ class TestIssueContexts {
         const issueTitle = "";
         const issueNr = 4;
         const result = IssueContexts.toBranchName(user, issueTitle, issueNr);
-        expect(result).to.equal("johndoe/4");
+        expect(result).to.equal("john-doe/4");
     }
 }
 

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -105,9 +105,9 @@ export const IPrefixContextParser = Symbol("IPrefixContextParser");
 // See https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
 // the magic sequence @{, consecutive dots, leading and trailing dot, ref ending in .lock
 // Adapted https://github.com/desktop/desktop/blob/1e3df9608a834dabdabe793b1b538e334f33c8a1/app/src/lib/sanitize-ref-name.ts
-const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g;
-/** Sanitize a proposed reference name by replacing illegal characters. */
+const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g;
 
+/** Sanitize a proposed reference name by replacing illegal characters. */
 function sanitizedRefName(name: string): string {
     return name.replace(invalidCharacterRegex, "-").replace(/^[-\+]*/g, "");
 }

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -113,6 +113,7 @@ function sanitizedRefName(name: string): string {
 }
 
 export namespace IssueContexts {
+    export const maxBaseBranchLength = 30;
     export function toBranchName(user: User, issueTitle: string, issueNr: number): string {
         const titleWords = issueTitle
             .toLowerCase()
@@ -121,7 +122,7 @@ export namespace IssueContexts {
             .filter((w) => w.length > 0);
         let localBranch = (user.name + "/").toLowerCase();
         for (const segment of titleWords) {
-            if (localBranch.length > 30) {
+            if (localBranch.length > maxBaseBranchLength) {
                 break;
             }
             localBranch += segment + "-";

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -111,6 +111,7 @@ const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""]+|@{|\.\.+|^\.|\.$|\.l
 function sanitizedRefName(name: string): string {
     return name.replace(invalidCharacterRegex, "-").replace(/^[-\+]*/g, "");
 }
+
 export namespace IssueContexts {
     export function toBranchName(user: User, issueTitle: string, issueNr: number): string {
         const titleWords = issueTitle

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -102,6 +102,15 @@ export interface IPrefixContextParser {
 }
 export const IPrefixContextParser = Symbol("IPrefixContextParser");
 
+// See https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
+// the magic sequence @{, consecutive dots, leading and trailing dot, ref ending in .lock
+// Adapted https://github.com/desktop/desktop/blob/1e3df9608a834dabdabe793b1b538e334f33c8a1/app/src/lib/sanitize-ref-name.ts
+const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g;
+/** Sanitize a proposed reference name by replacing illegal characters. */
+
+function sanitizedRefName(name: string): string {
+    return name.replace(invalidCharacterRegex, "-").replace(/^[-\+]*/g, "");
+}
 export namespace IssueContexts {
     export function toBranchName(user: User, issueTitle: string, issueNr: number): string {
         const titleWords = issueTitle
@@ -117,6 +126,6 @@ export namespace IssueContexts {
             localBranch += segment + "-";
         }
         localBranch += issueNr;
-        return localBranch;
+        return sanitizedRefName(localBranch);
     }
 }

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -104,7 +104,7 @@ export const IPrefixContextParser = Symbol("IPrefixContextParser");
 
 // See https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
 // the magic sequence @{, consecutive dots, leading and trailing dot, ref ending in .lock
-// Adapted https://github.com/desktop/desktop/blob/1e3df9608a834dabdabe793b1b538e334f33c8a1/app/src/lib/sanitize-ref-name.ts
+// Adapted from https://github.com/desktop/desktop/blob/1e3df9608a834dabdabe793b1b538e334f33c8a1/app/src/lib/sanitize-ref-name.ts
 const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g;
 
 /** Sanitize a proposed reference name by replacing illegal characters. */


### PR DESCRIPTION
## Description

Makes sure branches from issue contexts are always spec-compliant and therefore valid for git. 

Fixes WEB-375

## How to test

Testing should be done by logging in through SSO and starting a workspace from an issue context. I unfortunately couldn't find a way to do the SSO login, but for proper testing it has to be done like that.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-issd380c132cf</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-issd380c132cf.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-issd380c132cf.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
