### PR TITLE
Update login page icon size

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -157,7 +157,7 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                                 </Subheading>
                             </div>
                             <div className="flex mb-10">
-                                <Item icon={code} iconSize="16" text="Always Ready&#x2011;To&#x2011;Code" />
+                                <Item icon={code} text="Always Ready&#x2011;To&#x2011;Code" />
                                 <Item icon={customize} text="Personalize your Workspace" />
                                 <Item icon={automate} text="Automate Your Development Setup" />
                             </div>


### PR DESCRIPTION
## Description

There was a small icon size shift over the last few weeks. This will change the icon size of the first icon in the login page.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1684925014417869) (internal) and WEB-406.

| BEFORE | AFTER |
|--------|--------|
| <img width="1512" alt="Screenshot 2023-05-24 at 20 08 04" src="https://github.com/gitpod-io/gitpod/assets/120486/79708a2a-1d4c-428f-ae25-b0c4761bf2e1"> | <img width="1512" alt="Screenshot 2023-05-24 at 20 07 53" src="https://github.com/gitpod-io/gitpod/assets/120486/1dbd38eb-951a-4f16-9f6b-41db3edde668"> | 

## How to test

Try to login, and notice the different icon size on the login page when you're trying to login for the first time.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-3ff47c3aeb</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-3ff47c3aeb.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-3ff47c3aeb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
