### PR TITLE
Forward errors through /complete-auth endpoint – WEB-50

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -636,7 +636,7 @@ export class UserController {
     private async readAdminCredentials(): Promise<AdminCredentials> {
         const credentialsFilePath = this.config.admin.credentialsPath;
 
-        // Credentials do not have to be present in the system, if admin level sing-in is entirely disabled.
+        // Credentials do not have to be present in the system, if admin level sign-in is entirely disabled.
         if (!credentialsFilePath) {
             throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "No admin credentials");
         }


### PR DESCRIPTION
## Description
This PR improves reporting of errors which might happen during the OAuth/OIDC flow on backend.

Issues revealed:
* errors are reported twice, in some cases
* toast notification expires after a couple of seconds, user might miss them

<img width="495" alt="Screenshot 2023-05-26 at 11 01 31" src="https://github.com/gitpod-io/gitpod/assets/914497/1d9bd175-0264-4fd2-a9aa-f5dd61a3347e">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-50

## How to test
* create any SSO config, e.g. using `accounts.google.com`, set an invalid secret and try to verify

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-forward-errors</li>
	<li><b>🔗 URL</b> - <a href="https://at-forward-errors.preview.gitpod-dev.com/workspaces" target="_blank">at-forward-errors.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
