### PR TITLE
[idp] periodically persist public key

### DIFF
--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -236,6 +236,10 @@ func (rc *RedisCache) Signer(ctx context.Context) (jose.Signer, error) {
 }
 
 func (rc *RedisCache) reconcile(ctx context.Context) error {
+	if rc.current == nil {
+		return nil
+	}
+
 	resp := rc.Client.Expire(ctx, redisIDPKeyPrefix+rc.currentID, redisCacheDefaultTTL)
 	if err := resp.Err(); err != nil {
 		log.WithField("keyID", rc.currentID).WithError(err).Warn("cannot extend cached IDP public key TTL")

--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -259,7 +259,7 @@ func (rc *RedisCache) reconcile(ctx context.Context) error {
 func (rc *RedisCache) sync(ctx context.Context, period time.Duration) {
 	_ = rc.reconcile(ctx)
 	ticker := time.NewTicker(period)
-	for ctx.Err() == nil {
+	for {
 		select {
 		case <-ctx.Done():
 			return

--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -7,6 +7,8 @@ package identityprovider
 import (
 	"context"
 	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -114,7 +116,8 @@ func NewRedisCache(client *redis.Client) *RedisCache {
 }
 
 func defaultKeyID(current *rsa.PrivateKey) string {
-	return fmt.Sprintf("id-%d-%d", time.Now().UnixMicro(), rand.Int())
+	hashed := sha256.Sum256(current.N.Bytes())
+	return fmt.Sprintf("id-%s", hex.EncodeToString(hashed[:]))
 }
 
 type RedisCache struct {

--- a/components/public-api-server/pkg/identityprovider/cache_test.go
+++ b/components/public-api-server/pkg/identityprovider/cache_test.go
@@ -111,7 +111,7 @@ func TestRedisCachePublicKeys(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			s := miniredis.RunT(t)
 			client := redis.NewClient(&redis.Options{Addr: s.Addr()})
-			cache := NewRedisCache(client)
+			cache := NewRedisCache(context.Background(), client)
 			cache.keyID = testKeyID
 			for _, key := range test.Keys {
 				err := cache.Set(context.Background(), key)
@@ -157,7 +157,7 @@ func TestRedisCachePublicKeys(t *testing.T) {
 func TestRedisCacheSigner(t *testing.T) {
 	s := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	cache := NewRedisCache(client)
+	cache := NewRedisCache(context.Background(), client)
 
 	sig, err := cache.Signer(context.Background())
 	if sig != nil {

--- a/components/public-api-server/pkg/identityprovider/cache_test.go
+++ b/components/public-api-server/pkg/identityprovider/cache_test.go
@@ -110,8 +110,12 @@ func TestRedisCachePublicKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			s := miniredis.RunT(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(func() {
+				cancel()
+			})
 			client := redis.NewClient(&redis.Options{Addr: s.Addr()})
-			cache := NewRedisCache(context.Background(), client)
+			cache := NewRedisCache(ctx, client)
 			cache.keyID = testKeyID
 			for _, key := range test.Keys {
 				err := cache.Set(context.Background(), key)
@@ -205,4 +209,8 @@ func TestRedisCacheSigner(t *testing.T) {
 	if len(keys) == 0 {
 		t.Error("getting a new signer did not repersist the key")
 	}
+}
+
+func TestRedisSync(t *testing.T) {
+
 }

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -133,7 +133,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 	if redisClient == nil {
 		return fmt.Errorf("no Redis configiured")
 	}
-	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient, 10*time.Minute))
+	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient))
 	if err != nil {
 		return err
 	}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -133,7 +133,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 	if redisClient == nil {
 		return fmt.Errorf("no Redis configiured")
 	}
-	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(ctx, redisClient))
+	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient))
 	if err != nil {
 		return err
 	}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -133,7 +133,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 	if redisClient == nil {
 		return fmt.Errorf("no Redis configiured")
 	}
-	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient))
+	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient, 10*time.Minute))
 	if err != nil {
 		return err
 	}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -133,7 +133,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 	if redisClient == nil {
 		return fmt.Errorf("no Redis configiured")
 	}
-	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(redisClient))
+	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(ctx, redisClient))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[idp] periodically persist public key

The current implementation tries to refresh the ttl of the publickey only when someone uses the idp for authentication, the problem with this is that if no one uses it for `1 hour` (our default ttl), there will be no key on redis, which results in accessing the keys endpoint with the key of the current pod, which is an obvious problem for a `public-api-server` running with multiple replicates that only returns its own publickey each time.

In addition, the keyid in the previous implementation is always random, which leads to a random keyid being stored each time when trying to persist again once the key expires, which leads to a very long list of keys if more people use them, and they are all duplicates (only the key ids are different)

This PR fixes those two problem.

Relates to: [IDE-114](https://linear.app/gitpod/issue/IDE-114/attempt-to-stabilise-jwks-and-hence-the-idp-functionality)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. try to scale `public-api-server` to 3 replicate 
```shell
kubectl scale deployment public-api-server --replicas=3
```
2. check `https://api.pd-fix-key-id.preview.gitpod-dev.com/idp/keys` it should be 3 keys.
3. open workspace in this preview environment
4. execute `gp idp token` many times
5. check `https://api.pd-fix-key-id.preview.gitpod-dev.com/idp/keys` it should be still 3 keys.
6. wait for 1h or more
7. check `https://api.pd-fix-key-id.preview.gitpod-dev.com/idp/keys` it should be still 3 keys.
8. delete redis pod, after 10minutes
9. check `https://api.pd-fix-key-id.preview.gitpod-dev.com/idp/keys` it should be still 3 keys.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fix-key-id</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fix-key-id.preview.gitpod-dev.com/workspaces" target="_blank">pd-fix-key-id.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
