### PR TITLE
Fix dev settings link for git providers

### DIFF
--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -224,7 +224,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                         onBlur={hostOnBlur}
                     />
 
-                    <InputField label="Redirect URI" hint={<RedirectUrlDescription type={type} host={host} />}>
+                    <InputField label="Redirect URI" hint={<RedirectUrlDescription type={type} />}>
                         <InputWithCopy value={redirectURL} tip="Copy the redirect URI to clipboard" />
                     </InputField>
 
@@ -298,21 +298,8 @@ const getPlaceholderForIntegrationType = (type: string) => {
 
 type RedirectUrlDescriptionProps = {
     type: string;
-    host: string;
 };
-const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = ({ type, host }) => {
-    let settingsUrl = ``;
-    switch (type) {
-        case "GitHub":
-            settingsUrl = `${host || "github.com"}/settings/developers`;
-            break;
-        case "GitLab":
-            settingsUrl = `${host || "gitlab.com"}/-/profile/applications`;
-            break;
-        default:
-            return null;
-    }
-
+const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = ({ type }) => {
     let docsUrl = ``;
     switch (type) {
         case "GitHub":
@@ -327,15 +314,10 @@ const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = (
 
     return (
         <span>
-            Use this redirect URI to update the OAuth application. Go to{" "}
-            <a href={`https://${settingsUrl}`} target="_blank" rel="noreferrer noopener" className="gp-link">
-                developer settings
-            </a>{" "}
-            and setup the OAuth application.&nbsp;
+            Use this redirect URI to register a {type} instance as an authorized Git provider in Gitpod.{" "}
             <a href={docsUrl} target="_blank" rel="noreferrer noopener" className="gp-link">
                 Learn more
             </a>
-            .
         </span>
     );
 };

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -303,7 +303,7 @@ const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = (
     let docsUrl = ``;
     switch (type) {
         case "GitHub":
-            docsUrl = `https://www.gitpod.io/docs/github-integration/#oauth-application`;
+            docsUrl = `https://www.gitpod.io/docs/configure/authentication/github-enterprise`;
             break;
         case "GitLab":
             docsUrl = `https://www.gitpod.io/docs/gitlab-integration/#oauth-application`;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -48,11 +48,11 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
             url = savedProvider?.oauth.callBackUrl ?? url;
         } else {
             // Otherwise construct it w/ their provided host value or example
-            url = callbackUrl(host || "gitlab.example.com");
+            url = callbackUrl(host || getPlaceholderForIntegrationType(type));
         }
 
         return url;
-    }, [host, isNew, savedProvider?.oauth.callBackUrl]);
+    }, [host, isNew, savedProvider?.oauth.callBackUrl, type]);
 
     const [savingProvider, setSavingProvider] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -22,6 +22,8 @@ import { getGitpodService, gitpodHostUrl } from "../../service/service";
 import { UserContext } from "../../user-context";
 import { useToast } from "../../components/toasts/Toasts";
 
+type ProviderType = "GitHub" | "GitLab" | "BitbucketServer";
+
 type Props = {
     provider?: AuthProviderEntry;
     onClose: () => void;
@@ -31,7 +33,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     const { setUser } = useContext(UserContext);
     const { toast } = useToast();
     const team = useCurrentOrg().data;
-    const [type, setType] = useState<string>(props.provider?.type ?? "GitLab");
+    const [type, setType] = useState<ProviderType>((props.provider?.type as ProviderType) ?? "GitLab");
     const [host, setHost] = useState<string>(props.provider?.host ?? "");
     const [clientId, setClientId] = useState<string>(props.provider?.oauth.clientId ?? "");
     const [clientSecret, setClientSecret] = useState<string>(props.provider?.oauth.clientSecret ?? "");
@@ -209,7 +211,12 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                 )}
 
                 <div>
-                    <SelectInputField disabled={!isNew} label="Provider Type" value={type} onChange={setType}>
+                    <SelectInputField
+                        disabled={!isNew}
+                        label="Provider Type"
+                        value={type}
+                        onChange={(val) => setType(val as ProviderType)}
+                    >
                         <option value="GitHub">GitHub</option>
                         <option value="GitLab">GitLab</option>
                         <option value="BitbucketServer">Bitbucket Server</option>
@@ -283,7 +290,7 @@ const callbackUrl = (host: string) => {
     return gitpodHostUrl.with({ pathname }).toString();
 };
 
-const getPlaceholderForIntegrationType = (type: string) => {
+const getPlaceholderForIntegrationType = (type: ProviderType) => {
     switch (type) {
         case "GitHub":
             return "github.example.com";
@@ -297,7 +304,7 @@ const getPlaceholderForIntegrationType = (type: string) => {
 };
 
 type RedirectUrlDescriptionProps = {
-    type: string;
+    type: ProviderType;
 };
 const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = ({ type }) => {
     let docsUrl = ``;
@@ -306,7 +313,10 @@ const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = (
             docsUrl = `https://www.gitpod.io/docs/configure/authentication/github-enterprise`;
             break;
         case "GitLab":
-            docsUrl = `https://www.gitpod.io/docs/gitlab-integration/#oauth-application`;
+            docsUrl = `https://www.gitpod.io/docs/configure/authentication/gitlab#registering-a-self-hosted-gitlab-installation`;
+            break;
+        case "BitbucketServer":
+            docsUrl = "https://www.gitpod.io/docs/configure/authentication/bitbucket-server";
             break;
         default:
             return null;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -304,10 +304,10 @@ const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = (
     let settingsUrl = ``;
     switch (type) {
         case "GitHub":
-            settingsUrl = `${host}/settings/developers`;
+            settingsUrl = `${host || "github.com"}/settings/developers`;
             break;
         case "GitLab":
-            settingsUrl = `${host}/-/profile/applications`;
+            settingsUrl = `${host || "gitlab.com"}/-/profile/applications`;
             break;
         default:
             return null;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

If the user hasn’t entered a host value yet in the form, our links are broken as described in the issue. ~I’ve opted to have the links default to github.com and gitlab.com when there’s no custom host entered in the form yet, but once there is, the links will use that host.~

After some discussion, we'll simplify this view so the hint text links below the input aren't dynamic, and we just link to the corresponding GitLab or GitHub docs.

| GitLab | GitHub | Bitbucket Server |
|--------|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/ec562b7d-5979-49fb-bbe5-8967b9f1ce8a) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/1193091b-db40-43e5-b4cc-003134f9ec45) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/4c148161-e3bb-4ab5-88db-bb0a36fb7a81) |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-327

## How to test
<!-- Provide steps to test this PR -->
* Sign up and go to your Git Provider org settings: https://brad-web-3291aefe406.preview.gitpod-dev.com/settings/git
* Click `New Git Provider`
* Verify the hint text below the `Redirect URI` input matches the images above. 
* The Learn more link should link to either GitHub or GitLab docs depending on the type you've selected.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-3291aefe406</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-3291aefe406.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-3291aefe406.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
