### PR TITLE
Add phone verification analytics events

### DIFF
--- a/components/server/src/auth/verification-service.ts
+++ b/components/server/src/auth/verification-service.ts
@@ -108,7 +108,7 @@ export class VerificationService {
 
         // Help us identify if verification codes are not able to send via requested channel
         if (channel !== verification.channel) {
-            log.info("Verification code sent via different channel", {
+            log.info("Verification code sent via different channel than system requested", {
                 phoneNumber,
                 status: verification.status,
                 // actual channel verification was created on

--- a/components/server/src/auth/verification-service.ts
+++ b/components/server/src/auth/verification-service.ts
@@ -106,6 +106,18 @@ export class VerificationService {
             requestedChannel: channel,
         });
 
+        // Help us identify if verification codes are not able to send via requested channel
+        if (channel !== verification.channel) {
+            log.info("Verification code sent via different channel", {
+                phoneNumber,
+                status: verification.status,
+                // actual channel verification was created on
+                channel: verification.channel,
+                // channel we requested - these could differ if a channel is not enabled in a specific country
+                requestedChannel: channel,
+            });
+        }
+
         return verification;
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -739,20 +739,31 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     public async sendPhoneNumberVerificationToken(ctx: TraceContext, rawPhoneNumber: string): Promise<void> {
-        this.checkUser("sendPhoneNumberVerificationToken");
+        const user = this.checkUser("sendPhoneNumberVerificationToken");
 
         // Check if verify via call is enabled
         const phoneVerificationByCall = await this.configCatClientFactory().getValueAsync(
             "phoneVerificationByCall",
             false,
             {
-                user: this.user,
+                user,
             },
         );
 
         const channel = phoneVerificationByCall ? "call" : "sms";
 
-        return this.verificationService.sendVerificationToken(formatPhoneNumber(rawPhoneNumber), channel);
+        const verification = await this.verificationService.sendVerificationToken(
+            formatPhoneNumber(rawPhoneNumber),
+            channel,
+        );
+        this.analytics.track({
+            event: "phone_verification_sent",
+            userId: user.id,
+            properties: {
+                channel: verification.channel,
+                requestedChannel: channel,
+            },
+        });
     }
 
     public async verifyPhoneNumberVerificationToken(
@@ -762,8 +773,17 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<boolean> {
         const phoneNumber = formatPhoneNumber(rawPhoneNumber);
         const user = this.checkUser("verifyPhoneNumberVerificationToken");
-        const checked = await this.verificationService.verifyVerificationToken(phoneNumber, token);
-        if (!checked) {
+        const { verified, channel } = await this.verificationService.verifyVerificationToken(phoneNumber, token);
+        // TODO: do we want separate events for verified/failed?
+        this.analytics.track({
+            event: "phone_verification_verified",
+            userId: user.id,
+            properties: {
+                verified,
+                channel,
+            },
+        });
+        if (!verified) {
             return false;
         }
         this.verificationService.markVerified(user);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds three new analytics events for the phone number verification flow:

* `phone_verification_sent` : `{ properties: { channel: string, requestedChannel: string }
  * (channel could vary if we request voice in a country w/ only sms enabled)
* `phone_verification_completed` : `{ properties: { channel: string }`
* `phone_verification_failed` : `{ properties: { channel: string }`

| `phone_verification_sent` | `phone_verification_completed` | `phone_verification_failed` |
|--------|--------|--------|
| <img width="422" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/cc6ab4be-cb24-40a0-85c6-81ce3b86fa94"> | <img width="397" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/e0d709d9-67d9-4fd5-ab61-a2c993e9b907"> | <img width="412" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/c322dfff-8bb0-4e9b-8580-06500d4d6114"> | 

Fixes WEB-425

## How to test
<!-- Provide steps to test this PR -->
* Try to start a workspace on the Preview Env (hopefully twilio is configured still). You should get the phone verification.
* Put in the wrong number first, then try again and do the correct code.
* Check Segment Gitpod Staging Trusted debugger events and look for all three of the new `phone_verification_*` events listed above.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - bmh-analytc9ff31ed1c</li>
	<li><b>🔗 URL</b> - <a href="https://bmh-analytc9ff31ed1c.preview.gitpod-dev.com/workspaces" target="_blank">bmh-analytc9ff31ed1c.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
