### PR TITLE
[test] Add test for fuse device

### DIFF
--- a/test/pkg/integration/fuse.go
+++ b/test/pkg/integration/fuse.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package integration
+
+import (
+	"fmt"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+)
+
+const (
+	fuseProgram = `
+#define _GNU_SOURCE
+#include <unistd.h>
+
+#include <sys/syscall.h>
+#include <linux/fs.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+
+int main() {
+  const char* src_path = "/dev/fuse";
+  unsigned int flags = O_RDWR;
+  printf("RET: %ld\n", syscall(SYS_openat, AT_FDCWD, src_path, flags));
+}
+	`
+)
+
+func HasFuseDevice(rsa *RpcClient) (bool, error) {
+	var resp agent.WriteFileResponse
+	err := rsa.Call("WorkspaceAgent.WriteFile", &agent.WriteFileRequest{
+		Path:    "/workspace/fuse_test.c",
+		Content: []byte(fuseProgram),
+		Mode:    0644,
+	}, &resp)
+	if err != nil {
+		return false, err
+	}
+
+	var execResp agent.ExecResponse
+	err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     "/workspace",
+		Command: "gcc",
+		Args:    []string{"fuse_test.c", "-o", "fuse_test"},
+	}, &execResp)
+	if err != nil {
+		return false, err
+	}
+	if execResp.ExitCode != 0 {
+		return false, fmt.Errorf("gcc failed with code %d: %s", execResp.ExitCode, execResp.Stderr)
+	}
+
+	err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     "/workspace",
+		Command: "./fuse_test",
+	}, &execResp)
+	if err != nil {
+		return false, err
+	}
+	if execResp.ExitCode != 0 {
+		return false, fmt.Errorf("fuse_test failed with code %d: %s", execResp.ExitCode, execResp.Stderr)
+	}
+
+	if execResp.Stdout != "RET: 3\n" {
+		return false, fmt.Errorf("fuse_test returned unexpected output: %s", execResp.Stdout)
+	}
+	return true, nil
+}

--- a/test/tests/components/ws-daemon/fuse_device_test.go
+++ b/test/tests/components/ws-daemon/fuse_device_test.go
@@ -7,7 +7,9 @@ package wsdaemon
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -17,23 +19,48 @@ func TestFuseDevice(t *testing.T) {
 		WithLabel("component", "ws-daemon").
 		Assess("verify fuse device", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			t.Parallel()
-			// TODO(toru): check if this code works fine
-			// #define _GNU_SOURCE
-			// #include <unistd.h>
 
-			// #include <sys/syscall.h>
-			// #include <linux/fs.h>
-			// #include <sys/types.h>
-			// #include <sys/stat.h>
-			// #include <fcntl.h>
-			// #include <stdio.h>
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
 
-			// int main() {
-			//   const char* src_path = "/dev/fuse";
-			//   unsigned int flags = O_RDWR;
-			//   printf("RET: %ld\n", syscall(SYS_openat, AT_FDCWD, src_path, flags));
-			// }
-			t.Skip("unimplemented")
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id))
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+			integration.DeferCloser(t, closer)
+
+			t.Logf("checking fuse device")
+			hasFuse, err := integration.HasFuseDevice(rsa)
+			if err != nil {
+				t.Fatalf("unexpected error checking fuse device: %v", err)
+			}
+			if !hasFuse {
+				t.Fatalf("fuse device is not available: %v", err)
+			}
+
 			return ctx
 		}).Feature()
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add test for fuse device

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-217

## How to test
<!-- Provide steps to test this PR -->

```
cd test
go test -v ./... -run TestFuseDevice -kubeconfig /home/gitpod/.kube/config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
