### PR TITLE
Validate cloneUrl agains accessible repositories – WEB-402

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { AuthProviderInfo, Project, ProviderRepository, Team, User } from "@gitpod/gitpod-protocol";
+import { AuthProviderInfo, Project, ProviderRepository, Team } from "@gitpod/gitpod-protocol";
 import dayjs from "dayjs";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { trackEvent } from "../Analytics";
@@ -90,8 +90,8 @@ export default function NewProject() {
     }, [authProviders.data, isGitHubAppEnabled, selectedProviderHost]);
 
     useEffect(() => {
-        if (selectedRepo && user) {
-            createProject(currentTeam, user, selectedRepo);
+        if (selectedRepo && user && currentTeam) {
+            createProject(currentTeam, selectedRepo);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedRepo, currentTeam, user]);
@@ -188,7 +188,7 @@ export default function NewProject() {
 
     // TODO: Look into making this a react-query mutation
     const createProject = useCallback(
-        async (team: Team | undefined, user: User, repo: ProviderRepository) => {
+        async (team: Team, repo: ProviderRepository) => {
             if (!selectedProviderHost) {
                 return;
             }
@@ -199,7 +199,7 @@ export default function NewProject() {
                     name: repo.name,
                     slug: repoSlug,
                     cloneUrl: repo.cloneUrl,
-                    ...(team ? { teamId: team.id } : { userId: user.id }),
+                    teamId: team.id,
                     appInstallationId: String(repo.installationId),
                 });
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -289,8 +289,7 @@ export interface CreateProjectParams {
     name: string;
     slug: string;
     cloneUrl: string;
-    teamId?: string;
-    userId?: string;
+    teamId: string;
     appInstallationId: string;
 }
 export interface FindPrebuildsParams {

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -124,7 +124,7 @@ export class ProjectsService {
     }
 
     async createProject(
-        { name, slug, cloneUrl, teamId, userId, appInstallationId }: CreateProjectParams,
+        { name, slug, cloneUrl, teamId, appInstallationId }: CreateProjectParams,
         installer: User,
     ): Promise<Project> {
         const projects = await this.getProjectsByCloneUrls([cloneUrl]);
@@ -134,7 +134,7 @@ export class ProjectsService {
         // If the desired project slug already exists in this team or user account, add a unique suffix to avoid collisions.
         let uniqueSlug = slug;
         let uniqueSuffix = 0;
-        const existingProjects = await (!!userId ? this.getUserProjects(userId) : this.getTeamProjects(teamId!));
+        const existingProjects = await this.getTeamProjects(teamId!);
         while (existingProjects.some((p) => p.slug === uniqueSlug)) {
             uniqueSuffix++;
             uniqueSlug = `${slug}-${uniqueSuffix}`;
@@ -143,7 +143,7 @@ export class ProjectsService {
             name,
             slug: uniqueSlug,
             cloneUrl,
-            ...(!!userId ? { userId } : { teamId }),
+            teamId,
             appInstallationId,
         });
         await this.projectDB.storeProject(project);
@@ -156,8 +156,8 @@ export class ProjectsService {
                 project_id: project.id,
                 name: name,
                 clone_url: cloneUrl,
-                owner_type: teamId ? "team" : "user",
-                owner_id: teamId ? teamId : userId,
+                owner_type: "team",
+                owner_id: teamId,
                 app_installation_id: appInstallationId,
             },
         });

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3209,14 +3209,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { params });
 
         const user = this.checkUser("createProject");
-        if (params.userId) {
-            if (params.userId !== user.id) {
-                throw new ResponseError(ErrorCodes.PERMISSION_DENIED, `Cannot create Projects for other users`);
-            }
-        } else {
-            // Anyone who can read a team's information (i.e. any team member) can create a new project.
-            await this.guardTeamOperation(params.teamId || "", "get", "not_implemented");
-        }
+
+        // Anyone who can read a team's information (i.e. any team member) can create a new project.
+        await this.guardTeamOperation(params.teamId || "", "get", "not_implemented");
 
         const project = await this.projectsService.createProject(params, user);
         // update client registration for the logged in user


### PR DESCRIPTION
## Description
Only repositories with admin permissions should be allowed to create a Project for, otherwise the installation of webhooks fails silently.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-402

## How to test
* Verify that some project can be created using the UI.
* Verify that some cloneUrl for a repository without admin permissions is returning an error if trying to use the `createProject` API method.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
