### PR TITLE
[server] run job, that fixes bad stripe migration

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -134,6 +134,7 @@ import { UserToTeamMigrationService } from "./migration/user-to-team-migration-s
 import { SnapshotsJob } from "./jobs/snapshots";
 import { OrgOnlyMigrationJob } from "./jobs/org-only-migration-job";
 import { APIStatsService } from "./api/stats";
+import { FixStripeJob } from "./jobs/fix-stripe-job";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -362,6 +363,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(OTSGarbageCollector).toSelf().inSingletonScope();
     bind(SnapshotsJob).toSelf().inSingletonScope();
     bind(OrgOnlyMigrationJob).toSelf().inSingletonScope();
+    bind(FixStripeJob).toSelf().inSingletonScope();
     bind(JobRunner).toSelf().inSingletonScope();
 
     // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129

--- a/components/server/src/jobs/fix-stripe-job.spec.db.ts
+++ b/components/server/src/jobs/fix-stripe-job.spec.db.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM, testContainer } from "@gitpod/gitpod-db/lib";
+import * as chai from "chai";
+import { v4 as uuidv4 } from "uuid";
+import { fixInvoice } from "./fix-stripe-job";
+const expect = chai.expect;
+
+describe("Fix Stripe Job", () => {
+    const typeORM = testContainer.get<TypeORM>(TypeORM);
+
+    const wipeRepo = async () => {
+        const conn = await typeORM.getConnection();
+        await conn.query("DELETE FROM d_b_stripe_customer");
+        await conn.query("DELETE FROM d_b_usage");
+        await conn.query("DELETE FROM d_b_cost_center");
+    };
+
+    it("fix invoice", async () => {
+        await wipeRepo();
+        const c = await typeORM.getConnection();
+        const newAttributionID = "team:" + uuidv4();
+        const oldAttributionID = "user:" + uuidv4();
+        const now = new Date();
+        const lastMonth = new Date(now);
+        lastMonth.setMonth(lastMonth.getMonth() - 1);
+        const nextMonth = new Date(now);
+        nextMonth.setMonth(nextMonth.getMonth() + 1);
+        await c.query(
+            `INSERT into d_b_cost_center (id, spendingLimit, creationTime, billingStrategy, nextBillingTime, billingCycleStart) VALUES (?, ?, ?, ?, ?,?)`,
+            [newAttributionID, 500, lastMonth.toISOString(), "stripe", now.toISOString(), lastMonth.toISOString()],
+        );
+        await c.query(
+            `INSERT into d_b_usage (id, attributionId, description, creditCents, effectiveTime, kind, draft) VALUES (?, ?, ?, ?, ?,?,?)`,
+            [uuidv4(), oldAttributionID, "Credits", -2000, now.toISOString(), "invoice", 0],
+        );
+
+        await fixInvoice(c, oldAttributionID, newAttributionID);
+
+        const costCenter = await c.query(`SELECT * FROM d_b_cost_center WHERE id = ? order by creationTime DESC`, [
+            newAttributionID,
+        ]);
+        expect(costCenter.length).to.be.eq(2);
+        expect(costCenter[0].nextBillingTime).to.be.eq(nextMonth.toISOString());
+        let usage = await c.query(`SELECT * FROM d_b_usage WHERE attributionId = ?`, [oldAttributionID]);
+        expect(usage.length).to.be.eq(0);
+        usage = await c.query(`SELECT * FROM d_b_usage WHERE attributionId = ?`, [newAttributionID]);
+        expect(usage.length).to.be.eq(1);
+    });
+});

--- a/components/server/src/jobs/fix-stripe-job.ts
+++ b/components/server/src/jobs/fix-stripe-job.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM } from "@gitpod/gitpod-db/lib";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { StripeService } from "../user/stripe-service";
+import { Job } from "./runner";
+import { Config } from "../config";
+import { Connection } from "typeorm";
+
+@injectable()
+export class FixStripeJob implements Job {
+    @inject(TypeORM) protected readonly typeorm: TypeORM;
+    @inject(StripeService) protected readonly stripeService: StripeService;
+    @inject(Config) protected readonly config: Config;
+
+    public readonly name = "fix-stripe-attribution-ids";
+    public frequencyMs = 300 * 60 * 1000; // every 5 hours
+
+    public async run(): Promise<void> {
+        if (!this.config.stripeSecrets) {
+            log.info("Job disabled", { name: this.name, reason: "stripeSecrets not configured" });
+            return;
+        }
+        try {
+            const c = await this.typeorm.getConnection();
+            const result = await c.query(`
+                SELECT
+                    c.stripeCustomerid, o.id as organizationId, u.id as userId
+                FROM
+                    d_b_stripe_customer c, d_b_team o, d_b_team_membership m, d_b_user u
+                WHERE
+                    o.id = m.teamId AND
+                    m.userId = u.id AND
+                    (o.name = u.name OR o.name = u.fullName) AND
+                    u._lastModified >'2023-04-15' AND
+                    c.deleted = 0 AND
+                    u.additionalData->>'$.isMigratedToTeamOnlyAttribution' = 'true' AND
+                    SUBSTRING(c.attributionId,6) = o.id
+            `);
+            log.info(`Starting update for stripe customer ids`, { numberOfCustomers: result.length });
+            let migrated = 0;
+            // iterate over result set and update the attributionid stripe attributionid
+            for (const row of result) {
+                const userId = row.userId;
+                const organizationId = row.organizationId;
+                const stripeCustomerId = row.stripeCustomerid;
+                const newAttributionID = AttributionId.render({ kind: "team", teamId: organizationId });
+                const oldAttributionID = AttributionId.render({ kind: "user", userId: userId });
+                try {
+                    if (
+                        await this.stripeService.updateAttributionId(
+                            stripeCustomerId,
+                            newAttributionID,
+                            oldAttributionID,
+                        )
+                    ) {
+                        migrated++;
+                    }
+                } catch (err) {
+                    log.error("Failed to update stripe customer", err, { userId, organizationId, stripeCustomerId });
+                }
+                try {
+                    await fixInvoice(c, oldAttributionID, newAttributionID);
+                } catch (err) {
+                    log.error("Failed to fix invoice", err, { userId, organizationId, stripeCustomerId });
+                }
+                // wait a bit to not overload the stripe API
+                await new Promise((r) => setTimeout(r, 1000));
+            }
+
+            log.info(`Finished update for stripe customer ids`, { numberOfCustomers: result.length, migrated });
+        } catch (err) {
+            log.error("Failed to run job", err, { jobName: this.name });
+            throw err;
+        }
+    }
+}
+
+export async function fixInvoice(c: Connection, oldAttributionID: string, newAttributionID: string) {
+    const result = await c.query(`SELECT effectiveTime, kind FROM d_b_usage where attributionId = ?`, [
+        oldAttributionID,
+    ]);
+    if (result.length === 1) {
+        const invoiceTime = result[0].effectiveTime;
+        if (result[0].kind !== "invoice") {
+            throw new Error(`Expected kind invoice, got ${result[0].kind} (attributionId: ${oldAttributionID})`);
+        }
+        await c.query(`UPDATE d_b_usage set attributionId = ? WHERE attributionId= ?`, [
+            newAttributionID,
+            oldAttributionID,
+        ]);
+        log.info(`Updated usage table`, {
+            newAttributionID,
+            oldAttributionID,
+        });
+        const costCenters = await c.query(
+            `SELECT * FROM d_b_cost_center WHERE id= ? ORDER by creationTime DESC LIMIT 1`,
+            [newAttributionID],
+        );
+        const nextBillingTime = new Date(invoiceTime);
+        nextBillingTime.setMonth(nextBillingTime.getMonth() + 1);
+        await c.query(
+            `INSERT into d_b_cost_center (id, spendingLimit, creationTime, billingStrategy, nextBillingTime, billingCycleStart) VALUES (?, ?, ?, ?, ?, ?)`,
+            [
+                newAttributionID,
+                costCenters[0].spendingLimit,
+                new Date().toISOString(),
+                costCenters[0].billingStrategy,
+                nextBillingTime.toISOString(),
+                invoiceTime,
+            ],
+        );
+    }
+}

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -19,6 +19,7 @@ import { WorkspaceGarbageCollector } from "./workspace-gc";
 import { SnapshotsJob } from "./snapshots";
 import { OrgOnlyMigrationJob } from "./org-only-migration-job";
 import { JobStateDbImpl } from "@gitpod/gitpod-db/lib/typeorm/job-state-db-impl";
+import { FixStripeJob } from "./fix-stripe-job";
 
 export const Job = Symbol("Job");
 
@@ -40,6 +41,7 @@ export class JobRunner {
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
     @inject(SnapshotsJob) protected snapshotsJob: SnapshotsJob;
     @inject(OrgOnlyMigrationJob) protected orgOnlyMigrationJob: OrgOnlyMigrationJob;
+    @inject(FixStripeJob) protected fixStripeJob: FixStripeJob;
     @inject(JobStateDbImpl) protected jobStateDb: JobStateDbImpl;
 
     public start(): DisposableCollection {
@@ -53,6 +55,7 @@ export class JobRunner {
             this.workspaceGC,
             this.snapshotsJob,
             this.orgOnlyMigrationJob,
+            this.fixStripeJob,
         ];
 
         for (let job of jobs) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Run a job that fixes the users for which the stripe update didn'T work due to #17764

## Related Issue(s)
<!-- List the issue(s) this PR solves --
Fixes WEB-414

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
