### PR TITLE
[server] fix wrong use of redlock's resources argument

### DIFF
--- a/components/server/src/jobs/database-gc.ts
+++ b/components/server/src/jobs/database-gc.ts
@@ -16,7 +16,6 @@ export class DatabaseGarbageCollector implements Job {
     @inject(Config) protected readonly config: Config;
 
     public name = "database-gc";
-    public lockId = ["database-gc"];
     public frequencyMs = 30000; // every 30 seconds
 
     public async run(): Promise<void> {

--- a/components/server/src/jobs/org-only-migration-job.ts
+++ b/components/server/src/jobs/org-only-migration-job.ts
@@ -18,7 +18,6 @@ export class OrgOnlyMigrationJob implements Job {
     @inject(UserDB) protected readonly userDB: UserDB;
 
     public readonly name = "org-only-migration-job";
-    public readonly lockId = [this.name];
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
     public async migrateUsers(limit: number): Promise<User[]> {

--- a/components/server/src/jobs/ots-gc.ts
+++ b/components/server/src/jobs/ots-gc.ts
@@ -14,7 +14,6 @@ export class OTSGarbageCollector implements Job {
     @inject(TracedOneTimeSecretDB) protected readonly oneTimeSecretDB: DBWithTracing<OneTimeSecretDB>;
 
     public name = "ots-gc";
-    public lockId = ["ots-gc"];
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
     public async run(): Promise<void> {

--- a/components/server/src/jobs/snapshots.ts
+++ b/components/server/src/jobs/snapshots.ts
@@ -18,7 +18,6 @@ export class SnapshotsJob implements Job {
     @inject(Config) protected readonly config: Config;
 
     public name = "snapshots";
-    public lockId = ["snapshots"];
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
     public async run(): Promise<void> {

--- a/components/server/src/jobs/token-gc.ts
+++ b/components/server/src/jobs/token-gc.ts
@@ -20,7 +20,6 @@ export class TokenGarbageCollector implements Job {
     @inject(TracedWorkspaceDB) protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
 
     public name = "token-gc";
-    public lockId = ["token-gc"];
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
     public async run(): Promise<void> {

--- a/components/server/src/jobs/webhook-gc.ts
+++ b/components/server/src/jobs/webhook-gc.ts
@@ -17,7 +17,6 @@ export class WebhookEventGarbageCollector implements Job {
     @inject(WebhookEventDB) protected readonly db: WebhookEventDB;
 
     public name = "webhook-gc";
-    public lockId = ["webhook-gc"];
     public frequencyMs = 4 * 60 * 1000; // every 4 minutes
 
     public async run(): Promise<void> {

--- a/components/server/src/jobs/workspace-gc.ts
+++ b/components/server/src/jobs/workspace-gc.ts
@@ -25,7 +25,6 @@ export class WorkspaceGarbageCollector implements Job {
     @inject(Config) protected readonly config: Config;
 
     public name = "workspace-gc";
-    public lockId = ["workspace-gc"];
     public frequencyMs: number;
 
     @postConstruct()

--- a/components/server/src/migration/user-to-team-migration-service.ts
+++ b/components/server/src/migration/user-to-team-migration-service.ts
@@ -29,7 +29,7 @@ export class UserToTeamMigrationService {
         if (!this.needsMigration(candidate)) {
             return candidate;
         }
-        return this.redisMutex.using(["migrateUser", candidate.id], 5000, async () => {
+        return this.redisMutex.using(["migrateUser-" + candidate.id], 5000, async () => {
             const now = new Date();
             if (!this.needsMigration(candidate)) {
                 return candidate;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -300,7 +300,7 @@ export class WorkspaceStarter {
                 options.workspaceClass,
             );
             // we run the actual creation of a new instance in a distributed lock, to make sure we always only start one instance per workspace.
-            await this.redisMutex.using(["workspace-start", workspace.id], 2000, async () => {
+            await this.redisMutex.using(["workspace-start-" + workspace.id], 2000, async () => {
                 const runningInstance = await this.workspaceDb.trace({ span }).findRunningInstance(workspace.id);
                 if (runningInstance) {
                     throw new Error(`Workspace ${workspace.id} is already running`);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In a few places the resources argument to redlock.using had been interpreted as a key (like in react-query) but it is a list of locked resources.


This PR changes 
- the job API so that we use the job's name and optionally any number of additional resources for locking.
- two other places where an array of string was passed to make the lock more specific instead of widening it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
