### PR TITLE
[db] Add go model for User - WEB-263

### DIFF
--- a/components/gitpod-db/go/dbtest/identity.go
+++ b/components/gitpod-db/go/dbtest/identity.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"testing"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func NewIdentity(t *testing.T, idnt db.Identity) db.Identity {
+	t.Helper()
+
+	result := db.Identity{
+		AuthProviderID: uuid.NewString(),
+		AuthID:         uuid.NewString(),
+		AuthName:       "unittest",
+		UserID:         uuid.New(),
+		PrimaryEmail:   "test-identity@gitpod.io",
+	}
+
+	if idnt.AuthProviderID != "" {
+		result.AuthProviderID = idnt.AuthProviderID
+	}
+	if idnt.AuthID != "" {
+		result.AuthID = idnt.AuthID
+	}
+	if idnt.AuthName != "" {
+		result.AuthName = idnt.AuthName
+	}
+	if idnt.UserID != uuid.Nil {
+		result.UserID = idnt.UserID
+	}
+	if idnt.PrimaryEmail != "" {
+		result.PrimaryEmail = idnt.PrimaryEmail
+	}
+
+	return result
+}
+
+func CreateIdentities(t *testing.T, conn *gorm.DB, user ...db.Identity) []db.Identity {
+	t.Helper()
+
+	type tuple struct {
+		AuthProviderID string
+		AuthID         string
+	}
+
+	var records []db.Identity
+	var ids []tuple
+	for _, u := range user {
+		record := NewIdentity(t, u)
+		records = append(records, record)
+		ids = append(ids, tuple{
+			AuthProviderID: record.AuthProviderID,
+			AuthID:         record.AuthID,
+		})
+
+	}
+	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
+
+	t.Cleanup(func() {
+		for _, tup := range ids {
+			require.NoError(t, conn.Where("authProviderId = ?", tup.AuthProviderID).Where("authId = ?", tup.AuthID).Delete(&db.User{}).Error)
+		}
+	})
+
+	return records
+}

--- a/components/gitpod-db/go/dbtest/user.go
+++ b/components/gitpod-db/go/dbtest/user.go
@@ -14,24 +14,10 @@ import (
 	"gorm.io/gorm"
 )
 
-type User struct {
-	ID           uuid.UUID      `gorm:"primary_key;column:id;type:char;size:36;"`
-	AvatarURL    string         `gorm:"column:avatarUrl;type:char;size:255;"`
-	Name         string         `gorm:"column:name;type:char;size:255;"`
-	FullName     string         `gorm:"column:fullName;type:char;size:255;"`
-	CreationDate db.VarcharTime `gorm:"column:creationDate;type:varchar;size:255;"`
-
-	// user has more field but we don't care here as they are just used in tests.
-}
-
-func (user *User) TableName() string {
-	return "d_b_user"
-}
-
-func NewUser(t *testing.T, user User) User {
+func NewUser(t *testing.T, user db.User) db.User {
 	t.Helper()
 
-	result := User{
+	result := db.User{
 		ID:           uuid.New(),
 		AvatarURL:    "https://avatars.githubusercontent.com/u/9071",
 		Name:         "HomerJSimpson",
@@ -56,10 +42,10 @@ func NewUser(t *testing.T, user User) User {
 	return result
 }
 
-func CreatUser(t *testing.T, conn *gorm.DB, user ...User) []User {
+func CreatUser(t *testing.T, conn *gorm.DB, user ...db.User) []db.User {
 	t.Helper()
 
-	var records []User
+	var records []db.User
 	var ids []uuid.UUID
 	for _, u := range user {
 		record := NewUser(t, u)
@@ -71,7 +57,7 @@ func CreatUser(t *testing.T, conn *gorm.DB, user ...User) []User {
 
 	t.Cleanup(func() {
 		if len(ids) > 0 {
-			require.NoError(t, conn.Where(ids).Delete(&User{}).Error)
+			require.NoError(t, conn.Where(ids).Delete(&db.User{}).Error)
 		}
 	})
 

--- a/components/gitpod-db/go/dbtest/user.go
+++ b/components/gitpod-db/go/dbtest/user.go
@@ -34,6 +34,12 @@ func NewUser(t *testing.T, user db.User) db.User {
 	if user.ID != uuid.Nil {
 		result.ID = user.ID
 	}
+	if user.OrganizationID != nil {
+		result.OrganizationID = user.OrganizationID
+	}
+	if user.UsageAttributionID != "" {
+		result.UsageAttributionID = user.UsageAttributionID
+	}
 
 	if user.AvatarURL != "" {
 		result.AvatarURL = user.AvatarURL

--- a/components/gitpod-db/go/dbtest/user.go
+++ b/components/gitpod-db/go/dbtest/user.go
@@ -17,11 +17,17 @@ import (
 func NewUser(t *testing.T, user db.User) db.User {
 	t.Helper()
 
+	orgID := uuid.New()
+
 	result := db.User{
-		ID:           uuid.New(),
-		AvatarURL:    "https://avatars.githubusercontent.com/u/9071",
-		Name:         "HomerJSimpson",
-		FullName:     "Homer Simpson",
+		ID:                 uuid.New(),
+		OrganizationID:     &orgID,
+		UsageAttributionID: db.NewTeamAttributionID(uuid.NewString()),
+
+		Name:      "HomerJSimpson",
+		FullName:  "Homer Simpson",
+		AvatarURL: "https://avatars.githubusercontent.com/u/9071",
+
 		CreationDate: db.NewVarCharTime(time.Now()),
 	}
 
@@ -42,7 +48,7 @@ func NewUser(t *testing.T, user db.User) db.User {
 	return result
 }
 
-func CreatUser(t *testing.T, conn *gorm.DB, user ...db.User) []db.User {
+func CreatUsers(t *testing.T, conn *gorm.DB, user ...db.User) []db.User {
 	t.Helper()
 
 	var records []db.User

--- a/components/gitpod-db/go/dbtest/user.go
+++ b/components/gitpod-db/go/dbtest/user.go
@@ -19,8 +19,9 @@ func NewUser(t *testing.T, user db.User) db.User {
 
 	orgID := uuid.New()
 
+	userID := uuid.New()
 	result := db.User{
-		ID:                 uuid.New(),
+		ID:                 userID,
 		OrganizationID:     &orgID,
 		UsageAttributionID: db.NewTeamAttributionID(uuid.NewString()),
 
@@ -28,7 +29,13 @@ func NewUser(t *testing.T, user db.User) db.User {
 		FullName:  "Homer Simpson",
 		AvatarURL: "https://avatars.githubusercontent.com/u/9071",
 
-		CreationDate: db.NewVarCharTime(time.Now()),
+		CreationDate: db.NewVarCharTime(time.Now().Round(time.Second)),
+
+		Identities: []db.Identity{
+			NewIdentity(t, db.Identity{
+				UserID: userID,
+			}),
+		},
 	}
 
 	if user.ID != uuid.Nil {

--- a/components/gitpod-db/go/identity.go
+++ b/components/gitpod-db/go/identity.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db
+
+import "github.com/google/uuid"
+
+type Identity struct {
+	AuthProviderID string `gorm:"primary_key;column:authProviderId;type:char;size:255;not null;"`
+	AuthID         string `gorm:"primary_key;column:authId;type:char;size:255;not null;"`
+
+	AuthName string `gorm:"column:authName;type:char;size:255;not null;"`
+
+	UserID       uuid.UUID `gorm:"column:userId;type:char;size:36;"`
+	PrimaryEmail string    `gorm:"column:authName;type:char;size:255;not null;default:'';"`
+
+	Tokens string `gorm:"column:authName;type:text;"`
+
+	Deleted  bool `gorm:"column:deleted;type:tinyint;default:0;"`
+	Readonly bool `gorm:"column:readonly;type:tinyint;default:0;"`
+}
+
+func (i *Identity) TableName() string {
+	return "d_b_identity"
+}

--- a/components/gitpod-db/go/identity.go
+++ b/components/gitpod-db/go/identity.go
@@ -13,9 +13,7 @@ type Identity struct {
 	AuthName string `gorm:"column:authName;type:char;size:255;not null;"`
 
 	UserID       uuid.UUID `gorm:"column:userId;type:char;size:36;"`
-	PrimaryEmail string    `gorm:"column:authName;type:char;size:255;not null;default:'';"`
-
-	Tokens string `gorm:"column:authName;type:text;"`
+	PrimaryEmail string    `gorm:"column:primaryEmail;type:char;size:255;not null;default:'';"`
 
 	Deleted  bool `gorm:"column:deleted;type:tinyint;default:0;"`
 	Readonly bool `gorm:"column:readonly;type:tinyint;default:0;"`

--- a/components/gitpod-db/go/user.go
+++ b/components/gitpod-db/go/user.go
@@ -4,7 +4,9 @@
 
 package db
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
 type User struct {
 	ID uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;"`

--- a/components/gitpod-db/go/user.go
+++ b/components/gitpod-db/go/user.go
@@ -35,6 +35,8 @@ type User struct {
 
 	AdditionalData *string `gorm:"column:additionalData;type:text;"`
 
+	// Identities can be loaded with Preload("Identities") from the `d_b_identity` table as
+	// a One to Many relationship
 	Identities []Identity `gorm:"foreignKey:userId;references:id"`
 
 	CreationDate VarcharTime `gorm:"column:creationDate;type:varchar;size:255;"`

--- a/components/gitpod-db/go/user.go
+++ b/components/gitpod-db/go/user.go
@@ -5,14 +5,19 @@
 package db
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 type User struct {
 	ID uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;"`
 
 	// If the User is exclusively owned by an Organization, the owning Organization will be set.
-	OrganizationID     *uuid.UUID    `gorm:"column:avatarUrl;type:char;size:255;"`
+	OrganizationID     *uuid.UUID    `gorm:"column:organizationId;type:char;size:255;"`
 	UsageAttributionID AttributionID `gorm:"column:usageAttributionId;type:char;size:60;default:'';not null;"`
 
 	Name      string `gorm:"column:name;type:char;size:255;"`
@@ -23,12 +28,12 @@ type User struct {
 	Privileged bool `gorm:"column:privileged;type:tinyint;default:0;not null;" json:"privileged"`
 
 	RolesOrPermissions *string `gorm:"column:rolesOrPermissions;type:text;"`
-	FeatureFlags       *string `gorm:"column:text;type:text;"`
+	FeatureFlags       *string `gorm:"column:featureFlags;type:text;"`
 
 	VerificationPhoneNumber string      `gorm:"column:verificationPhoneNumber;type:char;size:30;default:'';not null;"`
 	LastVerificationTime    VarcharTime `gorm:"column:lastVerificationTime;type:char;size:30;default:'';not null;"`
 
-	AdditionalData *string `gorm:"column:text;type:text;"`
+	AdditionalData *string `gorm:"column:additionalData;type:text;"`
 
 	Identities []Identity `gorm:"foreignKey:userId;references:id"`
 
@@ -41,4 +46,26 @@ type User struct {
 
 func (user *User) TableName() string {
 	return "d_b_user"
+}
+
+func GetUser(ctx context.Context, conn *gorm.DB, id uuid.UUID) (User, error) {
+	if id == uuid.Nil {
+		return User{}, errors.New("id must be nil")
+	}
+
+	var user User
+	tx := conn.
+		Model(&User{}).
+		Preload("Identities").
+		First(&user, id)
+
+	if tx.Error != nil {
+		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+			return User{}, fmt.Errorf("user with ID %s does not exist: %w", id, ErrorNotFound)
+		}
+
+		return User{}, fmt.Errorf("Failed to retrieve user: %v", tx.Error)
+	}
+
+	return user, nil
 }

--- a/components/gitpod-db/go/user.go
+++ b/components/gitpod-db/go/user.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db
+
+import "github.com/google/uuid"
+
+type User struct {
+	ID uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;"`
+
+	// If the User is exclusively owned by an Organization, the owning Organization will be set.
+	OrganizationID     *uuid.UUID    `gorm:"column:avatarUrl;type:char;size:255;"`
+	UsageAttributionID AttributionID `gorm:"column:usageAttributionId;type:char;size:60;default:'';not null;"`
+
+	Name      string `gorm:"column:name;type:char;size:255;"`
+	FullName  string `gorm:"column:fullName;type:char;size:255;"`
+	AvatarURL string `gorm:"column:avatarUrl;type:char;size:255;"`
+
+	Blocked    bool `gorm:"column:blocked;type:tinyint;default:0;not null;" json:"blocked"`
+	Privileged bool `gorm:"column:privileged;type:tinyint;default:0;not null;" json:"privileged"`
+
+	RolesOrPermissions *string `gorm:"column:rolesOrPermissions;type:text;"`
+	FeatureFlags       *string `gorm:"column:text;type:text;"`
+
+	VerificationPhoneNumber string      `gorm:"column:verificationPhoneNumber;type:char;size:30;default:'';not null;"`
+	LastVerificationTime    VarcharTime `gorm:"column:lastVerificationTime;type:char;size:30;default:'';not null;"`
+
+	AdditionalData *string `gorm:"column:text;type:text;"`
+
+	CreationDate VarcharTime `gorm:"column:creationDate;type:varchar;size:255;"`
+
+	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"markedDeleted"`
+
+	// More undefined fields
+}
+
+func (user *User) TableName() string {
+	return "d_b_user"
+}

--- a/components/gitpod-db/go/user.go
+++ b/components/gitpod-db/go/user.go
@@ -30,6 +30,8 @@ type User struct {
 
 	AdditionalData *string `gorm:"column:text;type:text;"`
 
+	Identities []Identity `gorm:"foreignKey:userId;references:id"`
+
 	CreationDate VarcharTime `gorm:"column:creationDate;type:varchar;size:255;"`
 
 	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"markedDeleted"`

--- a/components/gitpod-db/go/user_test.go
+++ b/components/gitpod-db/go/user_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUser(t *testing.T) {
+	conn := dbtest.ConnectForTests(t).Debug()
+	user := dbtest.CreatUsers(t, conn, db.User{})[0]
+
+	retrived, err := db.GetUser(context.Background(), conn, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, user, retrived)
+
+}

--- a/components/gitpod-db/go/user_test.go
+++ b/components/gitpod-db/go/user_test.go
@@ -20,5 +20,4 @@ func TestGetUser(t *testing.T) {
 	retrived, err := db.GetUser(context.Background(), conn, user.ID)
 	require.NoError(t, err)
 	require.Equal(t, user, retrived)
-
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Defines a User model in go, such that we can being to issue OIDC sessions from public api

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
