### PR TITLE
User.getPrimaryEmail to return email of SSO identity – WEB-437

### DIFF
--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -30,18 +30,9 @@ export default function Account() {
         if (!user) {
             return;
         }
-        if (User.isOrganizationOwned(user)) {
-            const compareTime = (a?: string, b?: string) => (a || "").localeCompare(b || "");
-            const recentlyUsedSSOIdentity = user.identities
-                .sort((a, b) => compareTime(a.lastSigninTime, b.lastSigninTime))
-                // optimistically pick the most recent one
-                .reverse()[0];
-            setEmail(recentlyUsedSSOIdentity?.primaryEmail!);
-        } else {
-            const primaryEmail = User.getPrimaryEmail(user!);
-            if (primaryEmail) {
-                setEmail(primaryEmail);
-            }
+        const primaryEmail = User.getPrimaryEmail(user!);
+        if (primaryEmail) {
+            setEmail(primaryEmail);
         }
     }, [user]);
 

--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -5,7 +5,7 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -13,6 +13,9 @@ import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { Button } from "../components/Button";
 import { Heading2, Subheading } from "../components/typography/headings";
 import Alert from "../components/Alert";
+import { TextInputField } from "../components/forms/TextInputField";
+import isEmail from "validator/lib/isEmail";
+import { useToast } from "../components/toasts/Toasts";
 
 export default function Account() {
     const { user, setUser } = useContext(UserContext);
@@ -21,22 +24,14 @@ export default function Account() {
     const original = User.getProfile(user!);
     const [profileState, setProfileState] = useState(original);
     const [errorMessage, setErrorMessage] = useState("");
-    const [updated, setUpdated] = useState(false);
     const canUpdateEmail = user && !User.isOrganizationOwned(user);
+    const { toast } = useToast();
 
-    const [email, setEmail] = useState("");
-
-    useEffect(() => {
+    const saveProfileState = useCallback(() => {
         if (!user) {
             return;
         }
-        const primaryEmail = User.getPrimaryEmail(user!);
-        if (primaryEmail) {
-            setEmail(primaryEmail);
-        }
-    }, [user]);
 
-    const saveProfileState = useCallback(() => {
         if (profileState.name.trim() === "") {
             setErrorMessage("Name must not be empty.");
             return;
@@ -47,21 +42,19 @@ export default function Account() {
                 return;
             }
             // check valid email
-            if (
-                !/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
-                    profileState.email.trim(),
-                )
-            ) {
+            if (!isEmail(profileState.email.trim())) {
                 setErrorMessage("Please enter a valid email.");
                 return;
             }
+        } else {
+            profileState.email = User.getPrimaryEmail(user) || "";
         }
 
-        const updatedUser = User.setProfile(user!, profileState);
+        const updatedUser = User.setProfile(user, profileState);
         setUser(updatedUser);
         getGitpodService().server.updateLoggedInUser(updatedUser);
-        setUpdated(true);
-    }, [canUpdateEmail, profileState, setUser, user]);
+        toast("Your profile information has been updated.");
+    }, [canUpdateEmail, profileState, setUser, toast, user]);
 
     const deleteAccount = useCallback(async () => {
         await getGitpodService().server.deleteAccount();
@@ -75,7 +68,7 @@ export default function Account() {
                 title="Delete Account"
                 areYouSureText="You are about to permanently delete your account."
                 buttonText="Delete Account"
-                buttonDisabled={typedEmail !== email}
+                buttonDisabled={typedEmail !== original.email}
                 visible={modal}
                 onClose={close}
                 onConfirm={deleteAccount}
@@ -99,25 +92,20 @@ export default function Account() {
                 <Heading2>Profile</Heading2>
                 <form
                     onSubmit={(e) => {
-                        saveProfileState();
                         e.preventDefault();
+                        saveProfileState();
                     }}
                 >
                     <ProfileInformation
                         profileState={profileState}
                         setProfileState={(state) => {
                             setProfileState(state);
-                            setUpdated(false);
                         }}
                         errorMessage={errorMessage}
-                        updated={updated}
-                        email={email}
                         emailIsReadonly={!canUpdateEmail}
                     >
                         <div className="flex flex-row mt-8">
-                            <Button htmlType="submit" onClick={saveProfileState}>
-                                Update Profile
-                            </Button>
+                            <Button htmlType="submit">Update Profile</Button>
                         </div>
                     </ProfileInformation>
                 </form>
@@ -137,9 +125,7 @@ function ProfileInformation(props: {
     profileState: User.Profile;
     setProfileState: (newState: User.Profile) => void;
     errorMessage: string;
-    email: string;
     emailIsReadonly?: boolean;
-    updated: boolean;
     children?: React.ReactChild[] | React.ReactChild;
 }) {
     return (
@@ -154,34 +140,25 @@ function ProfileInformation(props: {
                     {props.errorMessage}
                 </Alert>
             )}
-            {props.updated && (
-                <Alert type="message" closable={true} className="mb-2 max-w-xl rounded-md">
-                    Profile information has been updated.
-                </Alert>
-            )}
             <div className="flex flex-col lg:flex-row">
                 <div>
-                    <div className="mt-4">
-                        <h4>Name</h4>
-                        <input
-                            type="text"
-                            value={props.profileState.name}
-                            onChange={(e) => props.setProfileState({ ...props.profileState, name: e.target.value })}
-                        />
-                    </div>
-                    <div className="mt-4">
-                        <h4>Email</h4>
-                        <input
-                            type="text"
-                            value={props.email}
-                            disabled={props.emailIsReadonly}
-                            onChange={(e) => props.setProfileState({ ...props.profileState, email: e.target.value })}
-                        />
-                    </div>
+                    <TextInputField
+                        label="Name"
+                        value={props.profileState.name}
+                        onChange={(val) => props.setProfileState({ ...props.profileState, name: val })}
+                    />
+                    <TextInputField
+                        label="Email"
+                        value={props.profileState.email}
+                        disabled={props.emailIsReadonly}
+                        onChange={(val) => {
+                            props.setProfileState({ ...props.profileState, email: val });
+                        }}
+                    />
                 </div>
                 <div className="lg:pl-14">
                     <div className="mt-4">
-                        <h4>Avatar</h4>
+                        <Subheading>Avatar</Subheading>
                         <img
                             className="rounded-full w-24 h-24"
                             src={props.profileState.avatarURL}


### PR DESCRIPTION
As a follow-up to WEB-437, this PR would move the selection of the email for SSO account to the `User.getPrimaryEmail`. By doing so we can expect the email be rendered consistently throughout the app.  


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related WEB-437

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
