### PR TITLE
Fix incorrect log level setup - IDE-127

### DIFF
--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -69,7 +69,7 @@ func NewClient(opts ...ClientOpt) Client {
 		return NewAlwaysReturningDefaultValueClient()
 	}
 	logger := log.Log.Dup()
-	logger.Logger.SetLevel(logrus.ErrorLevel)
+	logger.Level = logrus.ErrorLevel
 	return newConfigCatClient(configcat.Config{
 		SDKKey:       opt.sdkKey,
 		BaseURL:      opt.baseURL,

--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -171,7 +171,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	// 3. start debug
 	fmt.Println("")
 	runLog := log.New()
-	runLog.Logger.SetLevel(logrus.TraceLevel)
+	runLog.Level = logrus.TraceLevel
 	setLoggerFormatter(runLog.Logger)
 	runLog.Logger.SetOutput(os.Stdout)
 	runLog.Info("Starting the workspace...")
@@ -227,7 +227,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	}
 
 	serverLog := logrus.NewEntry(logrus.New())
-	serverLog.Logger.SetLevel(logLevel)
+	serverLog.Level = logLevel
 	setLoggerFormatter(serverLog.Logger)
 	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog})
 	if err != nil {

--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -171,7 +171,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	// 3. start debug
 	fmt.Println("")
 	runLog := log.New()
-	runLog.Level = logrus.TraceLevel
+	runLog.Logger.SetLevel(logrus.TraceLevel)
 	setLoggerFormatter(runLog.Logger)
 	runLog.Logger.SetOutput(os.Stdout)
 	runLog.Info("Starting the workspace...")
@@ -227,7 +227,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	}
 
 	serverLog := logrus.NewEntry(logrus.New())
-	serverLog.Level = logLevel
+	serverLog.Logger.SetLevel(logLevel)
 	setLoggerFormatter(serverLog.Logger)
 	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog})
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In `logrus`, log.Entry 's Logger property is the parent Logger. So we can't use `.Logger.SetLevel` to change log level

https://go.dev/play/p/OtGHXjEm7sL

Change value of `useParentLogger` to see different

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can open PR with Gitpod and use `hot-deploy.sh`

1. Add log.Info("helloooooooooo") to supervisor publicapi.go after configcat Client created `hot-deploy supervisor`
2. Start/Restart workspace in preview env it should log hello
3. Revert fixing changes in common-go and `hot-deploy supervisor`
4. It should log nothing

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-ide-127</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-ide-127.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-ide-127.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
