### PR TITLE
[registry-facade] Use resolverProvider for static layers

### DIFF
--- a/components/registry-facade/pkg/registry/layersource_test.go
+++ b/components/registry-facade/pkg/registry/layersource_test.go
@@ -65,7 +65,7 @@ func TestStaticLayerSource(t *testing.T) {
 		Test: func(t *testing.T, input interface{}) interface{} {
 			fixture := input.(*testStaticLayerSourceFixture)
 
-			src, err := NewStaticSourceFromImage(context.Background(), &fakeFetcher{Content: fixture.Content}, fixture.SourceRef)
+			src, err := NewStaticSourceFromImage(context.Background(), func() remotes.Resolver { return &fakeFetcher{Content: fixture.Content} }, fixture.SourceRef)
 			if err != nil {
 				return &gold{Error: err.Error()}
 			}

--- a/components/registry-facade/pkg/registry/registry.go
+++ b/components/registry-facade/pkg/registry/registry.go
@@ -52,7 +52,7 @@ func buildStaticLayer(ctx context.Context, cfg []config.StaticLayerCfg, newResol
 			}
 			l = append(l, src)
 		case "image":
-			src, err := NewStaticSourceFromImage(ctx, newResolver(), sl.Ref)
+			src, err := NewStaticSourceFromImage(ctx, newResolver, sl.Ref)
 			if err != nil {
 				return nil, xerrors.Errorf("cannot source layer from %s: %w", sl.Ref, err)
 			}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

To always use the latest (updated) image pull credentials

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-239

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
