### PR TITLE
[ws-manager-mk2] Ensure restarting ws-daemon does not break running workspaces

### DIFF
--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -107,6 +107,14 @@ func LoadFilter() (libseccomp.ScmpFd, error) {
 	return fd, nil
 }
 
+const (
+	// IWS backoff is the backoff configuration we use for interacting with the in-workspace service
+	iwsBackoffInitialWait = 10 * time.Millisecond
+	iwsBackoffSteps       = 6
+	iwsBackoffFactor      = 5
+	iwsBackoffMaxWait     = 2500 * time.Millisecond
+)
+
 // Handle actually listens on the seccomp notif FD and handles incoming requests.
 // This function returns when the notif FD is closed.
 func Handle(fd libseccomp.ScmpFd, handler SyscallHandler, wsid string) (stop chan<- struct{}, errchan <-chan error) {
@@ -284,25 +292,42 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		iws, err := h.Daemon(ctx)
-		if err != nil {
-			log.WithField("target", target).WithField("dest", dest).WithField("mode", stat.Mode()).WithError(err).Errorf("cannot get IWS client to mount %s", filesystem)
-			return Errno(unix.EFAULT)
-		}
-		defer iws.Close()
+		wait := iwsBackoffInitialWait
+		for i := 0; i < iwsBackoffSteps; i++ {
+			err = func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				iws, err := h.Daemon(ctx)
+				if err != nil {
+					log.WithField("target", target).WithField("dest", dest).WithField("mode", stat.Mode()).WithError(err).Errorf("cannot get IWS client to mount %s", filesystem)
+					return err
+				}
+				defer iws.Close()
 
-		call := iws.MountProc
-		if filesystem == "sysfs" {
-			call = iws.MountSysfs
+				call := iws.MountProc
+				if filesystem == "sysfs" {
+					call = iws.MountSysfs
+				}
+				_, err = call(ctx, &daemonapi.MountProcRequest{
+					Target: dest,
+					Pid:    int64(req.Pid),
+				})
+				if err != nil {
+					log.WithField("target", dest).WithError(err).Errorf("cannot mount %s", filesystem)
+					return err
+				}
+				return nil
+			}()
+			if err != nil {
+				time.Sleep(wait)
+				wait = wait * iwsBackoffFactor
+				if wait > iwsBackoffMaxWait {
+					wait = iwsBackoffMaxWait
+				}
+			}
 		}
-		_, err = call(ctx, &daemonapi.MountProcRequest{
-			Target: dest,
-			Pid:    int64(req.Pid),
-		})
 		if err != nil {
-			log.WithField("target", dest).WithError(err).Errorf("cannot mount %s", filesystem)
+			// We've already logged the reason above
 			return Errno(unix.EFAULT)
 		}
 

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -185,7 +185,7 @@ func (wso *DefaultWorkspaceOperations) creator(owner, workspaceID, instanceID st
 }
 
 func (wso *DefaultWorkspaceOperations) SetupWorkspace(ctx context.Context, instanceID string) error {
-	_, err := wso.provider.Get(ctx, instanceID)
+	_, err := wso.provider.GetAndConnect(ctx, instanceID)
 	if err != nil {
 		return fmt.Errorf("cannot setup workspace %s: %w", instanceID, err)
 	}
@@ -194,7 +194,7 @@ func (wso *DefaultWorkspaceOperations) SetupWorkspace(ctx context.Context, insta
 }
 
 func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts BackupOptions) (*csapi.GitStatus, error) {
-	ws, err := wso.provider.Get(ctx, opts.Meta.InstanceID)
+	ws, err := wso.provider.GetAndConnect(ctx, opts.Meta.InstanceID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find workspace %s during DisposeWorkspace: %w", opts.Meta.InstanceID, err)
 	}
@@ -234,7 +234,7 @@ func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts
 }
 
 func (wso *DefaultWorkspaceOperations) DeleteWorkspace(ctx context.Context, instanceID string) error {
-	ws, err := wso.provider.Get(ctx, instanceID)
+	ws, err := wso.provider.GetAndConnect(ctx, instanceID)
 	if err != nil {
 		return fmt.Errorf("cannot find workspace %s during DisposeWorkspace: %w", instanceID, err)
 	}
@@ -254,7 +254,7 @@ func (wso *DefaultWorkspaceOperations) DeleteWorkspace(ctx context.Context, inst
 }
 
 func (wso *DefaultWorkspaceOperations) SnapshotIDs(ctx context.Context, instanceID string) (snapshotUrl, snapshotName string, err error) {
-	sess, err := wso.provider.Get(ctx, instanceID)
+	sess, err := wso.provider.GetAndConnect(ctx, instanceID)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot find workspace %s during SnapshotName: %w", instanceID, err)
 	}
@@ -280,7 +280,7 @@ func (wso *DefaultWorkspaceOperations) Snapshot(ctx context.Context, workspaceID
 		return fmt.Errorf("workspaceID is required")
 	}
 
-	ws, err := wso.provider.Get(ctx, workspaceID)
+	ws, err := wso.provider.GetAndConnect(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf("cannot find workspace %s during DisposeWorkspace", workspaceID)
 	}


### PR DESCRIPTION
## Description
Ensure restarting ws-daemon does not break running workspaces and backups can be taken successfully.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-183, WKS-53 and WKS-91

## How to test
- Start imagebuild in preview environment
- Restart ws-daemon
- Wait until workspace is running. Once it's running delete the ws-daemon pod. At any point `docker run --rm  -t alpine:latest date`  should work
- Stop workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
