### PR TITLE
[server] expose admin ui for blocked email domains

### DIFF
--- a/components/dashboard/src/admin/BlockedEmailDomains.tsx
+++ b/components/dashboard/src/admin/BlockedEmailDomains.tsx
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { EmailDomainFilterEntry } from "@gitpod/gitpod-protocol";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import Alert from "../components/Alert";
+import { ContextMenuEntry } from "../components/ContextMenu";
+import { ItemFieldContextMenu } from "../components/ItemsList";
+import Modal from "../components/Modal";
+import { CheckboxInputField } from "../components/forms/CheckboxInputField";
+import searchIcon from "../icons/search.svg";
+import { getGitpodService } from "../service/service";
+import { AdminPageHeader } from "./AdminPageHeader";
+
+export function BlockedEmailDomains() {
+    return (
+        <AdminPageHeader title="Admin" subtitle="Block email domains.">
+            <BlockedEmailDomainsList />
+        </AdminPageHeader>
+    );
+}
+
+function useBlockedEmailDomains() {
+    return useQuery(["blockedEmailDomains"], () => getGitpodService().server.adminGetBlockedEmailDomains(), {
+        staleTime: 1000 * 60 * 5, // 5min
+    });
+}
+
+interface Props {}
+
+export function BlockedEmailDomainsList(props: Props) {
+    const blockedEmailDomains = useBlockedEmailDomains();
+    const [searchTerm, setSearchTerm] = useState("");
+
+    const [isAddModalVisible, setAddModalVisible] = useState(false);
+
+    const [currentBlockedDomain, setCurrentBlockedDomain] = useState<EmailDomainFilterEntry>({
+        domain: "",
+        negative: false,
+    });
+
+    const searchResult = useMemo(() => {
+        if (!blockedEmailDomains.data) {
+            return [];
+        }
+        return blockedEmailDomains.data.filter((entry) =>
+            entry.domain.toLowerCase().includes(searchTerm.toLowerCase()),
+        );
+    }, [blockedEmailDomains.data, searchTerm]);
+
+    const add = () => {
+        setCurrentBlockedDomain({
+            domain: "",
+            negative: false,
+        });
+        setAddModalVisible(true);
+    };
+
+    const save = async (blockedDomain: EmailDomainFilterEntry) => {
+        await getGitpodService().server.adminSaveBlockedEmailDomain(blockedDomain);
+        setAddModalVisible(false);
+        blockedEmailDomains.refetch();
+    };
+
+    const validate = (blockedDomain: EmailDomainFilterEntry): string | undefined => {
+        if (blockedDomain.domain === "" || blockedDomain.domain.trim() === "%") {
+            return "Domain can not be empty";
+        }
+    };
+
+    return (
+        <>
+            <div className="app-container">
+                {isAddModalVisible && (
+                    <AddBlockedDomainModal
+                        blockedDomain={currentBlockedDomain}
+                        validate={validate}
+                        save={save}
+                        onClose={() => setAddModalVisible(false)}
+                    />
+                )}
+                <div className="pb-3 mt-3 flex">
+                    <div className="flex justify-between w-full">
+                        <div className="flex relative h-10 my-auto">
+                            <img
+                                src={searchIcon}
+                                title="Search"
+                                className="filter-grayscale absolute top-3 left-3"
+                                alt="search icon"
+                            />
+                            <input
+                                className="w-64 pl-9 border-0"
+                                type="search"
+                                placeholder="Search by URL RegEx"
+                                onChange={(v) => {
+                                    setSearchTerm(v.target.value.trim());
+                                }}
+                            />
+                        </div>
+                        <div className="flex space-x-2">
+                            <button onClick={add}>New Blocked Domain</button>
+                        </div>
+                    </div>
+                </div>
+
+                <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
+                    Search entries by their repository URL <abbr title="regular expression">RegEx</abbr>.
+                </Alert>
+                <div className="flex flex-col space-y-2">
+                    <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
+                        <div className="w-9/12">Domain URL (RegEx)</div>
+                        <div className="w-1/12">Block Users</div>
+                        <div className="w-1/12"></div>
+                    </div>
+                    {searchResult.map((br) => (
+                        <BlockedDomainEntry
+                            br={br}
+                            toggleBlockUser={async () => {
+                                br.negative = !br.negative;
+                                await getGitpodService().server.adminSaveBlockedEmailDomain(br);
+                                blockedEmailDomains.refetch();
+                            }}
+                        />
+                    ))}
+                </div>
+            </div>
+        </>
+    );
+}
+
+function BlockedDomainEntry(props: {
+    br: EmailDomainFilterEntry;
+    toggleBlockUser: (br: EmailDomainFilterEntry) => void;
+}) {
+    const menuEntries: ContextMenuEntry[] = [
+        {
+            title: "Toggle Block User",
+            onClick: () => props.toggleBlockUser(props.br),
+            customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+        },
+    ];
+    return (
+        <div className="rounded whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+            <div className="flex flex-col w-9/12 truncate">
+                <span className="mr-3 text-lg text-gray-600 truncate">{props.br.domain}</span>
+            </div>
+            <div className="flex flex-col self-center w-1/12">
+                <span className="mr-3 text-lg text-gray-600 truncate">{props.br.negative ? "Yes" : "No"}</span>
+            </div>
+            <div className="flex flex-col w-1/12">
+                <ItemFieldContextMenu menuEntries={menuEntries} />
+            </div>
+        </div>
+    );
+}
+
+interface AddBlockedDomainModalProps {
+    blockedDomain: EmailDomainFilterEntry;
+    validate: (blockedDomain: EmailDomainFilterEntry) => string | undefined;
+    save: (br: EmailDomainFilterEntry) => void;
+    onClose: () => void;
+}
+
+function AddBlockedDomainModal(p: AddBlockedDomainModalProps) {
+    const [br, setBr] = useState({ ...p.blockedDomain });
+    const [error, setError] = useState("");
+    const ref = useRef(br);
+
+    const update = (previous: Partial<EmailDomainFilterEntry>) => {
+        const newEnv = { ...ref.current, ...previous };
+        setBr(newEnv);
+        ref.current = newEnv;
+    };
+
+    useEffect(() => {
+        setBr({ ...p.blockedDomain });
+        setError("");
+    }, [p.blockedDomain]);
+
+    const save = (): boolean => {
+        const v = ref.current;
+        const newError = p.validate(v);
+        if (!!newError) {
+            setError(newError);
+            return false;
+        }
+
+        p.save(v);
+        p.onClose();
+        return true;
+    };
+
+    return (
+        <Modal
+            visible={true}
+            title={"New Blocked Domain"}
+            onClose={p.onClose}
+            onEnter={save}
+            buttons={[
+                <button className="secondary" onClick={p.onClose}>
+                    Cancel
+                </button>,
+                <button className="ml-2" onClick={save}>
+                    Add Blocked Domain
+                </button>,
+            ]}
+        >
+            <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                Entries in this table have an immediate effect on all new users. Please use it carefully.
+            </Alert>
+            <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
+                Users are blocked by matching their email domain.
+            </Alert>
+            <Details br={br} update={update} error={error} />
+        </Modal>
+    );
+}
+
+function Details(props: {
+    br: EmailDomainFilterEntry;
+    error?: string;
+    update?: (pev: Partial<EmailDomainFilterEntry>) => void;
+}) {
+    return (
+        <div className="border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+            {props.error ? (
+                <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{props.error}</div>
+            ) : null}
+            <div>
+                <h4>Domain (may contain '%' as wild card)</h4>
+                <input
+                    autoFocus
+                    className="w-full"
+                    type="text"
+                    value={props.br.domain}
+                    placeholder={'e.g. "mailicous-domain.com"'}
+                    disabled={!props.update}
+                    onChange={(v) => {
+                        if (!!props.update) {
+                            props.update({ domain: v.target.value });
+                        }
+                    }}
+                />
+            </div>
+
+            <CheckboxInputField
+                label="Block Users"
+                hint="Block any user that tries to sign up with this email domain."
+                checked={props.br.negative}
+                disabled={!props.update}
+                onChange={(checked) => {
+                    if (!!props.update) {
+                        props.update({ negative: checked });
+                    }
+                }}
+            />
+        </div>
+    );
+}

--- a/components/dashboard/src/admin/admin.routes.ts
+++ b/components/dashboard/src/admin/admin.routes.ts
@@ -29,6 +29,10 @@ export function getAdminTabs(): TabEntry[] {
             link: "/admin/blocked-repositories",
         },
         {
+            title: "Blocked Email Domains",
+            link: "/admin/blocked-email-domains",
+        },
+        {
             title: "Settings",
             link: "/admin/settings",
             alternatives: getAdminSettingsMenu().flatMap((e) => e.link),

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -41,6 +41,7 @@ import PersonalAccessTokenCreateView from "../user-settings/PersonalAccessTokens
 import { CreateWorkspacePage } from "../workspaces/CreateWorkspacePage";
 import { WebsocketClients } from "./WebsocketClients";
 import { LinkedInCallback } from "react-linkedin-login-oauth2";
+import { BlockedEmailDomains } from "../admin/BlockedEmailDomains";
 
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));
 const Account = React.lazy(() => import(/* webpackPrefetch: true */ "../user-settings/Account"));
@@ -179,6 +180,7 @@ export const AppRoutes = () => {
                     <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
                     <AdminRoute path="/admin/projects" component={ProjectsSearch} />
                     <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositories} />
+                    <AdminRoute path="/admin/blocked-email-domains" component={BlockedEmailDomains} />
                     <AdminRoute path="/admin/settings" component={AdminSettings} />
 
                     <Route path={["/", "/login", "/login/:orgSlug"]} exact>

--- a/components/gitpod-db/src/email-domain-filter-db.ts
+++ b/components/gitpod-db/src/email-domain-filter-db.ts
@@ -9,6 +9,7 @@ import { EmailDomainFilterEntry } from "@gitpod/gitpod-protocol";
 export const EmailDomainFilterDB = Symbol("EmailDomainFilterDB");
 export interface EmailDomainFilterDB {
     storeFilterEntry(entry: EmailDomainFilterEntry): Promise<void>;
+    getFilterEntries(): Promise<EmailDomainFilterEntry[]>;
 
     /**
      * @param emailDomain

--- a/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
@@ -21,12 +21,17 @@ export class EmailDomainFilterDBImpl implements EmailDomainFilterDB {
     }
 
     protected async getRepo(): Promise<Repository<EmailDomainFilterEntry>> {
-        return await (await this.getManager()).getRepository<DBEmailDomainFilterEntry>(DBEmailDomainFilterEntry);
+        return (await this.getManager()).getRepository<DBEmailDomainFilterEntry>(DBEmailDomainFilterEntry);
     }
 
     async storeFilterEntry(entry: EmailDomainFilterEntry): Promise<void> {
         const repo = await this.getRepo();
         await repo.save(entry);
+    }
+
+    async getFilterEntries(): Promise<EmailDomainFilterEntry[]> {
+        const repo = await this.getRepo();
+        return repo.find();
     }
 
     async isBlocked(domain: string): Promise<boolean> {

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { User, Workspace, NamedWorkspaceFeatureFlag } from "./protocol";
+import { User, Workspace, NamedWorkspaceFeatureFlag, EmailDomainFilterEntry } from "./protocol";
 import { BlockedRepository } from "./blocked-repositories-protocol";
 import { FindPrebuildsParams } from "./gitpod-service";
 import { Project, Team, PrebuildWithStatus, TeamMemberInfo, TeamMemberRole } from "./teams-projects-protocol";
@@ -56,6 +56,9 @@ export interface AdminServer {
     adminListUsage(req: ListUsageRequest): Promise<ListUsageResponse>;
     adminAddUsageCreditNote(attributionId: string, credits: number, note: string): Promise<void>;
     adminGetUsageBalance(attributionId: string): Promise<number>;
+
+    adminGetBlockedEmailDomains(): Promise<EmailDomainFilterEntry[]>;
+    adminSaveBlockedEmailDomain(entry: EmailDomainFilterEntry): Promise<void>;
 
     // Admin Settings
     adminGetSettings(): Promise<InstallationAdminSettings>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -170,6 +170,8 @@ const defaultFunctions: FunctionsConfig = {
     adminListUsage: { group: "default", points: 1 },
     adminAddUsageCreditNote: { group: "default", points: 1 },
     adminGetUsageBalance: { group: "default", points: 1 },
+    adminGetBlockedEmailDomains: { group: "default", points: 1 },
+    adminSaveBlockedEmailDomain: { group: "default", points: 1 },
 
     accessCodeSyncStorage: { group: "default", points: 1 },
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allows admins to manage the list of blocked email domains.

<img width="1408" alt="Screenshot 2023-05-25 at 20 52 30" src="https://github.com/gitpod-io/gitpod/assets/372735/a8287775-dd6e-42a0-93fc-9f6acd55220d">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-admin-bb0a5e9ec1e</li>
	<li><b>🔗 URL</b> - <a href="https://se-admin-bb0a5e9ec1e.preview.gitpod-dev.com/workspaces" target="_blank">se-admin-bb0a5e9ec1e.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
