### PR TITLE
[obs] alert when cluster is under high load

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -5,53 +5,52 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  labels:
-    prometheus: k8s
-    role: alert-rules
-  name: workspace-nodes-monitoring-rules
+    labels:
+        prometheus: k8s
+        role: alert-rules
+    name: workspace-nodes-monitoring-rules
 spec:
-  groups:
-  - name: workspace-nodes-rules
-    rules:
-    - record: nodepool:node_load1:normalized
-      expr:
-        |
-          node_load1 * on(node) group_left(nodepool) kube_node_labels
-          /
-          count without (cpu) (
-            count without (mode) (
-              node_cpu_seconds_total * on(node) group_left(nodepool) kube_node_labels
-            )
-          )
-  - name: workspace-nodes-alerts
-    rules:
-    - alert: GitpodWorkspaceNodeHighNormalizedLoadAverage
-      labels:
-        severity: warning
-        team: workspace
-      for: 60m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
-        summary: Workspace node's normalized load average is higher than 10 for more than 60 minutes. Check for abuse.
-        description: Node {{ $labels.node }} in {{ $labels.cluster }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.
-      expr: nodepool:node_load1:normalized{nodepool=~".*workspace.*", cluster!~"ephemeral.*"} > 10
+    groups:
+        - name: workspace-nodes-rules
+          rules:
+              - record: nodepool:node_load1:normalized
+                expr: |
+                    node_load1 * on(node) group_left(nodepool) kube_node_labels
+                    /
+                    count without (cpu) (
+                      count without (mode) (
+                        node_cpu_seconds_total * on(node) group_left(nodepool) kube_node_labels
+                      )
+                    )
+        - name: workspace-nodes-alerts
+          rules:
+              - alert: GitpodWorkspaceNodeHighNormalizedLoadAverage
+                labels:
+                    severity: warning
+                    team: workspace
+                for: 60m
+                annotations:
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
+                    summary: Workspace node's normalized load average is higher than 10 for more than 60 minutes. Check for abuse.
+                    description: Node {{ $labels.node }} in {{ $labels.cluster }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.
+                expr: nodepool:node_load1:normalized{nodepool=~".*workspace.*", cluster!~"ephemeral.*"} > 10
 
-    - alert: AutoscalerAddsNodesTooFast
-      labels:
-        severity: critical
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscalerAddsNodesTooFast.md
-        summary: Autoscaler is adding new nodes rapidly
-        description: Autoscaler in cluster {{ $labels.cluster }} is rapidly adding new nodes.
-      expr: ((sum(kube_node_labels{nodepool=~"workspace-.*", cluster!~"ephemeral.*"}) by (cluster)) - (sum(kube_node_labels{nodepool=~"workspace-.*", cluster!~"ephemeral.*"} offset 10m) by (cluster))) > 15
+              - alert: AutoscalerAddsNodesTooFast
+                labels:
+                    severity: critical
+                annotations:
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscalerAddsNodesTooFast.md
+                    summary: Autoscaler is adding new nodes rapidly
+                    description: Autoscaler in cluster {{ $labels.cluster }} is rapidly adding new nodes.
+                expr: ((sum(kube_node_labels{nodepool=~"workspace-.*", cluster!~"ephemeral.*"}) by (cluster)) - (sum(kube_node_labels{nodepool=~"workspace-.*", cluster!~"ephemeral.*"} offset 10m) by (cluster))) > 15
 
-    - alert: AutoscaleFailure
-      labels:
-        severity: warning
-        team: workspace
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscaleFailure.md
-        summary: Automatic scale-up failed for some reason.
-        description: Automatic scale-up in cluster {{ $labels.cluster }} failed due to {{ $labels.reason }}.
-      expr: |
-        increase(cluster_autoscaler_failed_scale_ups_total{cluster!~"ephemeral.*"}[1m]) != 0
+              - alert: AutoscaleFailure
+                labels:
+                    severity: warning
+                    team: workspace
+                annotations:
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscaleFailure.md
+                    summary: Automatic scale-up failed for some reason.
+                    description: Automatic scale-up in cluster {{ $labels.cluster }} failed due to {{ $labels.reason }}.
+                expr: |
+                    increase(cluster_autoscaler_failed_scale_ups_total{cluster!~"ephemeral.*"}[1m]) != 0

--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -54,3 +54,15 @@ spec:
                     description: Automatic scale-up in cluster {{ $labels.cluster }} failed due to {{ $labels.reason }}.
                 expr: |
                     increase(cluster_autoscaler_failed_scale_ups_total{cluster!~"ephemeral.*"}[1m]) != 0
+
+              - alert: NodePoolLoad
+                labels:
+                    severity: critical
+                    team: workspace
+                for: 60m
+                annotations:
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodePoolLoad.md
+                    summary: Node pool load is high
+                    description: Node pool {{ $labels.nodepool }} in cluster {{ $labels.cluster }} has high, sustained load
+                expr: |
+                    sum by(nodepool) (nodepool:node_load1:normalized{nodepool=~".*workspace.*",cluster!~"ephemeral.*"}}) > 40


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Alert when workspace node pools are under high load.

[Runbook](https://github.com/gitpod-io/runbooks/pull/414).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
