### PR TITLE
Redact email instead of hashing

### DIFF
--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -15,6 +15,7 @@ var (
 		"key",
 		"jwt",
 		"secret",
+		"email",
 	}
 
 	// HashedFieldNames name fields whose values we'll hash
@@ -22,11 +23,13 @@ var (
 		"contextURL",
 		"workspaceID",
 		"username",
-		"email",
 	}
 
 	// HashedValues are regular expressions which - when matched - cause the entire value to be hashed
-	HashedValues = map[string]*regexp.Regexp{
+	HashedValues = map[string]*regexp.Regexp{}
+
+	// RedactedValues are regular expressions which - when matched - cause the entire value to be redacted
+	RedactedValues = map[string]*regexp.Regexp{
 		// https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
 		"email": regexp.MustCompile(`[a-zA-Z0-9.!#$%&'*+\/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*`),
 	}

--- a/components/scrubber/scrubber.go
+++ b/components/scrubber/scrubber.go
@@ -113,6 +113,12 @@ func (scrubberImpl) Value(value string) string {
 			return SanitiseHash(s, SanitiseWithKeyName(key))
 		})
 	}
+	for key, expr := range RedactedValues {
+		value = expr.ReplaceAllStringFunc(value, func(s string) string {
+			return SanitiseRedact(s, SanitiseWithKeyName(key))
+		})
+	}
+
 	return value
 }
 

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -18,8 +18,8 @@ func TestValue(t *testing.T) {
 		Expectation string
 	}{
 		{Name: "empty string"},
-		{Name: "email", Value: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email]"},
-		{Name: "email in text", Value: "The email is foo@bar.com or bar@foo.com", Expectation: "The email is [redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email] or [redacted:md5:dc8a42aba3651b0b1f088ef928ff3b1d:email]"},
+		{Name: "email", Value: "foo@bar.com", Expectation: "[redacted:email]"},
+		{Name: "email in text", Value: "The email is foo@bar.com or bar@foo.com", Expectation: "The email is [redacted:email] or [redacted:email]"},
 	}
 
 	for _, test := range tests {
@@ -39,7 +39,7 @@ func TestKeyValue(t *testing.T) {
 		Key         string
 		Expectation string
 	}{
-		{Key: "email", Expectation: "[redacted:md5:e9de89b0a5e9ad6efd5e5ab543ec617c]"},
+		{Key: "email", Expectation: "[redacted]"},
 		{Key: "token", Expectation: "[redacted]"},
 	}
 
@@ -79,7 +79,7 @@ func TestStruct(t *testing.T) {
 					Password     string
 					WorkspaceID  string
 					LeaveMeAlone string
-				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestStruct(t *testing.T) {
 				},
 			},
 			Expectation: Expectation{
-				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted:md5:aa7cedb94f5a9a40dc762b156272d991]")}},
+				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted]")}},
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestStruct(t *testing.T) {
 			Expectation: Expectation{
 				Result: &struct {
 					Slice []string
-				}{Slice: []string{"foo", "bar", "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:email]"}},
+				}{Slice: []string{"foo", "bar", "[redacted:email]"}},
 			},
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fully react emails. For more context see internal slack discussion [here](https://gitpod.slack.com/archives/C01KLC56NP7/p1685001594200189?thread_ts=1684936507.051249&cid=C01KLC56NP7).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes SID-311

## How to test
<!-- Provide steps to test this PR -->

Ran the unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
