### PR TITLE
Use forwardRef() for Button component

### DIFF
--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from "classnames";
-import { FC, RefObject } from "react";
+import { FC, ForwardedRef, ReactNode, forwardRef } from "react";
 import SpinnerWhite from "../icons/SpinnerWhite.svg";
 
 export type ButtonProps = {
@@ -17,67 +17,71 @@ export type ButtonProps = {
     loading?: boolean;
     className?: string;
     autoFocus?: boolean;
-    ref?: RefObject<HTMLButtonElement>;
     htmlType?: "button" | "submit" | "reset";
+    children: ReactNode;
     onClick?: ButtonOnClickHandler;
 };
 
 // Allow w/ or w/o handling event argument
 type ButtonOnClickHandler = React.DOMAttributes<HTMLButtonElement>["onClick"] | (() => void);
 
-export const Button: FC<ButtonProps> = ({
-    type = "primary",
-    className,
-    htmlType,
-    disabled = false,
-    loading = false,
-    autoFocus = false,
-    ref,
-    size,
-    children,
-    onClick,
-}) => {
-    return (
-        <button
-            type={htmlType}
-            className={classNames(
-                "cursor-pointer px-4 py-2 my-auto",
-                "text-sm font-medium",
-                "rounded-md focus:outline-none focus:ring transition ease-in-out",
-                type === "primary"
-                    ? [
-                          "bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600",
-                          "text-gray-100 dark:text-green-100",
-                      ]
-                    : null,
-                type === "secondary"
-                    ? [
-                          "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600",
-                          "text-gray-500 dark:text-gray-100 hover:text-gray-600",
-                      ]
-                    : null,
-                type === "danger" ? ["bg-red-600 hover:bg-red-700", "text-gray-100 dark:text-red-100"] : null,
-                type === "danger.secondary"
-                    ? [
-                          "bg-red-50 dark:bg-red-300 hover:bg-red-100 dark:hover:bg-red-200",
-                          "text-red-600 hover:text-red-700",
-                      ]
-                    : null,
-                {
-                    "w-full": size === "block",
-                    "cursor-default opacity-50 pointer-events-none": disabled || loading,
-                },
-                className,
-            )}
-            ref={ref}
-            disabled={disabled}
-            autoFocus={autoFocus}
-            onClick={onClick}
-        >
-            <ButtonContent loading={loading}>{children}</ButtonContent>
-        </button>
-    );
-};
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+    (
+        {
+            type = "primary",
+            className,
+            htmlType,
+            disabled = false,
+            loading = false,
+            autoFocus = false,
+            size,
+            children,
+            onClick,
+        },
+        ref: ForwardedRef<HTMLButtonElement>,
+    ) => {
+        return (
+            <button
+                type={htmlType}
+                className={classNames(
+                    "cursor-pointer px-4 py-2 my-auto",
+                    "text-sm font-medium",
+                    "rounded-md focus:outline-none focus:ring transition ease-in-out",
+                    type === "primary"
+                        ? [
+                              "bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600",
+                              "text-gray-100 dark:text-green-100",
+                          ]
+                        : null,
+                    type === "secondary"
+                        ? [
+                              "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600",
+                              "text-gray-500 dark:text-gray-100 hover:text-gray-600",
+                          ]
+                        : null,
+                    type === "danger" ? ["bg-red-600 hover:bg-red-700", "text-gray-100 dark:text-red-100"] : null,
+                    type === "danger.secondary"
+                        ? [
+                              "bg-red-50 dark:bg-red-300 hover:bg-red-100 dark:hover:bg-red-200",
+                              "text-red-600 hover:text-red-700",
+                          ]
+                        : null,
+                    {
+                        "w-full": size === "block",
+                        "cursor-default opacity-50 pointer-events-none": disabled || loading,
+                    },
+                    className,
+                )}
+                ref={ref}
+                disabled={disabled}
+                autoFocus={autoFocus}
+                onClick={onClick}
+            >
+                <ButtonContent loading={loading}>{children}</ButtonContent>
+            </button>
+        );
+    },
+);
 
 // TODO: Consider making this a LoadingButton variant instead
 type ButtonContentProps = {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If you have the Cancel button focused in a `ConfirmationModal` and click Enter, instead of canceling it, it treats it as if you confirmed, which results in a delete behavior in many scenarios. This is due to the `ref` not getting forwarded correctly in the `<Button>` component.

Turns out you can't just a `ref` prop to a component, you need to wrap your component in `forwardRef()` and use the `ref` argument it passes in. More info [in the docs](https://react.dev/reference/react/forwardRef).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-396

## How to test
<!-- Provide steps to test this PR -->
* Go to your org SSO settings and create a fake SSO config. You can use `https://accounts.google.com` for the url, and w/e for the rest. Save it.
* In the list view, click the overflow menu, and select delete.
* The Cancel button should be focused by default. Hit Enter.
* The config *should not* get deleted anymore now when you cancel.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
