### PR TITLE
configure BROWSER in supervisor

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1011,6 +1011,10 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 		envs["PROMPT_COMMAND"] = "history -a"
 	}
 
+	if _, ok := envs["BROWSER"]; !ok {
+		envs["BROWSER"] = "gp preview --external"
+	}
+
 	var env, envn []string
 	for nme, val := range envs {
 		log.WithField("envvar", nme).Debug("passing environment variable to IDE")

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,6 +21,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
+			"BROWSER=gp preview --external",
 			"HISTFILE=/workspace/.gitpod/.shell_history",
 			"PROMPT_COMMAND=history -a",
 		)
@@ -90,14 +91,20 @@ func TestBuildChildProcEnv(t *testing.T) {
 			Name:  "ots",
 			Input: []string{},
 			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
-			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.shell_history",
+			Expectation: []string{
+				"HOME=/home/gitpod",
+				"BROWSER=gp preview --external",
+				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
 		{
 			Name:  "failed ots",
 			Input: []string{},
 			OTS:   `invalid json`,
-			Expectation: []string{"HOME=/home/gitpod", "HISTFILE=/workspace/.gitpod/.shell_history",
+			Expectation: []string{
+				"HOME=/home/gitpod",
+				"BROWSER=gp preview --external",
+				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In order to allow tools to access the browser which rely on it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14046

## How to test
<!-- Provide steps to test this PR -->

Test both in VS Code Browser and Desktop for task and regular terminals:
```
yarn global add @teambit/bvm
bvm install
echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc && source ~/.bashrc
PATH=$HOME/bin:$PATH
bit login
```

In all cases it should open the browser.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-code-browser</li>
	<li><b>🔗 URL</b> - <a href="https://ak-code-browser.preview.gitpod-dev.com/workspaces" target="_blank">ak-code-browser.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
