### PR TITLE
Update admin search alert copy

### DIFF
--- a/components/dashboard/src/admin/BlockedEmailDomains.tsx
+++ b/components/dashboard/src/admin/BlockedEmailDomains.tsx
@@ -108,7 +108,7 @@ export function BlockedEmailDomainsList(props: Props) {
                 </div>
 
                 <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
-                    Search entries by their repository URL <abbr title="regular expression">RegEx</abbr>.
+                    Search by email domain URL using <abbr title="regular expression">RegEx</abbr>.
                 </Alert>
                 <div className="flex flex-col space-y-2">
                     <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -150,7 +150,7 @@ export function BlockedRepositoriesList(props: Props) {
                 </div>
 
                 <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
-                    Search entries by their repository URL <abbr title="regular expression">RegEx</abbr>.
+                    Search by repository URL using <abbr title="regular expression">RegEx</abbr>.
                 </Alert>
                 <div className="flex flex-col space-y-2">
                     <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">


### PR DESCRIPTION
## Description

Minor copy update for the search alert in `/admin`.

Follow-up from https://github.com/gitpod-io/gitpod/pull/17754. Cc @svenefftinge @AlexTugarev @geropl 

## How to test

1. Go to `/admin/blocked-email-domains`
2. Notice the search alert copy mentions the email domain URL, not the repository URL.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
