### PR TITLE
[supervisor] concurrent map writes when terminals close

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -469,10 +469,7 @@ func Run(options ...RunOption) {
 	cancel()
 	ideWG.Wait()
 	// terminate all terminal processes once the IDE is gone
-	err = termMux.Close(terminalShutdownCtx)
-	if err != nil {
-		log.WithError(err).Error("terminal closing failed")
-	}
+	termMux.Close(terminalShutdownCtx)
 
 	wg.Wait()
 }

--- a/components/supervisor/pkg/terminal/terminal.go
+++ b/components/supervisor/pkg/terminal/terminal.go
@@ -104,7 +104,6 @@ func (m *Mux) Close(ctx context.Context) error {
 			err := v.Close(ctx)
 			if err != nil {
 				log.WithError(err).WithField("alias", k).Warn("Error while closing pseudo-terminal")
-				return err
 			}
 			return nil
 		})

--- a/components/supervisor/pkg/terminal/terminal.go
+++ b/components/supervisor/pkg/terminal/terminal.go
@@ -91,7 +91,7 @@ func (m *Mux) Start(cmd *exec.Cmd, options TermOptions) (alias string, err error
 
 // Close closes all terminals.
 // force kills it's processes when the context gets cancelled
-func (m *Mux) Close(ctx context.Context) error {
+func (m *Mux) Close(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -114,8 +114,6 @@ func (m *Mux) Close(ctx context.Context) error {
 	for k := range m.terms {
 		delete(m.terms, k)
 	}
-
-	return nil
 }
 
 // CloseTerminal closes a terminal and ends the process that runs in it.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[supervisor] concurrent map writes when terminals close

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [IDE-147](https://linear.app/gitpod/issue/IDE-147)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fix-ide-147</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fix-ide-147.preview.gitpod-dev.com/workspaces" target="_blank">pd-fix-ide-147.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
