### PR TITLE
Have db-tests run during CI again

### DIFF
--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -8,7 +8,7 @@
     "build:clean": "yarn clean && yarn build",
     "rebuild": "yarn build:clean",
     "build:watch": "watch 'yarn build' .",
-    "test": "leeway build components/gitpod-db:dbtest",
+    "test": "yarn db-test",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
     "db-test-run": "mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -6,6 +6,7 @@ packages:
       - "test/**"
       - package.json
       - mocha.opts
+      - tslint.yaml
     deps:
       - components/content-service-api/typescript:lib
       - components/gitpod-db:lib
@@ -17,6 +18,7 @@ packages:
       - components/usage-api/typescript:lib
       - components/ide-service-api/typescript:lib
       - components/public-api/typescript:lib
+      - :dbtest
     config:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/yarn.lock
@@ -36,7 +38,7 @@ packages:
       image:
         - ${imageRepoBase}/server:${version}
         - ${imageRepoBase}/server:commit-${__git_commit}
-  - name: lib
+  - name: dbtest
     type: yarn
     srcs:
       - "src/**"
@@ -44,31 +46,6 @@ packages:
       - package.json
       - mocha.opts
       - tslint.yaml
-    deps:
-      - components/content-service-api/typescript:lib
-      - components/gitpod-db:lib
-      - components/gitpod-messagebus:lib
-      - components/gitpod-protocol:lib
-      - components/image-builder-api/typescript:lib
-      - components/ws-manager-api/typescript:lib
-      - components/supervisor-api/typescript-grpcweb:lib
-      - components/usage-api/typescript:lib
-      - components/ide-service-api/typescript:lib
-      - components/public-api/typescript:lib
-      - :dbtest
-    config:
-      packaging: library
-      yarnLock: ${coreYarnLockBase}/yarn.lock
-      tsconfig: tsconfig.json
-      commands:
-        test: ["yarn", "test"]
-        build: ["yarn", "build"]
-  - name: dbtest
-    type: yarn
-    srcs:
-      - "src/**/*.ts"
-      - package.json
-      - mocha.opts
     deps:
       - components/gitpod-db:dbtest-init
       - components/gitpod-db:lib

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -22,6 +22,8 @@ import { GetTeamRequest, Team, TeamMember, TeamRole } from "@gitpod/public-api/l
 import { DBTeam } from "@gitpod/gitpod-db/lib/typeorm/entity/db-team";
 import { Connection } from "typeorm";
 import { Timestamp } from "@bufbuild/protobuf";
+import { APIWorkspacesService } from "./workspaces";
+import { APIStatsService } from "./stats";
 
 const expect = chai.expect;
 
@@ -38,6 +40,8 @@ export class APITeamsServiceSpec {
         this.container.bind(API).toSelf().inSingletonScope();
         this.container.bind(APIUserService).toSelf().inSingletonScope();
         this.container.bind(APITeamsService).toSelf().inSingletonScope();
+        this.container.bind(APIWorkspacesService).toSelf().inSingletonScope();
+        this.container.bind(APIStatsService).toSelf().inSingletonScope();
 
         this.container.bind(WorkspaceStarter).toConstantValue({} as WorkspaceStarter);
         this.container.bind(UserService).toConstantValue({} as UserService);

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -136,7 +136,10 @@ import { APIStatsService } from "./api/stats";
 import { FixStripeJob } from "./jobs/fix-stripe-job";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(Config).toConstantValue(ConfigFile.fromFile());
+    // gpl: Making this dynamic enables re-use insides tests
+    bind(Config)
+        .toDynamicValue((ctx) => ConfigFile.fromFile())
+        .inSingletonScope();
     bind(IDEService).toSelf().inSingletonScope();
 
     bind(UserService).toSelf().inSingletonScope();


### PR DESCRIPTION
## Description

Enables `server` db-tests in CI (again). 

### Discussion
This restores the previous behavior: we leverage leeway to only run a db test per ~commit~ _leeway cache key_ (NOT on every CI/build run). This makes it harder to understand whether a test ran or not, and waaaay harder to find the relevant build for a component in the GitHub actions UI. Also, it's potentially subject to leeway issues and cache issues.
One could argue that we want to run it on every build, independent of caching. Let's have that discussion and adjustments in a follow up PR.

## Related Issue(s)
Fixes: WEB-436
Depends on: https://github.com/gitpod-io/gitpod/pull/17786

## How to test
 - look at the output of the build action
 - see that [the output for server:dbtest](https://github.com/gitpod-io/gitpod/actions/runs/5134617596/jobs/9238878908#step:14:4146), and verify that it not only loads the migrations, but also runs the tests.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
