### PR TITLE
Remove setup-gcloud from workspace integration tests workflow

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -36,6 +36,10 @@ jobs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
         steps:
+            - name: Configure workspace
+              run: |
+                # Needed by google-github-actions/setup-gcloud
+                sudo chown -R gitpod:gitpod /__t
             # sometimes auth fails with:
             # google-github-actions/setup-gcloud failed with: EACCES: permission denied, mkdir '/__t/gcloud'
             - name: Set up Cloud SDK
@@ -138,9 +142,9 @@ jobs:
                 # Needed by google-github-actions/setup-gcloud
                 sudo chown -R gitpod:gitpod /__t
 
-            - id: gcloud-sdk-setup
-              name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v1
+            # - id: gcloud-sdk-setup
+            #   name: Set up Cloud SDK
+            #   uses: google-github-actions/setup-gcloud@v1
             - id: auth
               uses: google-github-actions/auth@v1
               with:

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -36,14 +36,6 @@ jobs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
         steps:
-            - name: Configure workspace
-              run: |
-                # Needed by google-github-actions/setup-gcloud
-                sudo chown -R gitpod:gitpod /__t
-            # sometimes auth fails with:
-            # google-github-actions/setup-gcloud failed with: EACCES: permission denied, mkdir '/__t/gcloud'
-            - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v1
             - id: auth
               uses: google-github-actions/auth@v1
               continue-on-error: true
@@ -137,14 +129,6 @@ jobs:
                 - /tmp:/tmp
         steps:
             - uses: actions/checkout@v3
-            - name: Configure workspace
-              run: |
-                # Needed by google-github-actions/setup-gcloud
-                sudo chown -R gitpod:gitpod /__t
-
-            # - id: gcloud-sdk-setup
-            #   name: Set up Cloud SDK
-            #   uses: google-github-actions/setup-gcloud@v1
             - id: auth
               uses: google-github-actions/auth@v1
               with:


### PR DESCRIPTION
## Description

Remove setup of gcloud for workspace integration tests and use gcloud that's already installed in the dev image used by the jobs.

Should fix flakes where the job fails due to `google-github-actions/setup-gcloud failed with: EACCES: permission denied, mkdir '/__t/gcloud'`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-228

## How to test
<!-- Provide steps to test this PR -->

Example run: https://github.com/gitpod-io/gitpod/actions/runs/5254377210

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
