### PR TITLE
[db] removed unused instance join

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -68,37 +68,35 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
     protected abstract getManager(): Promise<EntityManager>;
 
     protected async getWorkspaceRepo(): Promise<Repository<DBWorkspace>> {
-        return await (await this.getManager()).getRepository<DBWorkspace>(DBWorkspace);
+        return (await this.getManager()).getRepository<DBWorkspace>(DBWorkspace);
     }
 
     protected async getWorkspaceInstanceRepo(): Promise<Repository<DBWorkspaceInstance>> {
-        return await (await this.getManager()).getRepository<DBWorkspaceInstance>(DBWorkspaceInstance);
+        return (await this.getManager()).getRepository<DBWorkspaceInstance>(DBWorkspaceInstance);
     }
 
     protected async getWorkspaceInstanceUserRepo(): Promise<Repository<DBWorkspaceInstanceUser>> {
-        return await (await this.getManager()).getRepository<DBWorkspaceInstanceUser>(DBWorkspaceInstanceUser);
+        return (await this.getManager()).getRepository<DBWorkspaceInstanceUser>(DBWorkspaceInstanceUser);
     }
 
     protected async getRepositoryWhitelist(): Promise<Repository<DBRepositoryWhiteList>> {
-        return await (await this.getManager()).getRepository<DBRepositoryWhiteList>(DBRepositoryWhiteList);
+        return (await this.getManager()).getRepository<DBRepositoryWhiteList>(DBRepositoryWhiteList);
     }
 
     protected async getSnapshotRepo(): Promise<Repository<DBSnapshot>> {
-        return await (await this.getManager()).getRepository<DBSnapshot>(DBSnapshot);
+        return (await this.getManager()).getRepository<DBSnapshot>(DBSnapshot);
     }
 
     protected async getPrebuiltWorkspaceRepo(): Promise<Repository<DBPrebuiltWorkspace>> {
-        return await (await this.getManager()).getRepository<DBPrebuiltWorkspace>(DBPrebuiltWorkspace);
+        return (await this.getManager()).getRepository<DBPrebuiltWorkspace>(DBPrebuiltWorkspace);
     }
 
     protected async getPrebuildInfoRepo(): Promise<Repository<DBPrebuildInfo>> {
-        return await (await this.getManager()).getRepository<DBPrebuildInfo>(DBPrebuildInfo);
+        return (await this.getManager()).getRepository<DBPrebuildInfo>(DBPrebuildInfo);
     }
 
     protected async getPrebuiltWorkspaceUpdatableRepo(): Promise<Repository<DBPrebuiltWorkspaceUpdatable>> {
-        return await (
-            await this.getManager()
-        ).getRepository<DBPrebuiltWorkspaceUpdatable>(DBPrebuiltWorkspaceUpdatable);
+        return (await this.getManager()).getRepository<DBPrebuiltWorkspaceUpdatable>(DBPrebuiltWorkspaceUpdatable);
     }
 
     public async connect(maxTries: number = 3, timeout: number = 2000): Promise<void> {
@@ -906,7 +904,6 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             .createQueryBuilder("pwsu")
             .innerJoinAndMapOne("pwsu.prebuild", DBPrebuiltWorkspace, "pws", "pwsu.prebuiltWorkspaceId = pws.id")
             .innerJoinAndMapOne("pwsu.workspace", DBWorkspace, "ws", "pws.buildWorkspaceId = ws.id")
-            .innerJoinAndMapOne("pwsu.instance", DBWorkspaceInstance, "wsi", "ws.id = wsi.workspaceId")
             .where("pwsu.isResolved = 0")
             .orderBy("ws.creationTime", "DESC");
 

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -40,7 +40,6 @@ export interface FindWorkspacesOptions {
 export interface PrebuiltUpdatableAndWorkspace extends PrebuiltWorkspaceUpdatable {
     prebuild: PrebuiltWorkspace;
     workspace: Workspace;
-    instance: WorkspaceInstance;
 }
 
 export type WorkspaceAuthData = Pick<Workspace, "id" | "ownerId" | "shareable">;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
removes a non used join in an [expensive query](https://console.cloud.google.com/sql/instances/gitpod-prod-us-west1/insights;database=gitpod;start=2023-05-22T05:26:09.107Z;end=2023-05-22T11:26:09.107Z;trace=285f231e970ccae54055b44e873b7b08;span=7371e3939908471b;query_hash=4131081551255458668;sort_by=TOTAL_EXEC_TIME?project=gitpod-191109)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold
