### PR TITLE
[POC] use mysql to persist public key

### DIFF
--- a/components/gitpod-db/go/dbtest/idp_public_keys.go
+++ b/components/gitpod-db/go/dbtest/idp_public_keys.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func NewIDPPublicKey(t *testing.T, record db.IDPPublicKey) db.IDPPublicKey {
+	t.Helper()
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	result := db.IDPPublicKey{
+		KeyID:          record.KeyID,
+		Data:           record.Data,
+		LastActiveTime: now,
+		LastModified:   now,
+	}
+	if !record.LastActiveTime.IsZero() {
+		result.LastActiveTime = record.LastActiveTime
+	}
+	return result
+}
+
+func CreateIDPPublicKeys(t *testing.T, conn *gorm.DB, entries ...db.IDPPublicKey) []db.IDPPublicKey {
+	t.Helper()
+
+	var records []db.IDPPublicKey
+	var ids []string
+	for _, entry := range entries {
+		record := NewIDPPublicKey(t, entry)
+		records = append(records, record)
+		ids = append(ids, record.KeyID)
+
+		foo, err := db.CreateIDPPublicKey(context.Background(), conn, record)
+		require.NoError(t, err)
+		require.NotNil(t, foo)
+	}
+
+	t.Cleanup(func() {
+		HardDeleteIDPPublicKeys(t, ids...)
+	})
+
+	return records
+}
+
+func HardDeleteIDPPublicKeys(t *testing.T, ids ...string) {
+	if len(ids) > 0 {
+		require.NoError(t, conn.Where(ids).Delete(&db.IDPPublicKey{}).Error)
+	}
+}

--- a/components/gitpod-db/go/idp_public_keys.go
+++ b/components/gitpod-db/go/idp_public_keys.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const IDPDefaultExpiredTime = time.Hour
+
+type IDPPublicKey struct {
+	KeyID string `gorm:"primary_key;column:kid;type:char;size:36;" json:"kid"`
+
+	Data string `gorm:"column:data;type:text;size:65535" json:"data"`
+
+	LastActiveTime time.Time `gorm:"column:last_active_time;type:timestamp;" json:"last_active_time"`
+
+	LastModified time.Time `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+
+	// deleted is reserved for use by periodic deleter.
+	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+func (c *IDPPublicKey) TableName() string {
+	return "d_b_idp_public_keys"
+}
+
+func CreateIDPPublicKey(ctx context.Context, conn *gorm.DB, key IDPPublicKey) (IDPPublicKey, error) {
+	if key.KeyID == "" {
+		return IDPPublicKey{}, errors.New("KeyID must be set")
+	}
+
+	if key.Data == "" {
+		return IDPPublicKey{}, errors.New("Data must be set")
+	}
+
+	if key.LastActiveTime.IsZero() {
+		return IDPPublicKey{}, errors.New("LastActiveTime must be set")
+	}
+
+	tx := conn.
+		WithContext(ctx).
+		Create(&key)
+	if tx.Error != nil {
+		return IDPPublicKey{}, fmt.Errorf("failed to create idp public key: %w", tx.Error)
+	}
+
+	return key, nil
+}
+
+func GetIDPPublicKey(ctx context.Context, conn *gorm.DB, keyId string) (IDPPublicKey, error) {
+	var key IDPPublicKey
+
+	if keyId == "" {
+		return IDPPublicKey{}, fmt.Errorf("IDP public key ID is a required argument")
+	}
+
+	tx := conn.
+		WithContext(ctx).
+		Where("kid = ?", keyId).
+		Where("deleted = ?", 0).
+		First(&key)
+	if tx.Error != nil {
+		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+			return IDPPublicKey{}, fmt.Errorf("IDP public key with keyID %s does not exist: %w", keyId, ErrorNotFound)
+		}
+		return IDPPublicKey{}, fmt.Errorf("Failed to retrieve idp public key: %v", tx.Error)
+	}
+
+	return key, nil
+}
+
+func ListActiveIDPPublicKeys(ctx context.Context, conn *gorm.DB) ([]IDPPublicKey, error) {
+	var results []IDPPublicKey
+
+	tx := conn.
+		WithContext(ctx).
+		Where("deleted = ?", 0).
+		Where("last_active_time > ?", time.Now().Add(-1*IDPDefaultExpiredTime)).
+		Order("last_active_time").
+		Find(&results)
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to list idp public keys: %w", tx.Error)
+	}
+
+	return results, nil
+}
+
+func DeleteExpiredIDPPublicKeys(ctx context.Context, conn *gorm.DB) error {
+	tx := conn.
+		WithContext(ctx).
+		Table((&IDPPublicKey{}).TableName()).
+		Where("last_active_time < ?", time.Now().Add(-1*IDPDefaultExpiredTime)).
+		Where("deleted = ?", 0).
+		Update("deleted", 1)
+
+	if tx.Error != nil {
+		return fmt.Errorf("failed to delete expired idp public keys: %w", tx.Error)
+	}
+	return nil
+}
+
+func MarkIDPPublicKeyActive(ctx context.Context, conn *gorm.DB, keyID string) error {
+	if keyID == "" {
+		return errors.New("KeyID is a required field")
+	}
+
+	_, err := GetIDPPublicKey(ctx, conn, keyID)
+	if err != nil {
+		return err
+	}
+
+	tx := conn.
+		WithContext(ctx).
+		Table((&IDPPublicKey{}).TableName()).
+		Where("kid = ?", keyID).
+		Where("deleted = ?", 0).
+		Update("last_active_time", time.Now())
+
+	if tx.Error != nil {
+		return fmt.Errorf("failed to update idp public key last active time: %s: %w", keyID, tx.Error)
+	}
+
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("IDP public key with keyID %s does not exist", keyID)
+	}
+
+	return nil
+}

--- a/components/gitpod-db/go/idp_public_keys_test.go
+++ b/components/gitpod-db/go/idp_public_keys_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateIDPPublicKey(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+	created := dbtest.CreateIDPPublicKeys(t, conn, db.IDPPublicKey{KeyID: "test-1", Data: "test-data"})[0]
+
+	retrieved, err := db.GetIDPPublicKey(context.Background(), conn, created.KeyID)
+	require.NoError(t, err)
+	require.Equal(t, created, retrieved)
+}
+
+func TestListActiveIDPPublicKeys(t *testing.T) {
+	ctx := context.Background()
+	conn := dbtest.ConnectForTests(t)
+
+	dbtest.CreateIDPPublicKeys(t, conn,
+		dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+			KeyID:          "key-1",
+			Data:           "data-1",
+			LastActiveTime: time.Now().Add(-62 * time.Minute),
+		}),
+		dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+			KeyID:          "key-2",
+			Data:           "data-2",
+			LastActiveTime: time.Now().Add(-30 * time.Minute),
+		}),
+		dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+			KeyID:          "key-3",
+			Data:           "data-3",
+			LastActiveTime: time.Now(),
+		}),
+	)
+
+	publicKeys, err := db.ListActiveIDPPublicKeys(ctx, conn)
+	require.NoError(t, err)
+	require.Len(t, publicKeys, 2)
+}
+
+func TestDeleteExpiredIDPPublicKeys(t *testing.T) {
+	t.Run("marks record deleted", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		created := dbtest.CreateIDPPublicKeys(t, conn,
+			dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+				KeyID:          "key-1",
+				Data:           "data-1",
+				LastActiveTime: time.Now().Add(-62 * time.Minute),
+			}),
+			dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+				KeyID:          "key-2",
+				Data:           "data-2",
+				LastActiveTime: time.Now().Add(-30 * time.Minute),
+			}),
+			dbtest.NewIDPPublicKey(t, db.IDPPublicKey{
+				KeyID:          "key-3",
+				Data:           "data-3",
+				LastActiveTime: time.Now(),
+			}),
+		)
+
+		err := db.DeleteExpiredIDPPublicKeys(context.Background(), conn)
+		require.NoError(t, err)
+
+		// Delete only sets the `deleted` field, verify that's true
+		var retrieved db.IDPPublicKey
+		tx := conn.Where("kid = ?", created[0].KeyID).Where("deleted = 1").First(&retrieved)
+		require.NoError(t, tx.Error)
+	})
+
+}
+
+func TestActivateIDPPublicKey(t *testing.T) {
+	t.Run("not found when idp public key does not exist", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		err := db.MarkIDPPublicKeyActive(context.Background(), conn, "test-1")
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
+
+	t.Run("public key which exists is marked as active", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		lastActiveTime := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Microsecond)
+		publicKey := dbtest.CreateIDPPublicKeys(t, conn, db.IDPPublicKey{
+			KeyID:          "key-1",
+			Data:           "data-1",
+			LastActiveTime: lastActiveTime,
+		})[0]
+		keyId := publicKey.KeyID
+
+		k, err := db.GetIDPPublicKey(context.Background(), conn, keyId)
+		require.NoError(t, err)
+		require.Equal(t, lastActiveTime, k.LastActiveTime)
+
+		err = db.MarkIDPPublicKeyActive(context.Background(), conn, keyId)
+		require.NoError(t, err)
+
+		k, err = db.GetIDPPublicKey(context.Background(), conn, keyId)
+		require.NoError(t, err)
+		require.Greater(t, 10, int(time.Since(k.LastActiveTime).Seconds()))
+	})
+}

--- a/components/gitpod-db/go/idp_public_keys_test.go
+++ b/components/gitpod-db/go/idp_public_keys_test.go
@@ -12,6 +12,7 @@ import (
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestCreateIDPPublicKey(t *testing.T) {
@@ -75,10 +76,9 @@ func TestDeleteExpiredIDPPublicKeys(t *testing.T) {
 		err := db.DeleteExpiredIDPPublicKeys(context.Background(), conn)
 		require.NoError(t, err)
 
-		// Delete only sets the `deleted` field, verify that's true
 		var retrieved db.IDPPublicKey
-		tx := conn.Where("kid = ?", created[0].KeyID).Where("deleted = 1").First(&retrieved)
-		require.NoError(t, tx.Error)
+		tx := conn.Where("kid = ?", created[0].KeyID).First(&retrieved)
+		require.ErrorIs(t, tx.Error, gorm.ErrRecordNotFound)
 	})
 
 }

--- a/components/gitpod-db/src/typeorm/migration/1685093642782-CreateIDPPublicKeysTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1685093642782-CreateIDPPublicKeysTable.ts
@@ -11,7 +11,7 @@ export class CreateIDPPublicKeysTable1685093642782 implements MigrationInterface
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (!(await tableExists(queryRunner, "d_b_idp_public_keys"))) {
             await queryRunner.query(
-                "CREATE TABLE IF NOT EXISTS `d_b_idp_public_keys` (`kid` varchar(255) NOT NULL, `last_active_time` timestamp(6) NOT NULL, `data` text(65535) NOT NULL, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `deleted` tinyint(4) NOT NULL DEFAULT '0', PRIMARY KEY (kid))",
+                "CREATE TABLE IF NOT EXISTS `d_b_idp_public_keys` (`kid` varchar(255) NOT NULL, `last_active_time` timestamp(6) NOT NULL, `data` text(65535) NOT NULL, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (kid))",
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1685093642782-CreateIDPPublicKeysTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1685093642782-CreateIDPPublicKeysTable.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { tableExists } from "./helper/helper";
+
+export class CreateIDPPublicKeysTable1685093642782 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await tableExists(queryRunner, "d_b_idp_public_keys"))) {
+            await queryRunner.query(
+                "CREATE TABLE IF NOT EXISTS `d_b_idp_public_keys` (`kid` varchar(255) NOT NULL, `last_active_time` timestamp(6) NOT NULL, `data` text(65535) NOT NULL, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `deleted` tinyint(4) NOT NULL DEFAULT '0', PRIMARY KEY (kid))",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await tableExists(queryRunner, "d_b_idp_public_keys")) {
+            await queryRunner.query("DROP TABLE `d_b_idp_public_keys`");
+        }
+    }
+}

--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -290,12 +290,12 @@ func (rc *RedisCache) sync(ctx context.Context, period time.Duration) {
 
 var _ KeyCache = ((*RedisCache)(nil))
 
-func NewMySQLCache(ctx context.Context, dbConn *gorm.DB, refreshPeriod int) *MySQLCache {
+func NewMySQLCache(ctx context.Context, dbConn *gorm.DB, refreshPeriod time.Duration) *MySQLCache {
 	cache := &MySQLCache{
 		dbConn: dbConn,
 		keyID:  defaultKeyID,
 	}
-	go cache.sync(ctx, time.Duration(refreshPeriod))
+	go cache.sync(ctx, refreshPeriod)
 	return cache
 }
 

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -133,7 +133,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 	if redisClient == nil {
 		return fmt.Errorf("no Redis configiured")
 	}
-	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewRedisCache(context.Background(), redisClient))
+	idpService, err := identityprovider.NewService(strings.TrimSuffix(cfg.PublicURL, "/")+"/idp", identityprovider.NewMySQLCache(context.Background(), dbConn, 10*time.Minute))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates [IDE-114](https://linear.app/gitpod/issue/IDE-114/attempt-to-stabilise-jwks-and-hence-the-idp-functionality)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-idp-key-db</li>
	<li><b>🔗 URL</b> - <a href="https://pd-idp-key-db.preview.gitpod-dev.com/workspaces" target="_blank">pd-idp-key-db.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
