### PR TITLE
Fix copy to clipboard in Modals

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -16,10 +16,11 @@ import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal"
 import Tooltip from "../components/Tooltip";
 import { useCurrentOrg, useOrganizationsInvalidator } from "../data/organizations/orgs-query";
 import searchIcon from "../icons/search.svg";
-import copy from "../images/copy.svg";
 import { teamsService } from "../service/public-api";
 import { useCurrentUser } from "../user-context";
 import { SpinnerLoader } from "../components/Loader";
+import { InputField } from "../components/forms/InputField";
+import { InputWithCopy } from "../components/InputWithCopy";
 
 export default function MembersPage() {
     const user = useCurrentUser();
@@ -44,21 +45,6 @@ export default function MembersPage() {
         }
         return link.href;
     }, [org.data]);
-
-    const [copied, setCopied] = useState<boolean>(false);
-    const copyToClipboard = (text: string) => {
-        const el = document.createElement("textarea");
-        el.value = text;
-        document.body.appendChild(el);
-        el.select();
-        try {
-            document.execCommand("copy");
-        } finally {
-            document.body.removeChild(el);
-        }
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
 
     const resetInviteLink = async () => {
         await teamsService.resetTeamInvitation({ teamId: org.data?.id });
@@ -258,29 +244,9 @@ export default function MembersPage() {
                 <Modal visible={true} onClose={() => setShowInviteModal(false)}>
                     <ModalHeader>Invite Members</ModalHeader>
                     <ModalBody>
-                        <label htmlFor="inviteUrl" className="font-medium">
-                            Invite URL
-                        </label>
-                        <div className="w-full relative">
-                            <input
-                                name="inviteUrl"
-                                disabled={true}
-                                readOnly={true}
-                                type="text"
-                                value={inviteUrl}
-                                className="rounded-md w-full truncate overflow-x-scroll pr-8"
-                            />
-                            <div className="cursor-pointer" onClick={() => copyToClipboard(inviteUrl)}>
-                                <div className="absolute top-1/3 right-3">
-                                    <Tooltip content={copied ? "Copied!" : "Copy Invite URL"}>
-                                        <img src={copy} title="Copy Invite URL" alt="copy icon" />
-                                    </Tooltip>
-                                </div>
-                            </div>
-                        </div>
-                        <p className="mt-1 text-gray-500 text-sm">
-                            Use this URL to join this organization as a member.
-                        </p>
+                        <InputField label="Invite URL" hint="Use this URL to join this organization as a member.">
+                            <InputWithCopy value={inviteUrl} tip="Copy Invite URL" />
+                        </InputField>
                     </ModalBody>
                     <ModalFooter>
                         {!!org?.data?.invitationId && (

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -78,15 +78,7 @@ export function inResource(pathname: string, resources: string[]): boolean {
 }
 
 export function copyToClipboard(text: string) {
-    const el = document.createElement("textarea");
-    el.value = text;
-    document.body.appendChild(el);
-    el.select();
-    try {
-        document.execCommand("copy");
-    } finally {
-        document.body.removeChild(el);
-    }
+    navigator.clipboard.writeText(text);
 }
 
 export function getURLHash() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Copy to clipboard functionality broke inside of modals in #17684 due to the focus trap, and the hidden textinput we append to the `document.body` (outside of the focus trap). This results in programatic select/copy to not work. We could adjust where we append that temporary element based on the active element, but I think we can avoid all that complexity and just use the builtin clipboard api that's [widely supported](https://caniuse.com/mdn-api_clipboard_writetext) now.

```ts
navigator.clipboard.writeText(text);
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-408

## How to test
<!-- Provide steps to test this PR -->
You'll need to have a copy to clipboard input inside of a modal to test this.

* Navigate to Org Members and click the Invite Members button. 
* Use the copy to clipboard icon and verify it works.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-4eed511e1c6</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-4eed511e1c6.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-4eed511e1c6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
