### PR TITLE
[obs] Fix workspace alerts to work in Grafana cloud

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: workspace-monitoring-rules
+  name: workspace-monitoring-central-rules
 spec:
   groups:
 

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -52,6 +52,7 @@ spec:
     - alert: GitpodWorkspaceStuckOnStoppingMk2
       labels:
         severity: critical
+        dedicated: included
       for: 30m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
@@ -74,6 +75,7 @@ spec:
     - alert: GitpodWorkspaceHighFailureRateMk2
       labels:
         severity: critical
+        dedicated: included
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceHighFailureRate.md
         summary: Workspaces are failing in cluster {{ $labels.cluster }}.
@@ -104,6 +106,7 @@ spec:
     - alert: GitpodTooManyWorkspacesInPendingMk2
       labels:
         severity: critical
+        dedicated: included
       for: 15m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyWorkspacesInPending.md
@@ -125,6 +128,7 @@ spec:
     - alert: GitpodTooManyPrebuildsInPendingMk2
       labels:
         severity: critical
+        dedicated: included
       for: 15m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyPrebuildsInPending.md

--- a/operations/observability/mixins/workspace/rules/central/ws-daemon.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-daemon.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: ws-daemon-monitoring-rules
+  name: ws-daemon-monitoring-central-rules
 spec:
   groups:
   - name: ws-daemon

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -25,6 +25,7 @@ spec:
     - alert: GitpodWsManagerCrashLoopingMk2
       labels:
         severity: critical
+        dedicated: included
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
         summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: workspace-monitoring-rules
+  name: workspace-monitoring-satellite-rules
 spec:
   groups:
   - name: workspace-rules

--- a/operations/observability/mixins/workspace/rules/satellite/ws-daemon.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/ws-daemon.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: ws-daemon-monitoring-rules
+  name: ws-daemon-monitoring-satellite-rules
 spec:
   groups:
   - name: ws-daemon


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. metadata.name (namespace) cannot be duplicate, renamed some rules.
2. added decorator labels so that the alerts get picked up by the sync process.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related SID-373

## How to test
<!-- Provide steps to test this PR -->
You can see the alerts here: https://gitpoddedicatedprod.grafana.net/alerting/list

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
