### PR TITLE
[IDP] use SSO email if user is org-owned user

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -2161,7 +2161,7 @@ type Identity struct {
 	Tokens       []*Token `json:"tokens,omitempty"`
 
 	// The last time this entry was touched during a signin.
-	LastSigninTime string `json:"last_signin_time,omitempty"`
+	LastSigninTime time.Time `json:"last_signin_time,omitempty"`
 }
 
 // User is the User message type

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -7,6 +7,7 @@ package apiv1
 import (
 	"context"
 	"fmt"
+	"time"
 
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -71,12 +72,12 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	}
 
 	var email string
-	var lastSigninTime string
+	var lastSigninTime time.Time
 	for _, id := range user.Identities {
 		if id == nil || id.Deleted || id.PrimaryEmail == "" {
 			continue
 		}
-		if email == "" || id.LastSigninTime > lastSigninTime {
+		if email == "" || id.LastSigninTime.After(lastSigninTime) {
 			email = id.PrimaryEmail
 			lastSigninTime = id.LastSigninTime
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[IDP] use SSO email if user is org-owned user

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-idp-use-sso-email</li>
	<li><b>🔗 URL</b> - <a href="https://pd-idp-use-sso-email.preview.gitpod-dev.com/workspaces" target="_blank">pd-idp-use-sso-email.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
