### PR TITLE
[dashboard] Handle users without an org

### DIFF
--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -10,6 +10,8 @@ import { useCurrentUser } from "../user-context";
 import { MigrationPage, useShouldSeeMigrationPage } from "../whatsnew/MigrationPage";
 import { useShowUserOnboarding } from "../onboarding/use-show-user-onboarding";
 import { useHistory } from "react-router";
+import { useCurrentOrg } from "../data/organizations/orgs-query";
+import { OrgNamingStep } from "../dedicated-setup/OrgNamingStep";
 
 const UserOnboarding = lazy(() => import(/* webpackPrefetch: true */ "../onboarding/UserOnboarding"));
 const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicated-setup/DedicatedSetup"));
@@ -19,6 +21,7 @@ const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicat
 export const AppBlockingFlows: FC = ({ children }) => {
     const history = useHistory();
     const user = useCurrentUser();
+    const org = useCurrentOrg();
     const shouldSeeMigrationPage = useShouldSeeMigrationPage();
     const showDedicatedSetup = useShowDedicatedSetup();
     const showUserOnboarding = useShowUserOnboarding();
@@ -51,6 +54,10 @@ export const AppBlockingFlows: FC = ({ children }) => {
     // New user onboarding flow
     if (showUserOnboarding) {
         return <UserOnboarding user={user} />;
+    }
+
+    if (!org.data) {
+        return <OrgNamingStep onComplete={() => {}} />;
     }
 
     return <>{children}</>;

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -23,7 +23,6 @@ const featureFlags = {
     newSignupFlow: false,
     linkedinConnectionForOnboarding: false,
     paymentVerificationFlow: false,
-    team_only_attribution: false,
     enableDedicatedOnboardingFlow: false,
 };
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -75,7 +75,6 @@ export const GitpodServer = Symbol("GitpodServer");
 export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, IDEServer {
     // User related API
     getLoggedInUser(): Promise<User>;
-    migrateLoggedInUserToOrgOnlyMode(): Promise<User>;
     updateLoggedInUser(user: Partial<User>): Promise<User>;
     sendPhoneNumberVerificationToken(phoneNumber: string): Promise<void>;
     verifyPhoneNumberVerificationToken(phoneNumber: string, token: string): Promise<boolean>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -273,8 +273,8 @@ export interface AdditionalUserData extends Partial<WorkspaceTimeoutSetting> {
     // additional user profile data
     profile?: ProfileDetails;
     // whether the user has been migrated to team attribution.
-    // a corresponding feature flag (team_only_attribution) triggers the migration.
     isMigratedToTeamOnlyAttribution?: boolean;
+    shouldSeeMigrationMessage?: boolean;
 
     // remembered workspace auto start options
     workspaceAutostartOptions?: WorkspaceAutostartOption[];

--- a/components/server/.vscode/launch.json
+++ b/components/server/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "env": {
+                "DB_PORT": "23306",
+                "DB_ENCRYPTION_KEYS": "[{\"name\":\"general\",\"version\":1,\"primary\":true,\"material\":\"5vRrp0H4oRgdkPnX1qQcS54Q0xggr6iyho42IQ1rO+c=\"}]"
+            },
+            "name": "Run Mocha Test in Editor",
+            "program": "${workspaceFolder}/node_modules/.bin/_mocha",
+            "args": [
+                "--opts",
+                "${workspaceFolder}/mocha.opts",
+                "--colors",
+                "--timeout",
+                "999999",
+                "${file}",
+                "-g",
+                "${selectedText}"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ],
+    "compounds": []
+}

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -44,7 +44,6 @@ export function isValidFunctionName(name: string): boolean {
 
 const defaultFunctions: FunctionsConfig = {
     getLoggedInUser: { group: "default", points: 1 },
-    migrateLoggedInUserToOrgOnlyMode: { group: "default", points: 1 },
     updateLoggedInUser: { group: "default", points: 1 },
     sendPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },
     verifyPhoneNumberVerificationToken: { group: "phoneVerification", points: 1 },

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -134,6 +134,7 @@ import { JobRunner } from "./jobs/runner";
 import { DatabaseGarbageCollector } from "./jobs/database-gc";
 import { OTSGarbageCollector } from "./jobs/ots-gc";
 import { UserToTeamMigrationService } from "./migration/user-to-team-migration-service";
+import { OrgOnlyMigrationJob } from "./jobs/org-only-migration-job";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -362,6 +363,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
     bind(DatabaseGarbageCollector).toSelf().inSingletonScope();
     bind(OTSGarbageCollector).toSelf().inSingletonScope();
+    bind(OrgOnlyMigrationJob).toSelf().inSingletonScope();
     bind(JobRunner).toSelf().inSingletonScope();
 
     // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129

--- a/components/server/src/jobs/org-only-migration-job.spec.db.ts
+++ b/components/server/src/jobs/org-only-migration-job.spec.db.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { AdditionalUserData } from "@gitpod/gitpod-protocol";
+import * as chai from "chai";
+import { Container, ContainerModule } from "inversify";
+import { RedlockAbortSignal } from "redlock";
+import { UserToTeamMigrationService } from "../migration/user-to-team-migration-service";
+import { RedisMutex } from "../redis/mutex";
+import { StripeService } from "../user/stripe-service";
+import { OrgOnlyMigrationJob } from "./org-only-migration-job";
+import { dbContainerModule } from "@gitpod/gitpod-db/lib/container-module";
+const expect = chai.expect;
+
+const mockedStripe = new StripeService();
+mockedStripe.updateAttributionId = async (
+    stripeCustomerId: string,
+    attributionId: string,
+    oldAttributionId: string,
+) => {
+    return true;
+};
+class TestingRedisMutex extends RedisMutex {
+    public using<T>(
+        resources: string[],
+        duration: number,
+        routine: (signal: RedlockAbortSignal) => Promise<T>,
+    ): Promise<T> {
+        return routine(undefined!);
+    }
+}
+export const testContainer = new Container();
+testContainer.load(dbContainerModule);
+testContainer.load(
+    new ContainerModule((bind) => {
+        bind(StripeService).toConstantValue(mockedStripe);
+        bind(OrgOnlyMigrationJob).toSelf().inSingletonScope();
+        bind(UserToTeamMigrationService).toSelf().inSingletonScope();
+        bind(RedisMutex).toConstantValue(new TestingRedisMutex());
+    }),
+);
+
+describe("Migration Job", () => {
+    const typeORM = testContainer.get<TypeORM>(TypeORM);
+    const migrationJob = testContainer.get<OrgOnlyMigrationJob>(OrgOnlyMigrationJob);
+    const userDB = testContainer.get<UserDB>(UserDB);
+
+    it("should migrate non migrated user", async () => {
+        const migratedUser = await userDB.newUser();
+        AdditionalUserData.set(migratedUser, { isMigratedToTeamOnlyAttribution: true });
+        await userDB.storeUser(migratedUser);
+        const nonMigratedUser = await userDB.newUser();
+        AdditionalUserData.set(nonMigratedUser, { isMigratedToTeamOnlyAttribution: false });
+        await userDB.storeUser(nonMigratedUser);
+
+        const users = await migrationJob.migrateUsers(1000);
+
+        expect(
+            users.some((u) => u.id === nonMigratedUser.id),
+            "should migrate non migrated user",
+        ).to.be.true;
+        expect(
+            users.some((u) => u.id === migratedUser.id),
+            "should not migrate already migrated user",
+        ).to.be.false;
+        expect(
+            users.find((u) => u.id === nonMigratedUser.id)?.additionalData?.isMigratedToTeamOnlyAttribution,
+            "user should be migrated",
+        ).to.be.true;
+
+        const c = await typeORM.getConnection();
+        await c.query("DELETE FROM d_b_user WHERE id in (?)", [[migratedUser.id, nonMigratedUser.id]]);
+        await c.close();
+    });
+});

--- a/components/server/src/jobs/org-only-migration-job.ts
+++ b/components/server/src/jobs/org-only-migration-job.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Job } from "./runner";
+import { UserToTeamMigrationService } from "../migration/user-to-team-migration-service";
+import { DBUser, TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { User } from "@gitpod/gitpod-protocol";
+
+@injectable()
+export class OrgOnlyMigrationJob implements Job {
+    @inject(UserToTeamMigrationService) protected readonly migrationService: UserToTeamMigrationService;
+    @inject(TypeORM) protected readonly db: TypeORM;
+    @inject(UserDB) protected readonly userDB: UserDB;
+
+    public readonly name = "org-only-migration-job";
+    public readonly lockId = [this.name];
+    public frequencyMs = 5 * 60 * 1000; // every 5 minutes
+
+    public async migrateUsers(limit: number): Promise<User[]> {
+        try {
+            const userRepo = (await this.db.getConnection()).manager.getRepository<DBUser>(DBUser);
+            const users = await userRepo
+                .createQueryBuilder("user")
+                .leftJoinAndSelect("user.identities", "identity")
+                .where("additionalData->>'$.isMigratedToTeamOnlyAttribution' != 'true'")
+                .limit(limit)
+                .getMany();
+
+            const result: User[] = [];
+            for (const user of users) {
+                result.push(await this.migrationService.migrateUser(user));
+            }
+            return result;
+        } catch (err) {
+            log.error("org-only-migration-job: error during run", err);
+            throw err;
+        }
+    }
+
+    public async run(): Promise<void> {
+        await this.migrateUsers(100);
+    }
+}

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -16,6 +16,7 @@ import { OTSGarbageCollector } from "./ots-gc";
 import { TokenGarbageCollector } from "./token-gc";
 import { WebhookEventGarbageCollector } from "./webhook-gc";
 import { WorkspaceGarbageCollector } from "./workspace-gc";
+import { OrgOnlyMigrationJob } from "./org-only-migration-job";
 
 export const Job = Symbol("Job");
 
@@ -35,11 +36,19 @@ export class JobRunner {
     @inject(TokenGarbageCollector) protected tokenGC: TokenGarbageCollector;
     @inject(WebhookEventGarbageCollector) protected webhookGC: WebhookEventGarbageCollector;
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
+    @inject(OrgOnlyMigrationJob) protected orgOnlyMigrationJob: OrgOnlyMigrationJob;
 
     public start(): DisposableCollection {
         const disposables = new DisposableCollection();
 
-        const jobs: Job[] = [this.databaseGC, this.otsGC, this.tokenGC, this.webhookGC, this.workspaceGC];
+        const jobs: Job[] = [
+            this.databaseGC,
+            this.otsGC,
+            this.tokenGC,
+            this.webhookGC,
+            this.workspaceGC,
+            this.orgOnlyMigrationJob,
+        ];
 
         for (let job of jobs) {
             log.info(`Registered job ${job.name} in job runner.`, {

--- a/components/server/src/migration/user-to-team-migration-service.spec.db.ts
+++ b/components/server/src/migration/user-to-team-migration-service.spec.db.ts
@@ -80,7 +80,7 @@ describe("Migration Service", () => {
         expect(userProjects.length, "personal projects should be migrated to the new team.").to.be.eq(0);
 
         await teamDB.removeMemberFromTeam(user.id, teams[0].id);
-        expect(await migrationService.needsMigration(user), "migrated user withoiut team needs migration").to.be.true;
+        expect(migrationService.needsMigration(user), "migrated user withoiut team needs migration").to.be.true;
         await migrationService.migrateUser(user);
         teams = await teamDB.findTeamsByUser(user.id);
         expect(teams.length, "rerunning the migration should not create a new team.").to.be.eq(1);

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -89,18 +89,12 @@ export class UserService {
         if (token) {
             await this.userDb.storeSingleToken(identity, token);
         }
-        if (
-            await this.configCatClientFactory().getValueAsync("migrate_new_users", false, {
-                user: newUser,
-            })
-        ) {
-            // org-owned users have an org and the setup user should not get one automatically
-            if (newUser.organizationId || newUser.id === BUILTIN_INSTLLATION_ADMIN_USER_ID) {
-                AdditionalUserData.set(newUser, { isMigratedToTeamOnlyAttribution: true });
-                newUser = await this.userDb.storeUser(newUser);
-            } else {
-                await this.migrationService.migrateUser(newUser);
-            }
+        // org-owned users have an org and the setup user should not get one automatically
+        if (newUser.organizationId || newUser.id === BUILTIN_INSTLLATION_ADMIN_USER_ID) {
+            AdditionalUserData.set(newUser, { isMigratedToTeamOnlyAttribution: true });
+            newUser = await this.userDb.storeUser(newUser);
+        } else {
+            newUser = await this.migrationService.migrateUser(newUser, false);
         }
 
         return newUser;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -674,23 +674,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return this.checkUser("getLoggedInUser");
     }
 
-    public async migrateLoggedInUserToOrgOnlyMode(ctx: TraceContext): Promise<User> {
-        await this.doUpdateUser();
-        const user = this.checkUser("migrateLoggedInUserToOrgOnlyMode");
-        if (!this.userToTeamMigrationService.needsMigration(user)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "User does not need migration.");
-        }
-        try {
-            await this.userToTeamMigrationService.migrateUser(user);
-            await this.doUpdateUser();
-            log.info({ userId: user.id }, "migrated user to org-only mode");
-            return this.user!;
-        } catch (error) {
-            console.error(error);
-            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, "Failed to migrate user to org-only mode.");
-        }
-    }
-
     protected showSetupCondition: { value: boolean } | undefined = undefined;
     protected enableDedicatedOnboardingFlow: boolean = false; // TODO(gpl): Remove once we have an onboarding setup
     protected async doUpdateUser(): Promise<void> {
@@ -720,9 +703,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
 
         if (this.user) {
-            const updatedUser = await this.userDB.findUserById(this.user.id);
+            let updatedUser = await this.userDB.findUserById(this.user.id);
             if (updatedUser) {
                 this.user = updatedUser;
+            }
+
+            if (this.userToTeamMigrationService.needsMigration(this.user)) {
+                this.user = await this.userToTeamMigrationService.migrateUser(this.user, true);
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Users that don't have an org (deleted it or have been dropped by an owner) will land on the create org page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-364

## How to test
<!-- Provide steps to test this PR -->
- login
- delete org
- land on the create org page

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-no-orgs-handling</li>
	<li><b>🔗 URL</b> - <a href="https://se-no-orgs-handling.preview.gitpod-dev.com/workspaces" target="_blank">se-no-orgs-handling.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
