### PR TITLE
[JetBrains] Update Platform Version from JetBrains Gateway Plugin (EAP)

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -1,10 +1,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=232.6095
+pluginSinceBuild=232.6734
 pluginUntilBuild=232.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2023.2
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=232.6095-EAP-CANDIDATE-SNAPSHOT
+platformVersion=232.6734-EAP-CANDIDATE-SNAPSHOT
 

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -30,7 +30,6 @@ import com.intellij.util.ui.UIUtil
 import com.jetbrains.gateway.api.ConnectionRequestor
 import com.jetbrains.gateway.api.GatewayConnectionHandle
 import com.jetbrains.gateway.api.GatewayConnectionProvider
-import com.jetbrains.gateway.ssh.ClientOverSshTunnelConnector
 import com.jetbrains.gateway.ssh.SshHostTunnelConnector
 import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.ConcurrentHashMap
@@ -262,12 +261,11 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                         setErrorMessage("failed to fetch JetBrains Gateway Join Link.")
                                         return@launch
                                     }
-                                    val connector = ClientOverSshTunnelConnector(
+                                    val clientHandle = connectionHandleFactory.connect(
                                         connectionLifetime,
                                         SshHostTunnelConnector(credentials),
                                         URI(joinLink)
                                     )
-                                    val clientHandle = connector.connect()
                                     clientHandle.clientClosed.advise(connectionLifetime) {
                                         application.invokeLater {
                                             connectionLifetime.terminate()

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
@@ -9,10 +9,17 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.gateway.GitpodConnectionProvider
 import javax.swing.JComponent
 
+@Suppress("UnstableApiUsage")
 interface GitpodConnectionHandleFactory {
     fun createGitpodConnectionHandle(
             lifetime: Lifetime,
             component: JComponent,
             params: GitpodConnectionProvider.ConnectParams
     ): GatewayConnectionHandle
+
+    suspend fun connect(
+        lifetime: Lifetime,
+        connector: com.jetbrains.gateway.ssh.HostTunnelConnector,
+        tcpJoinLink: java.net.URI
+    ): com.jetbrains.gateway.thinClientLink.ThinClientHandle
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
@@ -7,9 +7,13 @@ package io.gitpod.jetbrains.gateway.latest
 import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
 import com.jetbrains.gateway.api.CustomConnectionFrameContext
 import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.gateway.ssh.ClientOverSshTunnelConnector
+import com.jetbrains.gateway.ssh.HostTunnelConnector
+import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
 import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
+import java.net.URI
 import javax.swing.JComponent
 
 class GitpodConnectionHandle(
@@ -30,7 +34,7 @@ class GitpodConnectionHandle(
         return false
     }
 }
-
+@Suppress("UnstableApiUsage")
 class LatestGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
     override fun createGitpodConnectionHandle(
             lifetime: Lifetime,
@@ -38,5 +42,12 @@ class LatestGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
             params: ConnectParams
     ): GatewayConnectionHandle {
         return GitpodConnectionHandle(lifetime, component, params)
+    }
+
+    override suspend fun connect(lifetime: Lifetime, connector: HostTunnelConnector, tcpJoinLink: URI): ThinClientHandle {
+        return ClientOverSshTunnelConnector(
+            lifetime,
+            connector
+        ).connect(tcpJoinLink)
     }
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
@@ -7,9 +7,13 @@ package io.gitpod.jetbrains.gateway.stable
 import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
 import com.jetbrains.gateway.api.CustomConnectionFrameContext
 import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.gateway.ssh.ClientOverSshTunnelConnector
+import com.jetbrains.gateway.ssh.HostTunnelConnector
+import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
 import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
+import java.net.URI
 import javax.swing.JComponent
 
 class GitpodConnectionHandle(
@@ -31,6 +35,7 @@ class GitpodConnectionHandle(
     }
 }
 
+@Suppress("UnstableApiUsage")
 class StableGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
     override fun createGitpodConnectionHandle(
             lifetime: Lifetime,
@@ -38,5 +43,13 @@ class StableGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
             params: ConnectParams
     ): GatewayConnectionHandle {
         return GitpodConnectionHandle(lifetime, component, params)
+    }
+
+    override suspend fun connect(lifetime: Lifetime, connector: HostTunnelConnector, tcpJoinLink: URI): ThinClientHandle {
+        return ClientOverSshTunnelConnector(
+            lifetime,
+            connector,
+            tcpJoinLink
+        ).connect()
     }
 }

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -491,12 +491,11 @@ func (c *ComponentAPI) CreateUser(username string, token string) (string, error)
 	}
 	if authId == "" {
 		authId = strconv.FormatInt(time.Now().UnixMilli(), 10)
-		_, err = db.Exec(`INSERT IGNORE INTO d_b_identity (authProviderId, authId, authName, userId, tokens) VALUES (?, ?, ?, ?, ?)`,
+		_, err = db.Exec(`INSERT IGNORE INTO d_b_identity (authProviderId, authId, authName, userId) VALUES (?, ?, ?, ?)`,
 			"Public-GitHub",
 			authId,
 			username,
 			userId,
-			"[]",
 		)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Description
This PR updates the Platform Version from JetBrains Gateway Plugin (EAP) to the latest version.

## How to test

Merge if tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. Ensure you have the Gateway installed from [JetBrains Toolbox App](https://www.jetbrains.com/toolbox-app/) and have it up-to-date.
  - You should use Gateway version corresponding to plugin qualifier, i.e. for stable plugin test with released, for latest test with EAP.
  - It could be that a new Gateway is not published for the given SDK yet then wait for it to be published. You can check the build version in the About dialog.
2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
  - You can also uninstall current Gitpod plugin, configure dev channel using https://plugins.jetbrains.com/plugins/list?channel=dev&pluginId=18438-gitpod-gateway and restart GW to test that the proper version is detected and installed.
3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
</details>

## Release Notes
```release-note
NONE
```

## Werft options:
- [x] /werft publish-to-jb-marketplace
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=all
- [x] latest-ide-version=true
- [x] with-ws-manager-mk2

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._