### PR TITLE
✨ Show case specific error messages

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -496,11 +496,7 @@ const ErrorMessage: FunctionComponent<StatusMessageProps> = ({
     }
     switch (error.code) {
         case ErrorCodes.CONTEXT_PARSE_ERROR:
-            return renderError(
-                `Are you trying to open a Git repository from a self-managed git hoster?`,
-                "Add integration",
-                gitpodHostUrl.asAccessControl().toString(),
-            );
+            return renderError(`${error.message}`, "Add integration", gitpodHostUrl.asAccessControl().toString());
         case ErrorCodes.INVALID_GITPOD_YML:
             return renderError(`The gitpod.yml is invalid.`, `Use default config`, undefined, () => {
                 createWorkspace({ forceDefaultConfig: true });

--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -428,7 +428,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             }
             if (pr.headRef === null) {
                 throw new Error(
-                    `Could not open pull request ${owner}/${repoName}#${pullRequestNr}. Source branch may have been removed.`,
+                    `Could not open pull request ${owner}/${repoName}#${pullRequestNr}. Source branch may have been merged or closed.`,
                 );
             }
             return <PullRequestContext>{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR is a slight improvement to show meaningful error messages instead of generic error messages.

|Before|After|
|:---:|:---:|
|<img width="565" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/9efac23b-04e4-4bbf-9b18-62bf6a66ae26">|<img width="532" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/15a46100-3db5-4fd3-9f10-dfb185351f57">|


This is not the ideal fix but a slight improvement. Further ideal fix could be addition of following snippet ([here](https://github.com/gitpod-io/gitpod/blob/a9cb151830dddde5d3b6922df8ae2cb5db366794/components/server/src/github/github-context-parser.ts#L429-L433))

```ts
if (pr.merged) {
                return this.handleCommitContext({ span }, user, host, owner, repoName, pr.mergeCommit.oid);
            }
```

GitHub Docs:

- [`merged`](https://docs.github.com/en/graphql/reference/objects#pullrequest:~:text=of%20merge%20conflicts.-,merged,-(Boolean!))

- [`mergeCommit`](https://docs.github.com/en/graphql/reference/objects#pullrequest:~:text=the%20pull%20request.-,mergeCommit,-(Commit))

But, this would require some more refactoring for Pull Request Context to allow Navigator context.



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related WEB-462

## How to test
<!-- Provide steps to test this PR -->

- Open Preview
- Login & Hit "New Workspace" 
- Pass context URL: `https://github.com/gitpod-io/gitpod/pull/17780`
- See :eyes: error message

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

Gitpod was successfully deployed to your preview environment.

🏷️ Name - related-web-462
🔗 URL - [related-web-462.preview.gitpod-dev.com/workspaces](https://related-web-462.preview.gitpod-dev.com/workspaces).
📚 Documentation - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
