### PR TITLE
[test] Add test for process limit

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -255,6 +255,7 @@ CONTAINERD_RUNTIME_DIR="/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
 yq w -i "${INSTALLER_CONFIG_PATH}" workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}
 yq w -i "${INSTALLER_CONFIG_PATH}" workspace.resources.requests.cpu "100m"
 yq w -i "${INSTALLER_CONFIG_PATH}" workspace.resources.requests.memory "256Mi"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.procLimit 1000
 
 # create two workspace classes (default and small) in server-config configmap
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-standard"

--- a/test/tests/workspace/process_limit_test.go
+++ b/test/tests/workspace/process_limit_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestProcessLimit(t *testing.T) {
+	f := features.New("process limit").
+		WithLabel("component", "workspace").
+		WithLabel("type", "process limit").
+		Assess("it has a proc limit", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(ctx, time.Duration(5*time.Minute))
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			nfo, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				if _, err = stopWs(true, sapi); err != nil {
+					t.Errorf("cannot stop workspace: %v", err)
+				}
+			})
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.Req.Id))
+			integration.DeferCloser(t, closer)
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+
+			// Sometimes the workspace stops once we run out of processes (supervisor will exit with a failure),
+			// so also start watching for the workspace to stop and observe its exit status.
+			ready := make(chan struct{}, 1)
+			stopStatus := make(chan *wsmanapi.WorkspaceStatus, 1)
+			go func() {
+				status, err := integration.WaitForWorkspaceStop(t, ctx, ready, api, nfo.Req.Id, nfo.WorkspaceID, integration.WorkspaceCanFail)
+				if err != nil {
+					if !errors.Is(err, context.Canceled) {
+						// If context got canceled, we're just shutting down the test
+						// and the workspace didn't exit due to reaching the process limit.
+						t.Errorf("error waiting for workspace stop: %v", err)
+					}
+					stopStatus <- nil
+					return
+				}
+
+				t.Logf("workspace stopped: %v", stopStatus)
+				stopStatus <- status
+			}()
+
+			t.Logf("creating processes")
+			var res agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/workspace",
+				Command: "bash",
+				Args:    []string{"-c", "timeout 20s bash -c 'while true; do sleep 20 && date & done'"},
+			}, &res)
+			if err != nil {
+				t.Logf("exec failed, most likely the workspace failed due to the process limit, so check for workspace failure status instead. Exec err: %v", err)
+				select {
+				case <-ctx.Done():
+					t.Fatalf("expected workspace to stop, but it didn't")
+				case s := <-stopStatus:
+					if s == nil {
+						t.Fatalf("there was an error getting the workspace stop status")
+					}
+
+					if s.Conditions == nil || s.Conditions.Failed == "" {
+						t.Fatalf("expected workspace to fail, but it didn't: %v", s)
+					}
+					t.Logf("workspace stopped and failed (as expected): %v", s)
+				}
+				return ctx
+			}
+
+			t.Logf("checking output for fork errors due to process limiting")
+			if !strings.Contains(res.Stdout, "bash: fork: retry: Resource temporarily unavailable") {
+				t.Errorf("expected fork error (Resource temporarily unavailable), but got none (%d): %s", res.ExitCode, res.Stdout)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description

Add e2e test for max process limit.

It succeeds if either of the following happens:
- `bash: fork: retry: Resource temporarily unavailable` gets logged
- Or the workspace exits with a failure (due to supervisor crashing due to process limit being reached. See WKS-249)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-222

## How to test
<!-- Provide steps to test this PR -->

```
cd test
go test -v ./... -run TestProcessLimit -kubeconfig=/home/gitpod/.kube/config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
