### PR TITLE
[server] double amount of migrated users per run

### DIFF
--- a/components/server/src/jobs/org-only-migration-job.ts
+++ b/components/server/src/jobs/org-only-migration-job.ts
@@ -50,7 +50,7 @@ export class OrgOnlyMigrationJob implements Job<MigrationState> {
     }
 
     public async run(state?: MigrationState): Promise<MigrationState> {
-        const migratedUsers = await this.migrateUsers(1500, state?.migratedUpToCreationDate || "1900-01-01"); // in prod we do ~300 / minute
+        const migratedUsers = await this.migrateUsers(3000, state?.migratedUpToCreationDate || "1900-01-01"); // in prod we do ~300 / minute
         if (migratedUsers.length > 0) {
             const lastUser = migratedUsers[migratedUsers.length - 1];
             return {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We can migrate twice as many users per run

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
