### PR TITLE
Allow user env vars for GitLab subgroups

### DIFF
--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -38,6 +38,7 @@
         "clean": "rimraf lib",
         "build": "tsc",
         "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
+        "test-debug": "mocha --opts mocha.opts --inspect-brk './**/*.spec.ts' --exclude './node_modules/**'",
         "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput"
     },
     "dependencies": {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -427,6 +427,15 @@ export interface UserEnvVar extends UserEnvVarValue {
 }
 
 export namespace UserEnvVar {
+    export const DELIMITER = "/";
+    export const WILDCARD_ASTERISK = "*";
+    const WILDCARD_SHARP = "#"; // TODO(gpl) Where does this come from? Bc we have/had patterns as part of URLs somewhere, maybe...?
+    const MIN_PATTERN_SEGMENTS = 2;
+
+    function isWildcard(c: string): boolean {
+        return c === WILDCARD_ASTERISK || c === WILDCARD_SHARP;
+    }
+
     /**
      * @param variable
      * @returns Either a string containing an error message or undefined.
@@ -452,9 +461,9 @@ export namespace UserEnvVar {
         if (pattern.trim() === "") {
             return "Scope must not be empty.";
         }
-        const split = pattern.split("/");
-        if (split.length < 2) {
-            return "A scope must use the form 'organization/repo'.";
+        const split = splitRepositoryPattern(pattern);
+        if (split.length < MIN_PATTERN_SEGMENTS) {
+            return "A scope must use the form 'organization/repo(/...)'.";
         }
         for (const name of split) {
             if (name !== "*") {
@@ -466,12 +475,19 @@ export namespace UserEnvVar {
         return undefined;
     }
 
-    // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
     export function normalizeRepoPattern(pattern: string) {
         return pattern.toLocaleLowerCase();
     }
 
-    // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
+    export function splitRepositoryPattern(pattern: string): string[] {
+        return pattern.split(DELIMITER);
+    }
+
+    function joinRepositoryPattern(...parts: string[]): string {
+        return parts.join(DELIMITER);
+    }
+
+    // DEPRECATED
     export function score(value: UserEnvVarValue): number {
         // We use a score to enforce precedence:
         //      value/value = 0
@@ -494,27 +510,80 @@ export namespace UserEnvVar {
         return score;
     }
 
-    // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
-    export function filter<T extends UserEnvVarValue>(vars: T[], owner: string, repo: string): T[] {
-        let result = vars.filter((e) => {
-            const [ownerPattern, repoPattern] = splitRepositoryPattern(e.repositoryPattern);
-            if (ownerPattern !== "*" && ownerPattern !== "#" && !!owner && ownerPattern !== owner.toLocaleLowerCase()) {
-                return false;
-            }
-            if (repoPattern !== "*" && repoPattern !== "#" && !!repo && repoPattern !== repo.toLocaleLowerCase()) {
-                return false;
-            }
-            return true;
-        });
+    /**
+     * Matches the given EnvVar pattern against the fully qualified name of the repository:
+     *  - GitHub: "repo/owner"
+     *  - GitLab: "some/nested/repo" (up to MAX_PATTERN_SEGMENTS deep)
+     * @param pattern
+     * @param repoFqn
+     * @returns True if the pattern matches that fully qualified name
+     */
+    export function matchEnvVarPattern(pattern: string, repoFqn: string): boolean {
+        const fqnSegments = splitRepositoryPattern(repoFqn);
+        const patternSegments = splitRepositoryPattern(pattern);
+        if (patternSegments.length < MIN_PATTERN_SEGMENTS) {
+            // Technically not a problem, but we should not allow this for safety reasons.
+            // And because we hisotrically never allowed this (GitHub would always require at least "*/*") we are just keeping old constraints.
+            // Note: Most importantly this guards against arbitrary wildcard matches
+            return false;
+        }
 
+        let i = 0;
+        for (; i < patternSegments.length; i++) {
+            if (i >= fqnSegments.length) {
+                return false;
+            }
+            const fqnSegment = fqnSegments[i];
+            const patternSegment = patternSegments[i];
+            if (!isWildcard(patternSegment) && patternSegment !== fqnSegment.toLocaleLowerCase()) {
+                return false;
+            }
+        }
+        if (fqnSegments.length > i + 1) {
+            // Special case: "*" also matches arbitrary # of segments to the right
+            if (isWildcard(patternSegments[i])) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    // Matches the following patterns for "some/nested/repo", ordered by highest score:
+    //  - exact: some/nested/repo ()
+    //  - partial:
+    //    - some/nested/*
+    //    - some/*
+    //  - generic:
+    //    - */*/*
+    //    - */*
+    // Does NOT match:
+    //  - */repo (number of parts does not match)
+    // cmp. test cases in env-var-service.spec.ts
+    export function filter<T extends UserEnvVarValue>(vars: T[], owner: string, repo: string): T[] {
+        const matchedEnvVars = vars.filter((e) =>
+            matchEnvVarPattern(e.repositoryPattern, joinRepositoryPattern(owner, repo)),
+        );
         const resmap = new Map<string, T[]>();
-        result.forEach((e) => {
+        matchedEnvVars.forEach((e) => {
             const l = resmap.get(e.name) || [];
             l.push(e);
             resmap.set(e.name, l);
         });
 
-        result = [];
+        // In cases of multiple matches per env var: find the best match
+        // Best match is the most specific pattern, where the left-most segment is most significant
+        function scoreMatchedEnvVar(e: T): number {
+            const patternSegments = splitRepositoryPattern(e.repositoryPattern);
+            let result = 0;
+            for (const segment of patternSegments) {
+                // We can assume the pattern matches from context, so we just need to check whether it's a wildcard or not
+                const val = isWildcard(segment) ? 1 : 2;
+                result = result * 10 + val;
+            }
+            return result;
+        }
+        const result = [];
         for (const name of resmap.keys()) {
             const candidates = resmap.get(name);
             if (!candidates) {
@@ -527,12 +596,12 @@ export namespace UserEnvVar {
                 continue;
             }
 
-            let minscore = 10;
-            let bestCandidate: T | undefined;
-            for (const e of candidates) {
-                const score = UserEnvVar.score(e);
-                if (!bestCandidate || score < minscore) {
-                    minscore = score;
+            let bestCandidate = candidates[0];
+            let bestScore = scoreMatchedEnvVar(bestCandidate);
+            for (const e of candidates.slice(1)) {
+                const score = scoreMatchedEnvVar(e);
+                if (score > bestScore) {
+                    bestScore = score;
                     bestCandidate = e;
                 }
             }
@@ -540,14 +609,6 @@ export namespace UserEnvVar {
         }
 
         return result;
-    }
-
-    // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
-    export function splitRepositoryPattern(repositoryPattern: string): string[] {
-        const patterns = repositoryPattern.split("/");
-        const repoPattern = patterns.slice(1).join("/");
-        const ownerPattern = patterns[0];
-        return [ownerPattern, repoPattern];
     }
 }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -463,7 +463,7 @@ export namespace UserEnvVar {
         }
         const split = splitRepositoryPattern(pattern);
         if (split.length < MIN_PATTERN_SEGMENTS) {
-            return "A scope must use the form 'organization/repo(/...)'.";
+            return "A scope must use the form 'organization/repo'.";
         }
         for (const name of split) {
             if (name !== "*") {
@@ -479,35 +479,12 @@ export namespace UserEnvVar {
         return pattern.toLocaleLowerCase();
     }
 
-    export function splitRepositoryPattern(pattern: string): string[] {
+    function splitRepositoryPattern(pattern: string): string[] {
         return pattern.split(DELIMITER);
     }
 
     function joinRepositoryPattern(...parts: string[]): string {
         return parts.join(DELIMITER);
-    }
-
-    // DEPRECATED
-    export function score(value: UserEnvVarValue): number {
-        // We use a score to enforce precedence:
-        //      value/value = 0
-        //      value/*     = 1
-        //      */value     = 2
-        //      */*         = 3
-        //      #/#         = 4 (used for env vars passed through the URL)
-        // the lower the score, the higher the precedence.
-        const [ownerPattern, repoPattern] = splitRepositoryPattern(value.repositoryPattern);
-        let score = 0;
-        if (repoPattern == "*") {
-            score += 1;
-        }
-        if (ownerPattern == "*") {
-            score += 2;
-        }
-        if (ownerPattern == "#" || repoPattern == "#") {
-            score = 4;
-        }
-        return score;
     }
 
     /**

--- a/components/gitpod-protocol/src/user-env-var.spec.ts
+++ b/components/gitpod-protocol/src/user-env-var.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import * as chai from "chai";
+
+import { UserEnvVar } from "./protocol";
+
+const expect = chai.expect;
+
+@suite
+class TestUserEnvVar {
+    public before() {}
+
+    @test public testMatchEnvVarPattern() {
+        interface Test {
+            pattern: string;
+            repository: string;
+            result: boolean;
+        }
+        const tests: Test[] = [
+            {
+                pattern: "*/*",
+                repository: "some/repo",
+                result: true,
+            },
+            {
+                pattern: "*/*",
+                repository: "some/nested/repo",
+                result: false,
+            },
+            {
+                pattern: "*/*",
+                repository: "some/nested/deeply/repo",
+                result: false,
+            },
+            {
+                pattern: "some/*",
+                repository: "some/repo",
+                result: true,
+            },
+            {
+                pattern: "some/*",
+                repository: "some/nested/repo",
+                result: false,
+            },
+            {
+                pattern: "some/*",
+                repository: "some/nested/deeply/repo",
+                result: false,
+            },
+            {
+                pattern: "some/**",
+                repository: "some/repo",
+                result: true,
+            },
+            {
+                pattern: "some/**",
+                repository: "some/nested/repo",
+                result: true,
+            },
+            {
+                pattern: "some/**",
+                repository: "some/nested/deeply/repo",
+                result: true,
+            },
+            {
+                pattern: "some/nested/*",
+                repository: "some/repo",
+                result: false,
+            },
+            {
+                pattern: "some/nested/*",
+                repository: "some/nested/repo",
+                result: true,
+            },
+            {
+                pattern: "some/nested/*",
+                repository: "some/nested/deeply/repo",
+                result: false,
+            },
+            {
+                pattern: "some/nested/*",
+                repository: "another/repo",
+                result: false,
+            },
+            {
+                pattern: "some/nested/**",
+                repository: "some/nested/repo",
+                result: true,
+            },
+            {
+                pattern: "some/nested/**",
+                repository: "some/nested/deeply/repo",
+                result: true,
+            },
+            {
+                pattern: "some/nested/**",
+                repository: "another/repo",
+                result: false,
+            },
+            {
+                pattern: "*/repo",
+                repository: "some/repo",
+                result: true,
+            },
+            {
+                pattern: "*/repo",
+                repository: "some/nested/repo",
+                result: false,
+            },
+            {
+                pattern: "*/repo",
+                repository: "some/nested/deeply/repo",
+                result: false,
+            },
+            {
+                pattern: "*/repo",
+                repository: "another/repo",
+                result: true,
+            },
+            {
+                pattern: "*/*/repo",
+                repository: "some/repo",
+                result: false,
+            },
+            {
+                pattern: "*/*/repo",
+                repository: "some/nested/repo",
+                result: true,
+            },
+            {
+                pattern: "*/*/repo",
+                repository: "some/nested/deeply/repo",
+                result: false,
+            },
+            {
+                pattern: "*/*/repo",
+                repository: "another/repo",
+                result: false,
+            },
+        ];
+
+        for (const test of tests) {
+            const actual = UserEnvVar.matchEnvVarPattern(test.pattern, test.repository);
+            expect(actual, `'${test.repository}' % '${test.pattern}' -> ${test.result}`).to.eq(test.result);
+        }
+    }
+}
+
+module.exports = new TestUserEnvVar();

--- a/components/server/src/workspace/env-var-service.spec.ts
+++ b/components/server/src/workspace/env-var-service.spec.ts
@@ -303,14 +303,14 @@ class TestEnvVarService {
                 id: "1",
                 name: "USER_GLOBAL_TEST",
                 value: "true",
-                repositoryPattern: "*/*",
+                repositoryPattern: "*/**",
                 userId: "1",
             },
             {
                 id: "2",
                 name: "USER_GROUP_TEST",
                 value: "true",
-                repositoryPattern: "geropl-test-group/*",
+                repositoryPattern: "geropl-test-group/**",
                 userId: "1",
             },
             {

--- a/components/server/src/workspace/env-var-service.spec.ts
+++ b/components/server/src/workspace/env-var-service.spec.ts
@@ -286,6 +286,83 @@ class TestEnvVarService {
             });
         }
     }
+
+    @test
+    public async testRegularGitlabSubgroupWithUserEnvVars() {
+        const gitlabSubgroupCommitContext = {
+            repository: {
+                owner: "geropl-test-group/subgroup1",
+                name: "test-project-1",
+            },
+            revision: "abcd123",
+            title: "geropl-test-group/subgroup1/test-project-1",
+        } as CommitContext;
+
+        const userEnvVars: UserEnvVar[] = [
+            {
+                id: "1",
+                name: "USER_GLOBAL_TEST",
+                value: "true",
+                repositoryPattern: "*/*",
+                userId: "1",
+            },
+            {
+                id: "2",
+                name: "USER_GROUP_TEST",
+                value: "true",
+                repositoryPattern: "geropl-test-group/*",
+                userId: "1",
+            },
+            {
+                id: "3",
+                name: "USER_SUBGROUP_TEST",
+                value: "true",
+                repositoryPattern: "geropl-test-group/subgroup1/*",
+                userId: "1",
+            },
+            {
+                id: "4",
+                name: "USER_SUBGROUP_PROJECT_NEGATIVE_TEST",
+                value: "false",
+                repositoryPattern: "*/test-project-1",
+                userId: "1",
+            },
+            {
+                id: "5",
+                name: "USER_SUBGROUP_STAR_TEST",
+                value: "true",
+                repositoryPattern: "geropl-test-group/*/*",
+                userId: "1",
+            },
+            {
+                id: "6",
+                name: "USER_SUBGROUP_NEGATIVE_TEST",
+                value: "false",
+                repositoryPattern: "geropl-test-group/subgroup2/*",
+                userId: "1",
+            },
+            {
+                id: "7",
+                name: "USER_SUBGROUP_PROJECT_TEST",
+                value: "true",
+                repositoryPattern: "*/subgroup1/test-project-1",
+                userId: "1",
+            },
+        ];
+
+        this.init(userEnvVars, []);
+
+        const envVars = await this.envVarService.resolve({
+            owerId: "1",
+            type: "regular",
+            context: { ...gitlabSubgroupCommitContext },
+            projectId: "1",
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [],
+            workspace: userEnvVars.filter((ev) => ev.value === "true"),
+        });
+    }
 }
 
 module.exports = new TestEnvVarService();


### PR DESCRIPTION
## Description

This PR allows to specify environment variable patterns for subgroups in GitLab. This is a long-standing issue that we always avoided to fix, but is now requested/assumed to be working by multiple customers.

We had multiple discussions in the past about deprecating this feature in the first place. However never did so, because it's a very convenient feature, that even if we had better secret support, adds value for users.

For examples of what's possible see the tests [here](https://github.com/gitpod-io/gitpod/pull/17831/files#diff-bec292cdaefd0cda4dcc4402f0b610f28a9a81d5d4a2f90c57e8abb73abcc4a7) and [here](https://github.com/gitpod-io/gitpod/blob/996620b21db10109f15f0598d90f659e9449db53/components/gitpod-protocol/src/user-env-var.spec.ts#L24-L145).


The docs don't need to be changed, but could use a bit more explanation (see [here](https://www.gitpod.io/docs/configure/projects/environment-variables#using-the-account-settings)).

## Related Issue(s)

Fixes WEB-353

## How to test

### Resolution
 - add these user-level env vars to your user config: [link](https://github.com/gitpod-io/gitpod/blob/80b02f61afa159f126346e27863c6c74392dd2e7/components/server/src/workspace/env-var-service.spec.ts#L302-L350)
 - open two workspaces:
   - [project 1](https://gpl-gitlab-env-var.preview.gitpod-dev.com/#https://gitlab.com/geropl-test-group/subgroup1/test-project-1)
   - [project 2](https://gpl-gitlab-env-var.preview.gitpod-dev.com/#https://gitlab.com/geropl-test-group/test-project-2)
 - note that you only see the expected env vars only :heavy_check_mark: 

### Permissions 1
 - in one of the workspacex run `gp env -u USER_GROUP_TEST`, and see the "cannot delete" error :heavy_check_mark: 

### Permissions 2
- in one of the workspaces, run:
```
gp env TEST_NEW=abc
gp env
gp env -u TEST_NEW
gp env
```
and see that it does what you'd expect without errors :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-env-var-1</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-env-var-1.preview.gitpod-dev.com/workspaces" target="_blank">gpl-env-var-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
