### PR TITLE
[ws-manager-mk2] Log conflict errors as info

### DIFF
--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -471,7 +471,7 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 // behaviour as returning an error.
 func errorResultLogConflict(log logr.Logger, err error) (ctrl.Result, error) {
 	if errors.IsConflict(err) {
-		log.Info("conflict error", "error", err)
+		log.Info("conflict error", "error", err.Error())
 		return ctrl.Result{Requeue: true}, nil
 	} else {
 		return ctrl.Result{}, err

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -471,8 +471,8 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 // behaviour as returning an error.
 func errorResultLogConflict(log logr.Logger, err error) (ctrl.Result, error) {
 	if errors.IsConflict(err) {
-		log.Info("conflict error", "error", err.Error())
-		return ctrl.Result{Requeue: true}, nil
+		log.Info("conflict error, requeuing", "error", err.Error())
+		return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
 	} else {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
## Description

Also catch and log conflict errors as `info` from `actOnStatus`, as was already being done for updating the workspace status. 

Reduces error logging noise, after this PR we should now catch all conflict errors and log them at info level

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Check in a preview env that workspace start/stop works, and any reconciler conflict errors are logged at info level.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
