### PR TITLE
Rename manage billing settings button label

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -375,7 +375,7 @@ export default function UsageBasedBillingConfig({ attributionId, hideSubheading 
 
                             <a className="mt-5 self-end" href={stripePortalUrl}>
                                 <button className="secondary" disabled={!stripePortalUrl}>
-                                    Manage Plan ↗
+                                    Manage Billing Settings ↗
                                 </button>
                             </a>
                         </div>


### PR DESCRIPTION
## Description

This will rename the manage billing settings button.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1686296724834069) (internal). Cc @jankeromnes 

| BEFORE | AFTER |
|--------|--------|
|  <img width="608" alt="Frame 1584" src="https://github.com/gitpod-io/gitpod/assets/120486/cc736571-fa3a-40d7-90e1-ab8e044a501c"> | <img width="608" alt="Frame 1585" src="https://github.com/gitpod-io/gitpod/assets/120486/4764e107-8259-483a-a1a0-585493f829da"> |

## How to test

1. Go to `/billing` and upgrade to pay-as-you-go.
2. Notice the new _Manage Billing Settings_ button instead of a _Manage Plan_ button.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-rename-f71152cc32</li>
	<li><b>🔗 URL</b> - <a href="https://gt-rename-f71152cc32.preview.gitpod-dev.com/workspaces" target="_blank">gt-rename-f71152cc32.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
