### PR TITLE
Respond to `/idp/keys` with JSON

### DIFF
--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -22,7 +22,7 @@ import (
 // KeyCache caches public keys to ensure they're returned with the JWKS as long
 // as there are valid tokens out there using those keys.
 //
-// PoC Note: in production this cache would likely be implemted using Redis or the database.
+// PoC Note: in production this cache would likely be implemented using Redis or the database.
 type KeyCache interface {
 	// Set rotates the current key
 	Set(ctx context.Context, current *rsa.PrivateKey) error

--- a/components/public-api-server/pkg/identityprovider/idp.go
+++ b/components/public-api-server/pkg/identityprovider/idp.go
@@ -130,7 +130,7 @@ func (kp *Service) Router() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_, err = w.Write(keys)
 		if err != nil {
-			log.WithError(err).Error("cannot repond to /keys")
+			log.WithError(err).Error("cannot respond to /keys")
 		}
 	}))
 

--- a/components/public-api-server/pkg/identityprovider/idp.go
+++ b/components/public-api-server/pkg/identityprovider/idp.go
@@ -127,6 +127,7 @@ func (kp *Service) Router() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_, err = w.Write(keys)
 		if err != nil {
 			log.WithError(err).Error("cannot repond to /keys")

--- a/components/public-api-server/pkg/identityprovider/idp.go
+++ b/components/public-api-server/pkg/identityprovider/idp.go
@@ -115,6 +115,7 @@ func (kp *Service) Router() http.Handler {
 			EndSessionEndpoint:                                 notSupported,
 			JwksURI:                                            keysURL,
 		}
+		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(cfg)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/components/public-api-server/pkg/identityprovider/idp_test.go
+++ b/components/public-api-server/pkg/identityprovider/idp_test.go
@@ -25,14 +25,14 @@ const (
 
 func TestRouter(t *testing.T) {
 	type Expectation struct {
-		Error           string
-		Response        string
-		ExpectedHeaders map[string]string
+		Error    string
+		Response string
 	}
 	tests := []struct {
 		Name                string
 		Expectation         Expectation
 		ResponseExpectation func(*Service) string
+		ExpectedHeaders     map[string]string
 		Path                string
 	}{
 		{
@@ -40,9 +40,9 @@ func TestRouter(t *testing.T) {
 			Path: oidc.DiscoveryEndpoint,
 			Expectation: Expectation{
 				Response: `{"issuer":"https://api.gitpod.io/idp","authorization_endpoint":"https://api.gitpod.io/idp/not-supported","token_endpoint":"https://api.gitpod.io/idp/not-supported","introspection_endpoint":"https://api.gitpod.io/idp/not-supported","userinfo_endpoint":"https://api.gitpod.io/idp/not-supported","revocation_endpoint":"https://api.gitpod.io/idp/not-supported","end_session_endpoint":"https://api.gitpod.io/idp/not-supported","jwks_uri":"https://api.gitpod.io/idp/keys","scopes_supported":["openid","profile","email","phone","address","offline_access"],"response_types_supported":["code","id_token","id_token token"],"grant_types_supported":["authorization_code","implicit"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"revocation_endpoint_auth_methods_supported":["none"],"introspection_endpoint_auth_methods_supported":["none"],"introspection_endpoint_auth_signing_alg_values_supported":["RS256"],"claims_supported":["sub","aud","exp","iat","iss","auth_time","nonce","acr","amr","c_hash","at_hash","act","scopes","client_id","azp","preferred_username","name","family_name","given_name","locale","email"],"request_uri_parameter_supported":false}` + "\n",
-				ExpectedHeaders: map[string]string{
-					"Content-Type": "application/json",
-				},
+			},
+			ExpectedHeaders: map[string]string{
+				"Content-Type": "application/json",
 			},
 		},
 		{
@@ -52,10 +52,8 @@ func TestRouter(t *testing.T) {
 				r, _ := s.keys.PublicKeys(context.Background())
 				return string(r)
 			},
-			Expectation: Expectation{
-				ExpectedHeaders: map[string]string{
-					"Content-Type": "application/json",
-				},
+			ExpectedHeaders: map[string]string{
+				"Content-Type": "application/json",
 			},
 		},
 	}
@@ -89,7 +87,7 @@ func TestRouter(t *testing.T) {
 				t.Errorf("Router() mismatch (-want +got):\n%s", diff)
 			}
 
-			for name, expected := range test.Expectation.ExpectedHeaders {
+			for name, expected := range test.ExpectedHeaders {
 				actual := resp.Header.Get(name)
 				if actual != expected {
 					t.Errorf("Unexpected value for header '%s'. got: '%s', want: '%s'", name, actual, expected)

--- a/components/public-api-server/pkg/identityprovider/idp_test.go
+++ b/components/public-api-server/pkg/identityprovider/idp_test.go
@@ -25,8 +25,9 @@ const (
 
 func TestRouter(t *testing.T) {
 	type Expectation struct {
-		Error    string
-		Response string
+		Error           string
+		Response        string
+		ExpectedHeaders map[string]string
 	}
 	tests := []struct {
 		Name                string
@@ -39,6 +40,9 @@ func TestRouter(t *testing.T) {
 			Path: oidc.DiscoveryEndpoint,
 			Expectation: Expectation{
 				Response: `{"issuer":"https://api.gitpod.io/idp","authorization_endpoint":"https://api.gitpod.io/idp/not-supported","token_endpoint":"https://api.gitpod.io/idp/not-supported","introspection_endpoint":"https://api.gitpod.io/idp/not-supported","userinfo_endpoint":"https://api.gitpod.io/idp/not-supported","revocation_endpoint":"https://api.gitpod.io/idp/not-supported","end_session_endpoint":"https://api.gitpod.io/idp/not-supported","jwks_uri":"https://api.gitpod.io/idp/keys","scopes_supported":["openid","profile","email","phone","address","offline_access"],"response_types_supported":["code","id_token","id_token token"],"grant_types_supported":["authorization_code","implicit"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"revocation_endpoint_auth_methods_supported":["none"],"introspection_endpoint_auth_methods_supported":["none"],"introspection_endpoint_auth_signing_alg_values_supported":["RS256"],"claims_supported":["sub","aud","exp","iat","iss","auth_time","nonce","acr","amr","c_hash","at_hash","act","scopes","client_id","azp","preferred_username","name","family_name","given_name","locale","email"],"request_uri_parameter_supported":false}` + "\n",
+				ExpectedHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
 			},
 		},
 		{
@@ -47,6 +51,11 @@ func TestRouter(t *testing.T) {
 			ResponseExpectation: func(s *Service) string {
 				r, _ := s.keys.PublicKeys(context.Background())
 				return string(r)
+			},
+			Expectation: Expectation{
+				ExpectedHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
 			},
 		},
 	}
@@ -78,6 +87,13 @@ func TestRouter(t *testing.T) {
 
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
 				t.Errorf("Router() mismatch (-want +got):\n%s", diff)
+			}
+
+			for name, expected := range test.Expectation.ExpectedHeaders {
+				actual := resp.Header.Get(name)
+				if actual != expected {
+					t.Errorf("Unexpected value for header '%s'. got: '%s', want: '%s'", name, actual, expected)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Correctly set the `Content-Type` of the endpoint[^1]. Also changes two typos I noticed :).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Visit https://api.ft-idp-improvements.preview.gitpod-dev.com/idp/keys and check the headers

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-idp-improvements</li>
	<li><b>🔗 URL</b> - <a href="https://ft-idp-improvements.preview.gitpod-dev.com/workspaces" target="_blank">ft-idp-improvements.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
[^1]: Currently, it's inferred as "text/plain" 
