### PR TITLE
[ws-manager-mk2] Remove ws-manager-mk2 from experimental section

### DIFF
--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -33,7 +33,6 @@ type Config struct {
 }
 
 type WorkspaceControllerConfig struct {
-	Enabled                 bool   `json:"enabled"`
 	WorkingAreaSuffix       string `json:"workingAreaSuffix"`
 	MaxConcurrentReconciles int    `json:"maxConcurrentReconciles,omitempty"`
 }

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -33,8 +33,7 @@ type Config struct {
 }
 
 type WorkspaceControllerConfig struct {
-	WorkingAreaSuffix       string `json:"workingAreaSuffix"`
-	MaxConcurrentReconciles int    `json:"maxConcurrentReconciles,omitempty"`
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles,omitempty"`
 }
 
 type RuntimeConfig struct {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -180,8 +180,6 @@ func NewDaemon(config Config) (*Daemon, error) {
 	}
 
 	contentCfg := config.Content
-	contentCfg.WorkingArea += config.WorkspaceController.WorkingAreaSuffix
-	contentCfg.WorkingAreaNode += config.WorkspaceController.WorkingAreaSuffix
 
 	xfs, err := quota.NewXFS(contentCfg.WorkingArea)
 	if err != nil {

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -477,13 +477,6 @@ else
 fi
 
 #
-# wsManagerMk2
-#
-if [[ "${GITPOD_WSMANAGER_MK2}" == "true" ]]; then
-  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.workspace.useWsmanagerMk2" "true"
-fi
-
-#
 # Enable SpiceDB on all preview envs
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.spicedb.enabled "true"

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -104,7 +104,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 		procLimit = ucfg.Workspace.ProcLimit
 
-		wscontroller.Enabled = ucfg.Workspace.UseWsmanagerMk2
 		wscontroller.WorkingAreaSuffix = "-mk2"
 		wscontroller.MaxConcurrentReconciles = 15
 

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -104,7 +104,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 		procLimit = ucfg.Workspace.ProcLimit
 
-		wscontroller.WorkingAreaSuffix = "-mk2"
 		wscontroller.MaxConcurrentReconciles = 15
 
 		if ucfg.Workspace.WorkspaceCIDR != "" {
@@ -132,8 +131,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				WorkspaceCIDR: workspaceCIDR,
 			},
 			Content: content.Config{
-				WorkingArea:     "/mnt/workingarea",
-				WorkingAreaNode: HostWorkingArea,
+				WorkingArea:     ContainerWorkingAreaMk2,
+				WorkingAreaNode: HostWorkingAreaMk2,
 				TmpDir:          "/tmp",
 				UserNamespaces: content.UserNamespacesConfig{
 					FSShift: content.FSShiftMethod(fsshift),
@@ -167,7 +166,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Enabled:  true,
 				Interval: util.Duration(5 * time.Minute),
 				Locations: []diskguard.LocationConfig{{
-					Path:          "/mnt/workingarea",
+					Path:          ContainerWorkingAreaMk2,
 					MinBytesAvail: 21474836480,
 				}},
 			},

--- a/install/installer/pkg/components/ws-daemon/constants.go
+++ b/install/installer/pkg/components/ws-daemon/constants.go
@@ -9,7 +9,6 @@ import "github.com/gitpod-io/gitpod/common-go/baseserver"
 const (
 	Component               = "ws-daemon"
 	ServicePort             = 8080
-	HostWorkingArea         = "/var/gitpod/workspaces"
 	HostWorkingAreaMk2      = "/var/gitpod/workspaces-mk2"
 	ContainerWorkingAreaMk2 = "/mnt/workingarea-mk2"
 	HostBackupPath          = "/var/gitpod/tmp/backup"

--- a/install/installer/pkg/components/ws-daemon/constants.go
+++ b/install/installer/pkg/components/ws-daemon/constants.go
@@ -11,7 +11,6 @@ const (
 	ServicePort             = 8080
 	HostWorkingArea         = "/var/gitpod/workspaces"
 	HostWorkingAreaMk2      = "/var/gitpod/workspaces-mk2"
-	ContainerWorkingArea    = "/mnt/workingarea"
 	ContainerWorkingAreaMk2 = "/mnt/workingarea-mk2"
 	HostBackupPath          = "/var/gitpod/tmp/backup"
 	TLSSecretName           = "ws-daemon-tls"

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,9 +72,9 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			}},
 		},
 		{
-			Name: "working-area",
+			Name: "working-area-mk2",
 			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-				Path: HostWorkingArea,
+				Path: HostWorkingAreaMk2,
 				Type: func() *corev1.HostPathType { r := corev1.HostPathDirectoryOrCreate; return &r }(),
 			}},
 		},
@@ -146,8 +145,8 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:             "working-area",
-			MountPath:        ContainerWorkingArea,
+			Name:             "working-area-mk2",
+			MountPath:        ContainerWorkingAreaMk2,
 			MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationBidirectional; return &r }(),
 		},
 		{
@@ -187,29 +186,6 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		common.CAVolumeMount(),
 	}
-
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.Workspace != nil && cfg.Workspace.UseWsmanagerMk2 {
-			mk2WorkingAreaVolume := corev1.Volume{
-				Name: "working-area-mk2",
-				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-					Path: HostWorkingAreaMk2,
-					Type: func() *corev1.HostPathType { r := corev1.HostPathDirectoryOrCreate; return &r }(),
-				}},
-			}
-
-			mk2WorkingAreaMount := corev1.VolumeMount{
-				Name:             "working-area-mk2",
-				MountPath:        ContainerWorkingAreaMk2,
-				MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationBidirectional; return &r }(),
-			}
-
-			volumes = append(volumes, mk2WorkingAreaVolume)
-			volumeMounts = append(volumeMounts, mk2WorkingAreaMount)
-		}
-
-		return nil
-	})
 
 	tolerations := []corev1.Toleration{
 		{

--- a/install/installer/pkg/components/ws-daemon/role.go
+++ b/install/installer/pkg/components/ws-daemon/role.go
@@ -6,25 +6,12 @@ package wsdaemon
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func role(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var useMk2 bool
-	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		if ucfg.Workspace != nil {
-			useMk2 = ucfg.Workspace.UseWsmanagerMk2
-		}
-		return nil
-	})
-	if !useMk2 {
-		return nil, nil
-	}
-
 	return []runtime.Object{
 		&rbacv1.Role{
 			TypeMeta: common.TypeMetaRole,

--- a/install/installer/pkg/components/ws-daemon/rolebinding.go
+++ b/install/installer/pkg/components/ws-daemon/rolebinding.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,33 +54,26 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Namespace: ctx.Namespace,
 			}},
 		},
-	}
-
-	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		if ucfg.Workspace != nil && ucfg.Workspace.UseWsmanagerMk2 {
-			bindings = append(bindings, &rbacv1.RoleBinding{
-				TypeMeta: common.TypeMetaRoleBinding,
-				ObjectMeta: metav1.ObjectMeta{
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: common.WorkspaceSecretsNamespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     Component,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
 					Name:      Component,
-					Namespace: common.WorkspaceSecretsNamespace,
+					Namespace: ctx.Namespace,
 				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     Component,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      Component,
-						Namespace: ctx.Namespace,
-					},
-				},
-			})
-		}
-
-		return nil
-	})
+			},
+		},
+	}
 
 	return bindings, nil
 }

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -87,7 +87,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	workspaceClusterHost := fmt.Sprintf("ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
 	workspaceURLTemplate := fmt.Sprintf("https://{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
 	workspacePortURLTemplate := fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
-	hostWorkingArea := wsdaemon.HostWorkingArea
+	hostWorkingArea := wsdaemon.HostWorkingAreaMk2
 
 	rateLimits := map[string]grpc.RateLimit{}
 
@@ -148,10 +148,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		}
 		rateLimits = ucfg.Workspace.WSManagerRateLimits
 
-		if ucfg.Workspace.UseWsmanagerMk2 {
-			hostWorkingArea = wsdaemon.HostWorkingAreaMk2
-			experimentalMode = ucfg.Workspace.UseMk2ExperimentalMode
-		}
+		experimentalMode = ucfg.Workspace.UseMk2ExperimentalMode
 
 		return nil
 	})

--- a/install/installer/pkg/components/ws-manager-mk2/objects.go
+++ b/install/installer/pkg/components/ws-manager-mk2/objects.go
@@ -6,22 +6,10 @@ package wsmanagermk2
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var Objects common.RenderFunc = func(cfg *common.RenderContext) ([]runtime.Object, error) {
-	var useMk2 bool
-	_ = cfg.WithExperimental(func(ucfg *experimental.Config) error {
-		if ucfg.Workspace != nil {
-			useMk2 = ucfg.Workspace.UseWsmanagerMk2
-		}
-		return nil
-	})
-	if !useMk2 {
-		return nil, nil
-	}
-
 	return common.CompositeRenderFunc(
 		namespace,
 		crd,

--- a/install/installer/pkg/components/ws-proxy/role.go
+++ b/install/installer/pkg/components/ws-proxy/role.go
@@ -6,7 +6,6 @@ package wsproxy
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,23 +23,16 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{"workspace.gitpod.io"},
+			Resources: []string{"workspaces"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
 	}
-
-	ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		if ucfg.Workspace != nil && ucfg.Workspace.UseWsmanagerMk2 {
-			rules = append(rules, rbacv1.PolicyRule{
-				APIGroups: []string{"workspace.gitpod.io"},
-				Resources: []string{"workspaces"},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			})
-		}
-
-		return nil
-	})
 
 	return []runtime.Object{&rbacv1.Role{
 		TypeMeta: common.TypeMetaRole,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -133,7 +133,6 @@ type WorkspaceConfig struct {
 	} `json:"contentService"`
 
 	EnableProtectedSecrets *bool `json:"enableProtectedSecrets"`
-	UseWsmanagerMk2        bool  `json:"useWsmanagerMk2,omitempty"`
 	UseMk2ExperimentalMode bool  `json:"useMk2ExperimentalMode,omitempty"`
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-209

## How to test
- Open workspace in preview environment

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-remove-9db19ffeb4</li>
	<li><b>🔗 URL</b> - <a href="https://fo-remove-9db19ffeb4.preview.gitpod-dev.com/workspaces" target="_blank">fo-remove-9db19ffeb4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
