### PR TITLE
[server] Remove getIDToken

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -102,9 +102,6 @@ type APIInterface interface {
 	GetTeamProjects(ctx context.Context, teamID string) ([]*Project, error)
 
 	WorkspaceUpdates(ctx context.Context, workspaceID string) (<-chan *WorkspaceInstance, error)
-
-	// GetIDToken doesn't actually do anything, it just authorises
-	GetIDToken(ctx context.Context) (err error)
 }
 
 // FunctionName is the name of an RPC function
@@ -252,8 +249,6 @@ const (
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
-
-	FunctionGetIDToken FunctionName = "getIDToken"
 )
 
 var errNotConnected = errors.New("not connected to Gitpod server")
@@ -1561,16 +1556,6 @@ func (gp *APIoverJSONRPC) GetTeamProjects(ctx context.Context, teamID string) (r
 	}
 	_params := []interface{}{teamID}
 	err = gp.C.Call(ctx, string(FunctionGetTeamProjects), _params, &res)
-	return
-}
-
-func (gp *APIoverJSONRPC) GetIDToken(ctx context.Context) (err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	_params := []interface{}{}
-	err = gp.C.Call(ctx, string(FunctionGetIDToken), _params, nil)
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -432,20 +432,6 @@ func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokens(ctx interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokens", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokens), ctx)
 }
 
-// GetIDToken mocks base method.
-func (m *MockAPIInterface) GetIDToken(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIDToken", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetIDToken indicates an expected call of GetIDToken.
-func (mr *MockAPIInterfaceMockRecorder) GetIDToken(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDToken", reflect.TypeOf((*MockAPIInterface)(nil).GetIDToken), ctx)
-}
-
 // GetLoggedInUser mocks base method.
 func (m *MockAPIInterface) GetLoggedInUser(ctx context.Context) (*User, error) {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -267,11 +267,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
     maySetTimeout(): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
-
-    /**
-     * getIDToken - doesn't actually do anything, just used to authenticat/authorise
-     */
-    getIDToken(): Promise<void>;
 }
 
 export interface RateLimiterError {

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -52,12 +52,6 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 		return nil, err
 	}
 
-	// We use GetIDToken as standin for the IDP operation authorisation until we have a better way of handling this
-	err = conn.GetIDToken(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	workspace, err := conn.GetWorkspace(ctx, workspaceID)
 	if err != nil {
 		log.Extract(ctx).WithError(err).Error("Failed to get workspace.")

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -52,7 +52,6 @@ func TestGetIDToken(t *testing.T) {
 				})
 			},
 			ServerSetup: func(ma *protocol.MockAPIInterface) {
-				ma.EXPECT().GetIDToken(gomock.Any()).MinTimes(1).Return(nil)
 				ma.EXPECT().GetWorkspace(gomock.Any(), workspaceID).MinTimes(1).Return(
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{
@@ -95,7 +94,6 @@ func TestGetIDToken(t *testing.T) {
 				})
 			},
 			ServerSetup: func(ma *protocol.MockAPIInterface) {
-				ma.EXPECT().GetIDToken(gomock.Any()).MinTimes(1).Return(nil)
 				ma.EXPECT().GetWorkspace(gomock.Any(), workspaceID).MinTimes(1).Return(
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{
@@ -134,7 +132,6 @@ func TestGetIDToken(t *testing.T) {
 				})
 			},
 			ServerSetup: func(ma *protocol.MockAPIInterface) {
-				ma.EXPECT().GetIDToken(gomock.Any()).MinTimes(1).Return(nil)
 				ma.EXPECT().GetWorkspace(gomock.Any(), workspaceID).MinTimes(1).Return(
 					nil,
 					&jsonrpc2.Error{Code: 400, Message: "workspace not found"},
@@ -156,7 +153,6 @@ func TestGetIDToken(t *testing.T) {
 				})
 			},
 			ServerSetup: func(ma *protocol.MockAPIInterface) {
-				ma.EXPECT().GetIDToken(gomock.Any()).MinTimes(1).Return(nil)
 				ma.EXPECT().GetWorkspace(gomock.Any(), workspaceID).MinTimes(1).Return(
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{
@@ -200,7 +196,6 @@ func TestGetIDToken(t *testing.T) {
 				})
 			},
 			ServerSetup: func(ma *protocol.MockAPIInterface) {
-				ma.EXPECT().GetIDToken(gomock.Any()).MinTimes(1).Return(nil)
 				ma.EXPECT().GetWorkspace(gomock.Any(), workspaceID).MinTimes(1).Return(
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -198,7 +198,6 @@ const defaultFunctions: FunctionsConfig = {
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
     maySetTimeout: { group: "default", points: 1 },
     updateWorkspaceTimeoutSetting: { group: "default", points: 1 },
-    getIDToken: { group: "default", points: 1 },
     reportErrorBoundary: { group: "default", points: 1 },
     getOnboardingState: { group: "default", points: 1 },
 };

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -4253,8 +4253,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return targetRegion;
     }
 
-    async getIDToken(): Promise<void> {}
-
     public async controlAdmission(ctx: TraceContext, workspaceId: string, level: "owner" | "everyone"): Promise<void> {
         traceAPIParams(ctx, { workspaceId, level });
         traceWI(ctx, { workspaceId });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
