### PR TITLE
[db] Drop sessions table & db - WEB-106

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -29,21 +29,6 @@ export interface TableDescriptionProvider {
 export const TableDescriptionProvider = Symbol("TableDescriptionProvider");
 
 @injectable()
-export class GitpodSessionTableDescriptionProvider implements TableDescriptionProvider {
-    readonly name = "gitpod-sessions";
-    getSortedTables(): TableDescription[] {
-        return [
-            {
-                name: "sessions",
-                primaryKeys: ["session_id"],
-                timeColumn: "_lastModified",
-                expiryColumn: "expires",
-            },
-        ];
-    }
-}
-
-@injectable()
 export class GitpodTableDescriptionProvider implements TableDescriptionProvider {
     readonly name = "gitpod";
     protected readonly tables: TableDescription[] = [

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -16,7 +16,7 @@ import { Authenticator } from "./auth/authenticator";
 import { UserController } from "./user/user-controller";
 import { EventEmitter } from "events";
 import { toIWebSocket } from "@gitpod/gitpod-protocol/lib/messaging/node/connection";
-import { WsExpressHandler, WsRequestHandler } from "./express/ws-handler";
+import { WsExpressHandler, WsNextFunction, WsRequestHandler } from "./express/ws-handler";
 import { isAllowedWebsocketDomain, bottomErrorHandler, unhandledToError } from "./express-util";
 import { createWebSocketConnection } from "vscode-ws-jsonrpc/lib";
 import { MessageBusIntegration } from "./workspace/messagebus-integration";
@@ -226,11 +226,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                     const websocket = toIWebSocket(ws);
                     (request as any).wsConnection = createWebSocketConnection(websocket, console);
                 },
-<<<<<<< HEAD
                 this.sessionHandler.websocket(),
-=======
-                this.sessionHandler.websocket,
->>>>>>> d086117aa (add ws handler)
                 ...initSessionHandlers,
                 wsPingPongHandler.handler(),
                 (ws: ws, req: express.Request) => {

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -226,7 +226,11 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                     const websocket = toIWebSocket(ws);
                     (request as any).wsConnection = createWebSocketConnection(websocket, console);
                 },
+<<<<<<< HEAD
                 this.sessionHandler.websocket(),
+=======
+                this.sessionHandler.websocket,
+>>>>>>> d086117aa (add ws handler)
                 ...initSessionHandlers,
                 wsPingPongHandler.handler(),
                 (ws: ws, req: express.Request) => {

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -16,7 +16,7 @@ import { Authenticator } from "./auth/authenticator";
 import { UserController } from "./user/user-controller";
 import { EventEmitter } from "events";
 import { toIWebSocket } from "@gitpod/gitpod-protocol/lib/messaging/node/connection";
-import { WsExpressHandler, WsNextFunction, WsRequestHandler } from "./express/ws-handler";
+import { WsExpressHandler, WsRequestHandler } from "./express/ws-handler";
 import { isAllowedWebsocketDomain, bottomErrorHandler, unhandledToError } from "./express-util";
 import { createWebSocketConnection } from "vscode-ws-jsonrpc/lib";
 import { MessageBusIntegration } from "./workspace/messagebus-integration";

--- a/install/installer/pkg/components/database/incluster/init/01-create-and-init-sessions-db.sql
+++ b/install/installer/pkg/components/database/incluster/init/01-create-and-init-sessions-db.sql
@@ -7,6 +7,7 @@ CREATE DATABASE IF NOT EXISTS `gitpod-sessions` CHARSET utf8mb4;
 
 USE `gitpod-sessions`;
 
+-- This removed again in later migration -  in pkg/components/database/incluster/init/04-drop-sessions-db.sql
 CREATE TABLE IF NOT EXISTS sessions (
    `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
    `expires` int(11) unsigned NOT NULL,

--- a/install/installer/pkg/components/database/incluster/init/04-drop-sessions-db.sql
+++ b/install/installer/pkg/components/database/incluster/init/04-drop-sessions-db.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+-- must be idempotent
+
+USE `gitpod-sessions`;
+
+DROP TABLE IF EXISTS `sessions`;
+
+DROP DATABASE IF EXISTS `gitpod-sessions`;

--- a/install/installer/pkg/components/database/init/files/00-create-and-init-sessions-db.sql
+++ b/install/installer/pkg/components/database/init/files/00-create-and-init-sessions-db.sql
@@ -7,6 +7,7 @@ CREATE DATABASE IF NOT EXISTS `gitpod-sessions` CHARSET utf8mb4;
 
 USE `gitpod-sessions`;
 
+-- This removed again in later migration -  in pkg/components/database/incluster/init/04-drop-sessions-db.sql
 CREATE TABLE IF NOT EXISTS sessions (
    `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
    `expires` int(11) unsigned NOT NULL,

--- a/install/installer/pkg/components/database/init/files/02-drop-sessions-db.sql
+++ b/install/installer/pkg/components/database/init/files/02-drop-sessions-db.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+-- must be idempotent
+
+USE `gitpod-sessions`;
+
+DROP TABLE IF EXISTS `sessions`;
+
+DROP DATABASE IF EXISTS `gitpod-sessions`;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/17846

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-db-drop-sessions</li>
	<li><b>🔗 URL</b> - <a href="https://mp-db-drop-sessions.preview.gitpod-dev.com/workspaces" target="_blank">mp-db-drop-sessions.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
 
/hold
