### PR TITLE
removing usageDownload flag

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -22,7 +22,6 @@ const featureFlags = {
     userGitAuthProviders: false,
     linkedinConnectionForOnboarding: false,
     enableDedicatedOnboardingFlow: false,
-    usageDownload: false,
     phoneVerificationByCall: false,
 };
 

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -22,7 +22,6 @@ import { UsageEntry } from "./UsageEntry";
 import Alert from "../components/Alert";
 import classNames from "classnames";
 import { UsageDateFilters } from "./UsageDateFilters";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { DownloadUsage } from "./download/DownloadUsage";
 import { useQueryParams } from "../hooks/use-query-params";
 
@@ -34,7 +33,6 @@ interface UsageViewProps {
 export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
     const location = useLocation();
     const history = useHistory();
-    const usageDownload = useFeatureFlag("usageDownload");
     const params = useQueryParams();
 
     // page filter params are all in the url as querystring params
@@ -101,9 +99,7 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
                     )}
                 >
                     <UsageDateFilters startDate={startDate} endDate={endDate} onDateRangeChange={updatePageParams} />
-                    {usageDownload && (
-                        <DownloadUsage attributionId={attributionId} startDate={startDate} endDate={endDate} />
-                    )}
+                    <DownloadUsage attributionId={attributionId} startDate={startDate} endDate={endDate} />
                 </div>
 
                 {errorMessage && (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the `usageDownload` flag that was wrapping the usage `Export as CSV` button now that it's fully enabled.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-439

## How to test
<!-- Provide steps to test this PR -->
Verify the Usage page has the Export as CSV button

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
