### PR TITLE
Update usage export toast style

### DIFF
--- a/components/dashboard/src/components/toasts/Toast.tsx
+++ b/components/dashboard/src/components/toasts/Toast.tsx
@@ -70,7 +70,7 @@ export const Toast: FC<Props> = ({ id, message, duration = 5000, autoHide = true
                 "relative flex justify-between items-start",
                 "w-full md:w-112 max-w-full",
                 "p-4 md:rounded-md",
-                "bg-gray-800 dark:bg-gray-100",
+                "bg-gray-800 dark:bg-gray-50",
                 "text-white dark:text-gray-800",
                 "transition-transform animate-toast-in-right",
             )}

--- a/components/dashboard/src/usage/download/DownloadUsage.tsx
+++ b/components/dashboard/src/usage/download/DownloadUsage.tsx
@@ -129,7 +129,7 @@ const DownloadUsageToast: FC<DownloadUsageToastProps> = ({ attributionId, endDat
         <div className="flex flex-row items-start justify-between space-x-2">
             <div>
                 <span>Usage export complete.</span>
-                <p>
+                <p className="dark:text-gray-500">
                     {readableSize} &middot; {formattedCount} {data.count !== 1 ? "entries" : "entry"} exported
                 </p>
             </div>


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/17791 (Cc @selfcontained @easyCZ), this will make some minor style changes for the usage export toast on the dark theme. 🌔 

| BEFORE | AFTER |
|--------|--------|
| <img width="592" alt="Frame 1570" src="https://github.com/gitpod-io/gitpod/assets/120486/da1f7957-8725-449e-abe6-72fcc1098d4d"> | <img width="592" alt="Frame 1569" src="https://github.com/gitpod-io/gitpod/assets/120486/d5f50571-4e6e-4e47-83c3-5d47a45040a7"> |

## How to test
Try exporting usage for an organization and notice the subtle color changes as described above.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-8fb0b83e75</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-8fb0b83e75.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-8fb0b83e75.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
