### PR TITLE
Remove catch-all that isn't right most of the time

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -508,12 +508,6 @@ const ErrorMessage: FunctionComponent<StatusMessageProps> = ({
         return <></>;
     }
     switch (error.code) {
-        case ErrorCodes.CONTEXT_PARSE_ERROR:
-            return renderError(
-                `Are you trying to open a Git repository from a self-managed git hoster?`,
-                "Add integration",
-                gitpodHostUrl.asAccessControl().toString(),
-            );
         case ErrorCodes.INVALID_GITPOD_YML:
             return renderError(`The gitpod.yml is invalid.`, `Use default config`, undefined, () => {
                 createWorkspace({ forceDefaultConfig: true });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensuring we show the error.message by default for create workspace and context parsing calls in the dashboard.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-273

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
