### PR TITLE
[gitpod-db] don't leak DBUser

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -665,8 +665,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     public async getLoggedInUser(ctx: TraceContext): Promise<User> {
         await this.doUpdateUser();
-        const user = await this.checkUser("getLoggedInUser");
-        return this.cleanUser(user);
+        return this.checkUser("getLoggedInUser");
     }
 
     protected enableDedicatedOnboardingFlow: boolean = false; // TODO(gpl): Remove once we have an onboarding setup
@@ -710,7 +709,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             });
         }
 
-        return this.cleanUser(updatedUser);
+        return updatedUser;
     }
 
     public async maySetTimeout(ctx: TraceContext): Promise<boolean> {
@@ -3478,7 +3477,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!result) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, "not found");
         }
-        return this.cleanUser(result);
+        return result;
     }
 
     async adminGetUsers(ctx: TraceContext, req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>> {
@@ -3494,7 +3493,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 req.orderDir === "asc" ? "ASC" : "DESC",
                 req.searchTerm,
             );
-            res.rows = res.rows.map(this.cleanUser);
             return res;
         } catch (e) {
             throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
@@ -3562,9 +3560,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             workspaceIds: stoppedWorkspaces.map((w) => w.id),
         });
 
-        // For some reason, returning the result of `this.userDB.storeUser(target)` does not work. The response never arrives the caller.
-        // Returning `target` instead (which should be equivalent).
-        return this.cleanUser(targetUser);
+        return targetUser;
     }
 
     async adminDeleteUser(ctx: TraceContext, userId: string): Promise<void> {
@@ -3588,7 +3584,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             }
             this.verificationService.markVerified(user);
             await this.userDB.updateUserPartial(user);
-            return this.cleanUser(user);
+            return user;
         } catch (e) {
             throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
         }
@@ -3614,8 +3610,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         });
         target.rolesOrPermissions = Array.from(rolesOrPermissions.values()) as RoleOrPermission[];
 
-        const user = await this.userDB.storeUser(target);
-        return this.cleanUser(user);
+        return await this.userDB.storeUser(target);
     }
 
     async adminModifyPermanentWorkspaceFeatureFlag(
@@ -3643,8 +3638,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         featureSettings.permanentWSFeatureFlags = Array.from(featureFlags);
         target.featureFlags = featureSettings;
 
-        const user = await this.userDB.storeUser(target);
-        return this.cleanUser(user);
+        return await this.userDB.storeUser(target);
     }
 
     async adminGetWorkspaces(
@@ -3781,18 +3775,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<void> {
         await this.guardAdminAccess("adminSetTeamMemberRole", { teamId, userId, role }, Permission.ADMIN_WORKSPACES);
         return this.teamDB.setTeamMemberRole(userId, teamId, role);
-    }
-
-    protected cleanUser(user: User): User {
-        const res = { ...user };
-        res.identities = res.identities.map((i) => {
-            // The user field is not in the Identity shape, but actually exists on DBIdentity.
-            // Trying to push this object out via JSON RPC will fail because of the cyclic nature
-            // of this field.
-            delete (i as any).user;
-            return i;
-        });
-        return res;
     }
 
     async getOwnAuthProviders(ctx: TraceContext): Promise<AuthProviderEntry[]> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Encapsulates the DBUser object graph within user-db-impl

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-user-object</li>
	<li><b>🔗 URL</b> - <a href="https://se-user-object.preview.gitpod-dev.com/workspaces" target="_blank">se-user-object.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
