### PR TITLE
[server] Set maximum workspace lifetime

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -344,6 +344,8 @@ export namespace WorkspaceTimeoutDuration {
 export const WORKSPACE_TIMEOUT_DEFAULT_SHORT: WorkspaceTimeoutDuration = "30m";
 export const WORKSPACE_TIMEOUT_DEFAULT_LONG: WorkspaceTimeoutDuration = "60m";
 export const WORKSPACE_TIMEOUT_EXTENDED: WorkspaceTimeoutDuration = "180m";
+export const WORKSPACE_LIFETIME_SHORT: WorkspaceTimeoutDuration = "8h";
+export const WORKSPACE_LIFETIME_LONG: WorkspaceTimeoutDuration = "36h";
 
 export const createServiceMock = function <C extends GitpodClient, S extends GitpodServer>(
     methods: Partial<JsonRpcProxy<S>>,

--- a/components/server/src/billing/entitlement-service-ubp.ts
+++ b/components/server/src/billing/entitlement-service-ubp.ts
@@ -13,6 +13,8 @@ import {
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+    WORKSPACE_LIFETIME_LONG,
+    WORKSPACE_LIFETIME_SHORT,
 } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { inject, injectable } from "inversify";
@@ -97,6 +99,14 @@ export class EntitlementServiceUBP implements EntitlementService {
             return WORKSPACE_TIMEOUT_DEFAULT_LONG;
         } else {
             return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
+        }
+    }
+
+    async getDefaultWorkspaceLifetime(user: User, date: Date): Promise<WorkspaceTimeoutDuration> {
+        if (await this.hasPaidSubscription(user, date)) {
+            return WORKSPACE_LIFETIME_LONG;
+        } else {
+            return WORKSPACE_LIFETIME_SHORT;
         }
     }
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1505,6 +1505,7 @@ export class WorkspaceStarter {
         );
         const userTimeoutPromise = this.entitlementService.getDefaultWorkspaceTimeout(user, new Date());
         const allowSetTimeoutPromise = this.entitlementService.maySetTimeout(user, new Date());
+        const workspaceLifetimePromise = this.entitlementService.getDefaultWorkspaceLifetime(user, new Date());
 
         let featureFlags = instance.configuration!.featureFlags || [];
 
@@ -1535,8 +1536,13 @@ export class WorkspaceStarter {
         spec.setClass(instance.workspaceClass!);
 
         if (workspace.type === "regular") {
-            const [defaultTimeout, allowSetTimeout] = await Promise.all([userTimeoutPromise, allowSetTimeoutPromise]);
+            const [defaultTimeout, allowSetTimeout, workspaceLifetime] = await Promise.all([
+                userTimeoutPromise,
+                allowSetTimeoutPromise,
+                workspaceLifetimePromise,
+            ]);
             spec.setTimeout(defaultTimeout);
+            spec.setMaximumLifetime(workspaceLifetime);
             if (allowSetTimeout) {
                 if (user.additionalData?.workspaceTimeout) {
                     try {


### PR DESCRIPTION
## Description
Set maximum workspace lifetime. Followup to https://github.com/gitpod-io/gitpod/pull/17767

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-234

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
