### PR TITLE
Check workspace phase in ssh-gateway before connect to workspace

### DIFF
--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -69,6 +69,7 @@ type WorkspaceInfo struct {
 
 	OwnerUserId   string
 	SSHPublicKeys []string
+	IsRunning     bool
 }
 
 // RemoteWorkspaceInfoProvider provides (cached) infos about running workspaces that it queries from ws-manager.
@@ -170,6 +171,7 @@ func mapPodToWorkspaceInfo(pod *corev1.Pod) *WorkspaceInfo {
 		StartedAt:       pod.CreationTimestamp.Time,
 		OwnerUserId:     pod.Labels[kubernetes.OwnerLabel],
 		SSHPublicKeys:   extractUserSSHPublicKeys(pod),
+		IsRunning:       pod.DeletionTimestamp == nil,
 	}
 }
 
@@ -297,6 +299,7 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 		Auth:            &wsapi.WorkspaceAuthentication{Admission: admission, OwnerToken: ws.Status.OwnerToken},
 		StartedAt:       ws.CreationTimestamp.Time,
 		SSHPublicKeys:   ws.Spec.SshPublicKeys,
+		IsRunning:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 	}
 
 	r.store.Update(req.Name, wsinfo)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Check workspace phase in ssh-gateway before connect to workspace

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes IDE-109

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace using this branch
2. start a workspace using this preview env
3. upload your ssh public key, this step can make ssh connection url stable, otherwise you need get ownerToken everytime
4. in preview env workspace, do `dd if=/dev/random of=test.img bs=1M count=5000` it will created a large file in workspace folder, and run `gp stop` stop the workspace
5. during stopping, you can use ssh command trying to connect to workspace, it should failed
6. run `./dev/preview/portforward-monitoring-satellite.sh` in step 1 workspace, and open prometheus UI, search for `gitpod_ws_proxy_ssh_attempt_total` you should see there is a new error `WS_NOT_RUNNING`

<img width="1719" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/fd465fac-7e6e-4b9f-ad30-8905f50dca90">

7. repeat this test in preview env workspace Initializing, you should get same result.


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-ide-109</li>
	<li><b>🔗 URL</b> - <a href="https://pd-ide-109.preview.gitpod-dev.com/workspaces" target="_blank">pd-ide-109.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
