### PR TITLE
try to fix flaky terminal tests by using timeout context to unblock closing of terminals

### DIFF
--- a/components/supervisor/pkg/terminal/terminal.go
+++ b/components/supervisor/pkg/terminal/terminal.go
@@ -400,6 +400,9 @@ func (term *Term) Close(ctx context.Context) error {
 	var commandErr error
 	if term.Command.Process != nil {
 		commandErr = process.TerminateSync(ctx, term.Command.Process.Pid)
+		if process.IsNotChildProcess(commandErr) {
+			commandErr = nil
+		}
 	}
 
 	writeErr := term.Stdout.Close()

--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -47,8 +47,11 @@ func TestTitle(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
 			mux := NewMux()
-			defer mux.Close(context.Background())
+			defer mux.Close(ctx)
 
 			tmpWorkdir, err := os.MkdirTemp("", "workdirectory")
 			if err != nil {
@@ -59,7 +62,7 @@ func TestTitle(t *testing.T) {
 			terminalService := NewMuxTerminalService(mux)
 			terminalService.DefaultWorkdir = tmpWorkdir
 
-			term, err := terminalService.OpenWithOptions(context.Background(), &api.OpenTerminalRequest{}, TermOptions{
+			term, err := terminalService.OpenWithOptions(ctx, &api.OpenTerminalRequest{}, TermOptions{
 				Title: test.Title,
 			})
 			if err != nil {
@@ -71,6 +74,7 @@ func TestTitle(t *testing.T) {
 			}
 
 			listener := &TestTitleTerminalServiceListener{
+				ctx:   ctx,
 				resps: make(chan *api.ListenTerminalResponse),
 			}
 			titles := listener.Titles(2)
@@ -87,12 +91,12 @@ func TestTitle(t *testing.T) {
 				t.Errorf("unexpected output (-want +got):\n%s", diff)
 			}
 
-			_, err = terminalService.Write(context.Background(), &api.WriteTerminalRequest{Alias: term.Terminal.Alias, Stdin: []byte(test.Command + "\r\n")})
+			_, err = terminalService.Write(ctx, &api.WriteTerminalRequest{Alias: term.Terminal.Alias, Stdin: []byte(test.Command + "\r\n")})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, err = terminalService.Shutdown(context.Background(), &api.ShutdownTerminalRequest{Alias: term.Terminal.Alias})
+			_, err = terminalService.Shutdown(ctx, &api.ShutdownTerminalRequest{Alias: term.Terminal.Alias})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -106,6 +110,7 @@ func TestTitle(t *testing.T) {
 }
 
 type TestTitleTerminalServiceListener struct {
+	ctx   context.Context
 	resps chan *api.ListenTerminalResponse
 	grpc.ServerStream
 }
@@ -116,7 +121,7 @@ func (listener *TestTitleTerminalServiceListener) Send(resp *api.ListenTerminalR
 }
 
 func (listener *TestTitleTerminalServiceListener) Context() context.Context {
-	return context.Background()
+	return listener.ctx
 }
 
 func (listener *TestTitleTerminalServiceListener) Titles(size int) chan string {
@@ -186,22 +191,25 @@ func TestAnnotations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
 			mux := NewMux()
-			defer mux.Close(context.Background())
+			defer mux.Close(ctx)
 
 			terminalService := NewMuxTerminalService(mux)
 			var err error
 			if test.Opts == nil {
-				_, err = terminalService.Open(context.Background(), test.Req)
+				_, err = terminalService.Open(ctx, test.Req)
 			} else {
-				_, err = terminalService.OpenWithOptions(context.Background(), test.Req, *test.Opts)
+				_, err = terminalService.OpenWithOptions(ctx, test.Req, *test.Opts)
 			}
 			if err != nil {
 				t.Fatal(err)
 				return
 			}
 
-			lr, err := terminalService.List(context.Background(), &api.ListTerminalsRequest{})
+			lr, err := terminalService.List(ctx, &api.ListTerminalsRequest{})
 			if err != nil {
 				t.Fatal(err)
 				return
@@ -277,7 +285,8 @@ func TestConcurrent(t *testing.T) {
 		listenerCount = 2
 	)
 
-	eg, _ := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(context.Background())
+	defer terminals.Close(ctx)
 	for i := 0; i < terminalCount; i++ {
 		alias, err := terminals.Start(exec.Command("/bin/bash", "-i"), TermOptions{
 			ReadTimeout: 0,
@@ -314,8 +323,11 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestWorkDirProvider(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	mux := NewMux()
-	defer mux.Close(context.Background())
+	defer mux.Close(ctx)
 
 	terminalService := NewMuxTerminalService(mux)
 
@@ -324,7 +336,7 @@ func TestWorkDirProvider(t *testing.T) {
 		providedWorkDir string
 	}
 	assertWorkDir := func(arg *AssertWorkDirTest) {
-		term, err := terminalService.Open(context.Background(), &api.OpenTerminalRequest{
+		term, err := terminalService.Open(ctx, &api.OpenTerminalRequest{
 			Workdir: arg.providedWorkDir,
 		})
 		if err != nil {
@@ -333,7 +345,7 @@ func TestWorkDirProvider(t *testing.T) {
 		if diff := cmp.Diff(arg.expectedWorkDir, term.Terminal.CurrentWorkdir); diff != "" {
 			t.Errorf("unexpected output (-want +got):\n%s", diff)
 		}
-		_, err = terminalService.Shutdown(context.Background(), &api.ShutdownTerminalRequest{
+		_, err = terminalService.Shutdown(ctx, &api.ShutdownTerminalRequest{
 			Alias: term.Terminal.Alias,
 		})
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

fix IDE-16

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
