### PR TITLE
[server] Remove listAvailableUsageAttributionIds and setUsageAttribution

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -243,9 +243,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     listUsage(req: ListUsageRequest): Promise<ListUsageResponse>;
 
-    setUsageAttribution(usageAttribution: string): Promise<void>;
-    listAvailableUsageAttributionIds(): Promise<string[]>;
-
     getBillingModeForUser(): Promise<BillingMode>;
     getBillingModeForTeam(teamId: string): Promise<BillingMode>;
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -191,7 +191,6 @@ const defaultFunctions: FunctionsConfig = {
     identifyUser: { group: "default", points: 1 },
     getIDEOptions: { group: "default", points: 1 },
     getPrebuildEvents: { group: "default", points: 1 },
-    setUsageAttribution: { group: "default", points: 1 },
     getCostCenter: { group: "default", points: 1 },
     setUsageLimit: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -192,7 +192,6 @@ const defaultFunctions: FunctionsConfig = {
     getIDEOptions: { group: "default", points: 1 },
     getPrebuildEvents: { group: "default", points: 1 },
     setUsageAttribution: { group: "default", points: 1 },
-    listAvailableUsageAttributionIds: { group: "default", points: 1 },
     getCostCenter: { group: "default", points: 1 },
     setUsageLimit: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -222,12 +222,6 @@ export class UserService {
         return response.usedCredits < response.usageLimit;
     }
 
-    async setUsageAttribution(user: User, usageAttributionId: string): Promise<void> {
-        await this.validateUsageAttributionId(user, usageAttributionId);
-        user.usageAttributionId = usageAttributionId;
-        await this.userDb.storeUser(user);
-    }
-
     /**
      * Lists all valid AttributionIds a user can attributed (billed) usage to.
      * @param user

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -228,20 +228,6 @@ export class UserService {
         await this.userDb.storeUser(user);
     }
 
-    /**
-     * Lists all valid AttributionIds a user can attributed (billed) usage to.
-     * @param user
-     * @returns
-     */
-    async listAvailableUsageAttributionIds(user: User): Promise<AttributionId[]> {
-        // List all teams available for attribution
-        const result = (await this.teamDB.findTeamsByUser(user.id)).map((team) => AttributionId.create(team));
-        if (user?.additionalData?.isMigratedToTeamOnlyAttribution) {
-            return result;
-        }
-        return [AttributionId.create(user)].concat(result);
-    }
-
     async blockUser(targetUserId: string, block: boolean): Promise<User> {
         const target = await this.userDb.findUserById(targetUserId);
         if (!target) {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -228,6 +228,20 @@ export class UserService {
         await this.userDb.storeUser(user);
     }
 
+    /**
+     * Lists all valid AttributionIds a user can attributed (billed) usage to.
+     * @param user
+     * @returns
+     */
+    async listAvailableUsageAttributionIds(user: User): Promise<AttributionId[]> {
+        // List all teams available for attribution
+        const result = (await this.teamDB.findTeamsByUser(user.id)).map((team) => AttributionId.create(team));
+        if (user?.additionalData?.isMigratedToTeamOnlyAttribution) {
+            return result;
+        }
+        return [AttributionId.create(user)].concat(result);
+    }
+
     async blockUser(targetUserId: string, block: boolean): Promise<User> {
         const target = await this.userDb.findUserById(targetUserId);
         if (!target) {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4127,20 +4127,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return classes;
     }
 
-    //#region gitpod.io concerns
-    async setUsageAttribution(ctx: TraceContext, usageAttributionId: string): Promise<void> {
-        const user = await this.checkAndBlockUser("setUsageAttribution");
-        try {
-            const attrId = AttributionId.parse(usageAttributionId);
-            if (attrId) {
-                await this.userService.setUsageAttribution(user, usageAttributionId);
-            }
-        } catch (error) {
-            log.error({ userId: user.id }, "Cannot set usage attribution", error, { usageAttributionId });
-            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, `Cannot set usage attribution`);
-        }
-    }
-
     async getLinkedInClientId(ctx: TraceContextWithSpan): Promise<string> {
         traceAPIParams(ctx, {});
         await this.checkAndBlockUser("getLinkedInClientID");

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4141,13 +4141,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
     }
 
-    async listAvailableUsageAttributionIds(ctx: TraceContext): Promise<string[]> {
-        const user = await this.checkAndBlockUser("listAvailableUsageAttributionIds");
-
-        const attributionIds = await this.userService.listAvailableUsageAttributionIds(user);
-        return attributionIds.map(AttributionId.render);
-    }
-
     async getLinkedInClientId(ctx: TraceContextWithSpan): Promise<string> {
         traceAPIParams(ctx, {});
         await this.checkAndBlockUser("getLinkedInClientID");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Unused since the org-only migration ([see metrics](https://grafana.gitpod.io/d/server/gitpod-component-server?orgId=1&var-cluster=All&var-node=All&var-pod=All&var-method=listAvailableUsageAttributionIds&var-method=setUsageAttribution&var-datasource=VictoriaMetrics&var-http_route=All&from=now-30d&to=now))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
