### PR TITLE
[ws-manager-mk2] Remove maintenance CM from installer

### DIFF
--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -8,35 +8,29 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	LabelMaintenance = "gitpod.io/maintenanceConfig"
-	configMapName    = "ws-manager-mk2-maintenance-mode"
-)
-
 var (
-	indefinite = time.Now().Add(999999 * time.Hour)
+	configMapKey = types.NamespacedName{Name: "ws-manager-mk2-maintenance-mode", Namespace: "default"}
+	// lookupOnce is used for the first call to IsEnabled to load the maintenance mode state by looking
+	// up the ConfigMap, as it's possible we haven't received a reconcile event yet to load its state.
+	lookupOnce sync.Once
 )
 
 func NewMaintenanceReconciler(c client.Client) (*MaintenanceReconciler, error) {
 	return &MaintenanceReconciler{
-		Client: c,
-		// Enable maintenance by default, until we observe the ConfigMap with the actual value.
-		// Prevents a race on startup where the workspace reconciler might run before
-		// we observe the maintenance mode ConfigMap. Better be safe and prevent
-		// reconciliation of that workspace until it's certain maintenance mode is
-		// not enabled.
-		enabledUntil: &indefinite,
+		Client:       c,
+		enabledUntil: nil,
 	}, nil
 }
 
@@ -46,64 +40,75 @@ type MaintenanceReconciler struct {
 	enabledUntil *time.Time
 }
 
-func (r *MaintenanceReconciler) IsEnabled() bool {
+func (r *MaintenanceReconciler) IsEnabled(ctx context.Context) bool {
+	// On the first call, we load the maintenance mode state from the ConfigMap,
+	// as it's possible we haven't reconciled it yet.
+	lookupOnce.Do(func() {
+		if err := r.loadFromCM(ctx, configMapKey); err != nil {
+			log.FromContext(ctx).Error(err, "cannot load maintenance mode config")
+		}
+	})
+
 	return r.enabledUntil != nil && time.Now().Before(*r.enabledUntil)
 }
 
 //+kubebuilder:rbac:groups=core,resources=configmap,verbs=get;list;watch
 
 func (r *MaintenanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx).WithValues("configMap", req.NamespacedName)
-
-	if req.Name != configMapName {
+	if req.Name != configMapKey.Name || req.Namespace != configMapKey.Namespace {
+		// Ignore all other configmaps.
 		return ctrl.Result{}, nil
 	}
 
+	return ctrl.Result{}, r.loadFromCM(ctx, req.NamespacedName)
+}
+
+func (r *MaintenanceReconciler) loadFromCM(ctx context.Context, key types.NamespacedName) error {
+	log := log.FromContext(ctx)
+
 	var cm corev1.ConfigMap
-	if err := r.Get(ctx, req.NamespacedName, &cm); err != nil {
+	if err := r.Get(ctx, key, &cm); err != nil {
 		if errors.IsNotFound(err) {
 			// ConfigMap does not exist, disable maintenance mode.
-			r.setEnabledUntil(log, nil)
-			return ctrl.Result{}, nil
+			r.setEnabledUntil(ctx, nil)
+			return nil
 		}
 
 		log.Error(err, "unable to fetch configmap")
-		return ctrl.Result{}, fmt.Errorf("failed to fetch configmap: %w", err)
+		return fmt.Errorf("failed to fetch configmap: %w", err)
 	}
 
 	configJson, ok := cm.Data["config.json"]
 	if !ok {
 		log.Info("missing config.json, setting maintenance mode as disabled")
-		r.setEnabledUntil(log, nil)
-		return ctrl.Result{}, nil
+		r.setEnabledUntil(ctx, nil)
+		return nil
 	}
 
 	var cfg config.MaintenanceConfig
 	if err := json.Unmarshal([]byte(configJson), &cfg); err != nil {
 		log.Error(err, "failed to unmarshal maintenance config, setting maintenance mode as disabled")
-		r.setEnabledUntil(log, nil)
-		return ctrl.Result{}, nil
+		r.setEnabledUntil(ctx, nil)
+		return nil
 	}
 
-	r.setEnabledUntil(log, cfg.EnabledUntil)
-	return ctrl.Result{}, nil
+	r.setEnabledUntil(ctx, cfg.EnabledUntil)
+	return nil
 }
 
-func (r *MaintenanceReconciler) setEnabledUntil(log logr.Logger, enabledUntil *time.Time) {
+func (r *MaintenanceReconciler) setEnabledUntil(ctx context.Context, enabledUntil *time.Time) {
 	if enabledUntil == r.enabledUntil {
 		// Nothing to do.
 		return
 	}
 
 	r.enabledUntil = enabledUntil
-	log.Info("maintenance mode state change", "enabled", r.IsEnabled(), "enabledUntil", enabledUntil)
+	log.FromContext(ctx).Info("maintenance mode state change", "enabledUntil", enabledUntil)
 }
 
 func (r *MaintenanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("maintenance").
-		// The controller manager filters watch events only to ConfigMaps with the LabelMaintenance label set to "true".
-		// See components/ws-manager-mk2/main.go's NewCache function in the manager options.
 		For(&corev1.ConfigMap{}).
 		Complete(r)
 }

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -198,7 +198,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		} else if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped {
 			// Should be in Stopping phase, but isn't yet.
 			// Move to Stopping to start disposal, but only if maintenance mode is disabled.
-			if !r.maintenance.IsEnabled() {
+			if !r.maintenance.IsEnabled(ctx) {
 				workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
 			}
 		}

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -158,7 +158,7 @@ type fakeMaintenance struct {
 	enabled bool
 }
 
-func (f *fakeMaintenance) IsEnabled() bool {
+func (f *fakeMaintenance) IsEnabled(context.Context) bool {
 	return f.enabled
 }
 

--- a/components/ws-manager-mk2/controllers/timeout_controller.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller.go
@@ -87,7 +87,7 @@ func (r *TimeoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, nil
 	}
 
-	if r.maintenance.IsEnabled() {
+	if r.maintenance.IsEnabled(ctx) {
 		// Don't reconcile timeouts in maintenance mode, to prevent workspace deletion.
 		// Requeue after some time to ensure we do still reconcile this workspace when
 		// maintenance mode ends.

--- a/components/ws-manager-mk2/pkg/maintenance/maintenance.go
+++ b/components/ws-manager-mk2/pkg/maintenance/maintenance.go
@@ -4,9 +4,11 @@
 
 package maintenance
 
+import "context"
+
 // Maintenance is used to check whether ws-manager-mk2 is in maintenance mode,
 // which prevents pod creation/deletion and snapshots being taken, such that
 // the cluster can be updated in-place.
 type Maintenance interface {
-	IsEnabled() bool
+	IsEnabled(ctx context.Context) bool
 }

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -109,7 +109,7 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
-	if wsm.maintenance.IsEnabled() {
+	if wsm.maintenance.IsEnabled(ctx) {
 		return &wsmanapi.StartWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 
@@ -378,7 +378,7 @@ func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsman
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
-	if wsm.maintenance.IsEnabled() {
+	if wsm.maintenance.IsEnabled(ctx) {
 		return &wsmanapi.StopWorkspaceResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 
@@ -604,7 +604,7 @@ func (wsm *WorkspaceManagerServer) TakeSnapshot(ctx context.Context, req *wsmana
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	defer tracing.FinishSpan(span, &err)
 
-	if wsm.maintenance.IsEnabled() {
+	if wsm.maintenance.IsEnabled(ctx) {
 		return &wsmanapi.TakeSnapshotResponse{}, status.Error(codes.FailedPrecondition, "under maintenance")
 	}
 

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -276,17 +276,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, fmt.Errorf("failed to marshal ws-manager config: %w", err)
 	}
 
-	// Add label to maintenance ConfigMap that ws-manager-mk2 can filter the ConfigMap watch on.
-	maintenanceLabels := common.DefaultLabels(Component)
-	maintenanceLabels[LabelMaintenanceConfig] = "true"
-	maintenanceCfg := config.MaintenanceConfig{
-		EnabledUntil: nil,
-	}
-	mc, err := common.ToJSONString(maintenanceCfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal ws-manager maintenance config: %w", err)
-	}
-
 	res := []runtime.Object{
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
@@ -308,17 +297,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Data: tpls,
-		},
-		&corev1.ConfigMap{
-			TypeMeta: common.TypeMetaConfigmap,
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-maintenance-mode", Component),
-				Namespace: ctx.Namespace,
-				Labels:    maintenanceLabels,
-			},
-			Data: map[string]string{
-				"config.json": string(mc),
-			},
 		},
 	}
 	return res, nil

--- a/install/installer/pkg/components/ws-manager-mk2/constants.go
+++ b/install/installer/pkg/components/ws-manager-mk2/constants.go
@@ -18,5 +18,4 @@ const (
 	VolumeWorkspaceTemplate    = "workspace-template"
 	WorkspaceTemplatePath      = "/workspace-templates"
 	WorkspaceTemplateConfigMap = "workspace-templates"
-	LabelMaintenanceConfig     = "gitpod.io/maintenanceConfig"
 )


### PR DESCRIPTION
## Description

Removes the maintenance mode ConfigMap from the installer, such that its data does not get overwritten when a new install is applied. The alternative is filtering out the CM from the installer manifests but this seems simpler to reason about.

Also updated the maintenance logic to do load the ConfigMap on the first check. This fixes the case where after a rollout, maintenance mode will be briefly true until the first time the CM gets reconciled (which can take 10s of seconds due to waiting to acquire leader election).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-128 and WKS-129

## How to test
<!-- Provide steps to test this PR -->

In a preview env, check that maintenance is disabled when the maintenance CM does not exist, and that it gets enabled once it exists and has `enabledUntil` set to a future timestamp.

Preview URL: https://wv-mk2-remff5751beed.preview.gitpod-dev.com/workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
