### PR TITLE
[ts] initial scrubbing integrated in logging

### DIFF
--- a/components/gitpod-protocol/src/util/scrubbing-config.ts
+++ b/components/gitpod-protocol/src/util/scrubbing-config.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+// redactedFields are the names of fields we'll redact when matched
+export const redactedFields = ["auth_", "password", "token", "key", "jwt", "secret", "email"];
+// hashedFields are the names of fields we'll hash if matched
+export const hashedFields = ["contextURL", "workspaceID", "username"];
+
+// hashedValues are regular expressions which when matched cause the entire value to be hashed
+export const hashedValues = new Map<string, RegExp>([]);
+// redactedValues are regular expressions which when matched cause the entire value to be redacted
+export const redactedValues = new Map<string, RegExp>([
+    // https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
+    [
+        "email",
+        new RegExp(
+            /[a-zA-Z0-9.!#$%&'*+/=?^_\`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/,
+            "g",
+        ),
+    ],
+]);

--- a/components/gitpod-protocol/src/util/scrubbing.spec.ts
+++ b/components/gitpod-protocol/src/util/scrubbing.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+import { suite, test } from "mocha-typescript";
+import { TrustedValue, scrubber } from "./scrubbing";
+const expect = chai.expect;
+
+@suite
+export class ScrubbingTest {
+    @test public testValue_EmptyString() {
+        expect(scrubber.scrub("")).to.equal("");
+    }
+    @test public testValue_Email() {
+        expect(scrubber.scrub("foo@bar.com")).to.equal("[redacted:email]");
+    }
+    @test public testValue_EmailInText() {
+        expect(scrubber.scrub("The email is foo@bar.com or bar@foo.com")).to.equal(
+            "The email is [redacted:email] or [redacted:email]",
+        );
+    }
+
+    @test public testKeyValue_Email() {
+        expect(scrubber.scrub({ email: "testvalue" })).to.deep.equal({ email: "[redacted]" });
+    }
+    @test public testKeyValue_AuthorEmail() {
+        expect(scrubber.scrub({ author_email: "testvalue" })).to.deep.equal({ author_email: "[redacted]" });
+    }
+    @test public testKeyValue_Token() {
+        expect(scrubber.scrub({ token: "testvalue" })).to.deep.equal({ token: "[redacted]" });
+    }
+    @test public testKeyValue_OwnerToken() {
+        expect(scrubber.scrub({ owner_token: "testvalue" })).to.deep.equal({ owner_token: "[redacted]" });
+    }
+
+    @test public testKeyValue_NestedObject() {
+        expect(scrubber.scrub({ key: { owner_token: "testvalue" } }, true)).to.deep.equal({
+            key: { owner_token: "[redacted]" },
+        });
+    }
+    @test public testKeyValue_NoNestedObject() {
+        expect(scrubber.scrub({ key: { owner_token: "testvalue" } }, false)).to.deep.equal({
+            key: "[redacted:nested:object}]",
+        });
+    }
+
+    @test public testKeyValue_NestedArray() {
+        expect(scrubber.scrub([["foo@bar.com"]])).to.deep.equal([["[redacted:email]"]]);
+    }
+
+    @test public testKeyValue_NoNestedArray() {
+        expect(scrubber.scrub([["foo@bar.com"]], false)).to.deep.equal(["[redacted:nested:array]"]);
+    }
+
+    @test public testKeyValue_Scrubbable() {
+        const scrubbedValue = new TrustedValue(scrubber.scrubValue("foo@bar.com"));
+        expect(scrubber.scrub({ key: scrubbedValue })).to.deep.equal({ key: "[redacted:email]" });
+    }
+}
+module.exports = new ScrubbingTest();

--- a/components/gitpod-protocol/src/util/scrubbing.ts
+++ b/components/gitpod-protocol/src/util/scrubbing.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { createHash } from "crypto";
+import { hashedFields, hashedValues, redactedFields, redactedValues } from "./scrubbing-config";
+
+/**
+ * `TrustedValue` is a generic wrapper class used to mark certain values as "trusted".
+ * This means these values are safe from being scrubbed or redacted by the Scrubber interface.
+ * A typical use case is to prepare values for logging or similar uses where data sanitization is required.
+ *
+ * @see Scrubber to scrub an underlyig value as necessary.
+ *
+ * @template T - The type of the value being wrapped.
+ * @property value - The value being wrapped.
+ */
+export class TrustedValue<T = any> {
+    constructor(readonly value: T) {}
+}
+
+/**
+ * The `Scrubber` interface defines methods for scrubbing or anonymizing data.
+ * It helps in preparing data by sanitizing it and ensuring that sensitive information is either hashed or redacted.
+ * The scrubbing operation does not mutate the original data structure but creates a new one with the scrubbed data.
+ */
+export interface Scrubber {
+    /**
+     * Scrub an entire object, potentially recursively if `nested` is true.
+     *
+     * @param {any} obj - The object to be scrubbed. This object is not mutated.
+     * @param {boolean} [nested] - A flag indicating whether nested scrubbing should be performed. Defaults to true.
+     * @returns {any} - The scrubbed object. This is a new object, not a mutation of the original.
+     */
+    scrub(obj: any, nested?: boolean): any;
+
+    /**
+     * Takes a key-value pair and returns a scrubbed version of the value
+     * if the key matches any of the defined sensitive fields.
+     *
+     * @param {string} key - The key of the data to be scrubbed.
+     * @param {string} value - The value of the data to be scrubbed.
+     * @returns {string} - The scrubbed value. The original value is not mutated.
+     */
+    scrubKeyValue(key: string, value: string): string;
+
+    /**
+     * Takes a value and scrubs it based on defined sensitive patterns.
+     *
+     * @param {string} value - The value to be scrubbed.
+     * @returns {string} - The scrubbed value. The original value is not mutated.
+     */
+    scrubValue(value: string): string;
+}
+
+interface SanitizeOptions {
+    key?: string;
+}
+type Sanitisatiser = (value: string, options?: SanitizeOptions) => string;
+
+const SanitiseRedact: Sanitisatiser = (_: string, options?: SanitizeOptions) => {
+    if (options?.key) {
+        return `[redacted:${options?.key}]`;
+    }
+    return "[redacted]";
+};
+const SanitiseHash: Sanitisatiser = (value: string, options?: SanitizeOptions) => {
+    const hash = createHash("md5");
+    hash.update(value);
+
+    let res = `[redacted:md5:${hash.digest("hex")}`;
+    if (options?.key) {
+        res += `:${options?.key}`;
+    }
+    res += `]`;
+    return res;
+};
+
+const regexes = new Map<RegExp, Sanitisatiser>([
+    [new RegExp(redactedFields.join("|"), "i"), SanitiseRedact],
+    [new RegExp(hashedFields.join("|"), "i"), SanitiseHash],
+]);
+
+export const scrubber: Scrubber = {
+    scrub: function (obj: any, nested: boolean = true): any {
+        return doScrub(obj, 0, nested);
+    },
+    scrubKeyValue: function (key: string, value: string): string {
+        for (const [regex, sanitisatiser] of regexes) {
+            if (regex.test(key)) {
+                return sanitisatiser(value);
+            }
+        }
+        return value;
+    },
+    scrubValue: function (value: string): string {
+        for (const [key, expr] of hashedValues.entries()) {
+            value = value.replace(expr, (s) => SanitiseHash(s, { key }));
+        }
+        for (const [key, expr] of redactedValues.entries()) {
+            value = value.replace(expr, (s) => SanitiseRedact(s, { key }));
+        }
+        return value;
+    },
+};
+
+function doScrub(obj: any, depth: number, nested: boolean): any {
+    if (obj === undefined || obj === null) {
+        return undefined;
+    }
+    if (obj instanceof TrustedValue) {
+        return obj.value;
+    }
+    const objType = typeof obj;
+    if (objType === "string") {
+        return scrubber.scrubValue(obj);
+    }
+    if (objType === "boolean" || objType === "number") {
+        return obj;
+    }
+    if (Array.isArray(obj)) {
+        if (!nested && depth > 0) {
+            return "[redacted:nested:array]";
+        }
+        return obj.map((v) => doScrub(v, depth + 1, nested));
+    }
+    if (!nested && depth > 0) {
+        return `[redacted:nested:${objType}}]`;
+    }
+    if (objType === "object") {
+        const result: any = {};
+        for (const [key, value] of Object.entries(obj)) {
+            if (typeof value === "string") {
+                result[key] = scrubber.scrubKeyValue(key, value);
+            } else {
+                result[key] = doScrub(value, depth + 1, nested);
+            }
+        }
+        return result;
+    }
+    return obj;
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR ports scrubbing from golang to TS and integrate in logging. During logging we only scrub primitive properties of log context and payload. All nested properties are scrubbed with `redacted:nested` to avoid incurring performance costs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes SID-284
Fixes SID-288

## How to test
<!-- Provide steps to test this PR -->

- Tests should be green.
- Start/stop a workspace, review logs of server and bridge.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-scrub-ts</li>
	<li><b>🔗 URL</b> - <a href="https://ak-scrub-ts.preview.gitpod-dev.com/workspaces" target="_blank">ak-scrub-ts.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
