### PR TITLE
[periodic deleter] remove unmanaged tables

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -95,21 +95,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             dependencies: ["d_b_user"],
         },
         {
-            name: "d_b_workspace",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-            deletionColumn: "deleted",
-            dependencies: ["d_b_user"],
-        },
-        {
-            name: "d_b_workspace_instance",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-            dependencies: ["d_b_workspace"],
-            deletionColumn: "deleted",
-            ignoreColumns: ["phase"],
-        },
-        {
             name: "d_b_workspace_instance_user",
             primaryKeys: ["instanceId", "userId"],
             timeColumn: "_lastModified",
@@ -205,12 +190,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_prebuild_info",
-            primaryKeys: ["prebuildId"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_project_env_var",
             primaryKeys: ["id", "projectId"],
             deletionColumn: "deleted",
@@ -235,12 +214,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_webhook_event",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_cost_center",
             primaryKeys: ["id", "creationTime"],
             deletionColumn: "deleted",
@@ -250,18 +223,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             name: "d_b_usage",
             primaryKeys: ["id"],
             timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_prebuilt_workspace_updatable",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-            deletionColumn: "deleted",
-        },
-        {
-            name: "d_b_prebuilt_workspace",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-            deletionColumn: "deleted",
         },
         {
             name: "d_b_stripe_customer",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We have recently started to diirectly delete workspace related records but forgot to remove the config from the periodic deleter, which now tries to find records in very large tables without success.
E.g. 
```sql
SELECT
  `id`
FROM
  `d_b_workspace_instance`
WHERE
  `deleted` = TRUE
LIMIT
  ?
```

[runs for 15min on average](https://console.cloud.google.com/sql/instances/gitpod-prod-us-west1/insights;database=gitpod;start=2023-05-15T11:02:19.802Z;end=2023-05-22T11:02:19.802Z;trace=2e27a58eb21c6d5afd9c97345e491702;span=39ad907303feaa23;query_hash=14991341230805561798;sort_by=TOTAL_EXEC_TIME?project=gitpod-191109) because it scans the full table and doesn't find a single record.
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
