### PR TITLE
Report gp env arg parsing errors as user errors

### DIFF
--- a/components/gitpod-cli/cmd/env.go
+++ b/components/gitpod-cli/cmd/env.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	supervisorapi "github.com/gitpod-io/gitpod/supervisor/api"
@@ -253,18 +254,18 @@ func parseArgs(args []string, pattern string) ([]*serverapi.UserEnvVarValue, err
 	for i, arg := range args {
 		kv := strings.SplitN(arg, "=", 1)
 		if len(kv) != 1 || kv[0] == "" {
-			return nil, xerrors.Errorf("empty string (correct format is key=value)")
+			return nil, GpError{Err: xerrors.Errorf("empty string (correct format is key=value)"), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 
 		if !strings.Contains(kv[0], "=") {
-			return nil, xerrors.Errorf("%s has no equal character (correct format is %s=some_value)", arg, arg)
+			return nil, GpError{Err: xerrors.Errorf("%s has no equal character (correct format is %s=some_value)", arg, arg), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 
 		parts := strings.SplitN(kv[0], "=", 2)
 
 		key := strings.TrimSpace(parts[0])
 		if key == "" {
-			return nil, xerrors.Errorf("variable must have a name")
+			return nil, GpError{Err: xerrors.Errorf("variable must have a name"), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 
 		// Do not trim value - the user might want whitespace here
@@ -276,7 +277,7 @@ func parseArgs(args []string, pattern string) ([]*serverapi.UserEnvVarValue, err
 		val = strings.ReplaceAll(val, `\ `, " ")
 
 		if val == "" {
-			return nil, xerrors.Errorf("variable must have a value; use -u to unset a variable")
+			return nil, GpError{Err: xerrors.Errorf("variable must have a value; use -u to unset a variable"), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 
 		vars[i] = &serverapi.UserEnvVarValue{Name: key, Value: val, RepositoryPattern: pattern}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix IDE-130

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace
- Use gp env with invalid arguments
- Check logs of ide-metrics that they don't have such errors as before

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-gp-evn-0396c44d0d</li>
	<li><b>🔗 URL</b> - <a href="https://ak-gp-evn-0396c44d0d.preview.gitpod-dev.com/workspaces" target="_blank">ak-gp-evn-0396c44d0d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
