### PR TITLE
[server] remove user relation from gitpod_token

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-gitpod-token.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-gitpod-token.ts
@@ -5,9 +5,9 @@
  */
 
 import { GitpodToken, GitpodTokenType } from "@gitpod/gitpod-protocol";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { Column, Entity, PrimaryColumn } from "typeorm";
 import { Transformer } from "../transformer";
-import { DBUser } from "./db-user";
+import { TypeORM } from "../typeorm";
 
 @Entity()
 // on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
@@ -24,9 +24,8 @@ export class DBGitpodToken implements GitpodToken {
     @Column({ type: "int" })
     type: GitpodTokenType;
 
-    @ManyToOne((type) => DBUser)
-    @JoinColumn()
-    user: DBUser;
+    @Column(TypeORM.UUID_COLUMN_TYPE)
+    userId: string;
 
     @Column("simple-array")
     scopes: string[];

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -141,7 +141,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
     ): Promise<{ user: User; token: GitpodToken } | undefined>;
     findGitpodTokensOfUser(userId: string, tokenHash: string): Promise<GitpodToken | undefined>;
     findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]>;
-    storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
+    storeGitpodToken(token: GitpodToken): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;
     deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void>;
     countUsagesOfPhoneNumber(phoneNumber: string): Promise<number>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -624,7 +624,7 @@ export interface GitpodToken {
     type: GitpodTokenType;
 
     /** The user the token belongs to. */
-    user: User;
+    userId: string;
 
     /** Scopes (e.g. limition to read-only) */
     scopes: string[];

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -222,7 +222,7 @@ export class OwnerResourceGuard implements ResourceAccessGuard {
             case "contentBlob":
                 return resource.userID === this.userId;
             case "gitpodToken":
-                return resource.subject.user.id === this.userId;
+                return resource.subject.userId === this.userId;
             case "snapshot":
                 return resource.workspace.ownerId === this.userId;
             case "token":

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -6,7 +6,7 @@
 
 import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
-import { DBUser, OneTimeSecretDB, TeamDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { OneTimeSecretDB, TeamDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib/user-db";
 import * as express from "express";
 import { Authenticator } from "../auth/authenticator";
@@ -445,11 +445,11 @@ export class UserController {
 
                     const token = crypto.randomBytes(30).toString("hex");
                     const tokenHash = crypto.createHash("sha256").update(token, "utf8").digest("hex");
-                    const dbToken: GitpodToken & { user: DBUser } = {
+                    const dbToken: GitpodToken = {
                         tokenHash,
                         name: `local-app`,
                         type: GitpodTokenType.MACHINE_AUTH_TOKEN,
-                        user: req.user as DBUser,
+                        userId: req.user.id,
                         scopes: [
                             "function:getWorkspaces",
                             "function:listenForWorkspaceInstanceUpdates",

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -17,7 +17,6 @@ import {
     DBWithTracing,
     TracedWorkspaceDB,
     DBGitpodToken,
-    DBUser,
     UserStorageResourcesDB,
     TeamDB,
     ProjectDB,
@@ -3404,7 +3403,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             tokenHash,
             name: options.name,
             type: options.type,
-            user: user as DBUser,
+            userId: user.id,
             scopes: options.scopes || [],
             created: new Date().toISOString(),
         };

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -16,7 +16,6 @@ import {
 } from "@gitpod/content-service/lib";
 import { CompositeInitializer, FromBackupInitializer } from "@gitpod/content-service/lib/initializer_pb";
 import {
-    DBUser,
     DBWithTracing,
     ProjectDB,
     TeamDB,
@@ -1392,11 +1391,11 @@ export class WorkspaceStarter {
             const scopes = this.createDefaultGitpodAPITokenScopes(workspace, instance);
             const token = crypto.randomBytes(30).toString("hex");
             const tokenHash = crypto.createHash("sha256").update(token, "utf8").digest("hex");
-            const dbToken: GitpodToken & { user: DBUser } = {
+            const dbToken: GitpodToken = {
                 tokenHash,
                 name: `${instance.id}-default`,
                 type: GitpodTokenType.MACHINE_AUTH_TOKEN,
-                user: user as DBUser,
+                userId: user.id,
                 scopes,
                 created: new Date().toISOString(),
             };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The relation would pull non-fully initialized user objects into the system. We should rather not use relations but keys and explicitly fetch the user when needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-remove-relation</li>
	<li><b>🔗 URL</b> - <a href="https://se-remove-relation.preview.gitpod-dev.com/workspaces" target="_blank">se-remove-relation.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
