### PR TITLE
Add WorkspaceUpdates method

### DIFF
--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -806,6 +806,21 @@ func (mr *MockAPIInterfaceMockRecorder) InstanceUpdates(ctx, instanceID interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceUpdates", reflect.TypeOf((*MockAPIInterface)(nil).InstanceUpdates), ctx, instanceID)
 }
 
+// WorkspaceUpdates mocks base method.
+func (m *MockAPIInterface) WorkspaceUpdates(ctx context.Context, workspaceID string) (<-chan *WorkspaceInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkspaceUpdates", ctx, workspaceID)
+	ret0, _ := ret[0].(<-chan *WorkspaceInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstanceUpdates indicates an expected call of WorkspaceUpdates.
+func (mr *MockAPIInterfaceMockRecorder) WorkspaceUpdates(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkspaceUpdates", reflect.TypeOf((*MockAPIInterface)(nil).WorkspaceUpdates), ctx, workspaceID)
+}
+
 // IsPrebuildDone mocks base method.
 func (m *MockAPIInterface) IsPrebuildDone(ctx context.Context, pwsid string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -791,21 +791,6 @@ func (mr *MockAPIInterfaceMockRecorder) HasSSHPublicKey(ctx interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSSHPublicKey", reflect.TypeOf((*MockAPIInterface)(nil).HasSSHPublicKey), ctx)
 }
 
-// InstanceUpdates mocks base method.
-func (m *MockAPIInterface) InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceUpdates", ctx, instanceID)
-	ret0, _ := ret[0].(<-chan *WorkspaceInstance)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// InstanceUpdates indicates an expected call of InstanceUpdates.
-func (mr *MockAPIInterfaceMockRecorder) InstanceUpdates(ctx, instanceID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceUpdates", reflect.TypeOf((*MockAPIInterface)(nil).InstanceUpdates), ctx, instanceID)
-}
-
 // WorkspaceUpdates mocks base method.
 func (m *MockAPIInterface) WorkspaceUpdates(ctx context.Context, workspaceID string) (<-chan *WorkspaceInstance, error) {
 	m.ctrl.T.Helper()
@@ -815,7 +800,7 @@ func (m *MockAPIInterface) WorkspaceUpdates(ctx context.Context, workspaceID str
 	return ret0, ret1
 }
 
-// InstanceUpdates indicates an expected call of WorkspaceUpdates.
+// WorkspaceUpdates indicates an expected call of WorkspaceUpdates.
 func (mr *MockAPIInterfaceMockRecorder) WorkspaceUpdates(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkspaceUpdates", reflect.TypeOf((*MockAPIInterface)(nil).WorkspaceUpdates), ctx, workspaceID)

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -208,7 +208,7 @@ type Bastion struct {
 }
 
 func (b *Bastion) Run() error {
-	updates, err := b.Client.InstanceUpdates(b.ctx, "")
+	updates, err := b.Client.WorkspaceUpdates(b.ctx, "")
 	if err != nil {
 		return err
 	}

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -94,7 +94,7 @@ func (s *WorkspaceService) StreamWorkspaceStatus(ctx context.Context, req *conne
 		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("instance not found"))
 	}
 
-	ch, err := conn.InstanceUpdates(ctx, workspace.LatestInstance.ID)
+	ch, err := conn.WorkspaceUpdates(ctx, workspaceID)
 	if err != nil {
 		log.Extract(ctx).WithError(err).Error("Failed to get workspace instance updates.")
 		return proxy.ConvertError(err)

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -378,7 +378,7 @@ func TestWorkspaceService_StreamWorkspaceStatus(t *testing.T) {
 		serverMock, client := setupWorkspacesService(t)
 
 		serverMock.EXPECT().GetWorkspace(gomock.Any(), workspaceID).Return(&workspaceTestData[0].Protocol, nil)
-		serverMock.EXPECT().InstanceUpdates(gomock.Any(), instanceID).DoAndReturn(func(ctx context.Context, instanceID string) (<-chan *protocol.WorkspaceInstance, error) {
+		serverMock.EXPECT().WorkspaceUpdates(gomock.Any(), workspaceID).DoAndReturn(func(ctx context.Context, workspaceID string) (<-chan *protocol.WorkspaceInstance, error) {
 			ch := make(chan *protocol.WorkspaceInstance)
 			go func() {
 				ch <- workspaceTestData[0].Protocol.LatestInstance

--- a/components/supervisor/cmd/call-server.go
+++ b/components/supervisor/cmd/call-server.go
@@ -51,10 +51,10 @@ var callServerCmd = &cobra.Command{
 		enc.SetEscapeHTML(false)
 		enc.SetIndent("", "  ")
 
-		instanceID, _ := cmd.Flags().GetString("instance-id")
-		updates, err := api.InstanceUpdates(ctx, instanceID)
+		workspaceID, _ := cmd.Flags().GetString("workspace-id")
+		updates, err := api.WorkspaceUpdates(ctx, workspaceID)
 		if err != nil {
-			log.WithError(err).Fatal("InstanceUpdates")
+			log.WithError(err).Fatal("WorkspaceUpdates")
 		}
 		for u := range updates {
 			err := enc.Encode(u)
@@ -68,5 +68,5 @@ var callServerCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(callServerCmd)
 
-	callServerCmd.Flags().String("instance-id", os.Getenv("GITPOD_INSTANCE_ID"), "instance ID to listen for")
+	callServerCmd.Flags().String("workspace-id", os.Getenv("GITPOD_WORKSPACE_ID"), "workspace ID to listen for")
 }

--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -131,7 +131,7 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 		defer close(reschan)
 		defer close(errchan)
 
-		updates, err := g.gitpodService.InstanceUpdates(ctx)
+		updates, err := g.gitpodService.WorkspaceUpdates(ctx)
 		if err != nil {
 			errchan <- err
 			return


### PR DESCRIPTION
Add WorkspaceUpdates method, so it reports all events from a workspaceId

Also replace the old InstanceUpdates method

## How to test
- [x] Check updated ide components, specially supervisor,  work as expected

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-workspa63f29a1b95</li>
	<li><b>🔗 URL</b> - <a href="https://jp-workspa63f29a1b95.preview.gitpod-dev.com/workspaces" target="_blank">jp-workspa63f29a1b95.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
