### PR TITLE
Adjust filtering of usage entries

### DIFF
--- a/components/dashboard/src/usage/UsageEntry.tsx
+++ b/components/dashboard/src/usage/UsageEntry.tsx
@@ -18,6 +18,11 @@ type Props = {
     usage: Usage;
 };
 export const UsageEntry: FC<Props> = ({ usage }) => {
+    // We shouldn't be delivering these to the client, but just in case, don't try to render them
+    if (usage.kind !== "workspaceinstance") {
+        return null;
+    }
+
     const metadata = usage.metadata as WorkspaceInstanceUsageData;
 
     return (

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -88,11 +88,7 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
         return errorMessage;
     }, [usagePage.error]);
 
-    // TODO: filter this at the api layer
-    const currentPaginatedResults = useMemo(
-        () => usagePage.data?.usageEntriesList.filter((u) => u.kind === "workspaceinstance") ?? [],
-        [usagePage.data?.usageEntriesList],
-    );
+    const usageEntries = usagePage.data?.usageEntriesList || [];
 
     return (
         <>
@@ -146,13 +142,12 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
 
                         {/* results */}
                         {!usagePage.isLoading &&
-                            currentPaginatedResults &&
-                            currentPaginatedResults.map((usage) => {
+                            usageEntries.map((usage) => {
                                 return <UsageEntry key={usage.id} usage={usage} />;
                             })}
 
                         {/* No results */}
-                        {!usagePage.isLoading && currentPaginatedResults.length === 0 && !errorMessage && (
+                        {!usagePage.isLoading && usageEntries.length === 0 && !errorMessage && (
                             <div className="flex flex-col w-full mb-8">
                                 <Heading2 className="text-center mt-8">No sessions found.</Heading2>
                                 <Subheading className="text-center mt-1">

--- a/components/dashboard/src/usage/download/transform-usage-record.ts
+++ b/components/dashboard/src/usage/download/transform-usage-record.ts
@@ -7,8 +7,7 @@
 import { Usage, WorkspaceInstanceUsageData } from "@gitpod/gitpod-protocol/lib/usage";
 
 export const transformUsageRecord = (usage: Usage): UsageCSVRow | undefined => {
-    // TODO: figure out what we want to do w/ invoice usage entries
-    if (usage.kind === "invoice") {
+    if (usage.kind !== "workspaceinstance") {
         return;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adjusts a few places on the dashboard UI that are filtering usage entries by `kind`. The API already filters by `kind="workspaceinstance"`, but I think it would be good to be guarding a bit in the client still so we don't accidentally break if we try to render an unexpected entry. These changes optimize where we filter when rendering.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-438

## How to test
<!-- Provide steps to test this PR -->
* Load usage page, create a workspace to have a record. 
* There should be no visual changes with this PR

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-4990499d995</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-4990499d995.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-4990499d995.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
