### PR TITLE
Disable focus lock on billing modal

### DIFF
--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -25,6 +25,7 @@ type Props = {
     children: ReactNode;
     visible: boolean;
     closeable?: boolean;
+    disableFocusLock?: boolean;
     className?: string;
     onClose: () => void;
     onEnter?: () => boolean | Promise<boolean>;
@@ -37,6 +38,7 @@ export const Modal: FC<Props> = ({
     visible,
     children,
     closeable = true,
+    disableFocusLock = false,
     className,
     onClose,
     onEnter,
@@ -104,7 +106,12 @@ export const Modal: FC<Props> = ({
             >
                 {/* Modal outer-container for positioning */}
                 <div className="flex justify-center items-center w-screen h-screen">
-                    <FocusOn autoFocus onClickOutside={handleClickOutside} onEscapeKey={handleEscape}>
+                    <FocusOn
+                        autoFocus
+                        onClickOutside={handleClickOutside}
+                        onEscapeKey={handleEscape}
+                        focusLock={!disableFocusLock}
+                    >
                         {/* Visible Modal */}
                         <div
                             className={cn(

--- a/components/dashboard/src/components/billing/AddPaymentMethodModal.tsx
+++ b/components/dashboard/src/components/billing/AddPaymentMethodModal.tsx
@@ -35,7 +35,8 @@ export const AddPaymentMethodModal: FC<Props> = ({ attributionId, clientSecret, 
     );
 
     return (
-        <Modal visible={true} onClose={onClose}>
+        // Because we potentially have an 3DS verification iframe (appended to document.body) don't lock focus to modal
+        <Modal visible={true} onClose={onClose} disableFocusLock>
             <ModalHeader>Add Payment Method</ModalHeader>
             {!stripePromise ? (
                 <ModalBody>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The billing modal potentially renders an iframe for 3ds verification. Because this is appended to the document body, we need to disable focus lock on the modal to avoid interfering with the iframe form inputs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-413

## How to test
<!-- Provide steps to test this PR -->
* Upgrade billing plan using a stripe test credit that forces 3ds verification: `4000002760003184`
* When the test verification ui appears, try and tab through the buttons. If that works, then this is successfully disabling the focus lock.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-disablb1f1454002</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-disablb1f1454002.preview.gitpod-dev.com/workspaces" target="_blank">bmh-disablb1f1454002.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
