### PR TITLE
[server, db] Fix some imports to re-enable "yarn test" in server

### DIFF
--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 
 export const BlockedRepositoryDB = Symbol("BlockedRepositoryDB");
 

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -9,7 +9,7 @@ import { EntityManager, Repository } from "typeorm";
 import { TypeORM } from "./typeorm";
 import { DBBlockedRepository } from "./entity/db-blocked-repository";
 import { BlockedRepositoryDB } from "../blocked-repository-db";
-import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 
 @injectable()
 export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {

--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
 import { Transformer } from "../transformer";
 

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -18,6 +18,7 @@ import { AuthProviderService } from "./auth-provider-service";
 import { UserService } from "../user/user-service";
 import { increaseLoginCounter } from "../prometheus-metrics";
 import { SignInJWT } from "./jwt";
+import "../express"; // helps ts-loader to find the merged declarations in Express.User
 
 @injectable()
 export class Authenticator {

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { LinkedInProfile, User } from "@gitpod/gitpod-protocol/src/protocol";
+import { LinkedInProfile, User } from "@gitpod/gitpod-protocol/lib/protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { LinkedInProfileDB } from "@gitpod/gitpod-db/lib";
 import { inject, injectable } from "inversify";

--- a/components/server/src/prebuilds/incremental-prebuilds-service.ts
+++ b/components/server/src/prebuilds/incremental-prebuilds-service.ts
@@ -15,7 +15,7 @@ import {
     WorkspaceImageSource,
 } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { WithCommitHistory } from "@gitpod/gitpod-protocol/src/protocol";
+import { WithCommitHistory } from "@gitpod/gitpod-protocol/lib/protocol";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { Config } from "../config";
 import { ConfigProvider } from "../workspace/config-provider";


### PR DESCRIPTION
## Description
Fixes some imports so `yarn test` works reliably (again).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
