### PR TITLE
Don't change editor/ws class values if user has modified them

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -140,7 +140,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                 className={
                     "h-16 bg-gray-100 dark:bg-gray-800 flex items-center px-2 " +
                     (showDropDown
-                        ? "rounded-t-lg"
+                        ? "rounded-t-lg filter drop-shadow-xl"
                         : props?.disabled
                         ? "rounded-lg opacity-80 "
                         : "rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer")
@@ -154,7 +154,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                 </div>
             </div>
             {showDropDown && (
-                <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 max-h-72 overflow-auto rounded-b-lg mt-3 z-50 p-2">
+                <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 max-h-72 overflow-auto rounded-b-lg mt-3 z-50 p-2 filter drop-shadow-xl">
                     {!props.disableSearch && (
                         <div className="h-12">
                             <input

--- a/components/dashboard/src/hooks/use-dirty-state.ts
+++ b/components/dashboard/src/hooks/use-dirty-state.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useCallback, useState } from "react";
+
+// a hook that tracks whether a value has been changed from its initial value
+export const useDirtyState = <T>(initialValue: T): [T, (val: T, trackDirty?: boolean) => void, boolean] => {
+    const [value, setValue] = useState<T>(initialValue);
+    const [dirty, setDirty] = useState<boolean>(false);
+
+    // sets value, and by default sets dirty flag to true
+    // trackDirty can be optionally overridden to prevent setting the dirty flag
+    // this is useful for cases where a value needs to be updated, but not necessarily treat it as dirty
+    const setDirtyValue = useCallback((value: T, trackDirty = true) => {
+        setValue(value);
+        if (trackDirty) {
+            setDirty(true);
+        }
+    }, []);
+
+    return [value, setDirtyValue, dirty];
+};

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -125,8 +125,20 @@ export function CreateWorkspacePage() {
         }
     }, [projects.data, workspaceContext.data]);
 
+    // Apply project ws class settings
     useEffect(() => {
-        if (!project || props.workspaceClass) {
+        // If URL has a ws class set, we don't override it w/ project settings
+        if (props.workspaceClass) {
+            return;
+        }
+
+        if (!project) {
+            // If no project and user hasn't changed ws class, reset it to default value
+            // Empty value causes SelectWorkspaceClassComponent to use the dfeault ws class
+            if (!selectedWsClassIsDirty) {
+                console.log("resetting ws class");
+                setSelectedWsClass("", false);
+            }
             return;
         }
         const wsClass = project.settings?.workspaceClasses;

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -281,9 +281,14 @@ export function CreateWorkspacePage() {
                 }
             }
             setRememberOptions(true);
-            setSelectedIde(rememberedOptions.ideSettings?.defaultIde, false);
-            setUseLatestIde(!!rememberedOptions.ideSettings?.useLatestVersion);
-            setSelectedWsClass(rememberedOptions.workspaceClass, false);
+            if (!selectedIdeIsDirty) {
+                setSelectedIde(rememberedOptions.ideSettings?.defaultIde, false);
+                setUseLatestIde(!!rememberedOptions.ideSettings?.useLatestVersion);
+            }
+
+            if (!selectedWsClassIsDirty) {
+                setSelectedWsClass(rememberedOptions.workspaceClass, false);
+            }
             if (autostart === undefined) {
                 setAutostart(true);
             }
@@ -305,12 +310,12 @@ export function CreateWorkspacePage() {
     // if the context URL has a referrer prefix, we set the referrerIde as the selected IDE and autostart the workspace.
     useEffect(() => {
         if (workspaceContext.data && WithReferrerContext.is(workspaceContext.data)) {
-            if (workspaceContext.data.referrerIde) {
+            if (workspaceContext.data.referrerIde && !selectedIdeIsDirty) {
                 setSelectedIde(workspaceContext.data.referrerIde, false);
             }
             setAutostart(true);
         }
-    }, [setSelectedIde, workspaceContext.data]);
+    }, [selectedIdeIsDirty, setSelectedIde, workspaceContext.data]);
 
     if (SelectAccountPayload.is(selectAccountError)) {
         return (

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -44,6 +44,7 @@ export const useNewCreateWorkspacePage = () => {
     return !!startWithOptions || !!user?.additionalData?.isMigratedToTeamOnlyAttribution;
 };
 
+// TODO: wip for not changing "dirty" option values when context arrives
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
     const currentOrg = useCurrentOrg().data;

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -136,7 +136,6 @@ export function CreateWorkspacePage() {
             // If no project and user hasn't changed ws class, reset it to default value
             // Empty value causes SelectWorkspaceClassComponent to use the dfeault ws class
             if (!selectedWsClassIsDirty) {
-                console.log("resetting ws class");
                 setSelectedWsClass("", false);
             }
             return;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
On the create workspace page we have a few scenarios that auto-update the editor or ws class. Sometimes this can override a user's manual selection. In those cases, we don't want to update those values if the user has explicitly changed it already.

I accomplished this by creating a new `useDirtyState()` hook that behaves similar to `useState()`:

```ts
const [value, setValue, isDirty] = useDirtyState("initial value");

// isDirty will now be true
setValue(newValue);

// isDirty won't change based on this call
setValue(newValue, false);
```

It returns a third parameter indicating if the value is "dirty", meaning the value has been changed by the user. `setValue` can also be called with an optional 2nd argument to bypass tracking the dirty state (useful when we want to update the value behind the scenes, and not treat it as if the user modified it themselves.

🤫 I also snuck in a change to the `<Dropdown2/>` styling that George started in #17680 since I was already in this area.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-440

## How to test
<!-- Provide steps to test this PR -->
* Create a project and set the WS class in the Project settings to **Small**.
* Navigate to the Create Workspace page
* Pick the your project's repo
* WS Class should have updated to **Small**
* Pick a different repo that has no project
* WS Class should stay **Small**
* Change WS class to **Default**
* Pick your project's repo
* WS Class should stay **Default** and _not_ change the **Small**

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-4f04c798714</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-4f04c798714.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-4f04c798714.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
