### PR TITLE
Use a script for BROWSER variable

### DIFF
--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -23,6 +23,7 @@ packages:
     type: docker
     srcs:
       - "supervisor-config.json"
+      - "browser.sh"
     deps:
       - :app
       - components/supervisor/frontend:app

--- a/components/supervisor/browser.sh
+++ b/components/supervisor/browser.sh
@@ -1,3 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
 
 gp preview --external "$@"

--- a/components/supervisor/browser.sh
+++ b/components/supervisor/browser.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+gp preview --external "$@"

--- a/components/supervisor/leeway.Dockerfile
+++ b/components/supervisor/leeway.Dockerfile
@@ -23,6 +23,7 @@ COPY components-supervisor-frontend--app/node_modules/@gitpod/supervisor-fronten
 WORKDIR "/.supervisor"
 COPY components-supervisor--app/supervisor \
      supervisor-config.json \
+     browser.sh \
      components-gitpod-cli--app/gitpod-cli \
      ./
 

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1012,7 +1012,22 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 	}
 
 	if _, ok := envs["BROWSER"]; !ok {
-		envs["BROWSER"] = "gp preview --external"
+		// Create browser script
+		browser_script := filepath.Join("/ide", "gp_browser.sh")
+		if _, err := os.Stat(browser_script); err != nil {
+			if file, err := os.OpenFile(browser_script, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755); err == nil {
+				defer file.Close()
+				scriptContent := `#!/usr/bin/env bash
+gp preview --external "$@"`
+				if _, err := file.WriteString(scriptContent); err != nil {
+					log.WithError(err).Error("Error while writing")
+				}
+			} else {
+				log.WithError(err).Error("Failed to create script for $BROWSER")
+			}
+		}
+
+		envs["BROWSER"] = browser_script
 	}
 
 	var env, envn []string

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1012,7 +1012,7 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 	}
 
 	if _, ok := envs["BROWSER"]; !ok {
-		envs["BROWSER"] = "gp preview --external"
+		envs["BROWSER"] = "/.supervisor/browser.sh"
 	}
 
 	var env, envn []string

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1012,22 +1012,7 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 	}
 
 	if _, ok := envs["BROWSER"]; !ok {
-		// Create browser script
-		browser_script := filepath.Join("/ide", "gp_browser.sh")
-		if _, err := os.Stat(browser_script); err != nil {
-			if file, err := os.OpenFile(browser_script, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755); err == nil {
-				defer file.Close()
-				scriptContent := `#!/usr/bin/env bash
-gp preview --external "$@"`
-				if _, err := file.WriteString(scriptContent); err != nil {
-					log.WithError(err).Error("Error while writing")
-				}
-			} else {
-				log.WithError(err).Error("Failed to create script for $BROWSER")
-			}
-		}
-
-		envs["BROWSER"] = browser_script
+		envs["BROWSER"] = "gp preview --external"
 	}
 
 	var env, envn []string

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,7 +21,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
-			"BROWSER=gp preview --external",
+			"BROWSER=/ide/gp_browser.sh",
 			"HISTFILE=/workspace/.gitpod/.shell_history",
 			"PROMPT_COMMAND=history -a",
 		)
@@ -93,7 +93,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=gp preview --external",
+				"BROWSER=/ide/gp_browser.sh",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
@@ -103,7 +103,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `invalid json`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=gp preview --external",
+				"BROWSER=/ide/gp_browser.sh",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,7 +21,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
-			"BROWSER=gp preview --external",
+			"BROWSER=/.supervisor/browser.sh",
 			"HISTFILE=/workspace/.gitpod/.shell_history",
 			"PROMPT_COMMAND=history -a",
 		)
@@ -93,7 +93,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=gp preview --external",
+				"BROWSER=/.supervisor/browser.sh",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
@@ -103,7 +103,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `invalid json`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=gp preview --external",
+				"BROWSER=/.supervisor/browser.sh",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -21,7 +21,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			"SUPERVISOR_ADDR=localhost:8080",
 			"HOME=/home/gitpod",
 			"USER=gitpod",
-			"BROWSER=/ide/gp_browser.sh",
+			"BROWSER=gp preview --external",
 			"HISTFILE=/workspace/.gitpod/.shell_history",
 			"PROMPT_COMMAND=history -a",
 		)
@@ -93,7 +93,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `[{"name":"foo","value":"bar"},{"name":"GITPOD_TOKENS","value":"foobar"}]`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=/ide/gp_browser.sh",
+				"BROWSER=gp preview --external",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod", "foo=bar"},
 		},
@@ -103,7 +103,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 			OTS:   `invalid json`,
 			Expectation: []string{
 				"HOME=/home/gitpod",
-				"BROWSER=/ide/gp_browser.sh",
+				"BROWSER=gp preview --external",
 				"HISTFILE=/workspace/.gitpod/.shell_history",
 				"PROMPT_COMMAND=history -a", "SUPERVISOR_ADDR=localhost:8080", "USER=gitpod"},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Tools like `npm` expect the `$BROWSER` env var to correspond to an executable. Similar to VSCode's `BROWSER=/ide/bin/helpers/browser.sh`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/17913

## How to test
<!-- Provide steps to test this PR -->
- Open https://github.com/johnston9/shot-caller in Gitpod
- Run `npm start`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - axonasif-ue2f5466fab</li>
	<li><b>🔗 URL</b> - <a href="https://axonasif-ue2f5466fab.preview.gitpod-dev.com/workspaces" target="_blank">axonasif-ue2f5466fab.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
