### PR TITLE
Add Bitbucket to Git Providers under Orgs – WEB-454

### DIFF
--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -22,7 +22,7 @@ import { getGitpodService, gitpodHostUrl } from "../../service/service";
 import { UserContext } from "../../user-context";
 import { useToast } from "../../components/toasts/Toasts";
 
-type ProviderType = "GitHub" | "GitLab" | "BitbucketServer";
+type ProviderType = "GitHub" | "GitLab" | "Bitbucket" | "BitbucketServer";
 
 type Props = {
     provider?: AuthProviderEntry;
@@ -212,6 +212,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                     >
                         <option value="GitHub">GitHub</option>
                         <option value="GitLab">GitLab</option>
+                        <option value="Bitbucket">Bitbucket Cloud</option>
                         <option value="BitbucketServer">Bitbucket Server</option>
                     </SelectInputField>
                     <TextInputField
@@ -289,6 +290,8 @@ const getPlaceholderForIntegrationType = (type: ProviderType) => {
             return "github.example.com";
         case "GitLab":
             return "gitlab.example.com";
+        case "Bitbucket":
+            return "bitbucket.org";
         case "BitbucketServer":
             return "bitbucket.example.com";
         default:
@@ -307,6 +310,9 @@ const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = (
             break;
         case "GitLab":
             docsUrl = `https://www.gitpod.io/docs/configure/authentication/gitlab#registering-a-self-hosted-gitlab-installation`;
+            break;
+        case "Bitbucket":
+            docsUrl = `https://www.gitpod.io/docs/configure/authentication`;
             break;
         case "BitbucketServer":
             docsUrl = "https://www.gitpod.io/docs/configure/authentication/bitbucket-server";

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
-import { FunctionComponent, useCallback, useContext, useMemo, useState } from "react";
+import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Button } from "../../components/Button";
 import { InputField } from "../../components/forms/InputField";
 import { SelectInputField } from "../../components/forms/SelectInputField";
@@ -55,6 +55,13 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
 
         return url;
     }, [host, isNew, savedProvider?.oauth.callBackUrl, type]);
+
+    // "bitbucket.org" is set as host value whenever "Bitbucket" is selected
+    useEffect(() => {
+        if (isNew) {
+            setHost(type === "Bitbucket" ? "bitbucket.org" : "");
+        }
+    }, [isNew, type]);
 
     const [savingProvider, setSavingProvider] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
@@ -218,7 +225,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                     <TextInputField
                         label="Provider Host Name"
                         value={host}
-                        disabled={!isNew}
+                        disabled={!isNew || type === "Bitbucket"}
                         placeholder={getPlaceholderForIntegrationType(type)}
                         error={hostError}
                         onChange={setHost}

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -23,7 +23,6 @@ import exclamation from "../images/exclamation.svg";
 import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
-import { isGitpodIo } from "../utils";
 import { AuthEntryItem } from "./AuthEntryItem";
 import { IntegrationEntryItem } from "./IntegrationItemEntry";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
@@ -546,14 +545,6 @@ export function GitIntegrationModal(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clientId, clientSecret, type]);
 
-    // "bitbucket.org" is set as host value whenever "Bitbucket" is selected
-    useEffect(() => {
-        if (props.mode === "new") {
-            updateHostValue(type === "Bitbucket" ? "bitbucket.org" : "");
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [type]);
-
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
 
@@ -717,8 +708,6 @@ export function GitIntegrationModal(
                 return "gitlab.example.com";
             case "BitbucketServer":
                 return "bitbucket.example.com";
-            case "Bitbucket":
-                return "bitbucket.org";
             default:
                 return "";
         }
@@ -766,7 +755,6 @@ export function GitIntegrationModal(
                             >
                                 <option value="GitHub">GitHub</option>
                                 <option value="GitLab">GitLab</option>
-                                {!isGitpodIo() && <option value="Bitbucket">Bitbucket</option>}
                                 <option value="BitbucketServer">Bitbucket Server</option>
                             </select>
                         </div>
@@ -790,7 +778,7 @@ export function GitIntegrationModal(
                         </label>
                         <input
                             id="hostName"
-                            disabled={mode === "edit" || type === "Bitbucket"}
+                            disabled={mode === "edit"}
                             type="text"
                             placeholder={getPlaceholderForIntegrationType(type)}
                             value={host}


### PR DESCRIPTION
## Description
This PR adds the option to configure Bitbucket (Cloud) as Git provider under the organization. 

NOTE: This is currently only expected to work in Single-Org mode!

<img width="978" alt="Screenshot 2023-06-07 at 17 05 12" src="https://github.com/gitpod-io/gitpod/assets/914497/bd24cae4-3bb8-40b4-b149-1ee9d2d15580">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-454

## How to test
0. Edit `server-config` configmap and remove the bitbucket integration + restart server pod.
1. Create an Org
2. Under /settings/git, create a new integration with Bitbucket (Cloud)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-org-git04583328f9</li>
	<li><b>🔗 URL</b> - <a href="https://at-org-git04583328f9.preview.gitpod-dev.com/workspaces" target="_blank">at-org-git04583328f9.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
