### PR TITLE
[db] Find user by identity - WEB-263

### DIFF
--- a/components/gitpod-db/go/dbtest/identity.go
+++ b/components/gitpod-db/go/dbtest/identity.go
@@ -66,7 +66,7 @@ func CreateIdentities(t *testing.T, conn *gorm.DB, user ...db.Identity) []db.Ide
 
 	t.Cleanup(func() {
 		for _, tup := range ids {
-			require.NoError(t, conn.Where("authProviderId = ?", tup.AuthProviderID).Where("authId = ?", tup.AuthID).Delete(&db.User{}).Error)
+			require.NoError(t, conn.Model(&db.Identity{}).Where("authProviderId = ?", tup.AuthProviderID).Where("authId = ?", tup.AuthID).Delete(&db.User{}).Error)
 		}
 	})
 

--- a/components/gitpod-db/go/user_test.go
+++ b/components/gitpod-db/go/user_test.go
@@ -10,6 +10,7 @@ import (
 
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,11 +24,38 @@ func TestGetUser(t *testing.T) {
 }
 
 func TestGetUserByIdentity(t *testing.T) {
-	conn := dbtest.ConnectForTests(t).Debug()
-	user := dbtest.CreatUsers(t, conn, db.User{})[0]
 
-	retrived, err := db.GetUserByIdentity(context.Background(), conn, user.Identities[0].AuthProviderID, user.Identities[0].AuthID)
-	require.NoError(t, err)
-	require.Equal(t, user, retrived)
+	t.Run("retrieves all identities for a user", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		// Create additional identities not related to our user, to ensure we're selecting correctly
+		dbtest.CreateIdentities(t, conn, db.Identity{}, db.Identity{})
+
+		userID := uuid.New()
+		identities := []db.Identity{
+			dbtest.NewIdentity(t, db.Identity{UserID: userID}),
+			dbtest.NewIdentity(t, db.Identity{UserID: userID}),
+		}
+
+		user := dbtest.CreatUsers(t, conn, db.User{
+			ID:         userID,
+			Identities: identities,
+		})[0]
+
+		// Test that given any of the identities, we can find the user
+		for _, identity := range user.Identities {
+			retrived, err := db.GetUserByIdentity(context.Background(), conn, identity.AuthProviderID, identity.AuthID)
+			require.NoError(t, err)
+			require.Len(t, user.Identities, len(user.Identities), "must return all identities for the user")
+			require.Equal(t, user, retrived)
+		}
+	})
+
+	t.Run("not found when identity does not exist", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t).Debug()
+		_, err := db.GetUserByIdentity(context.Background(), conn, uuid.NewString(), uuid.NewString())
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
 
 }

--- a/components/gitpod-db/go/user_test.go
+++ b/components/gitpod-db/go/user_test.go
@@ -14,10 +14,20 @@ import (
 )
 
 func TestGetUser(t *testing.T) {
-	conn := dbtest.ConnectForTests(t).Debug()
+	conn := dbtest.ConnectForTests(t)
 	user := dbtest.CreatUsers(t, conn, db.User{})[0]
 
 	retrived, err := db.GetUser(context.Background(), conn, user.ID)
 	require.NoError(t, err)
 	require.Equal(t, user, retrived)
+}
+
+func TestGetUserByIdentity(t *testing.T) {
+	conn := dbtest.ConnectForTests(t).Debug()
+	user := dbtest.CreatUsers(t, conn, db.User{})[0]
+
+	retrived, err := db.GetUserByIdentity(context.Background(), conn, user.Identities[0].AuthProviderID, user.Identities[0].AuthID)
+	require.NoError(t, err)
+	require.Equal(t, user, retrived)
+
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Building blocks to be able to issue JWT session directly form public-api without needing to talk to the `iam-session-app`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17824

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
