### PR TITLE
[dashboard] remove `returnTo` param from /complete-auth endpoint

### DIFF
--- a/components/dashboard/public/complete-auth/index.html
+++ b/components/dashboard/public/complete-auth/index.html
@@ -12,11 +12,7 @@
     <script>
         if (window.opener) {
             const search = new URLSearchParams(window.location.search);
-            let message = search.get("message");
-            const returnTo = search.get("returnTo");
-            if (returnTo) {
-                message = `${message}&returnTo=${encodeURIComponent(returnTo)}`;
-            }
+            const message = search.get("message");
             window.opener.postMessage(message, `https://${window.location.hostname}`);
         } else {
             console.log("This page is supposed to be opened by Gitpod.")

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -9,7 +9,7 @@ import * as GitpodCookie from "@gitpod/gitpod-protocol/lib/util/gitpod-cookie";
 import { useContext, useEffect, useState, useMemo, useCallback, FC } from "react";
 import { UserContext } from "./user-context";
 import { getGitpodService } from "./service/service";
-import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName, getSafeURLRedirect } from "./provider-utils";
+import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "./provider-utils";
 import gitpod from "./images/gitpod.svg";
 import gitpodDark from "./images/gitpod-dark.svg";
 import gitpodIcon from "./icons/gitpod.svg";
@@ -92,21 +92,19 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
         markLoggedIn();
     }, [setUser]);
 
-    const authorizeSuccessful = useCallback(
-        async (payload?: string) => {
-            updateUser().catch(console.error);
+    const authorizeSuccessful = useCallback(async () => {
+        updateUser().catch(console.error);
 
-            onLoggedIn && onLoggedIn();
+        onLoggedIn && onLoggedIn();
 
-            // Check for a valid returnTo in payload
-            const safeReturnTo = getSafeURLRedirect(payload);
-            if (safeReturnTo) {
-                // ... and if it is, redirect to it
-                window.location.replace(safeReturnTo);
+        const returnToPath = new URLSearchParams(window.location.search).get("returnToPath");
+        if (returnToPath) {
+            const isAbsoluteURL = /^https?:\/\//i.test(returnToPath);
+            if (!isAbsoluteURL) {
+                window.location.replace(returnToPath);
             }
-        },
-        [onLoggedIn, updateUser],
-    );
+        }
+    }, [onLoggedIn, updateUser]);
 
     const openLogin = useCallback(
         async (host: string) => {

--- a/components/dashboard/src/OauthClientApproval.tsx
+++ b/components/dashboard/src/OauthClientApproval.tsx
@@ -5,16 +5,19 @@
  */
 
 import gitpodIcon from "./icons/gitpod.svg";
-import { getSafeURLRedirect } from "./provider-utils";
 
 export default function OAuthClientApproval() {
     const params = new URLSearchParams(window.location.search);
     const clientName = params.get("clientName") || "";
-    let redirectToParam = params.get("redirectTo") || undefined;
-    if (redirectToParam) {
-        redirectToParam = decodeURIComponent(redirectToParam);
+
+    let redirectTo = "/";
+    const returnToPath = params.get("returnToPath");
+    if (returnToPath) {
+        const isAbsoluteURL = /^https?:\/\//i.test(returnToPath);
+        if (!isAbsoluteURL) {
+            redirectTo = returnToPath;
+        }
     }
-    const redirectTo = getSafeURLRedirect(redirectToParam) || "/";
     const updateClientApproval = async (isApproved: boolean) => {
         if (redirectTo === "/") {
             window.location.replace(redirectTo);

--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -54,10 +54,6 @@ async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
     const { login, host, scopes, overrideScopes } = params;
     const successKey = getUniqueSuccessKey();
     let search = `message=${successKey}`;
-    const redirectURL = getSafeURLRedirect();
-    if (redirectURL) {
-        search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`;
-    }
     const returnTo = gitpodHostUrl.with({ pathname: "complete-auth", search: search }).toString();
     const requestedScopes = scopes || [];
     const url = login
@@ -143,10 +139,6 @@ async function openOIDCStartWindow(params: OpenOIDCStartWindowParams) {
     const { orgSlug, configId, activate = false, verify = false } = params;
     const successKey = getUniqueSuccessKey();
     let search = `message=${successKey}`;
-    const redirectURL = getSafeURLRedirect();
-    if (redirectURL) {
-        search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`;
-    }
     const returnTo = gitpodHostUrl.with({ pathname: "complete-auth", search }).toString();
     const searchParams = new URLSearchParams({ returnTo });
     if (orgSlug) {
@@ -172,19 +164,6 @@ async function openOIDCStartWindow(params: OpenOIDCStartWindowParams) {
 
     attachMessageListener(successKey, params);
 }
-const getSafeURLRedirect = (source?: string) => {
-    const returnToURL: string | null = new URLSearchParams(source ? source : window.location.search).get("returnTo");
-    if (returnToURL) {
-        // Only allow oauth on the same host
-        if (
-            returnToURL
-                .toLowerCase()
-                .startsWith(`${window.location.protocol}//${window.location.host}/api/oauth/`.toLowerCase())
-        ) {
-            return returnToURL;
-        }
-    }
-};
 
 // Used to ensure each callback is handled uniquely
 let counter = 0;
@@ -192,4 +171,4 @@ const getUniqueSuccessKey = () => {
     return `success:${counter++}`;
 };
 
-export { iconForAuthProvider, simplifyProviderName, openAuthorizeWindow, getSafeURLRedirect, openOIDCStartWindow };
+export { iconForAuthProvider, simplifyProviderName, openAuthorizeWindow, openOIDCStartWindow };

--- a/components/server/src/oauth-server/oauth-controller.ts
+++ b/components/server/src/oauth-server/oauth-controller.ts
@@ -25,8 +25,8 @@ export class OAuthController {
 
     private getValidUser(req: express.Request, res: express.Response): User | null {
         if (!req.isAuthenticated() || !User.is(req.user)) {
-            const redirectTarget = encodeURIComponent(`${this.config.hostUrl}api${req.originalUrl}`);
-            const redirectTo = `${this.config.hostUrl}login?returnTo=${redirectTarget}`;
+            const returnToPath = encodeURIComponent(`api${req.originalUrl}`);
+            const redirectTo = `${this.config.hostUrl}login?returnToPath=${returnToPath}`;
             res.redirect(redirectTo);
             return null;
         }
@@ -101,8 +101,8 @@ export class OAuthController {
             if (!oauthClientsApproved || !oauthClientsApproved[clientID]) {
                 const client = await clientRepository.getByIdentifier(clientID);
                 if (client) {
-                    const redirectTarget = encodeURIComponent(`${this.config.hostUrl}api${req.originalUrl}`);
-                    const redirectTo = `${this.config.hostUrl}oauth-approval?clientID=${client.id}&clientName=${client.name}&returnTo=${redirectTarget}`;
+                    const returnToPath = encodeURIComponent(`api${req.originalUrl}`);
+                    const redirectTo = `${this.config.hostUrl}oauth-approval?clientID=${client.id}&clientName=${client.name}&returnToPath=${returnToPath}`;
                     res.redirect(redirectTo);
                     return false;
                 } else {


### PR DESCRIPTION
## Description
The Login component can use the provided `returnToPath` to forward on client request. Passing the same value down into the callback handlers is completely unnecessary.

## Related Issue(s)
Part of WEB-50

## How to test
* try with local app and see if the OAuth service works as usual

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-cleanupc42cd04d49</li>
	<li><b>🔗 URL</b> - <a href="https://at-cleanupc42cd04d49.preview.gitpod-dev.com/workspaces" target="_blank">at-cleanupc42cd04d49.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
