### PR TITLE
enrich workspace events

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -616,6 +616,7 @@ export class WorkspaceStarter {
                         ideConfig: instance.configuration?.ideConfig,
                         usesPrebuild: spec.getInitializer()?.hasPrebuild(),
                     },
+                    timestamp: new Date(instance.creationTime),
                 });
 
                 {

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -320,6 +320,7 @@ export class WorkspaceManagerBridge implements Disposable {
                             messageId: `bridge-wsrun-${instance.id}`,
                             properties: { instanceId: instance.id, workspaceId: workspaceId },
                             userId,
+                            timestamp: new Date(instance.startedTime),
                         });
                     }
 

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -294,7 +294,14 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
                 userId: ownerUserID,
                 event: "workspace_stopped",
                 messageId: `bridge-wsstopped-${instance.id}`,
-                properties: { instanceId: instance.id, workspaceId: instance.workspaceId },
+                properties: {
+                    instanceId: instance.id,
+                    workspaceId: instance.workspaceId,
+                    stoppingTime: new Date(instance.stoppingTime!),
+                    conditions: instance.status.conditions,
+                    timeout: instance.status.timeout,
+                },
+                timestamp: new Date(instance.stoppedTime!),
             });
         } catch (err) {
             TraceContext.setError({ span }, err);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In order to avoid relying on DB in dedicated for general analytics and investigating timeouts:
- align with DB timestamps
- add info about stopping time, timeout and conditions to stopped event

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix IDE-133

## How to test
<!-- Provide steps to test this PR -->

- Start and stop workspace.
- Check events in segment source.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-wse-enrich</li>
	<li><b>🔗 URL</b> - <a href="https://ak-wse-enrich.preview.gitpod-dev.com/workspaces" target="_blank">ak-wse-enrich.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
