### PR TITLE
[obs] setup better names for alert rules

### DIFF
--- a/operations/observability/mixins/IDE/rules/vscode.yaml
+++ b/operations/observability/mixins/IDE/rules/vscode.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: openvsx-proxy-monitoring-rules
+  name: openvsx-monitoring-rules
   namespace: monitoring-satellite
 spec:
   groups:

--- a/operations/observability/mixins/meta/rules/content-service.yaml
+++ b/operations/observability/mixins/meta/rules/content-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: content-service-monitoring-rules
 spec:
   groups:
   - name: content-service


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some alert rule groups have duplicate metadata names.

To migrate our alerts to Dedicated, it will be easier to manage these as discrete namespaces.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related SID-373

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
