### PR TITLE
Remove hostname from callback URL – WEB-398

### DIFF
--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -42,19 +42,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     const isNew = !savedProvider;
 
     // This is a readonly value to copy and plug into external oauth config
-    const redirectURL = useMemo(() => {
-        let url = "";
-
-        // Once it's saved, use what's stored
-        if (!isNew) {
-            url = savedProvider?.oauth.callBackUrl ?? url;
-        } else {
-            // Otherwise construct it w/ their provided host value or example
-            url = callbackUrl(host || getPlaceholderForIntegrationType(type));
-        }
-
-        return url;
-    }, [host, isNew, savedProvider?.oauth.callBackUrl, type]);
+    const redirectURL = callbackUrl();
 
     // "bitbucket.org" is set as host value whenever "Bitbucket" is selected
     useEffect(() => {
@@ -281,13 +269,8 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     );
 };
 
-const callbackUrl = (host: string) => {
-    // Negative Lookahead (?!\/)
-    // `\/` matches the character `/`
-    // "https://foobar:80".replace(/:(?!\/)/, "_")
-    // => 'https://foobar_80'
-    host = host.replace(/:(?!\/)/, "_");
-    const pathname = `/auth/${host}/callback`;
+const callbackUrl = () => {
+    const pathname = `/auth/callback`;
     return gitpodHostUrl.with({ pathname }).toString();
 };
 

--- a/components/dashboard/src/user-settings/Integrations.test.tsx
+++ b/components/dashboard/src/user-settings/Integrations.test.tsx
@@ -20,5 +20,5 @@ test("should update redirectURL preview", async () => {
 
     const redirectURL = screen.getByLabelText(/Redirect/i);
     // screen.debug(redirectURL);
-    expect((redirectURL as HTMLInputElement).value).toEqual("http://localhost/auth/gitlab.gitpod.io_80/callback");
+    expect((redirectURL as HTMLInputElement).value).toEqual("http://localhost/auth/callback");
 });

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -504,13 +504,8 @@ export function GitIntegrationModal(
         onAuthorize?: (payload?: string) => void;
     },
 ) {
-    const callbackUrl = (host: string) => {
-        // Negative Lookahead (?!\/)
-        // `\/` matches the character `/`
-        // "https://foobar:80".replace(/:(?!\/)/, "_")
-        // => 'https://foobar_80'
-        host = host.replace(/:(?!\/)/, "_");
-        const pathname = `/auth/${host}/callback`;
+    const callbackUrl = () => {
+        const pathname = `/auth/callback`;
         return gitpodHostUrl.with({ pathname }).toString();
     };
 
@@ -519,7 +514,7 @@ export function GitIntegrationModal(
 
     const [type, setType] = useState<string>("GitLab");
     const [host, setHost] = useState<string>("");
-    const [redirectURI, setRedirectURI] = useState<string>(callbackUrl("gitlab.example.com"));
+    const [redirectURI, setRedirectURI] = useState<string>(callbackUrl());
     const [clientId, setClientId] = useState<string>("");
     const [clientSecret, setClientSecret] = useState<string>("");
     const [busy, setBusy] = useState<boolean>(false);
@@ -632,7 +627,6 @@ export function GitIntegrationModal(
             }
 
             setHost(newHostValue);
-            setRedirectURI(callbackUrl(newHostValue));
             setErrorMessage(undefined);
         }
     };

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -175,7 +175,7 @@ export class AuthProviderService {
         }
         const oauth: AuthProviderEntry["oauth"] = {
             ...urls,
-            callBackUrl: this.callbackUrl(host),
+            callBackUrl: this.callbackUrl(),
             clientId: clientId!,
             clientSecret: clientSecret!,
         };
@@ -239,9 +239,8 @@ export class AuthProviderService {
         }
     }
 
-    protected callbackUrl = (host: string) => {
-        const safeHost = host.replace(":", "_");
-        const pathname = `/auth/${safeHost}/callback`;
+    protected callbackUrl = () => {
+        const pathname = `/auth/callback`;
         return this.config.hostUrl.with({ pathname }).toString();
     };
 

--- a/components/server/src/express.ts
+++ b/components/server/src/express.ts
@@ -5,10 +5,15 @@
  */
 
 import { User as GitpodUser } from "@gitpod/gitpod-protocol";
+import { AuthFlow } from "./auth/auth-provider";
 
 // use declaration merging (https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to augment the standard passport/express definitions
 declare global {
     namespace Express {
         export interface User extends GitpodUser {}
+
+        interface Request {
+            authFlow?: AuthFlow;
+        }
     }
 }


### PR DESCRIPTION
## Description
Removing the `host_like` segment form the callback URL of git providers.

e.g. instead of `/auth/github.com/callback` it should work with `/auth/callback` once this is landed.

Here you can see, the legacy URL still works nicely:

<img width="1214" alt="Screenshot 2023-06-20 at 16 56 45" src="https://github.com/gitpod-io/gitpod/assets/914497/b5511bf5-8e70-4c2e-bf4b-5b3c06cbd692">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-398

## How to test
* test with github.com (legacy callback URL) directly through the sign-up
* [join](https://at-callback-url.preview.gitpod-dev.com/orgs/join?inviteId=ec3a1f1a-5e92-4d88-91f4-3546190e4818) my org to test with gitlab.com (simplified callback URL) which is configured under the Org

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-callback-url</li>
	<li><b>🔗 URL</b> - <a href="https://at-callback-url.preview.gitpod-dev.com/workspaces" target="_blank">at-callback-url.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
