### PR TITLE
[preview] Enable network limiting

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -498,6 +498,13 @@ rm -f spicedb-secret.yaml
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.frontendDevEnabled "true"
 
+#
+# Enable network limiting
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.enabled "true"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.enforce "true"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.connectionsPerMinute "3000"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.bucketSize "3000"
 
 log_success "Generated config at $INSTALLER_CONFIG_PATH"
 


### PR DESCRIPTION
## Description
Enables network limiting in preview environments

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-69

## How to test
- Open workspace in preview environment
- SSH into node
- Find workspacekit process and enter the network namespace with nsenter
- Use `nft list ruleset` to list networking rules

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-previewa1988b53bd</li>
	<li><b>🔗 URL</b> - <a href="https://fo-previewa1988b53bd.preview.gitpod-dev.com/workspaces" target="_blank">fo-previewa1988b53bd.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>
