### PR TITLE
[obs] remove ws-manager (mk1) alert references

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspacefailure-SLO.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspacefailure-SLO.yaml
@@ -17,9 +17,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[5m]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[5m]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[5m]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[5m]))
           )
         ) + (
           (
@@ -33,9 +33,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[30m]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[30m]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[30m]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[30m]))
           )
         ) + (
           (
@@ -49,9 +49,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[1h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[1h]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[1h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[1h]))
           )
         ) + (
           (
@@ -65,9 +65,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[2h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[2h]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[2h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[2h]))
           )
         ) + (
           (
@@ -81,9 +81,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[6h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[6h]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[6h]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[6h]))
           )
         ) + (
           (
@@ -97,9 +97,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[1d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[1d]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[1d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[1d]))
           )
         ) + (
           (
@@ -113,9 +113,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[3d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[3d]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[3d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[3d]))
           )
         ) + (
           (
@@ -129,9 +129,9 @@ spec:
       expr: |
         (
           (
-            sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[30d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{reason="failed",type!~"PREBUILD", cluster!~"ephemeral.*"}[30d]))
             /
-            sum(rate(gitpod_ws_manager_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[30d]))
+            sum(rate(gitpod_ws_manager_mk2_workspace_stops_total{type!~"PREBUILD", cluster!~"ephemeral.*"}[30d]))
           )
         ) + (
           (

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -93,19 +93,19 @@ spec:
 
     - alert: GitpodImagebuildDoneSuccess
       labels:
-        severity: critical
+        severity: warning
         team: workspace
-      for: 4h
+      for: 12h
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildDoneSuccess.md
         summary: imagebuilds done are failing at a high rate in cluster {{ $labels.cluster }}.
-        description: imagebuilds`s are not reaching done at too high of a rate in cluster {{ $labels.cluster }}.
+        description: imagebuilds are not reaching done at too high of a rate in cluster {{ $labels.cluster }}.
       expr: |
         (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.60
 
     - alert: GitpodImagebuildStartSuccess
       labels:
-        severity: critical
+        severity: warning
         team: workspace
       for: 2h
       annotations:
@@ -113,4 +113,4 @@ spec:
         summary: imagebuild start success rate is failing in cluster {{ $labels.cluster }}.
         description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
       expr: |
-        (1 - (sum(rate(gitpod_ws_manager_mk2_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_ws_manager_mk2_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99
+        (1 - (sum(rate(gitpod_ws_manager_mk2_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[8h])) / sum(rate(gitpod_ws_manager_mk2_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -14,17 +14,6 @@ spec:
 
   - name: workspace-alerts
     rules:
-    - alert: GitpodWorkspaceStuckOnStopped
-      labels:
-        severity: warning
-        team: workspace
-      for: 20m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopped.md
-        summary: Workspaces are stuck in STOPPED phase on cluster {{ $labels.cluster }}.
-        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on stopped for more than 20 minutes. Current status: {{ $labels.reason }}'
-      expr: |
-        sum(gitpod_ws_manager_workspace_phase_total{phase="STOPPED", cluster!~"ephemeral.*"}) > 5
     - alert: GitpodWorkspaceStuckOnStoppedMk2
       labels:
         severity: warning
@@ -37,18 +26,6 @@ spec:
       expr: |
         sum(gitpod_ws_manager_mk2_workspace_phase_total{phase="STOPPED", cluster!~"ephemeral.*"}) > 5
 
-    - alert: GitpodWorkspaceStuckOnStopping
-      labels:
-        severity: critical
-      for: 30m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
-        summary: 15 or more workspaces are stuck on stopping in cluster {{ $labels.cluster }}.
-        description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.'
-      expr: |
-        sum(
-          gitpod_ws_manager_workspace_phase_total{type="REGULAR", phase="STOPPING", cluster!~"ephemeral.*"}
-        ) without(phase) > 15
     - alert: GitpodWorkspaceStuckOnStoppingMk2
       labels:
         severity: critical
@@ -62,15 +39,6 @@ spec:
           gitpod_ws_manager_mk2_workspace_phase_total{type="REGULAR", phase="STOPPING", cluster!~"ephemeral.*"}
         ) without(phase) > 15
 
-    - alert: GitpodWorkspaceHighFailureRate
-      labels:
-        severity: critical
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceHighFailureRate.md
-        summary: Workspaces are failing in cluster {{ $labels.cluster }}.
-        description: Multiple workspaces are failing for the last 5 minutes
-      expr: |
-          rate(gitpod_ws_manager_workspace_stops_total{reason="failed", type="REGULAR", cluster!~"ephemeral.*"}[5m]) >= 1
     - alert: GitpodWorkspaceHighFailureRateMk2
       labels:
         severity: critical
@@ -91,16 +59,6 @@ spec:
       expr: |
         sum(rate(gitpod_ws_manager_bridge_status_updates_total[1m])) == 0 AND sum(rate(grpc_client_handled_total{grpc_method="StartWorkspace", grpc_service="wsman.WorkspaceManager"}[1m])) != 0
 
-    - alert: GitpodTooManyWorkspacesInPending
-      labels:
-        severity: critical
-      for: 15m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyWorkspacesInPending.md
-        summary: workspaces are in pending phase
-        description: regular workspaces are stuck in pending phase in cluster {{ $labels.cluster }}.
-      expr: |
-        gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="REGULAR", cluster!~"ephemeral.*"} > 20
     - alert: GitpodTooManyWorkspacesInPendingMk2
       labels:
         severity: critical
@@ -112,16 +70,6 @@ spec:
       expr: |
         gitpod_ws_manager_mk2_workspace_phase_total{phase="PENDING", type="REGULAR", cluster!~"ephemeral.*"} > 20
 
-    - alert: GitpodTooManyPrebuildsInPending
-      labels:
-        severity: critical
-      for: 15m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyPrebuildsInPending.md
-        summary: workspaces are in pending phase
-        description: prebuilds are stuck in pending phase in cluster {{ $labels.cluster }}.
-      expr: |
-        gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="PREBUILD", cluster!~"ephemeral.*"} > 20
     - alert: GitpodTooManyPrebuildsInPendingMk2
       labels:
         severity: critical
@@ -155,17 +103,6 @@ spec:
       expr: |
         (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.60
 
-    - alert: GitpodImagebuildStartSuccess
-      labels:
-        severity: critical
-        team: workspace
-      for: 2h
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildStartSuccess.md
-        summary: imagebuild start success rate is failing in cluster {{ $labels.cluster }}.
-        description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
-      expr: |
-        (1 - (sum(rate(gitpod_ws_manager_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_ws_manager_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99
     - alert: GitpodImagebuildStartSuccess
       labels:
         severity: critical

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -13,27 +13,12 @@ spec:
   groups:
   - name: workspace-rules
     rules:
-    - record: gitpod_workspace_regular_not_active_percentage
-      expr: |
-        gitpod_ws_manager_workspace_activity_total{active="false"} / gitpod_ws_manager_workspace_activity_total
     - record: gitpod_workspace_regular_not_active_percentage_mk2
       expr: |
         gitpod_ws_manager_mk2_workspace_activity_total{active="false"} / gitpod_ws_manager_mk2_workspace_activity_total
 
   - name: workspace-alerts
     rules:
-    - alert: GitpodWorkspaceTooManyRegularNotActive
-      labels:
-        severity: critical
-      for: 10m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
-        summary: too many running but inactive workspaces
-        description: too many running but inactive workspaces.
-      expr: |
-        gitpod_workspace_regular_not_active_percentage > 0.10
-        AND
-        sum(gitpod_ws_manager_workspace_activity_total) by(cluster) > 20
     - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
       labels:
         severity: critical
@@ -47,18 +32,6 @@ spec:
         AND
         sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 20
 
-    - alert: GitpodWorkspacesNotStarting
-      labels:
-        severity: critical
-      for: 10m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md
-        summary: workspaces are not starting.
-        description: inactive regular workspaces exists but workspaces are not being started.
-      expr: |
-        avg_over_time(gitpod_workspace_regular_not_active_percentage[1m]) > 0
-        AND
-        rate(gitpod_ws_manager_workspace_startup_seconds_sum{type="REGULAR"}[1m]) == 0
     - alert: GitpodWorkspacesNotStartingMk2
       labels:
         severity: critical

--- a/operations/observability/mixins/workspace/rules/satellite/ws-daemon.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/ws-daemon.yaml
@@ -22,4 +22,4 @@ spec:
         description: Ws-daemon is restarting {{ printf "%.2f" $value }} times / 10 minutes.
         dashboard_url: https://grafana.gitpod.io/d/ws-daemon/gitpod-component-ws-daemon
       expr: |
-        sum(increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m])) by(cluster) > 0 AND sum(increase(gitpod_ws_manager_workspace_backups_failure_total{type="REGULAR"}[10m])) by(cluster) > 0
+        sum(increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m])) by(cluster) > 0 AND sum(increase(gitpod_ws_manager_mk2_workspace_backups_failure_total{type="REGULAR"}[10m])) by(cluster) > 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This includes old alerts, old recording rules, what appear to be SLO alert rules that appear incomplete, and fixing a bug with BackupFailureBecauseOfGitpodWsDaemonCrash.

Also, flip a couple image builder alerts back to warning to avoid false positives.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related SID-373

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
