### PR TITLE
[ws-manager-mk2] Cleanup mk1 from workflow inputs and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,7 +412,6 @@ jobs:
             TEST_BUILD_ID: ${{ github.run_id }}
             TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
-            WS_MANAGER_MK2: ${{ needs.configuration.outputs.with_ws_manager_mk2 != 'false' }}
         run: |
             set -euo pipefail
 

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -10,11 +10,6 @@ on:
                 required: true
                 description: "The version of Gitpod to install"
                 default: "latest"
-            wsman_mk2:
-                required: false
-                type: boolean
-                default: true
-                description: "Run tests against ws-manager-mk2"
             skip_deploy:
                 required: false
                 description: "Skip deploy preview environment (debug only)"
@@ -90,7 +85,6 @@ jobs:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
-                  wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -142,8 +136,6 @@ jobs:
                   JETBRAINS_TESTS="$IDE_TESTS_DIR/jetbrains"
                   VSCODE_TESTS="$IDE_TESTS_DIR/vscode"
                   SSH_TESTS="$IDE_TESTS_DIR/ssh"
-
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -106,7 +106,6 @@ jobs:
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
                       - [x] latest-ide-version=${{ contains(inputs.pluginId, 'latest') }}
-                      - [x] with-ws-manager-mk2
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -67,7 +67,6 @@ jobs:
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
                       - [x] latest-ide-version=false
-                      - [x] with-ws-manager-mk2
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_
                   commit-message: "[JetBrains] Update IDE images to new build version"

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -16,11 +16,6 @@ on:
                 description: "The infrastructure provider to use. Valid options: harvester, gcp"
                 required: false
                 default: gcp
-            wsman_mk2:
-                required: false
-                type: boolean
-                default: true
-                description: "Run tests against ws-manager-mk2"
 
 jobs:
     configuration:
@@ -76,7 +71,6 @@ jobs:
                   name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
-                  wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -123,8 +117,6 @@ jobs:
                   args+=( "-timeout=60m" )
 
                   TESTS_DIR="$GITHUB_WORKSPACE/test/tests/smoke-test"
-
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
 
                   go install github.com/jstemmer/go-junit-report/v2@latest
 

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -16,11 +16,6 @@ on:
                 required: false
                 type: boolean
                 description: "Skip delete preview environment (debug only)"
-            wsman_mk2:
-                required: false
-                type: boolean
-                default: true
-                description: "Run tests against ws-manager-mk2"
     schedule:
         - cron: "0 3,12 * * *"
 jobs:
@@ -81,10 +76,6 @@ jobs:
                           echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
                       } >> $GITHUB_OUTPUT
                   fi
-
-                  {
-                      echo "Using ws-manager-mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}"
-                  } >> "${GITHUB_STEP_SUMMARY}"
             - name: Slack Notification
               uses: rtCamp/action-slack-notify@v2
               if: failure()
@@ -116,7 +107,6 @@ jobs:
             name: ${{ needs.configuration.outputs.name }}
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             version: ${{ needs.configuration.outputs.version}}
-            wsmanager_mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }}
 
     check:
         name: Check for regressions
@@ -183,8 +173,6 @@ jobs:
                   WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
                   WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
 
-                  export WS_MANAGER_MK2="${{ github.event.inputs.wsman_mk2 != 'false' }}"
-
                   go install github.com/jstemmer/go-junit-report/v2@latest
 
                   FAILURE_COUNT=0
@@ -230,7 +218,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed (mk2: ${{ github.event.inputs.wsman_mk2 != 'false' }})"
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }}/${{ steps.test_summary.outputs.total }} tests passed"
 
     delete:
       name: Delete preview environment

--- a/test/README.md
+++ b/test/README.md
@@ -70,8 +70,6 @@ If your integration tests depends on having having a user token available, then 
 1. Get credentials persisted as secrets (either in Github Actions, or GCP Secret Manager via the `core-dev` project), which vary by job that trigger tests. Refer to `run.sh` for details.
 2. In your Gitpod (preview) environment, log into the preview environment, set `USER_NAME` to the user you logged in with, and set `USER_TOKEN` to any (does not have to be valid).
 
-By default the workspace tests run against `ws-manager-mk2`, set `WS_MANAGER_MK2=false` to run against mk1.
-
 ```console
 cd test
 go test -v ./... \

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -660,11 +660,7 @@ func (c *ComponentAPI) WorkspaceManager() (wsmanapi.WorkspaceManagerClient, erro
 		return c.wsmanStatus.Client, nil
 	}
 
-	var wsman = ComponentWorkspaceManager
-	if UseWsmanMk2() {
-		wsman = ComponentWorkspaceManagerMK2
-	}
-
+	var wsman = ComponentWorkspaceManagerMK2
 	if c.wsmanStatus.Port == 0 {
 		c.wsmanStatusMu.Lock()
 		defer c.wsmanStatusMu.Unlock()

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -142,23 +142,17 @@ func waitOnGitpodRunning(namespace string, waitTimeout time.Duration) env.Func {
 	klog.V(2).Info("Checking status of Gitpod components...")
 
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		imgBuilder := "image-builder-mk3"
-		wsman := "ws-manager"
-		if UseWsmanMk2() {
-			wsman = "ws-manager-mk2"
-		}
-
 		components := []string{
 			"agent-smith",
 			"blobserve",
 			"content-service",
 			"dashboard",
-			imgBuilder,
+			"image-builder-mk3",
 			"proxy",
 			"registry-facade",
 			"server",
 			"ws-daemon",
-			wsman,
+			"ws-manager-mk2",
 			"ws-manager-bridge",
 			"ws-proxy",
 		}
@@ -226,8 +220,4 @@ func getNamespace(path string) (string, error) {
 	}
 
 	return namespace, nil
-}
-
-func UseWsmanMk2() bool {
-	return os.Getenv("WS_MANAGER_MK2") != "false"
 }

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -120,11 +120,7 @@ func assertEnvSuppliedBySecret(t *testing.T, wsPod *corev1.Pod, secretEnv string
 					t.Fatalf("environment variable value is not supplied by secret")
 				}
 
-				expectedName := wsPod.Name
-				if integration.UseWsmanMk2() {
-					expectedName = fmt.Sprintf("%s-env", strings.TrimPrefix(wsPod.Name, "ws-"))
-				}
-
+				expectedName := fmt.Sprintf("%s-env", strings.TrimPrefix(wsPod.Name, "ws-"))
 				if env.ValueFrom.SecretKeyRef.Name != expectedName {
 					t.Fatalf("expected environment variable values are not supplied by secret %s", expectedName)
 				}


### PR DESCRIPTION
## Description

Clean up ws-manager-mk2 options from github actions workflows and integration tests.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
