### PR TITLE
[papi] Start request should search for single Org with active SSO – WEB-409

### DIFF
--- a/components/public-api-server/pkg/oidc/service.go
+++ b/components/public-api-server/pkg/oidc/service.go
@@ -134,7 +134,7 @@ func (s *Service) getClientConfigFromStartRequest(r *http.Request) (*ClientConfi
 
 	// if no org slug is given, we assume the request is for the default org
 	if orgSlug == "" && idParam == "" {
-		org, err := db.GetTheSingleTeam(r.Context(), s.dbConn)
+		org, err := db.GetSingleTeamWithActiveSSO(r.Context(), s.dbConn)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to find team: %w", err)
 		}


### PR DESCRIPTION
This PR fixes the lookup for SSO configs in Dedicated installations. If no identifier is provided, it should try to find a single Org which has an active SSO config. 

This PR doesn't solve the issue, that more than one Org was created on an internal Dedicated installation. Evaluating `isSingleOrgInstallation` sound reasonable to solve that task. This change improves resilience and unblocks users.  

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-409

## How to test
See unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
