### PR TITLE
[db] optimize often used qery

### DIFF
--- a/components/gitpod-db/src/typeorm/app-installation-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/app-installation-db-impl.ts
@@ -49,14 +49,15 @@ export class TypeORMAppInstallationDBImpl implements AppInstallationDB {
         installationID: string,
     ): Promise<AppInstallation | undefined> {
         const repo = await this.getRepo();
-        const qb = repo
+        const installation = await repo
             .createQueryBuilder("installation")
             .where("installation.installationID = :installationID", { installationID })
-            .andWhere('installation.state != "uninstalled"')
-            .orderBy("installation.lastUpdateTime", "DESC")
-            .limit(1);
+            .andWhere("installation.platform = :platform", { platform })
+            .andWhere("installation.state IN ('claimed.user', 'claimed.platform', 'installed')")
+            .orderBy("installation.creationTime", "DESC")
+            .getOne();
 
-        return (await qb.getMany())[0];
+        return installation;
     }
 
     public async recordUninstallation(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The query to fetch the installation is called on every github event. It is not using the given indexes properly and creates therefore unnecessarly high load.
See [dashboard](https://console.cloud.google.com/sql/instances/gitpod-prod-us-west1/insights;start=2023-05-23T13:45:11.764Z;end=2023-05-23T19:45:11.764Z;span=0d8e47e9f396d891;sort_by=TOTAL_EXEC_TIME?project=gitpod-191109)

<img width="1567" alt="Screenshot 2023-05-23 at 21 46 50" src="https://github.com/gitpod-io/gitpod/assets/372735/a3b78b42-298c-438d-bdc4-8cbb18d48c4f">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
