### PR TITLE
[public-api] Update getWorkspace api response implementation

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1718,6 +1718,10 @@ type WorkspaceContext struct {
 	ForceCreateNewWorkspace bool   `json:"forceCreateNewWorkspace,omitempty"`
 	NormalizedContextURL    string `json:"normalizedContextURL,omitempty"`
 	Title                   string `json:"title,omitempty"`
+
+	// Commit context
+	Repository *Repository `json:"repository,omitempty"`
+	Revision   string      `json:"revision,omitempty"`
 }
 
 // WorkspaceImageSourceDocker is the WorkspaceImageSourceDocker message type

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"path/filepath"
+
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
@@ -46,7 +48,13 @@ func (s *WorkspaceService) GetWorkspace(ctx context.Context, req *connect.Reques
 		return nil, proxy.ConvertError(err)
 	}
 
-	workspace, err := convertWorkspaceInfo(ws)
+	authProviders, err := conn.GetAuthProviders(ctx)
+	if err != nil {
+		log.Extract(ctx).WithError(err).Error("Failed to get auth providers.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	workspace, err := convertWorkspaceInfo(ws, authProviders)
 	if err != nil {
 		log.Extract(ctx).WithError(err).Error("Failed to convert workspace.")
 		return nil, err
@@ -86,7 +94,7 @@ func (s *WorkspaceService) StreamWorkspaceStatus(ctx context.Context, req *conne
 	}
 
 	for update := range ch {
-		instance, err := convertWorkspaceInstance(update, workspace.Workspace.Shareable)
+		instance, err := convertWorkspaceInstance(update, workspace.Workspace.Context, workspace.Workspace.Config, workspace.Workspace.Shareable)
 		if err != nil {
 			log.Extract(ctx).WithError(err).Error("Failed to convert workspace instance.")
 			return proxy.ConvertError(err)
@@ -144,9 +152,15 @@ func (s *WorkspaceService) ListWorkspaces(ctx context.Context, req *connect.Requ
 		return nil, proxy.ConvertError(err)
 	}
 
+	authProviders, err := conn.GetAuthProviders(ctx)
+	if err != nil {
+		log.Extract(ctx).WithError(err).Error("Failed to get auth providers.")
+		return nil, proxy.ConvertError(err)
+	}
+
 	res := make([]*v1.Workspace, 0, len(serverResp))
 	for _, ws := range serverResp {
-		workspace, err := convertWorkspaceInfo(ws)
+		workspace, err := convertWorkspaceInfo(ws, authProviders)
 		if err != nil {
 			// convertWorkspaceInfo returns gRPC errors
 			return nil, err
@@ -229,7 +243,13 @@ func (s *WorkspaceService) StartWorkspace(ctx context.Context, req *connect.Requ
 		return nil, proxy.ConvertError(err)
 	}
 
-	workspace, err := convertWorkspaceInfo(ws)
+	authProviders, err := conn.GetAuthProviders(ctx)
+	if err != nil {
+		log.Extract(ctx).WithError(err).Error("Failed to get auth providers.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	workspace, err := convertWorkspaceInfo(ws, authProviders)
 	if err != nil {
 		log.Extract(ctx).WithError(err).Error("Failed to convert workspace.")
 		return nil, err
@@ -261,7 +281,13 @@ func (s *WorkspaceService) StopWorkspace(ctx context.Context, req *connect.Reque
 		return nil, proxy.ConvertError(err)
 	}
 
-	workspace, err := convertWorkspaceInfo(ws)
+	authProviders, err := conn.GetAuthProviders(ctx)
+	if err != nil {
+		log.Extract(ctx).WithError(err).Error("Failed to get auth providers.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	workspace, err := convertWorkspaceInfo(ws, authProviders)
 	if err != nil {
 		log.Extract(ctx).WithError(err).Error("Failed to convert workspace.")
 		return nil, err
@@ -310,11 +336,22 @@ func getLimitFromPagination(pagination *v1.Pagination) (int, error) {
 }
 
 // convertWorkspaceInfo convers a "protocol workspace" to a "public API workspace". Returns gRPC errors if things go wrong.
-func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.Workspace, error) {
-	instance, err := convertWorkspaceInstance(input.LatestInstance, input.Workspace.Shareable)
+func convertWorkspaceInfo(input *protocol.WorkspaceInfo, authProviders []*protocol.AuthProviderInfo) (*v1.Workspace, error) {
+	instance, err := convertWorkspaceInstance(input.LatestInstance, input.Workspace.Context, input.Workspace.Config, input.Workspace.Shareable)
 	if err != nil {
 		return nil, err
 	}
+
+	providerHostname := ""
+	providerType := ""
+	if input.Workspace.Context.Repository != nil {
+		providerHostname = input.Workspace.Context.Repository.Host
+		providerInfo := findAuthProvider(providerHostname, authProviders)
+		if providerInfo != nil {
+			providerType = providerInfo.AuthProviderType
+		}
+	}
+
 	return &v1.Workspace{
 		WorkspaceId: input.Workspace.ID,
 		OwnerId:     input.Workspace.OwnerID,
@@ -324,6 +361,10 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.Workspace, error) 
 			Details: &v1.WorkspaceContext_Git_{Git: &v1.WorkspaceContext_Git{
 				NormalizedContextUrl: input.Workspace.ContextURL,
 				Commit:               "",
+				Provider: &v1.WorkspaceContext_GitProvider{
+					Type:     providerType,
+					Hostname: providerHostname,
+				},
 			}},
 		},
 		Description: input.Workspace.Description,
@@ -333,7 +374,7 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.Workspace, error) 
 	}, nil
 }
 
-func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, shareable bool) (*v1.WorkspaceInstance, error) {
+func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, wsCtx *protocol.WorkspaceContext, config *protocol.WorkspaceConfig, shareable bool) (*v1.WorkspaceInstance, error) {
 	if wsi == nil {
 		return nil, nil
 	}
@@ -403,6 +444,21 @@ func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, shareable bool) (
 		ports = append(ports, port)
 	}
 
+	// Calculate initial workspace folder location
+	var recentFolders []string
+	location := ""
+	if config != nil {
+		location = config.WorkspaceLocation
+		if location == "" {
+			location = config.CheckoutLocation
+		}
+	}
+	if location == "" && wsCtx != nil && wsCtx.Repository != nil {
+		location = wsCtx.Repository.Name
+
+	}
+	recentFolders = append(recentFolders, filepath.Join("/workspace", location))
+
 	return &v1.WorkspaceInstance{
 		InstanceId:  wsi.ID,
 		WorkspaceId: wsi.WorkspaceID,
@@ -418,7 +474,17 @@ func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, shareable bool) (
 				Timeout:           wsi.Status.Conditions.Timeout,
 				FirstUserActivity: firstUserActivity,
 			},
-			Ports: ports,
+			Ports:         ports,
+			RecentFolders: recentFolders,
 		},
 	}, nil
+}
+
+func findAuthProvider(hostname string, authProviders []*protocol.AuthProviderInfo) *protocol.AuthProviderInfo {
+	for _, provider := range authProviders {
+		if hostname == provider.Host {
+			return provider
+		}
+	}
+	return nil
 }

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -81,6 +81,72 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 
 		requireEqualProto(t, workspaceTestData[0].API, resp.Msg.GetResult())
 	})
+
+	t.Run("returns a proper RecentFolders with when config.WorkspaceLocation exists", func(t *testing.T) {
+		serverMock, client := setupWorkspacesService(t)
+
+		wsInfo := workspaceTestData[0].Protocol
+		wsInfo.Workspace = nil
+		wsWorkspace := *workspaceTestData[0].Protocol.Workspace
+		wsWorkspace.Config = &protocol.WorkspaceConfig{
+			WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
+		}
+		wsInfo.Workspace = &wsWorkspace
+
+		serverMock.EXPECT().GetWorkspace(gomock.Any(), workspaceID).Return(&wsInfo, nil)
+
+		resp, err := client.GetWorkspace(context.Background(), connect.NewRequest(&v1.GetWorkspaceRequest{
+			WorkspaceId: workspaceID,
+		}))
+		require.NoError(t, err)
+
+		expectedWs := *workspaceTestData[0].API
+		expectedWs.Status = nil
+		expectedWsStatus := *workspaceTestData[0].API.Status
+		expectedWsStatus.Instance = nil
+		expectedInstance := *workspaceTestData[0].API.Status.Instance
+		expectedInstance.Status = nil
+		expectedInstanceStatus := *workspaceTestData[0].API.Status.Instance.Status
+		expectedInstanceStatus.RecentFolders = []string{"/workspace/gitpod/gitpod-ws.code-workspace"}
+		expectedInstance.Status = &expectedInstanceStatus
+		expectedWsStatus.Instance = &expectedInstance
+		expectedWs.Status = &expectedWsStatus
+
+		requireEqualProto(t, expectedWs, resp.Msg.GetResult())
+	})
+
+	t.Run("returns a proper RecentFolders with when config.CheckoutLocation exists", func(t *testing.T) {
+		serverMock, client := setupWorkspacesService(t)
+
+		wsInfo := workspaceTestData[0].Protocol
+		wsInfo.Workspace = nil
+		wsWorkspace := *workspaceTestData[0].Protocol.Workspace
+		wsWorkspace.Config = &protocol.WorkspaceConfig{
+			CheckoutLocation: "foo",
+		}
+		wsInfo.Workspace = &wsWorkspace
+
+		serverMock.EXPECT().GetWorkspace(gomock.Any(), workspaceID).Return(&wsInfo, nil)
+
+		resp, err := client.GetWorkspace(context.Background(), connect.NewRequest(&v1.GetWorkspaceRequest{
+			WorkspaceId: workspaceID,
+		}))
+		require.NoError(t, err)
+
+		expectedWs := *workspaceTestData[0].API
+		expectedWs.Status = nil
+		expectedWsStatus := *workspaceTestData[0].API.Status
+		expectedWsStatus.Instance = nil
+		expectedInstance := *workspaceTestData[0].API.Status.Instance
+		expectedInstance.Status = nil
+		expectedInstanceStatus := *workspaceTestData[0].API.Status.Instance.Status
+		expectedInstanceStatus.RecentFolders = []string{"/workspace/foo"}
+		expectedInstance.Status = &expectedInstanceStatus
+		expectedWsStatus.Instance = &expectedInstance
+		expectedWs.Status = &expectedWsStatus
+
+		requireEqualProto(t, expectedWs, resp.Msg.GetResult())
+	})
 }
 
 func TestWorkspaceService_StartWorkspace(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update getWorkspace api response with new `recent_folders` attribute

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
