### PR TITLE
[server] Helper for req.login with async support

### DIFF
--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -17,6 +17,7 @@ import { trackLogin } from "../analytics";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { SessionHandler } from "../session-handler";
 import { AuthJWT } from "./jwt";
+import { login } from "../express-util";
 
 /**
  * The login completion handler pulls the strings between the OAuth2 flow, the ToS flow, and the session management.
@@ -38,15 +39,7 @@ export class LoginCompletionHandler {
         const logContext = LogContext.from({ user, request });
 
         try {
-            await new Promise<void>((resolve, reject) => {
-                request.login(user, (err) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });
+            await login(request, user);
         } catch (err) {
             if (authHost) {
                 increaseLoginCounter("failed", authHost);

--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -8,6 +8,7 @@ import { URL } from "url";
 import * as express from "express";
 import * as crypto from "crypto";
 import * as session from "express-session";
+import { User } from "@gitpod/gitpod-protocol";
 
 export const query = (...tuples: [string, string][]) => {
     if (tuples.length === 0) {
@@ -50,6 +51,18 @@ export function destroySession(session: session.Session): Promise<void> {
         session.destroy((error: any) => {
             if (error) {
                 reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+export function login(req: express.Request, user: User): Promise<void> {
+    return new Promise((resolve, reject) => {
+        req.login(user, (err) => {
+            if (err) {
+                reject(err);
             } else {
                 resolve();
             }

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -16,6 +16,7 @@ import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib
 import { ResponseError } from "vscode-ws-jsonrpc";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { reportJWTCookieIssued } from "../prometheus-metrics";
+import { login } from "../express-util";
 
 @injectable()
 export class IamSessionApp {
@@ -64,15 +65,7 @@ export class IamSessionApp {
 
         const user = existingUser || (await this.createNewOIDCUser(payload));
 
-        await new Promise<void>((resolve, reject) => {
-            req.login(user, (err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
+        await login(req, user);
 
         const isJWTCookieExperimentEnabled = await getExperimentsClientForBackend().getValueAsync(
             "jwtSessionCookieEnabled",

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -19,6 +19,7 @@ import { reportJWTCookieIssued, reportSessionWithJWT } from "./prometheus-metric
 import { AuthJWT } from "./auth/jwt";
 import { UserDB } from "@gitpod/gitpod-db/lib";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { login } from "./express-util";
 
 @injectable()
 export class SessionHandler {
@@ -154,7 +155,7 @@ export class SessionHandler {
             // We set the user object on the request to signal the user is authenticated.
             // Passport uses the `user` property on the request to determine if the session
             // is authenticated.
-            req.user = user;
+            await login(req, user);
 
             req.sessionID = uuidv4();
 

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -17,7 +17,7 @@ import { Permission } from "@gitpod/gitpod-protocol/lib/permission";
 import { parseWorkspaceIdFromHostname } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
 import { SessionHandler } from "../session-handler";
 import { URL } from "url";
-import { saveSession, getRequestingClientInfo, destroySession } from "../express-util";
+import { saveSession, getRequestingClientInfo, destroySession, login } from "../express-util";
 import { GitpodToken, GitpodTokenType, User } from "@gitpod/gitpod-protocol";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { increaseLoginCounter } from "../prometheus-metrics";
@@ -167,15 +167,7 @@ export class UserController {
                 }
 
                 // Create a session for the admin user.
-                await new Promise<void>((resolve, reject) => {
-                    req.login(user, (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    });
-                });
+                await login(req, user);
 
                 // Redirect the admin-user to the Org Settings page.
                 // The dashboard is expected to render the Onboading flow instead of the regular view,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Helper to execute req.login but with async support, reduces duplication across files

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
