### PR TITLE
[server] Removed deprecated api.getEnvVars

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -144,7 +144,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getWorkspaceEnvVars(workspaceId: string): Promise<EnvVarWithValue[]>;
 
     // User env vars
-    getEnvVars(): Promise<UserEnvVarValue[]>;
     getAllEnvVars(): Promise<UserEnvVarValue[]>;
     setEnvVar(variable: UserEnvVarValue): Promise<void>;
     deleteEnvVar(variable: UserEnvVarValue): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -89,7 +89,6 @@ const defaultFunctions: FunctionsConfig = {
     getUserStorageResource: { group: "default", points: 1 },
     updateUserStorageResource: { group: "default", points: 1 },
     getWorkspaceEnvVars: { group: "default", points: 1 },
-    getEnvVars: { group: "default", points: 1 },
     getAllEnvVars: { group: "default", points: 1 },
     setEnvVar: { group: "default", points: 1 },
     deleteEnvVar: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2439,29 +2439,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return result;
     }
 
-    // Get environment variables (filter by repository pattern precedence)
-    // TODO remove then latsest gitpod-cli is deployed
-    async getEnvVars(ctx: TraceContext): Promise<UserEnvVarValue[]> {
-        const user = this.checkUser("getEnvVars");
-        const result = new Map<string, { value: UserEnvVar; score: number }>();
-        for (const value of await this.userDB.getEnvVars(user.id)) {
-            if (!(await this.resourceAccessGuard.canAccess({ kind: "envVar", subject: value }, "get"))) {
-                continue;
-            }
-            const score = UserEnvVar.score(value);
-            const current = result.get(value.name);
-            if (!current || score < current.score) {
-                result.set(value.name, { value, score });
-            }
-        }
-        return [...result.values()].map(({ value: { id, name, value, repositoryPattern } }) => ({
-            id,
-            name,
-            value,
-            repositoryPattern,
-        }));
-    }
-
     // Get all environment variables (unfiltered)
     async getAllEnvVars(ctx: TraceContext): Promise<UserEnvVarValue[]> {
         const user = this.checkUser("getAllEnvVars");


### PR DESCRIPTION
## Description
 Removes a deprecated and unused API method

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
