### PR TITLE
[server] Remove hasPermission rpc

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -50,7 +50,6 @@ import { WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstancePhase } from
 import { AdminServer } from "./admin-protocol";
 import { GitpodHostUrl } from "./util/gitpod-host-url";
 import { WebSocketConnectionProvider } from "./messaging/browser/connection";
-import { PermissionName } from "./permission";
 import { Emitter } from "./util/event";
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from "./analytics";
 import { IDEServer } from "./ide-protocol";
@@ -87,7 +86,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getGitpodTokenScopes(tokenHash: string): Promise<string[]>;
     deleteAccount(): Promise<void>;
     getClientRegion(): Promise<string | undefined>;
-    hasPermission(permission: PermissionName): Promise<boolean>;
 
     // Query/retrieve workspaces
     getWorkspaces(options: GitpodServer.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -60,7 +60,6 @@ const defaultFunctions: FunctionsConfig = {
     getToken: { group: "default", points: 1 },
     deleteAccount: { group: "default", points: 1 },
     getClientRegion: { group: "default", points: 1 },
-    hasPermission: { group: "default", points: 1 },
     getWorkspaces: { group: "default", points: 1 },
     getWorkspaceOwner: { group: "default", points: 1 },
     getWorkspaceUsers: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3444,13 +3444,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return this.userDB.deleteGitpodToken(tokenHash);
     }
 
-    public async hasPermission(ctx: TraceContext, permission: PermissionName): Promise<boolean> {
-        traceAPIParams(ctx, { permission });
-
-        const user = await this.checkUser("hasPermission");
-        return this.authorizationService.hasPermission(user, permission);
-    }
-
     async guessGitTokenScopes(ctx: TraceContext, params: GuessGitTokenScopesParams): Promise<GuessedGitTokenScopes> {
         traceAPIParams(ctx, { params: censor(params, "currentToken") });
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Obsolete

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
