### PR TITLE
ensure progress bar width is not greater than 100%

### DIFF
--- a/components/dashboard/src/components/ProgressBar.tsx
+++ b/components/dashboard/src/components/ProgressBar.tsx
@@ -12,7 +12,10 @@ type Props = {
     value: number;
     inverted?: boolean;
 };
-export const ProgressBar: FC<Props> = ({ value: percent, inverted }) => {
+export const ProgressBar: FC<Props> = ({ value, inverted }) => {
+    // ensure we have a whole number <= 100
+    const percent = Math.min(Math.round(value), 100);
+
     return (
         <div
             className={classNames("w-full rounded-full h-2 my-1.5", invertable("bg-gray-300", "bg-gray-600", inverted))}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensure progress bar is not wider than 100%

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-451

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
