### PR TITLE
Unwanted characters in workspace create error message

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -598,8 +598,7 @@ export function RepositoryNotFound(p: { error: StartWorkspaceError }) {
 
     if (!updatedRecently) {
         return renderError(
-            `Permission to access private repositories has been granted. If you are a member of{" "}
-                '${owner}', please try to request access for Gitpod.`,
+            `Permission to access private repositories has been granted. If you are a member of '${owner}', please try to request access for Gitpod.`,
             "Request access",
             authorizeURL,
         );


### PR DESCRIPTION
## Description

When creating workspaces in organizations you have not requested access for Gitpod yet, `{" "}` would appear as part of the message, which is unwanted.

<img width="604" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/26f8e8d4-0dff-4f58-b828-02be0c4abcee">

## How to test

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-create-ws-msg</li>
	<li><b>🔗 URL</b> - <a href="https://ft-create-ws-msg.preview.gitpod-dev.com/workspaces" target="_blank">ft-create-ws-msg.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
