### PR TITLE
[test] Check gp top output for non-zero values

### DIFF
--- a/test/tests/workspace/gp_top_test.go
+++ b/test/tests/workspace/gp_top_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestGpTop(t *testing.T) {
+	f := features.New("gp top").
+		WithLabel("component", "workspace").
+		WithLabel("type", "gp top").
+		Assess("it can run gp top and retrieve cpu/memory usage", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(ctx, time.Duration(5*time.Minute))
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			nfo, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				if _, err = stopWs(true, sapi); err != nil {
+					t.Errorf("cannot stop workspace: %q", err)
+				}
+			})
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.Req.Id))
+			integration.DeferCloser(t, closer)
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+
+			t.Logf("running gp top")
+			var res agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/workspace",
+				Command: "gp",
+				Env:     []string{"SUPERVISOR_ADDR=10.0.5.2:22999"},
+				Args:    []string{"top", "--json"},
+			}, &res)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.ExitCode != 0 {
+				t.Fatalf("gp top failed (%d): %s", res.ExitCode, res.Stderr)
+			}
+
+			t.Logf("gp top: %s", res.Stdout)
+
+			type gpTop struct {
+				Resources struct {
+					CPU struct {
+						Used  int `json:"used"`
+						Limit int `json:"limit"`
+					} `json:"cpu"`
+					Memory struct {
+						Used  int `json:"used"`
+						Limit int `json:"limit"`
+					} `json:"memory"`
+				} `json:"resources"`
+			}
+			var top gpTop
+			err = json.Unmarshal([]byte(res.Stdout), &top)
+			if err != nil {
+				t.Fatalf("cannot unmarshal gp top output: %v", err)
+			}
+
+			t.Logf("verifying gp top output is not empty")
+			if top.Resources.CPU.Used == 0 {
+				t.Errorf("gp top reports 0 CPU usage")
+			}
+			if top.Resources.Memory.Used == 0 {
+				t.Errorf("gp top reports 0 memory usage")
+			}
+			if top.Resources.CPU.Limit == 0 {
+				t.Errorf("gp top reports 0 CPU limit")
+			}
+			if top.Resources.Memory.Limit == 0 {
+				t.Errorf("gp top reports 0 memory limit")
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add e2e test for `gp top`. Checks that it outputs non-zero values for cpu and memory usage. Think that's as far as this test can go, as the actual usage values will differ for each test run.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-218

## How to test
<!-- Provide steps to test this PR -->

```
cd test
go test -v ./... -run TestGpTop -kubeconfig=/home/gitpod/.kube/config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
