### PR TITLE
Fix double submission on SSO Config modal

### DIFF
--- a/components/dashboard/src/admin/BlockedEmailDomains.tsx
+++ b/components/dashboard/src/admin/BlockedEmailDomains.tsx
@@ -10,12 +10,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Alert from "../components/Alert";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import { ItemFieldContextMenu } from "../components/ItemsList";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import searchIcon from "../icons/search.svg";
 import { getGitpodService } from "../service/service";
 import { AdminPageHeader } from "./AdminPageHeader";
 import Pagination from "../Pagination/Pagination";
+import { Button } from "../components/Button";
 
 export function BlockedEmailDomains() {
     return (
@@ -208,41 +209,35 @@ function AddBlockedDomainModal(p: AddBlockedDomainModalProps) {
         setError("");
     }, [p.blockedDomain]);
 
-    const save = (): boolean => {
+    const save = () => {
         const v = ref.current;
         const newError = p.validate(v);
         if (!!newError) {
             setError(newError);
-            return false;
         }
 
         p.save(v);
         p.onClose();
-        return true;
     };
 
     return (
-        <Modal
-            visible={true}
-            title={"New Blocked Domain"}
-            onClose={p.onClose}
-            onEnter={save}
-            buttons={[
-                <button className="secondary" onClick={p.onClose}>
+        <Modal visible={true} onClose={p.onClose} onSubmit={save}>
+            <ModalHeader>New Blocked Domain</ModalHeader>
+            <ModalBody>
+                <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                    Entries in this table have an immediate effect on all new users. Please use it carefully.
+                </Alert>
+                <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                    Users are blocked by matching their email domain.
+                </Alert>
+                <Details br={br} update={update} error={error} />
+            </ModalBody>
+            <ModalFooter>
+                <Button type="secondary" onClick={p.onClose}>
                     Cancel
-                </button>,
-                <button className="ml-2" onClick={save}>
-                    Add Blocked Domain
-                </button>,
-            ]}
-        >
-            <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                Entries in this table have an immediate effect on all new users. Please use it carefully.
-            </Alert>
-            <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                Users are blocked by matching their email domain.
-            </Alert>
-            <Details br={br} update={update} error={error} />
+                </Button>
+                <Button htmlType="submit">Add Blocked Domain</Button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -114,7 +114,7 @@ export function BlockedRepositoriesList(props: Props) {
                 {isDeleteModalVisible && (
                     <DeleteBlockedRepositoryModal
                         blockedRepository={currentBlockedRepository}
-                        deleteBlockedRepository={() => deleteBlockedRepository(currentBlockedRepository)}
+                        deleteBlockedRepository={async () => await deleteBlockedRepository(currentBlockedRepository)}
                         onClose={() => setDeleteModalVisible(false)}
                     />
                 )}
@@ -263,8 +263,8 @@ function DeleteBlockedRepositoryModal(props: {
             areYouSureText="Are you sure you want to delete this repository from the list?"
             buttonText="Delete Blocked Repository"
             onClose={props.onClose}
-            onConfirm={() => {
-                props.deleteBlockedRepository();
+            onConfirm={async () => {
+                await props.deleteBlockedRepository();
                 props.onClose();
             }}
         >

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -5,18 +5,19 @@
  */
 
 import { AdminGetListResult } from "@gitpod/gitpod-protocol";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { AdminPageHeader } from "./AdminPageHeader";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import ConfirmationModal from "../components/ConfirmationModal";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import { ItemFieldContextMenu } from "../components/ItemsList";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import Alert from "../components/Alert";
 import { SpinnerLoader } from "../components/Loader";
 import searchIcon from "../icons/search.svg";
+import { Button } from "../components/Button";
 
 export function BlockedRepositories() {
     return (
@@ -213,41 +214,34 @@ function AddBlockedRepositoryModal(p: AddBlockedRepositoryModalProps) {
         setError("");
     }, [p.blockedRepository]);
 
-    const save = (): boolean => {
+    const save = useCallback(() => {
         const v = ref.current;
         const newError = p.validate(v);
         if (!!newError) {
             setError(newError);
-            return false;
         }
 
         p.save(v);
-        p.onClose();
-        return true;
-    };
+    }, [p]);
 
     return (
-        <Modal
-            visible={true}
-            title={"New Blocked Repository"}
-            onClose={p.onClose}
-            onEnter={save}
-            buttons={[
-                <button className="secondary" onClick={p.onClose}>
+        <Modal visible onClose={p.onClose} onSubmit={save}>
+            <ModalHeader>New Blocked Repository</ModalHeader>
+            <ModalBody>
+                <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                    Entries in this table have an immediate effect on all users. Please use it carefully.
+                </Alert>
+                <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                    Repositories are blocked by matching their URL against this regular expression.
+                </Alert>
+                <Details br={br} update={update} error={error} />
+            </ModalBody>
+            <ModalFooter>
+                <Button type="secondary" onClick={p.onClose}>
                     Cancel
-                </button>,
-                <button className="ml-2" onClick={save}>
-                    Add Blocked Repository
-                </button>,
-            ]}
-        >
-            <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                Entries in this table have an immediate effect on all users. Please use it carefully.
-            </Alert>
-            <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                Repositories are blocked by matching their URL against this regular expression.
-            </Alert>
-            <Details br={br} update={update} error={error} />
+                </Button>
+                <Button htmlType="submit">Add Blocked Repository</Button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -228,7 +228,6 @@ export default function TeamDetail(props: { team: Team }) {
                 visible={editSpendingLimit}
                 onClose={() => setEditSpendingLimit(false)}
                 title="Change Usage Limit"
-                onEnter={() => false}
                 buttons={[
                     <button
                         disabled={usageLimit === costCenter?.spendingLimit}
@@ -263,7 +262,6 @@ export default function TeamDetail(props: { team: Team }) {
                 </div>
             </Modal>
             <Modal
-                onEnter={() => false}
                 visible={editAddCreditNote}
                 onClose={() => setEditAddCreditNote(false)}
                 title="Add Credits"

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -235,7 +235,6 @@ export default function UserDetail(p: { user: User }) {
                 visible={editSpendingLimit}
                 onClose={() => setEditSpendingLimit(false)}
                 title="Change Usage Limit"
-                onEnter={() => false}
                 buttons={[
                     <button
                         disabled={usageLimit === costCenter?.spendingLimit}
@@ -269,7 +268,6 @@ export default function UserDetail(p: { user: User }) {
                 </div>
             </Modal>
             <Modal
-                onEnter={() => false}
                 visible={editAddCreditNote}
                 onClose={() => setEditAddCreditNote(false)}
                 title="Add Credits"

--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ReactComponent as Exclamation } from "../images/exclamation.svg";
 import { ReactComponent as Exclamation2 } from "../images/exclamation2.svg";
 import { ReactComponent as InfoSvg } from "../images/info.svg";
@@ -32,6 +32,7 @@ export interface AlertProps {
     // Without background color, default false
     light?: boolean;
     closable?: boolean;
+    autoFocusClose?: boolean;
     onClose?: () => void;
     showIcon?: boolean;
     icon?: React.ReactNode;
@@ -87,14 +88,25 @@ const infoMap: Record<AlertType, AlertInfo> = {
 
 export default function Alert(props: AlertProps) {
     const [visible, setVisible] = useState(true);
-    if (!visible) {
-        return null;
-    }
+
     const type: AlertType = props.type ?? "info";
     const info = infoMap[type];
     const showIcon = props.showIcon ?? true;
     const light = props.light ?? false;
     const rounded = props.rounded ?? true;
+    const autoFocusClose = props.autoFocusClose ?? false;
+
+    const handleClose = useCallback(() => {
+        setVisible(false);
+        if (props.onClose) {
+            props.onClose();
+        }
+    }, [props]);
+
+    if (!visible) {
+        return null;
+    }
+
     return (
         <div
             className={classNames(
@@ -108,16 +120,16 @@ export default function Alert(props: AlertProps) {
             {showIcon && <span className={`mt-1 mr-4 h-4 w-4 ${info.iconColor}`}>{props.icon ?? info.icon}</span>}
             <span className="flex-1 text-left">{props.children}</span>
             {props.closable && (
-                <span className={`mt-1 ml-4 h-4 w-4`}>
-                    <XSvg
-                        onClick={() => {
-                            setVisible(false);
-                            if (props.onClose) {
-                                props.onClose();
-                            }
-                        }}
-                        className="w-3 h-4 cursor-pointer"
-                    ></XSvg>
+                <span className={`mt-1 ml-4`}>
+                    {/* Use an IconButton component once we make it */}
+                    <button
+                        type="button"
+                        className="bg-transparent p-1"
+                        onClick={handleClose}
+                        autoFocus={autoFocusClose}
+                    >
+                        <XSvg className="w-3 h-4 cursor-pointer" />
+                    </button>
                 </span>
             )}
         </div>

--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -30,7 +30,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {
             type = "primary",
             className,
-            htmlType,
+            htmlType = "button",
             disabled = false,
             loading = false,
             autoFocus = false,

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -6,89 +6,85 @@
 
 import Alert from "./Alert";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "./Modal";
-import { useRef, useEffect, ReactNode } from "react";
+import { FC, ReactNode, useCallback, useState } from "react";
 import { Button, ButtonProps } from "./Button";
 
-export default function ConfirmationModal(props: {
+type Props = {
     title?: string;
     areYouSureText?: string;
     children?: Entity | ReactNode;
     buttonText?: string;
     buttonDisabled?: boolean;
-    buttonLoading?: boolean;
     buttonType?: ButtonProps["type"];
     visible?: boolean;
     warningHead?: string;
     warningText?: string;
     footerAlert?: ReactNode;
     onClose: () => void;
-    onConfirm: () => void;
-}) {
-    const buttonType = props.buttonType || "danger";
-    const cancelButtonRef = useRef<HTMLButtonElement>(null);
+    onConfirm: () => void | Promise<void>;
+};
+export const ConfirmationModal: FC<Props> = ({
+    title = "Confirm",
+    areYouSureText,
+    children,
+    buttonText = "Yes, I'm Sure",
+    buttonDisabled,
+    buttonType = "danger",
+    visible,
+    warningHead,
+    warningText,
+    footerAlert,
+    onClose,
+    onConfirm,
+}) => {
+    const [isLoading, setIsLoading] = useState(false);
+    const handleSubmit = useCallback(async () => {
+        setIsLoading(true);
 
-    const buttonDisabled = useRef(props.buttonDisabled);
-    useEffect(() => {
-        buttonDisabled.current = props.buttonDisabled;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        await onConfirm();
+
+        setIsLoading(false);
+    }, [onConfirm]);
 
     return (
-        <Modal
-            visible={props.visible === undefined ? true : props.visible}
-            onClose={props.onClose}
-            onEnter={() => {
-                if (cancelButtonRef?.current?.contains(document.activeElement)) {
-                    props.onClose();
-                    return false;
-                }
-                if (buttonDisabled.current) {
-                    return false;
-                }
-                props.onConfirm();
-                return true;
-            }}
-        >
-            <ModalHeader>{props.title || "Confirm"}</ModalHeader>
+        <Modal visible={visible === undefined ? true : visible} onClose={onClose} onSubmit={handleSubmit}>
+            <ModalHeader>{title}</ModalHeader>
             <ModalBody>
-                {props.warningText && (
+                {warningText && (
                     <Alert type="warning" className="mb-4">
-                        <strong>{props.warningHead}</strong>
-                        {props.warningHead ? ": " : ""}
-                        {props.warningText}
+                        <strong>{warningHead}</strong>
+                        {warningHead ? ": " : ""}
+                        {warningText}
                     </Alert>
                 )}
-                <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
-                {isEntity(props.children) ? (
+                <p className="mb-3 text-base text-gray-500">{areYouSureText}</p>
+                {isEntity(children) ? (
                     <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
-                        <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">
-                            {props.children.name}
-                        </p>
-                        {props.children.description && (
-                            <p className="text-gray-500 truncate">{props.children.description}</p>
-                        )}
+                        <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{children.name}</p>
+                        {children.description && <p className="text-gray-500 truncate">{children.description}</p>}
                     </div>
                 ) : (
-                    props.children
+                    children
                 )}
             </ModalBody>
-            <ModalFooter alert={props.footerAlert}>
-                <Button type="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>
+            <ModalFooter alert={footerAlert}>
+                <Button type="secondary" onClick={onClose} autoFocus>
                     Cancel
                 </Button>
                 <Button
+                    htmlType="submit"
                     type={buttonType}
                     className="ml-2"
-                    onClick={props.onConfirm}
-                    disabled={props.buttonDisabled}
-                    loading={props.buttonLoading}
+                    disabled={buttonDisabled}
+                    loading={isLoading}
                 >
-                    {props.buttonText || "Yes, I'm Sure"}
+                    {buttonText}
                 </Button>
             </ModalFooter>
         </Modal>
     );
-}
+};
+export default ConfirmationModal;
 
 export interface Entity {
     name: string;

--- a/components/dashboard/src/components/LinkButton.tsx
+++ b/components/dashboard/src/components/LinkButton.tsx
@@ -6,14 +6,16 @@
 
 import classNames from "classnames";
 import { FC, MouseEvent, useCallback } from "react";
+import { ButtonProps } from "./Button";
 
 type Props = {
     className?: string;
+    htmlType?: ButtonProps["htmlType"];
     onClick: () => void;
 };
 
 // A button that looks like a link
-export const LinkButton: FC<Props> = ({ className, children, onClick }) => {
+export const LinkButton: FC<Props> = ({ className, htmlType = "button", children, onClick }) => {
     const handleClick = useCallback(
         (e: MouseEvent<HTMLButtonElement>) => {
             e.preventDefault();
@@ -24,6 +26,7 @@ export const LinkButton: FC<Props> = ({ className, children, onClick }) => {
 
     return (
         <button
+            type={htmlType}
             className={classNames(
                 "text-sm font-normal",
                 "bg-transparent hover:bg-transparent p-0 rounded-none",

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -142,7 +142,13 @@ const MaybeWithForm: FC<MaybeWithFormProps> = ({ onSubmit, children }) => {
         return <>{children}</>;
     }
 
-    return <form onSubmit={handleSubmit}>{children}</form>;
+    return (
+        <form onSubmit={handleSubmit}>
+            {/* including a hidden submit button ensures submit on enter works despite a button w/ type="submit" existing or not */}
+            <input type="submit" className="hidden" hidden />
+            {children}
+        </form>
+    );
 };
 
 type ModalHeaderProps = {

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -80,7 +80,6 @@ export const Modal: FC<Props> = ({
     // when enter is pressed vs. inside an input, <form> handles that for us already
     const handleKeydown = useCallback(
         async (evt: KeyboardEvent) => {
-            console.log("keydown handler");
             if (!visible || evt.defaultPrevented) {
                 return;
             }

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -29,7 +29,7 @@ type Props = {
     className?: string;
     onClose: () => void;
     /**
-     * @deprecated
+     * @deprecated Use onSubmit() instead and include a Button w/ htmlType="submit"
      */
     onEnter?: () => boolean | Promise<boolean>;
     onSubmit?: () => void | Promise<void>;
@@ -98,19 +98,6 @@ export const Modal: FC<Props> = ({
         [closeModal, onEnter, visible],
     );
 
-    const handleSubmit = useCallback(
-        (e: FormEvent) => {
-            console.log("handleSubmit");
-            e.preventDefault();
-
-            if (onSubmit) {
-                console.log("onSubmit()");
-                onSubmit();
-            }
-        },
-        [onSubmit],
-    );
-
     if (!visible) {
         return null;
     }
@@ -146,7 +133,7 @@ export const Modal: FC<Props> = ({
                             aria-labelledby="modal-header"
                             tabIndex={-1}
                         >
-                            <form onSubmit={handleSubmit}>
+                            <MaybeWithForm onSubmit={onSubmit}>
                                 {closeable && <ModalCloseIcon onClose={() => closeModal("x")} />}
                                 {title ? (
                                     <>
@@ -157,7 +144,7 @@ export const Modal: FC<Props> = ({
                                 ) : (
                                     children
                                 )}
-                            </form>
+                            </MaybeWithForm>
                         </div>
                     </FocusOn>
                 </div>
@@ -167,6 +154,28 @@ export const Modal: FC<Props> = ({
 };
 
 export default Modal;
+
+type MaybeWithFormProps = {
+    onSubmit: Props["onSubmit"];
+};
+const MaybeWithForm: FC<MaybeWithFormProps> = ({ onSubmit, children }) => {
+    const handleSubmit = useCallback(
+        (e: FormEvent) => {
+            e.preventDefault();
+
+            if (onSubmit) {
+                onSubmit();
+            }
+        },
+        [onSubmit],
+    );
+
+    if (!onSubmit) {
+        return <>{children}</>;
+    }
+
+    return <form onSubmit={handleSubmit}>{children}</form>;
+};
 
 type ModalHeaderProps = {
     children: ReactNode;

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, KeyboardEvent, ReactNode, useCallback } from "react";
+import { FC, FormEvent, KeyboardEvent, ReactNode, useCallback } from "react";
 import { Portal } from "react-portal";
 import { FocusOn, AutoFocusInside } from "react-focus-on";
 import cn from "classnames";
@@ -28,7 +28,11 @@ type Props = {
     disableFocusLock?: boolean;
     className?: string;
     onClose: () => void;
+    /**
+     * @deprecated
+     */
     onEnter?: () => boolean | Promise<boolean>;
+    onSubmit?: () => void | Promise<void>;
 };
 export const Modal: FC<Props> = ({
     title,
@@ -42,6 +46,7 @@ export const Modal: FC<Props> = ({
     className,
     onClose,
     onEnter,
+    onSubmit,
 }) => {
     const trackEvent = useTrackEvent();
 
@@ -75,6 +80,7 @@ export const Modal: FC<Props> = ({
     // when enter is pressed vs. inside an input, <form> handles that for us already
     const handleKeydown = useCallback(
         async (evt: KeyboardEvent) => {
+            console.log("keydown handler");
             if (!visible || evt.defaultPrevented) {
                 return;
             }
@@ -92,6 +98,19 @@ export const Modal: FC<Props> = ({
         [closeModal, onEnter, visible],
     );
 
+    const handleSubmit = useCallback(
+        (e: FormEvent) => {
+            console.log("handleSubmit");
+            e.preventDefault();
+
+            if (onSubmit) {
+                console.log("onSubmit()");
+                onSubmit();
+            }
+        },
+        [onSubmit],
+    );
+
     if (!visible) {
         return null;
     }
@@ -101,7 +120,7 @@ export const Modal: FC<Props> = ({
             {/* backdrop overlay */}
             <div
                 className="fixed top-0 left-0 bg-black bg-opacity-70 z-50 w-screen h-screen focus:ring-0"
-                onKeyDown={handleKeydown}
+                onKeyDown={onEnter ? handleKeydown : undefined}
                 tabIndex={0}
             >
                 {/* Modal outer-container for positioning */}
@@ -127,16 +146,18 @@ export const Modal: FC<Props> = ({
                             aria-labelledby="modal-header"
                             tabIndex={-1}
                         >
-                            {closeable && <ModalCloseIcon onClose={() => closeModal("x")} />}
-                            {title ? (
-                                <>
-                                    <ModalHeader>{title}</ModalHeader>
-                                    <ModalBody hideDivider={hideDivider}>{children}</ModalBody>
-                                    <ModalFooter>{buttons}</ModalFooter>
-                                </>
-                            ) : (
-                                children
-                            )}
+                            <form onSubmit={handleSubmit}>
+                                {closeable && <ModalCloseIcon onClose={() => closeModal("x")} />}
+                                {title ? (
+                                    <>
+                                        <ModalHeader>{title}</ModalHeader>
+                                        <ModalBody hideDivider={hideDivider}>{children}</ModalBody>
+                                        <ModalFooter>{buttons}</ModalFooter>
+                                    </>
+                                ) : (
+                                    children
+                                )}
+                            </form>
                         </div>
                     </FocusOn>
                 </div>
@@ -205,7 +226,12 @@ export const ModalFooter: FC<ModalFooterProps> = ({ className, alert, children }
 };
 
 // Wrapper around Alert to ensure it's used correctly in a Modal
-export const ModalFooterAlert: FC<AlertProps> = ({ closable = true, children, ...alertProps }) => {
+export const ModalFooterAlert: FC<AlertProps> = ({
+    closable = true,
+    autoFocusClose = true,
+    children,
+    ...alertProps
+}) => {
     return (
         <div
             className={classNames({
@@ -213,7 +239,7 @@ export const ModalFooterAlert: FC<AlertProps> = ({ closable = true, children, ..
                 "gp-modal-footer-alert_animate absolute": closable,
             })}
         >
-            <Alert rounded={false} closable={closable} {...alertProps}>
+            <Alert rounded={false} closable={closable} autoFocusClose={autoFocusClose} {...alertProps}>
                 {children}
             </Alert>
         </div>
@@ -227,8 +253,9 @@ const ModalCloseIcon: FC<ModalCloseIconProps> = ({ onClose }) => {
     return (
         // TODO: Create an IconButton component
         <button
+            type="button"
             aria-label="Close modal"
-            className="bg-transparent absolute right-7 top-6 cursor-pointer text-gray-800 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
+            className="bg-transparent absolute right-7 top-6 text-gray-800 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
             onClick={onClose}
         >
             <svg version="1.1" width="14px" height="14px" viewBox="0 0 100 100">

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, FormEvent, KeyboardEvent, ReactNode, useCallback } from "react";
+import { FC, FormEvent, ReactNode, useCallback } from "react";
 import { Portal } from "react-portal";
 import { FocusOn, AutoFocusInside } from "react-focus-on";
 import cn from "classnames";
@@ -28,10 +28,6 @@ type Props = {
     disableFocusLock?: boolean;
     className?: string;
     onClose: () => void;
-    /**
-     * @deprecated Use onSubmit() instead and include a Button w/ htmlType="submit"
-     */
-    onEnter?: () => boolean | Promise<boolean>;
     onSubmit?: () => void | Promise<void>;
 };
 export const Modal: FC<Props> = ({
@@ -45,7 +41,6 @@ export const Modal: FC<Props> = ({
     disableFocusLock = false,
     className,
     onClose,
-    onEnter,
     onSubmit,
 }) => {
     const trackEvent = useTrackEvent();
@@ -75,28 +70,6 @@ export const Modal: FC<Props> = ({
         closeModal("esc");
     }, [closeModal]);
 
-    // TODO: look into deprecating onEnter for Modals - use <form onSubmit> instead
-    // onEnter requires consumers do things like check if a non-submit button is focused
-    // when enter is pressed vs. inside an input, <form> handles that for us already
-    const handleKeydown = useCallback(
-        async (evt: KeyboardEvent) => {
-            if (!visible || evt.defaultPrevented) {
-                return;
-            }
-
-            if (evt.key === "Enter") {
-                if (onEnter) {
-                    if (await onEnter()) {
-                        closeModal("enter");
-                    }
-                } else {
-                    closeModal("enter");
-                }
-            }
-        },
-        [closeModal, onEnter, visible],
-    );
-
     if (!visible) {
         return null;
     }
@@ -104,11 +77,7 @@ export const Modal: FC<Props> = ({
     return (
         <Portal>
             {/* backdrop overlay */}
-            <div
-                className="fixed top-0 left-0 bg-black bg-opacity-70 z-50 w-screen h-screen focus:ring-0"
-                onKeyDown={onEnter ? handleKeydown : undefined}
-                tabIndex={0}
-            >
+            <div className="fixed top-0 left-0 bg-black bg-opacity-70 z-50 w-screen h-screen focus:ring-0" tabIndex={0}>
                 {/* Modal outer-container for positioning */}
                 <div className="flex justify-center items-center w-screen h-screen">
                     <FocusOn

--- a/components/dashboard/src/components/billing/AddPaymentMethodModal.tsx
+++ b/components/dashboard/src/components/billing/AddPaymentMethodModal.tsx
@@ -130,7 +130,7 @@ function AddPaymentMethodForm({ attributionId }: { attributionId: string }) {
                         ]}
                     />
                 </div>
-                <Button disabled={!stripe} loading={confirmPayment.isLoading}>
+                <Button htmlType="submit" disabled={!stripe} loading={confirmPayment.isLoading}>
                     Confirm
                 </Button>
             </ModalFooter>

--- a/components/dashboard/src/data/projects/set-project-env-var-mutation.ts
+++ b/components/dashboard/src/data/projects/set-project-env-var-mutation.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+type SetProjectEnvVarArgs = {
+    projectId: string;
+    name: string;
+    value: string;
+    censored: boolean;
+};
+export const useSetProjectEnvVar = () => {
+    return useMutation<void, Error, SetProjectEnvVarArgs>(async ({ projectId, name, value, censored }) => {
+        return getGitpodService().server.setProjectEnvironmentVariable(projectId, name, value, censored);
+    });
+};

--- a/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
+++ b/components/dashboard/src/dedicated-setup/OrgNamingStep.tsx
@@ -73,6 +73,7 @@ export const OrgNamingStep: FC<Props> = ({ onComplete, progressCurrent, progress
                 />
                 <div className="mt-6">
                     <Button
+                        htmlType="submit"
                         size="block"
                         disabled={!nameError.isValid}
                         loading={createOrg.isLoading || updateOrg.isLoading}

--- a/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
+++ b/components/dashboard/src/dedicated-setup/SSOSetupStep.tsx
@@ -103,7 +103,7 @@ export const SSOSetupStep: FC<Props> = ({ config, onComplete, progressCurrent, p
                 <SSOConfigForm config={ssoConfig} onChange={dispatch} />
 
                 <div className="mt-6">
-                    <Button size="block" disabled={!configIsValid} loading={isLoading}>
+                    <Button htmlType="submit" size="block" disabled={!configIsValid} loading={isLoading}>
                         Verify SSO Configuration
                     </Button>
                 </div>

--- a/components/dashboard/src/login/SSOLoginForm.tsx
+++ b/components/dashboard/src/login/SSOLoginForm.tsx
@@ -80,6 +80,7 @@ export const SSOLoginForm: FC<Props> = ({ singleOrgMode, onSuccess }) => {
                     />
                 )}
                 <Button
+                    htmlType="submit"
                     className="w-full"
                     type="secondary"
                     disabled={!singleOrgMode && (!orgSlug.trim() || !slugError.isValid)}

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -5,17 +5,19 @@
  */
 
 import { Project, ProjectEnvVar } from "@gitpod/gitpod-protocol";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Redirect } from "react-router";
 import Alert from "../components/Alert";
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
-import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../components/Modal";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { getGitpodService } from "../service/service";
 import { useCurrentProject } from "./project-context";
 import { ProjectSettingsPage } from "./ProjectSettings";
+import { Button } from "../components/Button";
+import { useSetProjectEnvVar } from "../data/projects/set-project-env-var-mutation";
 
 export default function ProjectVariablesPage() {
     const { project, loading } = useCurrentProject();
@@ -111,31 +113,26 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
     const [name, setName] = useState<string>("");
     const [value, setValue] = useState<string>("");
     const [censored, setCensored] = useState<boolean>(true);
-    const [error, setError] = useState<Error | undefined>();
+    const setProjectEnvVar = useSetProjectEnvVar();
 
-    const addVariable = async () => {
+    const addVariable = useCallback(async () => {
         if (!props.project) {
             return;
         }
-        try {
-            await getGitpodService().server.setProjectEnvironmentVariable(props.project.id, name, value, censored);
-            props.onClose();
-        } catch (err) {
-            console.error(err);
-            setError(err);
-        }
-    };
+
+        await setProjectEnvVar.mutate(
+            {
+                projectId: props.project.id,
+                name,
+                value,
+                censored,
+            },
+            { onSuccess: props.onClose },
+        );
+    }, [censored, name, props.onClose, props.project, setProjectEnvVar, value]);
 
     return (
-        // TODO: Use title and buttons props
-        <Modal
-            visible={true}
-            onClose={props.onClose}
-            onEnter={() => {
-                addVariable();
-                return false;
-            }}
-        >
+        <Modal visible onClose={props.onClose} onSubmit={addVariable}>
             <ModalHeader>New Variable</ModalHeader>
             <ModalBody>
                 <Alert type="warning">
@@ -145,11 +142,6 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
                     repository can access secret values if they are printed in the terminal, logged, or persisted to the
                     file system.
                 </Alert>
-                {error && (
-                    <Alert type="error" className="mt-4">
-                        {String(error).replace(/Error: Request \w+ failed with message: /, "")}
-                    </Alert>
-                )}
                 <div className="mt-8">
                     <h4>Name</h4>
                     <input
@@ -185,13 +177,21 @@ function AddVariableModal(props: { project?: Project; onClose: () => void }) {
                     </div>
                 )}
             </ModalBody>
-            <ModalFooter>
-                <button className="secondary" onClick={props.onClose}>
+            <ModalFooter
+                alert={
+                    setProjectEnvVar.isError ? (
+                        <ModalFooterAlert type="danger">
+                            {String(setProjectEnvVar.error).replace(/Error: Request \w+ failed with message: /, "")}
+                        </ModalFooterAlert>
+                    ) : null
+                }
+            >
+                <Button type="secondary" onClick={props.onClose}>
                     Cancel
-                </button>
-                <button className="ml-2" onClick={addVariable}>
+                </Button>
+                <Button htmlType="submit" loading={setProjectEnvVar.isLoading}>
                     Add Variable
-                </button>
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -84,7 +84,7 @@ export default function ProjectVariablesPage() {
                         </Item>
                         {envVars.map((variable) => {
                             return (
-                                <Item className="grid grid-cols-3 items-center">
+                                <Item key={variable.id} className="grid grid-cols-3 items-center">
                                     <ItemField className="truncate">{variable.name}</ItemField>
                                     <ItemField>{variable.censored ? "Hidden" : "Visible"}</ItemField>
                                     <ItemField className="flex justify-end">

--- a/components/dashboard/src/start/VerifyModal.tsx
+++ b/components/dashboard/src/start/VerifyModal.tsx
@@ -6,11 +6,13 @@
 
 import { useState } from "react";
 import Alert, { AlertType } from "../components/Alert";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { getGitpodService } from "../service/service";
 import PhoneInput from "react-intl-tel-input";
 import "react-intl-tel-input/dist/main.css";
 import "./phone-input.css";
+import { Button } from "../components/Button";
+import { LinkButton } from "../components/LinkButton";
 
 interface VerifyModalState {
     phoneNumber?: string;
@@ -42,7 +44,6 @@ export function VerifyModal() {
                     sending: false,
                     sent: new Date(),
                 });
-                return true;
             } catch (err) {
                 setState({
                     sent: undefined,
@@ -52,20 +53,19 @@ export function VerifyModal() {
                         text: err.toString(),
                     },
                 });
-                return false;
             }
         };
         return (
             <Modal
                 onClose={() => {}}
                 closeable={false}
-                onEnter={sendCode}
+                onSubmit={sendCode}
                 title="User Validation Required"
                 buttons={
                     <div>
-                        <button className="ml-2" disabled={!state.phoneNumberValid || state.sending} onClick={sendCode}>
+                        <Button htmlType="submit" disabled={!state.phoneNumberValid || state.sending}>
                             Send Code via SMS
-                        </button>
+                        </Button>
                     </div>
                 }
                 visible={true}
@@ -138,7 +138,6 @@ export function VerifyModal() {
                         },
                     });
                 }
-                return verified;
             } catch (err) {
                 setState({
                     sent: undefined,
@@ -148,7 +147,6 @@ export function VerifyModal() {
                         text: err.toString(),
                     },
                 });
-                return false;
             }
         };
 
@@ -164,13 +162,13 @@ export function VerifyModal() {
             <Modal
                 onClose={() => {}}
                 closeable={false}
-                onEnter={verifyToken}
+                onSubmit={verifyToken}
                 title="User Validation Required"
                 buttons={
                     <div>
-                        <button className="ml-2" disabled={!isTokenFilled()} onClick={verifyToken}>
+                        <Button htmlType="submit" disabled={!isTokenFilled()}>
                             Validate Account
-                        </button>
+                        </Button>
                     </div>
                 }
                 visible={true}
@@ -180,9 +178,7 @@ export function VerifyModal() {
                     discourage and reduce abuse on Gitpod infrastructure.
                 </Alert>
                 <div className="pt-4">
-                    <button className="gp-link" onClick={reset}>
-                        &larr; Use a different phone number
-                    </button>
+                    <LinkButton onClick={reset}>&larr; Use a different phone number</LinkButton>
                 </div>
                 <div className="text-gray-600 dark:text-gray-400 pt-4">
                     Enter the verification code we sent to {state.phoneNumber}.<br />
@@ -218,26 +214,18 @@ export function VerifyModal() {
     } else {
         const continueStartWorkspace = () => {
             window.location.reload();
-            return true;
         };
         return (
-            <Modal
-                onClose={continueStartWorkspace}
-                closeable={false}
-                onEnter={continueStartWorkspace}
-                title="User Validation Successful"
-                buttons={
-                    <div>
-                        <button className="ml-2" onClick={continueStartWorkspace}>
-                            Continue
-                        </button>
-                    </div>
-                }
-                visible={true}
-            >
-                <Alert type="success" className="mt-2">
-                    Your account has been successfully verified.
-                </Alert>
+            <Modal onClose={continueStartWorkspace} closeable={false} onSubmit={continueStartWorkspace} visible={true}>
+                <ModalHeader>User Validation Successful</ModalHeader>
+                <ModalBody>
+                    <Alert type="success" className="mt-2">
+                        Your account has been successfully verified.
+                    </Alert>
+                </ModalBody>
+                <ModalFooter>
+                    <Button htmlType="submit">Continue</Button>
+                </ModalFooter>
             </Modal>
         );
     }

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -11,6 +11,7 @@ import { Heading1, Heading3, Subheading } from "../components/typography/heading
 import { useOrganizationsInvalidator } from "../data/organizations/orgs-query";
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { publicApiTeamToProtocol, teamsService } from "../service/public-api";
+import { Button } from "../components/Button";
 
 export default function NewTeamPage() {
     const invalidateOrgs = useOrganizationsInvalidator();
@@ -71,10 +72,10 @@ export default function NewTeamPage() {
                     )}
                 </div>
                 <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-2">
-                    <button type="submit">Create Organization</button>
-                    <button className="secondary" onClick={() => history.push("/")}>
+                    <Button htmlType="submit">Create Organization</Button>
+                    <Button type="secondary" onClick={() => history.push("/")}>
                         Cancel
-                    </button>
+                    </Button>
                 </div>
             </form>
         </div>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -13,6 +13,7 @@ import { useDeleteOrgAuthProviderMutation } from "../../data/auth-providers/dele
 import { GitIntegrationModal } from "./GitIntegrationModal";
 import { useCurrentOrg } from "../../data/organizations/orgs-query";
 import { ModalFooterAlert } from "../../components/Modal";
+import { useToast } from "../../components/toasts/Toasts";
 
 type Props = {
     provider: AuthProviderEntry;
@@ -22,6 +23,7 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
     const deleteAuthProvider = useDeleteOrgAuthProviderMutation();
     const { data: org } = useCurrentOrg();
+    const { toast } = useToast();
 
     const memberCount = org?.members.length ?? 1;
 
@@ -43,11 +45,11 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
     const deleteProvider = useCallback(async () => {
         try {
             await deleteAuthProvider.mutateAsync({ providerId: provider.id });
+
+            toast("Git provider was deleted");
             setShowDeleteConfirmation(false);
-        } catch (error) {
-            console.log(error);
-        }
-    }, [deleteAuthProvider, provider.id]);
+        } catch (e) {}
+    }, [deleteAuthProvider, provider.id, toast]);
 
     return (
         <>
@@ -83,7 +85,6 @@ export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) =
                         description: provider.host,
                     }}
                     buttonText="Remove Provider"
-                    buttonDisabled={deleteAuthProvider.isLoading}
                     footerAlert={
                         deleteAuthProvider.isError ? (
                             <ModalFooterAlert type="danger">There was a problem deleting the provider</ModalFooterAlert>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -194,14 +194,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     );
 
     return (
-        <Modal
-            visible
-            onClose={props.onClose}
-            onEnter={() => {
-                activate();
-                return false;
-            }}
-        >
+        <Modal visible onClose={props.onClose} onSubmit={activate}>
             <ModalHeader>{isNew ? "New Git Provider" : "Git Provider"}</ModalHeader>
             <ModalBody>
                 {isNew && (
@@ -272,7 +265,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                 <Button type="secondary" onClick={props.onClose}>
                     Cancel
                 </Button>
-                <Button onClick={activate} disabled={!isValid || savingProvider} loading={savingProvider}>
+                <Button htmlType="submit" disabled={!isValid} loading={savingProvider}>
                     Activate
                 </Button>
             </ModalFooter>

--- a/components/dashboard/src/teams/sso/ActivateConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/ActivateConfigModal.tsx
@@ -27,18 +27,12 @@ export const ActivateConfigModal: FC<Props> = ({ configId, hasActiveConfig, onCl
             return;
         }
 
-        activateClient.mutate(
-            { id: config.id },
-            {
-                onSuccess: () => {
-                    toast("Single sign-on configuration was activated.");
-                    onClose();
-                },
-                onError: (error) => {
-                    console.error(error);
-                },
-            },
-        );
+        try {
+            await activateClient.mutateAsync({ id: config.id });
+
+            toast("Single sign-on configuration was activated.");
+            onClose();
+        } catch (e) {}
     }, [activateClient, config, onClose, toast]);
 
     // We should already have the config in all the scenarios we show this modal. If we don't, wait for it.
@@ -56,7 +50,6 @@ export const ActivateConfigModal: FC<Props> = ({ configId, hasActiveConfig, onCl
             }}
             buttonText="Activate"
             buttonType="primary"
-            buttonLoading={activateClient.isLoading}
             warningText={
                 hasActiveConfig
                     ? "Activating this SSO configuration will also deactivate the currently active configuration."

--- a/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientConfigModal.tsx
@@ -57,14 +57,7 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onSaved, onClos
     }, [isLoading, onClose, onSaved, save, ssoConfig]);
 
     return (
-        <Modal
-            visible
-            onClose={onClose}
-            onEnter={() => {
-                saveConfig();
-                return false;
-            }}
-        >
+        <Modal visible onClose={onClose} onSubmit={saveConfig}>
             <ModalHeader>
                 {isNew
                     ? "New SSO Configuration"
@@ -86,7 +79,7 @@ export const OIDCClientConfigModal: FC<Props> = ({ clientConfig, onSaved, onClos
                     Cancel
                 </Button>
                 <Button
-                    onClick={saveConfig}
+                    htmlType="submit"
                     disabled={!configIsValid || clientConfig?.active === true}
                     loading={isLoading}
                 >

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -108,7 +108,6 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig, hasActiveConfig, o
                         description: clientConfig.oauth2Config?.clientId ?? "",
                     }}
                     buttonText="Remove"
-                    buttonLoading={deleteOIDCClient.isLoading}
                     warningText={
                         clientConfig.active
                             ? "Warning, you are about to remove the active SSO configuration. If you continue, SSO will be disabled for your organization and no one, including yourself, will be able to log in."

--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -103,7 +103,9 @@ export default function Account() {
                         emailIsReadonly={!canUpdateEmail}
                     >
                         <div className="flex flex-row mt-8">
-                            <Button onClick={saveProfileState}>Update Profile</Button>
+                            <Button htmlType="submit" onClick={saveProfileState}>
+                                Update Profile
+                            </Button>
                         </div>
                     </ProfileInformation>
                 </form>

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -5,7 +5,7 @@
  */
 
 import { UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { Item, ItemField, ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
@@ -39,22 +39,19 @@ function AddEnvVarModal(p: EnvVarModalProps) {
     }, [p.envVar]);
 
     const isNew = !p.envVar.id;
-    let save = () => {
+    let save = useCallback(async () => {
         const v = ref.current;
         const errorMsg = p.validate(v);
         if (!!errorMsg) {
             setError(errorMsg);
-            return false;
         } else {
-            p.save(v);
+            await p.save(v);
             p.onClose();
-            return true;
         }
-    };
+    }, [p]);
 
     return (
-        // TODO: Use title and buttons props
-        <Modal visible={true} onClose={p.onClose} onEnter={save}>
+        <Modal visible={true} onClose={p.onClose} onSubmit={save}>
             <ModalHeader>{isNew ? "New" : "Edit"} Variable</ModalHeader>
             <ModalBody>
                 {error ? (
@@ -106,7 +103,7 @@ function AddEnvVarModal(p: EnvVarModalProps) {
                 <Button type="secondary" onClick={p.onClose}>
                     Cancel
                 </Button>
-                <Button onClick={save}>{isNew ? "Add" : "Update"} Variable</Button>
+                <Button htmlType="submit">{isNew ? "Add" : "Update"} Variable</Button>
             </ModalFooter>
         </Modal>
     );
@@ -264,6 +261,7 @@ export default function EnvVars() {
                     </Item>
                     {envVars.map((variable) => (
                         <EnvironmentVariableEntry
+                            key={variable.id}
                             variable={variable}
                             edit={edit}
                             confirmDeleteVariable={confirmDeleteVariable}

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -116,8 +116,8 @@ function DeleteEnvVarModal(p: { variable: UserEnvVarValue; deleteVariable: () =>
             areYouSureText="Are you sure you want to delete this variable?"
             buttonText="Delete Variable"
             onClose={p.onClose}
-            onConfirm={() => {
-                p.deleteVariable();
+            onConfirm={async () => {
+                await p.deleteVariable();
                 p.onClose();
             }}
         >
@@ -213,7 +213,7 @@ export default function EnvVars() {
             {isDeleteEnvVarModalVisible && (
                 <DeleteEnvVarModal
                     variable={currentEnvVar}
-                    deleteVariable={() => deleteVariable(currentEnvVar)}
+                    deleteVariable={async () => await deleteVariable(currentEnvVar)}
                     onClose={() => setDeleteEnvVarModalVisible(false)}
                 />
             )}

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -442,7 +442,7 @@ function GitIntegrations() {
                     }}
                     buttonText="Remove Integration"
                     onClose={() => setModal(undefined)}
-                    onConfirm={() => deleteProvider(modal.provider)}
+                    onConfirm={async () => await deleteProvider(modal.provider)}
                 />
             )}
 

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -239,6 +239,7 @@ function PersonalAccessTokenCreateView() {
                                 <CheckboxListField label="Permission">
                                     {AllPermissions.map((item) => (
                                         <CheckboxInputField
+                                            key={item.name}
                                             value={item.name}
                                             label={item.name}
                                             hint={item.description}

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -119,6 +119,7 @@ export default function Preferences() {
                                 />
                             </div>
                             <Button
+                                htmlType="submit"
                                 loading={updateDotfileRepo.isLoading}
                                 disabled={
                                     updateDotfileRepo.isLoading ||
@@ -165,6 +166,7 @@ export default function Preferences() {
                                         />
                                     </div>
                                     <Button
+                                        htmlType="submit"
                                         loading={timeoutUpdating}
                                         disabled={workspaceTimeout === user?.additionalData?.workspaceTimeout ?? ""}
                                     >

--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useState } from "react";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import Alert from "../components/Alert";
 import { Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -15,6 +15,7 @@ import dayjs from "dayjs";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { EmptyMessage } from "../components/EmptyMessage";
+import { Button } from "../components/Button";
 
 interface AddModalProps {
     value: SSHPublicKeyValue;
@@ -46,81 +47,77 @@ export function AddSSHKeyModal(props: AddModalProps) {
         const tmp = SSHPublicKeyValue.validate(value);
         if (tmp) {
             setErrorMsg(tmp);
-            return false;
+            return;
         }
         try {
             await getGitpodService().server.addSSHPublicKey(value);
+            props.onClose();
+            props.onSave();
         } catch (e) {
             setErrorMsg(e.message.replace("Request addSSHPublicKey failed with message: ", ""));
-            return false;
+            return;
         }
-        props.onClose();
-        props.onSave();
-        return true;
     };
 
     return (
-        <Modal
-            title="New SSH Key"
-            buttons={
-                <button className="ml-2" onClick={save}>
-                    Add SSH Key
-                </button>
-            }
-            visible={true}
-            onClose={props.onClose}
-            onEnter={save}
-        >
-            <>
+        <Modal visible onClose={props.onClose} onSubmit={save}>
+            <ModalHeader>New SSH Key</ModalHeader>
+            <ModalBody>
                 {errorMsg.length > 0 && (
                     <Alert type="error" className="mb-2">
                         {errorMsg}
                     </Alert>
                 )}
-            </>
-            <div className="text-gray-500 dark:text-gray-400 text-md">
-                Add an SSH key for secure access workspaces via SSH.{" "}
-                <a href="/docs/configure/ssh" target="gitpod-ssh-doc" className="gp-link">
-                    Learn more
-                </a>
-            </div>
-            <Alert type="info" className="mt-2">
-                SSH key are used to connect securely to workspaces.{" "}
-                <a
-                    href="https://www.gitpod.io/docs/configure/ssh#create-an-ssh-key"
-                    target="gitpod-create-ssh-key-doc"
-                    className="gp-link"
-                >
-                    Learn how to create an SSH Key
-                </a>
-            </Alert>
-            <div className="mt-2">
-                <h4>Key</h4>
-                <textarea
-                    autoFocus
-                    style={{ height: "160px" }}
-                    className="w-full resize-none"
-                    value={value.key}
-                    placeholder="Begins with 'ssh-rsa', 'ecdsa-sha2-nistp256',
+                <div className="text-gray-500 dark:text-gray-400 text-md">
+                    Add an SSH key for secure access workspaces via SSH.{" "}
+                    <a href="/docs/configure/ssh" target="gitpod-ssh-doc" className="gp-link">
+                        Learn more
+                    </a>
+                </div>
+                <Alert type="info" className="mt-2">
+                    SSH key are used to connect securely to workspaces.{" "}
+                    <a
+                        href="https://www.gitpod.io/docs/configure/ssh#create-an-ssh-key"
+                        target="gitpod-create-ssh-key-doc"
+                        className="gp-link"
+                    >
+                        Learn how to create an SSH Key
+                    </a>
+                </Alert>
+                <div className="mt-2">
+                    <h4>Key</h4>
+                    <textarea
+                        autoFocus
+                        style={{ height: "160px" }}
+                        className="w-full resize-none"
+                        value={value.key}
+                        placeholder="Begins with 'ssh-rsa', 'ecdsa-sha2-nistp256',
                         'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521',
                         'ssh-ed25519',
                         'sk-ecdsa-sha2-nistp256@openssh.com', or
                         'sk-ssh-ed25519@openssh.com'"
-                    onChange={(v) => update({ key: v.target.value })}
-                />
-            </div>
-            <div className="mt-4">
-                <h4>Title</h4>
-                <input
-                    className="w-full"
-                    type="text"
-                    placeholder="e.g. laptop"
-                    value={value.name}
-                    onChange={(v) => {
-                        update({ name: v.target.value });
-                    }}
-                />
-            </div>
+                        onChange={(v) => update({ key: v.target.value })}
+                    />
+                </div>
+                <div className="mt-4">
+                    <h4>Title</h4>
+                    <input
+                        className="w-full"
+                        type="text"
+                        placeholder="e.g. laptop"
+                        value={value.name}
+                        onChange={(v) => {
+                            update({ name: v.target.value });
+                        }}
+                    />
+                </div>
+            </ModalBody>
+            <ModalFooter>
+                <Button type="secondary" onClick={props.onClose}>
+                    Cancel
+                </Button>
+                <Button htmlType="submit">Add SSH Key</Button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import Alert from "../components/Alert";
 import { Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
@@ -123,11 +123,12 @@ export function AddSSHKeyModal(props: AddModalProps) {
 }
 
 export function DeleteSSHKeyModal(props: DeleteModalProps) {
-    const confirmDelete = async () => {
+    const confirmDelete = useCallback(async () => {
         await getGitpodService().server.deleteSSHPublicKey(props.value.id!);
         props.onConfirm();
         props.onClose();
-    };
+    }, [props]);
+
     return (
         <ConfirmationModal
             title="Delete SSH Key"
@@ -223,7 +224,7 @@ export default function SSHKeys() {
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
                     {dataList.map((key) => {
                         return (
-                            <Item solid className="items-start">
+                            <Item key={key.id} solid className="items-start">
                                 <KeyItem sshKey={key}></KeyItem>
                                 <ItemFieldContextMenu
                                     position="start"

--- a/components/dashboard/src/user-settings/ShowTokenModal.tsx
+++ b/components/dashboard/src/user-settings/ShowTokenModal.tsx
@@ -29,13 +29,13 @@ function ShowTokenModal(props: TokenModalProps) {
         expirationDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
     });
 
-    const onEnter = () => {
+    const save = () => {
         props.onSave({ expirationDate: expiration.expirationDate });
         props.onClose();
     };
 
     return (
-        <Modal visible onClose={props.onClose} onSubmit={onEnter}>
+        <Modal visible onClose={props.onClose} onSubmit={save}>
             <ModalHeader>{props.title}</ModalHeader>
             <ModalBody>
                 <div className="text-gray-500 dark:text-gray-400 text-md">

--- a/components/dashboard/src/user-settings/ShowTokenModal.tsx
+++ b/components/dashboard/src/user-settings/ShowTokenModal.tsx
@@ -8,8 +8,9 @@ import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/
 import dayjs from "dayjs";
 import { useState } from "react";
 import DateSelector from "../components/DateSelector";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { TokenExpirationDays } from "./PersonalAccessTokens";
+import { Button } from "../components/Button";
 
 interface TokenModalProps {
     token: PersonalAccessToken;
@@ -30,51 +31,49 @@ function ShowTokenModal(props: TokenModalProps) {
 
     const onEnter = () => {
         props.onSave({ expirationDate: expiration.expirationDate });
-        return true;
+        props.onClose();
     };
 
     return (
-        <Modal
-            title={props.title}
-            buttons={[
-                <button className="secondary" onClick={() => props.onClose()}>
-                    Cancel
-                </button>,
-                <button className="danger" onClick={onEnter}>
-                    {props.actionDescription}
-                </button>,
-            ]}
-            visible={true}
-            onClose={() => props.onClose()}
-            onEnter={onEnter}
-        >
-            <div className="text-gray-500 dark:text-gray-400 text-md">
-                <span>{props.description}</span> <span className="font-semibold">{props.descriptionImportant}</span>
-            </div>
-            <div className="p-4 mt-2 rounded-xl bg-gray-50 dark:bg-gray-800">
-                <div className="font-semibold text-gray-700 dark:text-gray-200">{props.token.name}</div>
-                <div className="font-medium text-gray-400 dark:text-gray-300">
-                    Expires on {dayjs(props.token.expirationTime!.toDate()).format("MMM D, YYYY")}
+        <Modal visible onClose={props.onClose} onSubmit={onEnter}>
+            <ModalHeader>{props.title}</ModalHeader>
+            <ModalBody>
+                <div className="text-gray-500 dark:text-gray-400 text-md">
+                    <span>{props.description}</span> <span className="font-semibold">{props.descriptionImportant}</span>
                 </div>
-            </div>
-            <div className="mt-4">
-                {props.showDateSelector && (
-                    <DateSelector
-                        title="Expiration Date"
-                        description={`The token will expire on ${dayjs(expiration.expirationDate).format(
-                            "MMM D, YYYY",
-                        )}`}
-                        options={TokenExpirationDays}
-                        value={TokenExpirationDays.find((i) => i.value === expiration.expirationDays)?.value}
-                        onChange={(value) =>
-                            setExpiration({
-                                expirationDays: value,
-                                expirationDate: new Date(Date.now() + Number(value) * 24 * 60 * 60 * 1000),
-                            })
-                        }
-                    />
-                )}
-            </div>
+                <div className="p-4 mt-2 rounded-xl bg-gray-50 dark:bg-gray-800">
+                    <div className="font-semibold text-gray-700 dark:text-gray-200">{props.token.name}</div>
+                    <div className="font-medium text-gray-400 dark:text-gray-300">
+                        Expires on {dayjs(props.token.expirationTime!.toDate()).format("MMM D, YYYY")}
+                    </div>
+                </div>
+                <div className="mt-4">
+                    {props.showDateSelector && (
+                        <DateSelector
+                            title="Expiration Date"
+                            description={`The token will expire on ${dayjs(expiration.expirationDate).format(
+                                "MMM D, YYYY",
+                            )}`}
+                            options={TokenExpirationDays}
+                            value={TokenExpirationDays.find((i) => i.value === expiration.expirationDays)?.value}
+                            onChange={(value) =>
+                                setExpiration({
+                                    expirationDays: value,
+                                    expirationDate: new Date(Date.now() + Number(value) * 24 * 60 * 60 * 1000),
+                                })
+                            }
+                        />
+                    )}
+                </div>
+            </ModalBody>
+            <ModalFooter>
+                <Button type="secondary" onClick={props.onClose}>
+                    Cancel
+                </Button>
+                <Button htmlType="submit" type="danger">
+                    {props.actionDescription}
+                </Button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/dashboard/src/workspaces/DeleteWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/DeleteWorkspaceModal.tsx
@@ -8,6 +8,7 @@ import { Workspace } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { useDeleteWorkspaceMutation } from "../data/workspaces/delete-workspace-mutation";
+import { useToast } from "../components/toasts/Toasts";
 
 type Props = {
     workspace: Workspace;
@@ -15,15 +16,16 @@ type Props = {
 };
 export const DeleteWorkspaceModal: FunctionComponent<Props> = ({ workspace, onClose }) => {
     const deleteWorkspace = useDeleteWorkspaceMutation();
+    const { toast } = useToast();
 
     const handleConfirmation = useCallback(async () => {
         try {
             await deleteWorkspace.mutateAsync({ workspaceId: workspace.id });
+
+            toast("Your workspace was deleted");
             onClose();
-        } catch (e) {
-            console.error(e);
-        }
-    }, [deleteWorkspace, onClose, workspace.id]);
+        } catch (e) {}
+    }, [deleteWorkspace, onClose, toast, workspace.id]);
 
     return (
         <ConfirmationModal
@@ -35,10 +37,9 @@ export const DeleteWorkspaceModal: FunctionComponent<Props> = ({ workspace, onCl
             }}
             buttonText="Delete Workspace"
             warningText={deleteWorkspace.isError ? "There was a problem deleting your workspace." : undefined}
-            visible
-            buttonDisabled={deleteWorkspace.isLoading}
             onClose={onClose}
             onConfirm={handleConfirmation}
+            visible
         />
     );
 };

--- a/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
@@ -8,6 +8,7 @@ import { Workspace } from "@gitpod/gitpod-protocol";
 import { FunctionComponent, useCallback, useState } from "react";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { useUpdateWorkspaceDescriptionMutation } from "../data/workspaces/update-workspace-description-mutation";
+import { Button } from "../components/Button";
 
 type Props = {
     workspace: Workspace;
@@ -22,33 +23,28 @@ export const RenameWorkspaceModal: FunctionComponent<Props> = ({ workspace, onCl
         try {
             if (description.length === 0) {
                 setErrorMessage("Description cannot not be empty.");
-                return false;
+                return;
             }
 
             if (description.length > 250) {
                 setErrorMessage("Description is too long for readability.");
-                return false;
+                return;
             }
 
             setErrorMessage("");
 
             // Using mutateAsync here so we can close the modal after it completes successfully
             await updateDescription.mutateAsync({ workspaceId: workspace.id, newDescription: description });
+
+            // Close the modal
+            onClose();
         } catch (error) {
-            console.error(error);
             setErrorMessage("Something went wrong. Please try renaming again.");
         }
-    }, [description, updateDescription, workspace.id]);
+    }, [description, onClose, updateDescription, workspace.id]);
 
     return (
-        <Modal
-            visible
-            onClose={onClose}
-            onEnter={async () => {
-                await updateWorkspaceDescription();
-                return true;
-            }}
-        >
+        <Modal visible onClose={onClose} onSubmit={updateWorkspaceDescription}>
             <ModalHeader>Rename Workspace Description</ModalHeader>
             <ModalBody>
                 {errorMessage.length > 0 ? (
@@ -70,20 +66,12 @@ export const RenameWorkspaceModal: FunctionComponent<Props> = ({ workspace, onCl
                 </div>
             </ModalBody>
             <ModalFooter>
-                <button disabled={updateDescription.isLoading} className="secondary" onClick={onClose}>
+                <Button type="secondary" disabled={updateDescription.isLoading} onClick={onClose}>
                     Cancel
-                </button>
-                <button
-                    disabled={updateDescription.isLoading}
-                    className="ml-2"
-                    type="submit"
-                    onClick={async () => {
-                        await updateWorkspaceDescription();
-                        onClose();
-                    }}
-                >
+                </Button>
+                <Button htmlType="submit" loading={updateDescription.isLoading}>
                     Update Description
-                </button>
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -16,6 +16,7 @@ import { EmptyWorkspacesContent } from "./EmptyWorkspacesContent";
 import { WorkspacesSearchBar } from "./WorkspacesSearchBar";
 import { hoursBefore, isDateSmallerOrEqual } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { useDeleteInactiveWorkspacesMutation } from "../data/workspaces/delete-inactive-workspaces-mutation";
+import { useToast } from "../components/toasts/Toasts";
 
 const WorkspacesPage: FunctionComponent = () => {
     const [limit, setLimit] = useState(50);
@@ -24,6 +25,7 @@ const WorkspacesPage: FunctionComponent = () => {
     const [deleteModalVisible, setDeleteModalVisible] = useState(false);
     const { data, isLoading } = useListWorkspacesQuery({ limit });
     const deleteInactiveWorkspaces = useDeleteInactiveWorkspacesMutation();
+    const { toast } = useToast();
 
     // Sort workspaces into active/inactive groups
     const { activeWorkspaces, inactiveWorkspaces } = useMemo(() => {
@@ -67,12 +69,11 @@ const WorkspacesPage: FunctionComponent = () => {
             await deleteInactiveWorkspaces.mutateAsync({
                 workspaceIds: inactiveWorkspaces.map((info) => info.workspace.id),
             });
-        } catch (e) {
-            console.error("error deleting inactive workspaces");
-        }
 
-        setDeleteModalVisible(false);
-    }, [deleteInactiveWorkspaces, inactiveWorkspaces]);
+            setDeleteModalVisible(false);
+            toast("Your workspace was deleted");
+        } catch (e) {}
+    }, [deleteInactiveWorkspaces, inactiveWorkspaces, toast]);
 
     return (
         <>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This work is intended to address a double submit issue on the SSO Config modal. Digging in, I think we can make some adjustments to how we use `Modal`s to more easily avoid this issue. In summary, these are the primary changes in this PR:

* Removed `Modal.onEnter`: No more listening to the `Enter` key manually and calling `onClose` based on the response of callback.
* Added `Modal.onSubmit`: utilizes a `<form>` to capture submission on `Enter` w/ native behavior. 
* Updated `ConfirmationModal` to account for the Modal change. It will also now put the confirm button into a `loading` state while `await`ing the `onConfirm` callback.

A callout here is if you pass an `onSubmit` to a Modal, you must have `<Button htmlType="submit">` in the `Modal` to have things like submit on Enter to work, which is typically your "Save" style button. This is how forms work in html though, so it feels correct.

I've also add a fixed width for the Modals above small screen sizes. A previous change to Modals seems to have allowed them to shrink a bit narrower than they used to be.

### A more in-depth explanation/opinion

The Modal `onEnter` prop is a bit problematic with how it listens to an `Enter` keypress and fires a handler/closes the modal. This leads to situations where `Enter` is pressed on a button, and it may or may not do what you want (i.e. a cancel vs. a save), and easy potential for double-fires if you’ve got an `onEnter` on the Modal, and an `onClick` on a Button. We work around this in a few places, but I think a better pattern is to rely on html `<form>` native behavior for submit on `Enter` functionality.

I also think we shouldn’t automatically fire `onClose`, and leave that up to the consumer of the Modal to do in their `onSubmit` handler. I've found that having a boolean return control that behavior can end up leaving a lot of room for bugs where one might not return the right value all the time. Consumers calling `onClose` is quite a bit more explicit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-397

## How to test
<!-- Provide steps to test this PR -->
As this PR effects all of our Modals, I've spent quite a bit of time testing them to make sure they keep working as expected. There were a few opportunities to improve some of them a little, and fix a few bugs along the way.

Testing out any of the Modals in the product is the best way to verify behavior w/ these changes.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-31eab1565e2</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-31eab1565e2.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-31eab1565e2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
