### PR TITLE
[server] allow debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,19 @@
 {
     "configurations": [
         {
+            "name": "Attach to Kubernetes Node",
+            "type": "node",
+            "request": "attach",
+            "smartStep": true,
+            "port": 9229,
+            "address": "127.0.0.1",
+            "localRoot": "${workspaceFolder}/components",
+            "remoteRoot": "/app/node_modules/@gitpod",
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        },
+        {
             "name": "Attach to Node",
             "type": "node",
             "request": "attach",
@@ -21,15 +34,14 @@
             "mode": "remote"
         },
         {
-            // This will run the db-test yarn target in the gitpod-db component.
-            // This allows you to set breakpoints in your tests and step through
-            // them with the VSCode debugger.
             "type": "node",
             "request": "launch",
             "name": "gitpod-db-tests",
             "cwd": "${workspaceFolder}/components/gitpod-db",
             "runtimeExecutable": "yarn",
-            "runtimeArgs": ["db-test"],
+            "runtimeArgs": [
+                "db-test"
+            ],
             "internalConsoleOptions": "openOnSessionStart",
             "skipFiles": [
                 "<node_internals>/**"

--- a/components/server/debug.sh
+++ b/components/server/debug.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
 
-set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment server
+deploymentName="server"
+debugPort="9229"
+
+echo "Storing the original deployment configuration in a file"
+kubectl get deployment $deploymentName -o json > original_deployment_$deploymentName.json
+
+function restore {
+  echo "Restoring the original deployment configuration and stop port forwarding"
+  kubectl replace --force -f original_deployment_$deploymentName.json
+  rm original_deployment_$deploymentName.json
+}
+trap restore EXIT
+
+echo "Add the inspect flag and debug port to the configuration"
+jq '.spec.template.spec.containers[0].command = ["yarn", "start-inspect"]' original_deployment_$deploymentName.json > new_deployment_$deploymentName.json
+
+echo "Apply the new configuration"
+kubectl apply -f new_deployment_$deploymentName.json
+rm new_deployment_$deploymentName.json
+
+echo "Scale down to one pod"
+kubectl scale deployment $deploymentName --replicas=1
+
+echo "Forward the port $debugPort to localhost. Waiting for a debugger to attach ..."
+kubectl port-forward deployment/$deploymentName $debugPort

--- a/components/server/deploy.sh
+++ b/components/server/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+source /workspace/gitpod/scripts/ws-deploy.sh deployment server

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "start": "node ./dist/main.js",
-    "start-inspect": "node --inspect=9229 ./dist/main.js",
+    "start-inspect": "node --inspect=0.0.0.0:9229 ./dist/main.js",
     "prepare": "yarn clean && yarn build",
     "build": "yarn lint && npx tsc",
     "build:clean": "yarn clean && yarn build",
@@ -22,7 +22,8 @@
     "telepresence": "telepresence --swap-deployment server --method inject-tcp --run yarn start-inspect"
   },
   "files": [
-    "/dist"
+    "/dist",
+    "/src"
   ],
   "dependencies": {
     "@authzed/authzed-node": "^0.10.0",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allows to debug the server pod in preview environments

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1) Start a workspace on this PR
2) cd components/server
3) ./debug.sh
4) Launch "Attach to Node (gitpod)" in VS Code

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-debug-server</li>
	<li><b>🔗 URL</b> - <a href="https://se-debug-server.preview.gitpod-dev.com/workspaces" target="_blank">se-debug-server.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
