### PR TITLE
[supervisor] fix port config nil panic

### DIFF
--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -672,8 +672,15 @@ func (pm *Manager) Expose(ctx context.Context, port uint32) error {
 	pm.mu.RUnlock()
 	unlock = false
 
-	public := exists && config.Visibility != "private"
-	err := <-pm.E.Expose(ctx, port, public, config.Protocol)
+	public := false
+	protocol := gitpod.PortProtocolHTTP
+
+	if exists {
+		public = config.Visibility != "private"
+		protocol = config.Protocol
+	}
+
+	err := <-pm.E.Expose(ctx, port, public, protocol)
 	if err != nil && err != context.Canceled {
 		log.WithError(err).WithField("port", port).Error("cannot expose port")
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[supervisor] fix port config nil panic

https://cloudlogging.app.goo.gl/XZuETDEqpauQJjwx9

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal thread](https://gitpod.slack.com/archives/C01KGM9BH54/p1685978831757399)

## How to test
<!-- Provide steps to test this PR -->

This PR contains a test commit, which can help reviewers with testing, but it should be removed before merging

1. start a workspace in preview env
2. run `gp ports test`, workspace should not stop
3. a port should be add in port list

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fix-port-panic</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fix-port-panic.preview.gitpod-dev.com/workspaces" target="_blank">pd-fix-port-panic.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
