### PR TITLE
[test] Speed up integration tests

### DIFF
--- a/test/pkg/integration/common/port_forward.go
+++ b/test/pkg/integration/common/port_forward.go
@@ -80,7 +80,7 @@ func forwardPort(ctx context.Context, kubeconfig string, namespace, resourceType
 	// wait until we can reach the local port before signaling we are ready
 	go func() {
 		localPort := strings.Split(port, ":")[0]
-		waitErr := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+		waitErr := wait.PollImmediate(500*time.Millisecond, 1*time.Minute, func() (bool, error) {
 			conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", localPort), 1*time.Second)
 			if err != nil {
 				return false, nil

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -288,7 +288,7 @@ func Instrument(component ComponentType, agentName string, namespace string, kub
 		res, cl, err = portfw(podExec, kubeconfig, podName, namespace, containerName, tgtFN, options)
 		if err != nil {
 			var serror error
-			waitErr := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
+			waitErr := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
 				serror = shutdownAgent(podExec, kubeconfig, podName, namespace, containerName)
 				if serror != nil {
 					if strings.Contains(serror.Error(), "exit code 7") {
@@ -408,7 +408,7 @@ L:
 
 	var res *rpc.Client
 	var lastError error
-	waitErr := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
+	waitErr := wait.PollImmediate(500*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		res, lastError = rpc.DialHTTP("tcp", net.JoinHostPort("localhost", strconv.Itoa(localAgentPort)))
 		if lastError != nil {
 			return false, nil

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -164,7 +164,7 @@ func waitOnGitpodRunning(namespace string, waitTimeout time.Duration) env.Func {
 		}
 
 		client := cfg.Client()
-		err := wait.PollImmediate(5*time.Second, waitTimeout, func() (bool, error) {
+		err := wait.PollImmediate(1*time.Second, waitTimeout, func() (bool, error) {
 			for _, component := range components {
 				var pods corev1.PodList
 				err := client.Resources(namespace).List(context.Background(), &pods, func(opts *metav1.ListOptions) {

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -165,7 +165,7 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 		}
 	}
 
-	waitErr := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	waitErr := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
 		workspaceImage, err = resolveOrBuildImage(ctx, api, options.BaseImage)
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
 			api.ClearImageBuilderClientCache()
@@ -692,7 +692,7 @@ func WaitForWorkspaceStart(t *testing.T, ctx context.Context, instanceID string,
 		return nil, true, nil
 	}
 
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Some low-hanging fruit to speed up the integration tests:
- Cache DB connections within a single test
  - Each connection takes up to 10s to set up (port forwarding etc.), and connections are set up multiple times _per test_. Caching the connection saves 10s of seconds
- Reduce the poll interval for port-forwarding. 
  - Port-forwarding is done a number of times per test, and each was taking at least 5 seconds (the original poll interval). The port-forward is usually set up within 1.5s from observations, so this should save ~3.5s per port-forward
- Reduce a number of other poll intervals and tickers, saving a couple of additional seconds per test

A basic test that starts a workspace and installs the instrumentation binary is reduced from **~90s total to ~26s** (3.5x!)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-227

## How to test
<!-- Provide steps to test this PR -->

Used this branch to test and measure speedups: https://github.com/gitpod-io/gitpod/compare/wv/test-tests?expand=1

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
