### PR TITLE
[server] Show maintenance error message

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -179,6 +179,7 @@ export type FailedInstanceStartReason =
     | "startOnClusterFailed"
     | "imageBuildFailed"
     | "resourceExhausted"
+    | "clusterMaintenance"
     | "other";
 export function increaseFailedInstanceStartCounter(reason: FailedInstanceStartReason) {
     instanceStartsFailedTotal.inc({ reason });

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -179,7 +179,7 @@ export type FailedInstanceStartReason =
     | "startOnClusterFailed"
     | "imageBuildFailed"
     | "resourceExhausted"
-    | "clusterMaintenance"
+    | "workspaceClusterMaintenance"
     | "other";
 export function increaseFailedInstanceStartCounter(reason: FailedInstanceStartReason) {
     instanceStartsFailedTotal.inc({ reason });

--- a/components/server/src/workspace/workspace-starter.spec.ts
+++ b/components/server/src/workspace/workspace-starter.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import "reflect-metadata";
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import { isClusterMaintenanceError, isResourceExhaustedError } from "./workspace-starter";
+const expect = chai.expect;
+
+@suite
+class TestWorkspaceStarter {
+    @test
+    public testMaintenancePreconditionError() {
+        const err = {
+            details: "under maintenance",
+            code: 9,
+        };
+
+        let result = isClusterMaintenanceError(err);
+        expect(result).to.be.true;
+    }
+
+    @test
+    public testOtherPreconditionError() {
+        const err = {
+            details: "foobar",
+            code: 9,
+        };
+
+        let result = isClusterMaintenanceError(err);
+        expect(result).to.be.false;
+    }
+
+    @test
+    public testResourceExhaustedError() {
+        const err = {
+            code: 8,
+        };
+
+        let result = isResourceExhaustedError(err);
+        expect(result).to.be.true;
+    }
+}
+
+module.exports = new TestWorkspaceStarter();

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -558,10 +558,9 @@ export class WorkspaceStarter {
                     if (this.isClusterMaintenanceError(err)) {
                         reason = "clusterMaintenance";
                         err = new Error(
-                            "cannot start a workspace because the workspace cluster is temporarily unavailable due to maintenance. Please try again in a few minutes",
+                            "Cannot start a workspace because the workspace cluster is temporarily unavailable due to maintenance. Please try again in a few minutes",
                         );
                     }
-
                     await this.failInstanceStart({ span }, err, workspace, instance);
                     throw new StartInstanceError(reason, err);
                 }
@@ -636,7 +635,12 @@ export class WorkspaceStarter {
     }
 
     private isClusterMaintenanceError(err: any): boolean {
-        return "code" in err && err.code == grpc.status.FAILED_PRECONDITION;
+        return (
+            "code" in err &&
+            err.code == grpc.status.FAILED_PRECONDITION &&
+            "details" in err &&
+            err.details == "under maintenance"
+        );
     }
 
     protected logAndTraceStartWorkspaceError(ctx: TraceContext, logCtx: LogContext, err: any) {


### PR DESCRIPTION
## Description
Show error message when cluster is not available due to maintenance

![image](https://github.com/gitpod-io/gitpod/assets/24721048/c2f6dfeb-db98-4f71-afff-61f37d772bef)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-185

## How to test
- Open workspace in preview environment

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-wks-185d6a652c34e</li>
	<li><b>🔗 URL</b> - <a href="https://fo-wks-185d6a652c34e.preview.gitpod-dev.com/workspaces" target="_blank">fo-wks-185d6a652c34e.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
