### PR TITLE
[gitpod-db] Fix tables.ts – WEB-441

### DIFF
--- a/components/gitpod-db/src/tables.spec.ts
+++ b/components/gitpod-db/src/tables.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+const expect = chai.expect;
+import { suite, test, timeout } from "mocha-typescript";
+
+import { GitpodTableDescriptionProvider } from "./tables";
+
+@suite.only
+class TablesSpec {
+    async before() {}
+
+    async after() {}
+
+    @test(timeout(10000))
+    public async createAndFindATeam() {
+        const thing = new GitpodTableDescriptionProvider();
+        try {
+            thing.getSortedTables();
+        } catch (error) {
+            expect.fail(error);
+        }
+    }
+}
+
+module.exports = new TablesSpec();

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -98,19 +98,19 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             name: "d_b_workspace_instance_user",
             primaryKeys: ["instanceId", "userId"],
             timeColumn: "_lastModified",
-            dependencies: ["d_b_workspace_instance", "d_b_user"],
+            dependencies: ["d_b_user"],
         },
         {
             name: "d_b_workspace_report_entry",
             primaryKeys: ["uid"],
             timeColumn: "time",
-            dependencies: ["d_b_workspace"],
+            dependencies: [],
         },
         {
             name: "d_b_snapshot",
             primaryKeys: ["id"],
             timeColumn: "creationTime",
-            dependencies: ["d_b_workspace"],
+            dependencies: [],
         },
         {
             name: "d_b_email_domain_filter",


### PR DESCRIPTION
Removed dependencies to tables which were un-configured in https://github.com/gitpod-io/gitpod/pull/17698. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-441

## How to test
* unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
