### PR TITLE
[public-api] Update getWorkspace proto

### DIFF
--- a/components/public-api/gitpod/experimental/v1/workspaces.proto
+++ b/components/public-api/gitpod/experimental/v1/workspaces.proto
@@ -133,6 +133,9 @@ message Workspace {
 
     // status is the current status of this Workspace.
     WorkspaceStatus status = 6;
+
+    // recentFolders is the opened folders inside the workspace. Used to determine the folder path to load the workspace in.
+    repeated string recentFolders = 7;
 }
 
 // WorkspaceStatus represents the currently observed status of a Workspace, including data about child resources that belong to this Workspace.
@@ -147,6 +150,9 @@ message WorkspaceContext {
     message Git {
         string normalized_context_url = 1;
         string commit = 2;
+
+        // gitProvider is the git provider, e.g. 'github', 'gitlab', self hosted, etc
+        string gitProvider = 3;
     }
 
     // Workspace was created from a prebuild

--- a/components/public-api/gitpod/experimental/v1/workspaces.proto
+++ b/components/public-api/gitpod/experimental/v1/workspaces.proto
@@ -134,8 +134,8 @@ message Workspace {
     // status is the current status of this Workspace.
     WorkspaceStatus status = 6;
 
-    // recentFolders is the opened folders inside the workspace. Used to determine the folder path to load the workspace in.
-    repeated string recentFolders = 7;
+    // recent_folders is the opened folders inside the workspace. Used to determine the folder path to load the workspace in.
+    repeated string recent_folders = 7;
 }
 
 // WorkspaceStatus represents the currently observed status of a Workspace, including data about child resources that belong to this Workspace.
@@ -151,8 +151,8 @@ message WorkspaceContext {
         string normalized_context_url = 1;
         string commit = 2;
 
-        // gitProvider is the git provider, e.g. 'github', 'gitlab', self hosted, etc
-        string gitProvider = 3;
+        // git_provider is the git provider, e.g. 'github', 'gitlab', self hosted, etc
+        string git_provider = 3;
     }
 
     // Workspace was created from a prebuild

--- a/components/public-api/gitpod/experimental/v1/workspaces.proto
+++ b/components/public-api/gitpod/experimental/v1/workspaces.proto
@@ -133,9 +133,6 @@ message Workspace {
 
     // status is the current status of this Workspace.
     WorkspaceStatus status = 6;
-
-    // recent_folders is the opened folders inside the workspace. Used to determine the folder path to load the workspace in.
-    repeated string recent_folders = 7;
 }
 
 // WorkspaceStatus represents the currently observed status of a Workspace, including data about child resources that belong to this Workspace.
@@ -146,13 +143,22 @@ message WorkspaceStatus {
 
 // WorkspaceContext describes the context a workspace was created from
 message WorkspaceContext {
+    // GitProvider describes the git provider
+    message GitProvider {
+        // type is the git provider type, e.g. 'github', 'gitlab', 'bitbucked'
+        string type = 1;
+
+        // hostname is the git provider hostname
+        string hostname = 2;
+    }
+
     // Explicit Git context
     message Git {
         string normalized_context_url = 1;
         string commit = 2;
 
-        // git_provider is the git provider, e.g. 'github', 'gitlab', self hosted, etc
-        string git_provider = 3;
+        // provider is the git provider
+        GitProvider provider = 3;
     }
 
     // Workspace was created from a prebuild
@@ -282,6 +288,9 @@ message WorkspaceInstanceStatus {
 
     // ports is the list of exposed ports in the workspace.
     repeated Port ports = 7;
+
+    // recent_folders is the opened folders inside the workspace. Used to determine the folder path to load the workspace in.
+    repeated string recent_folders = 8;
 
     // repo details the Git working copy status of the workspace.
     // Note: this is a best-effort field and more often than not will not be present. Its absence does not


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## How to test
<!-- Provide steps to test this PR -->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
