### PR TITLE
Add organization id in claims

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1683,7 +1683,7 @@ type Workspace struct {
 	// during workspace creation. Once a base image has been built the information in here
 	// is superseded by baseImageNameResolved.
 	ImageSource interface{} `json:"imageSource,omitempty"`
-	// undefined means it is owned by the user (legacy mode, soon to be removed)
+	// empty string means it is owned by the user (legacy mode, soon to be removed)
 	OrganizationId string `json:"organizationId,omitempty"`
 	OwnerID        string `json:"ownerId,omitempty"`
 	Pinned         bool   `json:"pinned,omitempty"`

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1683,9 +1683,11 @@ type Workspace struct {
 	// during workspace creation. Once a base image has been built the information in here
 	// is superseded by baseImageNameResolved.
 	ImageSource interface{} `json:"imageSource,omitempty"`
-	OwnerID     string      `json:"ownerId,omitempty"`
-	Pinned      bool        `json:"pinned,omitempty"`
-	Shareable   bool        `json:"shareable,omitempty"`
+	// undefined means it is owned by the user (legacy mode, soon to be removed)
+	OrganizationId string `json:"organizationId,omitempty"`
+	OwnerID        string `json:"ownerId,omitempty"`
+	Pinned         bool   `json:"pinned,omitempty"`
+	Shareable      bool   `json:"shareable,omitempty"`
 
 	// Mark as deleted (user-facing). The actual deletion of the workspace content is executed
 	// with a (configurable) delay

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1682,12 +1682,11 @@ type Workspace struct {
 	// The source where to get the workspace base image from. This source is resolved
 	// during workspace creation. Once a base image has been built the information in here
 	// is superseded by baseImageNameResolved.
-	ImageSource interface{} `json:"imageSource,omitempty"`
-	// empty string means it is owned by the user (legacy mode, soon to be removed)
-	OrganizationId string `json:"organizationId,omitempty"`
-	OwnerID        string `json:"ownerId,omitempty"`
-	Pinned         bool   `json:"pinned,omitempty"`
-	Shareable      bool   `json:"shareable,omitempty"`
+	ImageSource    interface{} `json:"imageSource,omitempty"`
+	OrganizationId string      `json:"organizationId,omitempty"`
+	OwnerID        string      `json:"ownerId,omitempty"`
+	Pinned         bool        `json:"pinned,omitempty"`
+	Shareable      bool        `json:"shareable,omitempty"`
 
 	// Mark as deleted (user-facing). The actual deletion of the workspace content is executed
 	// with a (configurable) delay

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -88,6 +88,13 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo := oidc.NewUserInfo()
 	userInfo.SetName(user.Name)
 	userInfo.SetSubject(subject)
+
+	if user.OrganizationId != "" {
+		userInfo.AppendClaims("org_id", user.OrganizationId)
+	} else if workspace.Workspace.OrganizationId != "" {
+		userInfo.AppendClaims("org_id", workspace.Workspace.OrganizationId)
+	}
+
 	if email != "" {
 		userInfo.SetEmail(email, user.OrganizationId != "")
 	}

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -88,12 +88,7 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo := oidc.NewUserInfo()
 	userInfo.SetName(user.Name)
 	userInfo.SetSubject(subject)
-
-	if user.OrganizationId != "" {
-		userInfo.AppendClaims("org_id", user.OrganizationId)
-	} else if workspace.Workspace.OrganizationId != "" {
-		userInfo.AppendClaims("org_id", workspace.Workspace.OrganizationId)
-	}
+	userInfo.AppendClaims("org_id", workspace.Workspace.OrganizationId)
 
 	if email != "" {
 		userInfo.SetEmail(email, user.OrganizationId != "")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add organization id in claims

the claim name is `org_id`

if user is Org-owned user `org_id` is organization id. 
if user is normal user, then `org_id` workspace's organization id.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes IDE-103

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
