### PR TITLE
Show User ID on Account page

### DIFF
--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -16,6 +16,7 @@ import Alert from "../components/Alert";
 import { TextInputField } from "../components/forms/TextInputField";
 import isEmail from "validator/lib/isEmail";
 import { useToast } from "../components/toasts/Toasts";
+import { InputWithCopy } from "../components/InputWithCopy";
 
 export default function Account() {
     const { user, setUser } = useContext(UserContext);
@@ -103,6 +104,7 @@ export default function Account() {
                         }}
                         errorMessage={errorMessage}
                         emailIsReadonly={!canUpdateEmail}
+                        user={user}
                     >
                         <div className="flex flex-row mt-8">
                             <Button htmlType="submit">Update Profile</Button>
@@ -126,6 +128,7 @@ function ProfileInformation(props: {
     setProfileState: (newState: User.Profile) => void;
     errorMessage: string;
     emailIsReadonly?: boolean;
+    user?: User;
     children?: React.ReactChild[] | React.ReactChild;
 }) {
     return (
@@ -164,6 +167,12 @@ function ProfileInformation(props: {
                             src={props.profileState.avatarURL}
                             alt={props.profileState.name}
                         />
+                        {props.user && (
+                            <p className={"text-sm text-gray-500 dark:text-gray-500"}>
+                                User ID:
+                                <InputWithCopy className="max-w-md" value={props.user.id} tip="Copy Token" />
+                            </p>
+                        )}
                     </div>
                 </div>
             </div>

--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -144,7 +144,7 @@ function ProfileInformation(props: {
                 </Alert>
             )}
             <div className="flex flex-col lg:flex-row">
-                <div>
+                <fieldset>
                     <TextInputField
                         label="Name"
                         value={props.profileState.name}
@@ -158,7 +158,15 @@ function ProfileInformation(props: {
                             props.setProfileState({ ...props.profileState, email: val });
                         }}
                     />
-                </div>
+                    {props.user && (
+                        <div className="flex flex-col space-y-2 mt-4">
+                            <label className={"text-md font-semibold dark:text-gray-400 text-gray-600"}>User ID</label>
+                            <p className={"text-sm text-gray-500 dark:text-gray-500"}>
+                                <InputWithCopy className="max-w-md w-32" value={props.user.id} tip="Copy Token" />
+                            </p>
+                        </div>
+                    )}
+                </fieldset>
                 <div className="lg:pl-14">
                     <div className="mt-4">
                         <Subheading>Avatar</Subheading>
@@ -167,12 +175,6 @@ function ProfileInformation(props: {
                             src={props.profileState.avatarURL}
                             alt={props.profileState.name}
                         />
-                        {props.user && (
-                            <p className={"text-sm text-gray-500 dark:text-gray-500"}>
-                                User ID:
-                                <InputWithCopy className="max-w-md" value={props.user.id} tip="Copy Token" />
-                            </p>
-                        )}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Description

Surfaces the user's ID through the Account settings in the Dashboard.

![image](https://github.com/gitpod-io/gitpod/assets/29888641/34f74aa3-a916-4bb7-9e22-251982dea444)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Falls under https://github.com/gitpod-io/gitpod/issues/15654

## How to test

Open the Dashboard in the preview environment :)

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-user-idf0721f5345</li>
	<li><b>🔗 URL</b> - <a href="https://ft-user-idf0721f5345.preview.gitpod-dev.com/workspaces" target="_blank">ft-user-idf0721f5345.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
