### PR TITLE
[gitpod-db] remove deprected/unused `tokens` column – WEB-400

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-identity.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-identity.ts
@@ -6,7 +6,7 @@
 
 import { Entity, Column, PrimaryColumn, ManyToOne, Index } from "typeorm";
 
-import { Identity, Token } from "@gitpod/gitpod-protocol";
+import { Identity } from "@gitpod/gitpod-protocol";
 import { DBUser } from "./db-user";
 import { Transformer } from "../transformer";
 
@@ -32,21 +32,6 @@ export class DBIdentity implements Identity {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     primaryEmail?: string;
-
-    /** @deprecated */
-    @Column({
-        type: "simple-json",
-        // We want to deprecate the field without changing the schema just yet so we silence all writes and reads
-        transformer: {
-            to(value: any): any {
-                return [];
-            },
-            from(value: any): any {
-                return [];
-            },
-        },
-    })
-    tokens: Token[];
 
     @Column()
     deleted?: boolean;

--- a/components/gitpod-db/src/typeorm/migration/1685694597883-RemoveIdentityTokens.ts
+++ b/components/gitpod-db/src/typeorm/migration/1685694597883-RemoveIdentityTokens.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const table = "d_b_identity";
+const column = "tokens";
+
+export class RemoveIdentityTokens1685694597883 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, table, column)) {
+            await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN ${column}`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // obsolete column, thus we don't need to recreate it
+    }
+}

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -360,8 +360,6 @@ export class TypeORMUserDBImpl implements UserDB {
         const dbUser = user as DBUser;
         // Here we need to fill the pseudo column 'user' in DBIdentity (see there for details)
         dbUser.identities.forEach((id) => (id.user = dbUser));
-        // TODO deprecated: Remove once we delete that column
-        dbUser.identities.forEach((id) => (id.tokens = []));
         return dbUser;
     }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -72,8 +72,6 @@ export namespace User {
         const res = { ...user };
         delete res.additionalData;
         res.identities = res.identities.map((i) => {
-            delete i.tokens;
-
             // The user field is not in the Identity shape, but actually exists on DBIdentity.
             // Trying to push this object out via JSON RPC will fail because of the cyclic nature
             // of this field.
@@ -657,8 +655,6 @@ export interface Identity {
     authId: string;
     authName: string;
     primaryEmail?: string;
-    /** @deprecated */
-    tokens?: Token[];
     /** This is a flag that triggers the HARD DELETION of this entity */
     deleted?: boolean;
     // readonly identities cannot be modified by the user

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3761,8 +3761,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const res = { ...user };
         delete res.additionalData;
         res.identities = res.identities.map((i) => {
-            delete i.tokens;
-
             // The user field is not in the Identity shape, but actually exists on DBIdentity.
             // Trying to push this object out via JSON RPC will fail because of the cyclic nature
             // of this field.


### PR DESCRIPTION
`tokens` column is unused for long time, but we forgot to remove it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of WEB-400

## How to test
* Verify that login into the preview env is working.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
