### PR TITLE
don't log http headers

### DIFF
--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -24,9 +24,8 @@ var ErrClosed = errors.New("reconnecting-ws: closed")
 // ErrBadHandshake is returned when the server response to opening handshake is
 // invalid.
 type ErrBadHandshake struct {
-	URL       string
-	ReqHeader http.Header
-	Resp      *http.Response
+	URL  string
+	Resp *http.Response
 }
 
 func (e *ErrBadHandshake) Error() string {
@@ -34,7 +33,7 @@ func (e *ErrBadHandshake) Error() string {
 	if e.Resp != nil {
 		statusCode = e.Resp.StatusCode
 	}
-	return fmt.Sprintf("reconnecting-ws: bad handshake: code %v - URL: %v - headers: %v", statusCode, e.URL, e.ReqHeader)
+	return fmt.Sprintf("reconnecting-ws: bad handshake: code %v - URL: %v", statusCode, e.URL)
 }
 
 // The ReconnectingWebsocket represents a Reconnecting WebSocket connection.
@@ -223,7 +222,7 @@ func (rc *ReconnectingWebsocket) connect(ctx context.Context) *WebsocketConnecti
 			// if mal-formed handshake request (unauthorized, forbidden) or client actions (redirect) are required then fail immediately
 			// otherwise try several times and fail, maybe temporarily unavailable, like server restart
 			if rc.badHandshakeCount > rc.badHandshakeMax || (http.StatusMultipleChoices <= statusCode && statusCode < http.StatusInternalServerError) {
-				_ = rc.closeWithError(&ErrBadHandshake{rc.url, rc.reqHeader, resp})
+				_ = rc.closeWithError(&ErrBadHandshake{rc.url, resp})
 				return nil
 			}
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

to avoid leaking tokens in logs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

build should be green, you can checkout logs in production for this message

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
