### PR TITLE
[dashboard] Always use Public API for workspace stop & delete

### DIFF
--- a/components/dashboard/src/data/workspaces/delete-inactive-workspaces-mutation.ts
+++ b/components/dashboard/src/data/workspaces/delete-inactive-workspaces-mutation.ts
@@ -6,17 +6,14 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { workspacesService } from "../../service/public-api";
-import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
 import { useCurrentOrg } from "../organizations/orgs-query";
-import { useFeatureFlag } from "../featureflag-query";
 
 type DeleteInactiveWorkspacesArgs = {
     workspaceIds: string[];
 };
 export const useDeleteInactiveWorkspacesMutation = () => {
     const queryClient = useQueryClient();
-    const usePublicApiWorkspacesService = useFeatureFlag("publicApiExperimentalWorkspaceService");
     const org = useCurrentOrg();
 
     return useMutation({
@@ -25,9 +22,7 @@ export const useDeleteInactiveWorkspacesMutation = () => {
 
             for (const workspaceId of workspaceIds) {
                 try {
-                    usePublicApiWorkspacesService
-                        ? await workspacesService.deleteWorkspace({ workspaceId })
-                        : await getGitpodService().server.deleteWorkspace(workspaceId);
+                    await workspacesService.deleteWorkspace({ workspaceId });
 
                     deletedWorkspaceIds.push(workspaceId);
                 } catch (e) {

--- a/components/dashboard/src/data/workspaces/delete-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/delete-workspace-mutation.ts
@@ -6,10 +6,8 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { workspacesService } from "../../service/public-api";
-import { getGitpodService } from "../../service/service";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
 import { useCurrentOrg } from "../organizations/orgs-query";
-import { useFeatureFlag } from "../featureflag-query";
 
 type DeleteWorkspaceArgs = {
     workspaceId: string;
@@ -17,14 +15,11 @@ type DeleteWorkspaceArgs = {
 
 export const useDeleteWorkspaceMutation = () => {
     const queryClient = useQueryClient();
-    const usePublicApiWorkspacesService = useFeatureFlag("publicApiExperimentalWorkspaceService");
     const org = useCurrentOrg();
 
     return useMutation({
         mutationFn: async ({ workspaceId }: DeleteWorkspaceArgs) => {
-            return usePublicApiWorkspacesService
-                ? await workspacesService.deleteWorkspace({ workspaceId })
-                : await getGitpodService().server.deleteWorkspace(workspaceId);
+            return await workspacesService.deleteWorkspace({ workspaceId });
         },
         onSuccess: (_, { workspaceId }) => {
             const queryKey = getListWorkspacesQueryKey(org.data?.id);

--- a/components/dashboard/src/data/workspaces/stop-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/stop-workspace-mutation.ts
@@ -6,22 +6,16 @@
 
 import { useMutation } from "@tanstack/react-query";
 import { workspacesService } from "../../service/public-api";
-import { getGitpodService } from "../../service/service";
-import { useFeatureFlag } from "../featureflag-query";
 
 type StopWorkspaceArgs = {
     workspaceId: string;
 };
 
 export const useStopWorkspaceMutation = () => {
-    const usePublicApiWorkspacesService = useFeatureFlag("publicApiExperimentalWorkspaceService");
-
     // No need to manually update workspace in cache here, we'll receive messages over the ws that will update it
     return useMutation({
         mutationFn: async ({ workspaceId }: StopWorkspaceArgs) => {
-            return usePublicApiWorkspacesService
-                ? workspacesService.stopWorkspace({ workspaceId })
-                : getGitpodService().server.stopWorkspace(workspaceId);
+            return workspacesService.stopWorkspace({ workspaceId });
         },
     });
 };

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -556,11 +556,9 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                         {
                                             title: "Stop Workspace",
                                             onClick: () =>
-                                                this.context.usePublicApiWorkspacesService
-                                                    ? workspacesService.stopWorkspace({
-                                                          workspaceId: this.props.workspaceId,
-                                                      })
-                                                    : getGitpodService().server.stopWorkspace(this.props.workspaceId),
+                                                workspacesService.stopWorkspace({
+                                                    workspaceId: this.props.workspaceId,
+                                                }),
                                         },
                                         {
                                             title: "Connect via SSH",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-dashboa62efb578df</li>
	<li><b>🔗 URL</b> - <a href="https://mp-dashboa62efb578df.preview.gitpod-dev.com/workspaces" target="_blank">mp-dashboa62efb578df.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
