### PR TITLE
Remove some leftover ws-man refs to fix vscode workspace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,6 @@
 /install/installer/pkg/components/workspace @gitpod-io/engineering-workspace
 /install/installer/pkg/components/workspace/ide @gitpod-io/engineering-ide
 /install/installer/pkg/components/ws-daemon @gitpod-io/engineering-workspace
-/install/installer/pkg/components/ws-manager @gitpod-io/engineering-workspace
 /install/installer/pkg/components/ws-manager-mk2 @gitpod-io/engineering-workspace
 /install/installer/pkg/components/ws-manager-bridge @gitpod-io/engineering-webapp
 /install/installer/pkg/components/ws-proxy @gitpod-io/engineering-workspace
@@ -85,7 +84,6 @@
 /components/ws-manager-api @gitpod-io/engineering-workspace
 /components/ws-manager-bridge-api @gitpod-io/engineering-webapp
 /components/ws-manager-bridge @gitpod-io/engineering-webapp
-/components/ws-manager @gitpod-io/engineering-workspace
 /components/ws-manager-mk2 @gitpod-io/engineering-workspace
 /components/ws-proxy @gitpod-io/engineering-workspace
 /components/node-labeler @gitpod-io/engineering-workspace
@@ -143,4 +141,3 @@
 /test/tests/components/image-builder @gitpod-io/engineering-workspace
 /test/tests/components/server @gitpod-io/engineering-webapp
 /test/tests/components/ws-daemon @gitpod-io/engineering-workspace
-/test/tests/components/ws-manager @gitpod-io/engineering-workspace

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,1 @@
 [allowlist]
-    paths = [
-        '''^components/ws-manager/pkg/manager/testdata/.*\.(golden|json)$'''
-    ]

--- a/codecov.yml
+++ b/codecov.yml
@@ -80,9 +80,6 @@ flags:
   components-ws-manager-bridge-app:
     paths:
       - components/ws-manager-bridge/
-  components-ws-manager-app:
-    paths:
-      - components/ws-manager/
   dev-blowtorch-app:
     paths:
       - dev/blowtorch/

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -20,7 +20,6 @@
         { "path": "components/usage-api" },
         { "path": "components/workspacekit" },
         { "path": "components/ws-daemon" },
-        { "path": "components/ws-manager" },
         { "path": "components/ws-manager-mk2" },
         { "path": "components/ws-proxy" },
         { "path": "components/public-api" },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->
Workspace no longer reports:
```
Error loading workspace folders (expected 37, got 36) failed to load view for file:///workspace/gitpod/components/ws-manager: err: chdir /workspace/gitpod/components/ws-manager: no such file or directory: stderr:
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
