### PR TITLE
Fix /login/slug handling – WEB-458

### DIFF
--- a/components/dashboard/src/login/SSOLoginForm.tsx
+++ b/components/dashboard/src/login/SSOLoginForm.tsx
@@ -19,7 +19,12 @@ type Props = {
 };
 
 function getOrgSlugFromPath(path: string) {
-    return path.split("/")[2];
+    // '/login/acme' => ['', 'login', 'acme']
+    const pathSegments = path.split("/");
+    if (pathSegments[1] !== "login") {
+        return;
+    }
+    return pathSegments[2];
 }
 
 export const SSOLoginForm: FC<Props> = ({ singleOrgMode, onSuccess }) => {


### PR DESCRIPTION
If not authenticated, the login component is rendered no any location. Given that, the second path segment should only be considered if the browser's location is /login/slug. Otherwise, if any other string is read as second path segment, it uses it as Org's slug and fails to find the SSO config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-458

## How to test
* setup sso
* use /settings/git as location when not authenticated
* `git` should not be used as slug to do the SSO signin

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
