### PR TITLE
[gitpod-db] cache user object

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -45,71 +45,74 @@ import { PersonalAccessTokenDBImpl } from "./typeorm/personal-access-token-db-im
 import { LinkedInProfileDBImpl } from "./typeorm/linked-in-profile-db-impl";
 import { LinkedInProfileDB } from "./linked-in-profile-db";
 import { JobStateDbImpl } from "./typeorm/job-state-db-impl";
+import { DataCache, DataCacheNoop } from "./data-cache";
 
 // THE DB container module that contains all DB implementations
-export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(Config).toSelf().inSingletonScope();
-    bind(TypeORM).toSelf().inSingletonScope();
-    bind(DBWithTracing).toSelf().inSingletonScope();
-    bind(TransactionalWorkspaceDbImpl).toSelf().inSingletonScope();
+export const dbContainerModule = (cacheClass = DataCacheNoop) =>
+    new ContainerModule((bind, unbind, isBound, rebind) => {
+        bind(Config).toSelf().inSingletonScope();
+        bind(TypeORM).toSelf().inSingletonScope();
+        bind(DBWithTracing).toSelf().inSingletonScope();
+        bind(DataCache).to(cacheClass).inSingletonScope();
+        bind(TransactionalWorkspaceDbImpl).toSelf().inSingletonScope();
 
-    bind(TypeORMBlockedRepositoryDBImpl).toSelf().inSingletonScope();
-    bind(BlockedRepositoryDB).toService(TypeORMBlockedRepositoryDBImpl);
+        bind(TypeORMBlockedRepositoryDBImpl).toSelf().inSingletonScope();
+        bind(BlockedRepositoryDB).toService(TypeORMBlockedRepositoryDBImpl);
 
-    bind(TypeORMUserDBImpl).toSelf().inSingletonScope();
-    bind(UserDB).toService(TypeORMUserDBImpl);
-    bindDbWithTracing(TracedUserDB, bind, UserDB).inSingletonScope();
+        bind(TypeORMUserDBImpl).toSelf().inSingletonScope();
+        bind(UserDB).toService(TypeORMUserDBImpl);
+        bindDbWithTracing(TracedUserDB, bind, UserDB).inSingletonScope();
 
-    bind(AuthProviderEntryDB).to(AuthProviderEntryDBImpl).inSingletonScope();
+        bind(AuthProviderEntryDB).to(AuthProviderEntryDBImpl).inSingletonScope();
 
-    bind(TypeORMWorkspaceDBImpl).toSelf().inSingletonScope();
-    bind(WorkspaceDB).toService(TypeORMWorkspaceDBImpl);
-    bindDbWithTracing(TracedWorkspaceDB, bind, WorkspaceDB).inSingletonScope();
+        bind(TypeORMWorkspaceDBImpl).toSelf().inSingletonScope();
+        bind(WorkspaceDB).toService(TypeORMWorkspaceDBImpl);
+        bindDbWithTracing(TracedWorkspaceDB, bind, WorkspaceDB).inSingletonScope();
 
-    bind(TypeORMUserStorageResourcesDBImpl).toSelf().inSingletonScope();
-    bind(UserStorageResourcesDB).toService(TypeORMUserStorageResourcesDBImpl);
+        bind(TypeORMUserStorageResourcesDBImpl).toSelf().inSingletonScope();
+        bind(UserStorageResourcesDB).toService(TypeORMUserStorageResourcesDBImpl);
 
-    bind(TypeORMAppInstallationDBImpl).toSelf().inSingletonScope();
-    bind(AppInstallationDB).toService(TypeORMAppInstallationDBImpl);
+        bind(TypeORMAppInstallationDBImpl).toSelf().inSingletonScope();
+        bind(AppInstallationDB).toService(TypeORMAppInstallationDBImpl);
 
-    bind(TypeORMOneTimeSecretDBImpl).toSelf().inSingletonScope();
-    bind(OneTimeSecretDB).toService(TypeORMOneTimeSecretDBImpl);
-    bindDbWithTracing(TracedOneTimeSecretDB, bind, OneTimeSecretDB).inSingletonScope();
+        bind(TypeORMOneTimeSecretDBImpl).toSelf().inSingletonScope();
+        bind(OneTimeSecretDB).toService(TypeORMOneTimeSecretDBImpl);
+        bindDbWithTracing(TracedOneTimeSecretDB, bind, OneTimeSecretDB).inSingletonScope();
 
-    encryptionModule(bind, unbind, isBound, rebind);
-    bind(KeyProviderConfig)
-        .toDynamicValue((ctx) => {
-            const config = ctx.container.get<Config>(Config);
-            return {
-                keys: KeyProviderImpl.loadKeyConfigFromJsonString(config.dbEncryptionKeys),
-            };
-        })
-        .inSingletonScope();
+        encryptionModule(bind, unbind, isBound, rebind);
+        bind(KeyProviderConfig)
+            .toDynamicValue((ctx) => {
+                const config = ctx.container.get<Config>(Config);
+                return {
+                    keys: KeyProviderImpl.loadKeyConfigFromJsonString(config.dbEncryptionKeys),
+                };
+            })
+            .inSingletonScope();
 
-    bind(GitpodTableDescriptionProvider).toSelf().inSingletonScope();
-    bind(TableDescriptionProvider).toService(GitpodTableDescriptionProvider);
-    bind(PeriodicDbDeleter).toSelf().inSingletonScope();
+        bind(GitpodTableDescriptionProvider).toSelf().inSingletonScope();
+        bind(TableDescriptionProvider).toService(GitpodTableDescriptionProvider);
+        bind(PeriodicDbDeleter).toSelf().inSingletonScope();
 
-    bind(CodeSyncResourceDB).toSelf().inSingletonScope();
+        bind(CodeSyncResourceDB).toSelf().inSingletonScope();
 
-    bind(WorkspaceClusterDB).to(WorkspaceClusterDBImpl).inSingletonScope();
+        bind(WorkspaceClusterDB).to(WorkspaceClusterDBImpl).inSingletonScope();
 
-    bind(AuthCodeRepositoryDB).toSelf().inSingletonScope();
+        bind(AuthCodeRepositoryDB).toSelf().inSingletonScope();
 
-    bind(TeamDBImpl).toSelf().inSingletonScope();
-    bind(TeamDB).toService(TeamDBImpl);
-    bind(ProjectDBImpl).toSelf().inSingletonScope();
-    bind(ProjectDB).toService(ProjectDBImpl);
-    bind(WebhookEventDBImpl).toSelf().inSingletonScope();
-    bind(WebhookEventDB).toService(WebhookEventDBImpl);
+        bind(TeamDBImpl).toSelf().inSingletonScope();
+        bind(TeamDB).toService(TeamDBImpl);
+        bind(ProjectDBImpl).toSelf().inSingletonScope();
+        bind(ProjectDB).toService(ProjectDBImpl);
+        bind(WebhookEventDBImpl).toSelf().inSingletonScope();
+        bind(WebhookEventDB).toService(WebhookEventDBImpl);
 
-    bind(PersonalAccessTokenDBImpl).toSelf().inSingletonScope();
-    bind(PersonalAccessTokenDB).toService(PersonalAccessTokenDBImpl);
+        bind(PersonalAccessTokenDBImpl).toSelf().inSingletonScope();
+        bind(PersonalAccessTokenDB).toService(PersonalAccessTokenDBImpl);
 
-    bind(JobStateDbImpl).toSelf().inSingletonScope();
+        bind(JobStateDbImpl).toSelf().inSingletonScope();
 
-    // com concerns
-    bind(EmailDomainFilterDB).to(EmailDomainFilterDBImpl).inSingletonScope();
-    bind(LinkedInProfileDBImpl).toSelf().inSingletonScope();
-    bind(LinkedInProfileDB).toService(LinkedInProfileDBImpl);
-});
+        // com concerns
+        bind(EmailDomainFilterDB).to(EmailDomainFilterDBImpl).inSingletonScope();
+        bind(LinkedInProfileDBImpl).toSelf().inSingletonScope();
+        bind(LinkedInProfileDB).toService(LinkedInProfileDBImpl);
+    });

--- a/components/gitpod-db/src/data-cache.ts
+++ b/components/gitpod-db/src/data-cache.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { injectable } from "inversify";
+
+/**
+ * A cache that can be used to cache expensive operations, such as retrieving data from the database.
+ */
+export interface DataCache {
+    /**
+     * Retrieves the value for the given key from the cache. If the value is not in the cache, the provider is called and the result is stored in the cache.
+     * @param key the key to retrieve the value for. Should be segmented using `:`. For example: `user:123`
+     * @param provider the provider to call if the value is not in the cache
+     */
+    get<T>(key: string, provider: () => Promise<T | undefined>): Promise<T | undefined>;
+
+    /**
+     * @param keyPattern the key pattern to invalidate. The `*` denotes a wildcard segment. For example: `user:*` invalidates all keys starting with `user:`
+     */
+    invalidate(keyPattern: string): Promise<void>;
+}
+export const DataCache = Symbol("DataCache");
+
+@injectable()
+export class DataCacheNoop implements DataCache {
+    get<T>(key: string, provider: () => Promise<T | undefined>): Promise<T | undefined> {
+        return provider();
+    }
+
+    async invalidate(partialKey: string): Promise<void> {
+        // noop
+    }
+}

--- a/components/gitpod-db/src/test-container.ts
+++ b/components/gitpod-db/src/test-container.ts
@@ -8,4 +8,4 @@ import { Container } from "inversify";
 import { dbContainerModule } from "./container-module";
 
 export const testContainer = new Container();
-testContainer.load(dbContainerModule);
+testContainer.load(dbContainerModule());

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -64,6 +64,7 @@
     "heapdump": "^0.3.15",
     "inversify": "^5.0.1",
     "ioredis": "^5.3.2",
+    "ioredis-mock": "^8.7.0",
     "is-reachable": "^5.2.1",
     "js-yaml": "^3.10.0",
     "json-stream": "^1.0.0",

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -92,7 +92,7 @@ export class LoginCompletionHandler {
 
     public async updateAuthProviderAsVerified(hostname: string, user: User) {
         const hostCtx = this.hostContextProvider.get(hostname);
-        log.info("Updating auth provider as verified", { hostname, hostCtx });
+        log.info("Updating auth provider as verified", { hostname });
         if (hostCtx) {
             const { params: config } = hostCtx.authProvider;
             const { id, verified, builtin } = config;

--- a/components/server/src/billing/billing-mode.spec.db.ts
+++ b/components/server/src/billing/billing-mode.spec.db.ts
@@ -164,7 +164,7 @@ class BillingModeSpec {
         for (const test of tests) {
             // Setup test code, environment and data
             const testContainer = new Container();
-            testContainer.load(dbContainerModule);
+            testContainer.load(dbContainerModule());
             testContainer.load(
                 new ContainerModule((bind, unbind, isBound, rebind) => {
                     bind(Config).toConstantValue({ enablePayment: test.config.enablePayment } as Config);

--- a/components/server/src/jobs/org-only-migration-job.spec.db.ts
+++ b/components/server/src/jobs/org-only-migration-job.spec.db.ts
@@ -34,7 +34,7 @@ class TestingRedisMutex extends RedisMutex {
     }
 }
 export const testContainer = new Container();
-testContainer.load(dbContainerModule);
+testContainer.load(dbContainerModule());
 testContainer.load(
     new ContainerModule((bind) => {
         bind(StripeService).toConstantValue(mockedStripe);

--- a/components/server/src/main.ts
+++ b/components/server/src/main.ts
@@ -11,10 +11,11 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Container } from "inversify";
 import { productionContainerModule } from "./container-module";
 import { dbContainerModule } from "@gitpod/gitpod-db/lib/container-module";
+import { DataCacheRedis } from "./redis/data-cache";
 
 const container = new Container();
+container.load(dbContainerModule(DataCacheRedis));
 container.load(productionContainerModule);
-container.load(dbContainerModule);
 
 start(container).catch((err) => {
     log.error("Error during startup or operation. Exiting.", err);

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -29,6 +29,8 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(jobStartedTotal);
     registry.registerMetric(jobsCompletedTotal);
     registry.registerMetric(jobsDurationSeconds);
+    registry.registerMetric(redisCacheGetLatencyHistogram);
+    registry.registerMetric(redisCacheRequestsTotal);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -285,4 +287,29 @@ export const jobsDurationSeconds = new prometheusClient.Histogram({
     help: "Histogram of job duration",
     buckets: [10, 30, 60, 2 * 60, 3 * 60, 5 * 60, 10 * 60, 15 * 60],
     labelNames: ["name"],
+});
+
+// Total requests (with label on hit/miss)
+export const redisCacheRequestsTotal = new prometheusClient.Counter({
+    name: "gitpod_redis_cache_requests_total",
+    help: "Total number of cache requests",
+    labelNames: ["hit"],
+});
+
+export function reportRedisCacheRequest(hit: boolean) {
+    redisCacheRequestsTotal.inc({ hit: String(hit) });
+}
+
+export const redisCacheGetLatencyHistogram = new prometheusClient.Histogram({
+    name: "gitpod_redis_cache_get_latency_seconds",
+    help: "Cache get latency in seconds",
+    labelNames: ["cache_group"],
+    buckets: [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+});
+
+export const redisCacheSetLatencyHistogram = new prometheusClient.Histogram({
+    name: "gitpod_redis_cache_set_latency_seconds",
+    help: "Cache set latency in seconds",
+    labelNames: ["cache_group"],
+    buckets: [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10],
 });

--- a/components/server/src/redis/data-cache.spec.ts
+++ b/components/server/src/redis/data-cache.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+import { suite, test } from "mocha-typescript";
+import { DataCacheRedis } from "./data-cache";
+import * as IORedis from "ioredis";
+
+const Redis = require("ioredis-mock");
+const expect = chai.expect;
+const client: IORedis.Redis = new Redis();
+
+class DataCacheRedisMock extends DataCacheRedis {
+    constructor() {
+        super();
+        this.redis = { get: () => client } as any;
+    }
+}
+
+@suite
+export class RedisClientSpec {
+    @test public async testGet() {
+        const redisClient = new DataCacheRedisMock();
+
+        expect(await redisClient.get("foo:bar", () => Promise.resolve("A"))).to.eq("A");
+        expect(await redisClient.get("foo:bar", () => Promise.resolve("B"))).to.eq("A");
+
+        await redisClient.invalidate("foo:bar");
+        expect(await redisClient.get("foo:bar", () => Promise.resolve("C"))).to.eq("C");
+        await redisClient.invalidate("foo:*");
+        expect(await redisClient.get("foo:bar", () => Promise.resolve("D"))).to.eq("D");
+    }
+}

--- a/components/server/src/redis/data-cache.ts
+++ b/components/server/src/redis/data-cache.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable } from "inversify";
+import { RedisClient } from "./client";
+import {
+    reportRedisCacheRequest,
+    redisCacheGetLatencyHistogram,
+    redisCacheSetLatencyHistogram,
+} from "../prometheus-metrics";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { DataCache } from "@gitpod/gitpod-db/lib/data-cache";
+
+const TTL_SEC = 5 * 60; // 5 minutes
+
+@injectable()
+export class DataCacheRedis implements DataCache {
+    @inject(RedisClient) protected redis: RedisClient;
+
+    async get<T>(cacheKey: string, provider: () => Promise<T | undefined>): Promise<T | undefined> {
+        const cache_group = cacheKey.split(":")[0];
+        const stopGetTimer = redisCacheGetLatencyHistogram.startTimer({ cache_group });
+        let result: string | null = null;
+        try {
+            result = await this.redis.get().get(cacheKey);
+        } catch (error) {
+            log.error("Error retrieving cache value", error, { cacheKey });
+        } finally {
+            stopGetTimer();
+        }
+        reportRedisCacheRequest(result !== null);
+        if (result) {
+            return JSON.parse(result);
+        } else {
+            const value = await provider();
+            if (value) {
+                const stopSetTimer = redisCacheSetLatencyHistogram.startTimer({ cache_group });
+                try {
+                    await this.redis.get().set(cacheKey, JSON.stringify(value), "EX", TTL_SEC);
+                } catch (error) {
+                    log.error("Error while setting cache value", error, { cacheKey });
+                } finally {
+                    stopSetTimer();
+                }
+            }
+            return value;
+        }
+    }
+
+    async invalidate(cacheKeyPattern: string): Promise<void> {
+        const keys = await this.redis.get().keys(cacheKeyPattern);
+        if (keys.length > 0) {
+            await this.redis.get().del(keys);
+        }
+    }
+}

--- a/components/server/src/test/authentication-github.spec.ts
+++ b/components/server/src/test/authentication-github.spec.ts
@@ -46,8 +46,8 @@ class TestAuthenticationGitHub {
 
         // Create Server
         const container = new Container();
+        container.load(dbContainerModule());
         container.load(productionContainerModule);
-        container.load(dbContainerModule);
         const server = container.get(Server);
         server.init(app).catch((err) => {
             /** ignore */

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -18,26 +18,25 @@ import { User } from "@gitpod/gitpod-protocol";
 
 const expect = chai.expect;
 
-export const testContainer = new Container();
+const testContainer = new Container();
+testContainer.load(dbContainerModule());
 testContainer.load(productionContainerModule);
-testContainer.load(dbContainerModule);
+testContainer.rebind(Config).toConstantValue({
+    blockNewUsers: {
+        enabled: false,
+    },
+} as any);
+testContainer.rebind(UserToTeamMigrationService).toConstantValue({
+    migrateUser: (user: User) => {
+        return user;
+    },
+} as any);
 
 @suite
 class UserServiceSpec {
     userDB = testContainer.get<TypeORMUserDBImpl>(TypeORMUserDBImpl);
 
     async before() {
-        testContainer.rebind(Config).toConstantValue({
-            blockNewUsers: {
-                enabled: false,
-            },
-        } as any);
-        testContainer.rebind(UserToTeamMigrationService).toConstantValue({
-            migrateUser: (user: User) => {
-                return user;
-            },
-        } as any);
-
         await this.wipeRepos();
     }
 

--- a/components/ws-manager-bridge/ee/src/index.ts
+++ b/components/ws-manager-bridge/ee/src/index.ts
@@ -15,6 +15,6 @@ import { dbContainerModule } from "@gitpod/gitpod-db/lib/container-module";
 const container = new Container();
 container.load(containerModule);
 container.load(containerModuleEE);
-container.load(dbContainerModule);
+container.load(dbContainerModule());
 
 start(container);

--- a/components/ws-manager-bridge/src/index.ts
+++ b/components/ws-manager-bridge/src/index.ts
@@ -14,6 +14,6 @@ import { dbContainerModule } from "@gitpod/gitpod-db/lib/container-module";
 
 const container = new Container();
 container.load(containerModule);
-container.load(dbContainerModule);
+container.load(dbContainerModule());
 
 start(container);

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -1,41 +1,116 @@
 {
     "folders": [
-        { "path": "." },
-        { "path": "components/blobserve" },
-        { "path": "components/common-go" },
-        { "path": "components/content-service" },
-        { "path": "components/docker-up" },
-        { "path": "components/ee/agent-smith" },
-        { "path": "components/gitpod-cli" },
-        { "path": "components/gitpod-protocol" },
-        { "path": "components/ide-metrics" },
-        { "path": "components/ide-service" },
-        { "path": "components/image-builder-bob" },
-        { "path": "components/image-builder-mk3" },
-        { "path": "components/local-app" },
-        { "path": "components/registry-facade" },
-        { "path": "components/service-waiter" },
-        { "path": "components/supervisor" },
-        { "path": "components/usage" },
-        { "path": "components/usage-api" },
-        { "path": "components/workspacekit" },
-        { "path": "components/ws-daemon" },
-        { "path": "components/ws-manager-mk2" },
-        { "path": "components/ws-proxy" },
-        { "path": "components/public-api" },
-        { "path": "components/public-api-server" },
-        { "path": "components/public-api/typescript" },
-        { "path": "components/gitpod-db" },
-        { "path": "test" },
-        { "path": "dev/blowtorch" },
-        { "path": "dev/changelog" },
-        { "path": "dev/gpctl" },
-        { "path": "dev/gp-gcloud" },
-        { "path": "dev/loadgen" },
-        { "path": "dev/preview/previewctl" },
-        { "path": "install/installer" },
-        { "path": "install/preview" },
-        { "path": "components/node-labeler" },
+        {
+            "path": "."
+        },
+        {
+            "path": "components/blobserve"
+        },
+        {
+            "path": "components/common-go"
+        },
+        {
+            "path": "components/content-service"
+        },
+        {
+            "path": "components/docker-up"
+        },
+        {
+            "path": "components/ee/agent-smith"
+        },
+        {
+            "path": "components/gitpod-cli"
+        },
+        {
+            "path": "components/gitpod-protocol"
+        },
+        {
+            "path": "components/ide-metrics"
+        },
+        {
+            "path": "components/ide-service"
+        },
+        {
+            "path": "components/image-builder-bob"
+        },
+        {
+            "path": "components/image-builder-mk3"
+        },
+        {
+            "path": "components/local-app"
+        },
+        {
+            "path": "components/registry-facade"
+        },
+        {
+            "path": "components/service-waiter"
+        },
+        {
+            "path": "components/supervisor"
+        },
+        {
+            "path": "components/usage"
+        },
+        {
+            "path": "components/usage-api"
+        },
+        {
+            "path": "components/workspacekit"
+        },
+        {
+            "path": "components/ws-daemon"
+        },
+        {
+            "path": "components/ws-manager-mk2"
+        },
+        {
+            "path": "components/ws-proxy"
+        },
+        {
+            "path": "components/public-api"
+        },
+        {
+            "path": "components/public-api-server"
+        },
+        {
+            "path": "components/public-api/typescript"
+        },
+        {
+            "path": "components/gitpod-db"
+        },
+        {
+            "path": "test"
+        },
+        {
+            "path": "dev/blowtorch"
+        },
+        {
+            "path": "dev/changelog"
+        },
+        {
+            "path": "dev/gpctl"
+        },
+        {
+            "path": "dev/gp-gcloud"
+        },
+        {
+            "path": "dev/loadgen"
+        },
+        {
+            "path": "dev/preview/previewctl"
+        },
+        {
+            "path": "install/installer"
+        },
+        {
+            "path": "install/preview"
+        },
+        {
+            "path": "components/node-labeler"
+        },
+        {
+            "path": "components/server"
+        }
     ],
     "settings": {
         "typescript.tsdk": "gitpod/node_modules/typescript/lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,7 +1590,12 @@
   dependencies:
     browser-headers "^0.4.1"
 
-"@ioredis/commands@^1.1.1":
+"@ioredis/as-callback@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/as-callback/-/as-callback-3.0.0.tgz#b96c9b05e6701e85ec6a5e62fa254071b0aec97f"
+  integrity sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==
+
+"@ioredis/commands@^1.1.1", "@ioredis/commands@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
@@ -8063,6 +8068,20 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fengari-interop@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fengari-interop/-/fengari-interop-0.1.3.tgz#3ad37a90e7430b69b365441e9fc0ba168942a146"
+  integrity sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==
+
+fengari@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/fengari/-/fengari-0.1.4.tgz#72416693cd9e43bd7d809d7829ddc0578b78b0bb"
+  integrity sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==
+  dependencies:
+    readline-sync "^1.4.9"
+    sprintf-js "^1.1.1"
+    tmp "^0.0.33"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz"
@@ -9552,6 +9571,17 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ioredis-mock@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/ioredis-mock/-/ioredis-mock-8.7.0.tgz#9877a85e0d233e1b49123d1c6e320df01e9a1d36"
+  integrity sha512-BJcSjkR3sIMKbH93fpFzwlWi/jl1kd5I3vLvGQxnJ/W/6bD2ksrxnyQN186ljAp3Foz4p1ivViDE3rZeKEAluA==
+  dependencies:
+    "@ioredis/as-callback" "^3.0.0"
+    "@ioredis/commands" "^1.2.0"
+    fengari "^0.1.4"
+    fengari-interop "^0.1.3"
+    semver "^7.3.8"
 
 ioredis@^4.27.8:
   version "4.28.0"
@@ -12524,7 +12554,7 @@ os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -14993,6 +15023,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+readline-sync@^1.4.9:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
 rechoir@^0.7.0:
   version "0.7.1"
   resolved "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz"
@@ -16146,6 +16181,11 @@ split2@^4.0.0:
   resolved "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz"
   integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
 
+sprintf-js@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
@@ -16921,6 +16961,13 @@ tmatch@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz"
   integrity sha1-DFYkbzPzDaG409colauvFmYPOM8=
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmp@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introduces a CachingService that is used to cache user objects retrieved by its id (happens on most requests).

The primary interface is 

```typescript
/**
 * A cache that can be used to cache expensive operations, such as retrieving data from the database.
 */
export interface DataCache {
    /**
     * Retrieves the value for the given key from the cache. If the value is not in the cache, the provider is called and the result is stored in the cache.
     * @param key the key to retrieve the value for. Should be segmented using `:`. For example: `user:123`
     * @param provider the provider to call if the value is not in the cache
     */
    get<T>(key: string, provider: () => Promise<T | undefined>): Promise<T | undefined>;

    /**
     * @param keyPattern the key pattern to invalidate. The `*` denotes a wildcard segment. For example: `user:*` invalidates all keys starting with `user:`
     */
    invalidate(keyPattern: string): Promise<void>;
}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-cache-user</li>
	<li><b>🔗 URL</b> - <a href="https://se-cache-user.preview.gitpod-dev.com/workspaces" target="_blank">se-cache-user.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
