### PR TITLE
Remove getContentBlob Upload/Download URL

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -70,8 +70,6 @@ type APIInterface interface {
 	GetSSHPublicKeys(ctx context.Context) (res []*UserSSHPublicKeyValue, err error)
 	AddSSHPublicKey(ctx context.Context, value *SSHPublicKeyValue) (res *UserSSHPublicKeyValue, err error)
 	DeleteSSHPublicKey(ctx context.Context, id string) (err error)
-	GetContentBlobUploadURL(ctx context.Context, name string) (url string, err error)
-	GetContentBlobDownloadURL(ctx context.Context, name string) (url string, err error)
 	GetGitpodTokens(ctx context.Context) (res []*APIToken, err error)
 	GenerateNewGitpodToken(ctx context.Context, options *GenerateNewGitpodTokenOptions) (res string, err error)
 	DeleteGitpodToken(ctx context.Context, tokenHash string) (err error)
@@ -199,10 +197,6 @@ const (
 	FunctionAddSSHPublicKey FunctionName = "addSSHPublicKey"
 	// FunctionDeleteSSHPublicKey is the name of the deleteSSHPublicKey function
 	FunctionDeleteSSHPublicKey FunctionName = "deleteSSHPublicKey"
-	// FunctionGetContentBlobUploadURL is the name fo the getContentBlobUploadUrl function
-	FunctionGetContentBlobUploadURL FunctionName = "getContentBlobUploadUrl"
-	// FunctionGetContentBlobDownloadURL is the name fo the getContentBlobDownloadUrl function
-	FunctionGetContentBlobDownloadURL FunctionName = "getContentBlobDownloadUrl"
 	// FunctionGetGitpodTokens is the name of the getGitpodTokens function
 	FunctionGetGitpodTokens FunctionName = "getGitpodTokens"
 	// FunctionGenerateNewGitpodToken is the name of the generateNewGitpodToken function
@@ -1209,46 +1203,6 @@ func (gp *APIoverJSONRPC) DeleteSSHPublicKey(ctx context.Context, id string) (er
 	}
 	_params := []interface{}{id}
 	err = gp.C.Call(ctx, "deleteSSHPublicKey", _params, nil)
-	return
-}
-
-// GetContentBlobUploadURL calls getContentBlobUploadUrl on the server
-func (gp *APIoverJSONRPC) GetContentBlobUploadURL(ctx context.Context, name string) (url string, err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	var _params []interface{}
-
-	_params = append(_params, name)
-
-	var result string
-	err = gp.C.Call(ctx, string(FunctionGetContentBlobUploadURL), _params, &result)
-	if err != nil {
-		return
-	}
-	url = result
-
-	return
-}
-
-// GetContentBlobDownloadURL calls getContentBlobDownloadUrl on the server
-func (gp *APIoverJSONRPC) GetContentBlobDownloadURL(ctx context.Context, name string) (url string, err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	var _params []interface{}
-
-	_params = append(_params, name)
-
-	var result string
-	err = gp.C.Call(ctx, string(FunctionGetContentBlobDownloadURL), _params, &result)
-	if err != nil {
-		return
-	}
-	url = result
-
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -327,36 +327,6 @@ func (mr *MockAPIInterfaceMockRecorder) GetConfiguration(ctx interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockAPIInterface)(nil).GetConfiguration), ctx)
 }
 
-// GetContentBlobDownloadURL mocks base method.
-func (m *MockAPIInterface) GetContentBlobDownloadURL(ctx context.Context, name string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContentBlobDownloadURL", ctx, name)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetContentBlobDownloadURL indicates an expected call of GetContentBlobDownloadURL.
-func (mr *MockAPIInterfaceMockRecorder) GetContentBlobDownloadURL(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentBlobDownloadURL", reflect.TypeOf((*MockAPIInterface)(nil).GetContentBlobDownloadURL), ctx, name)
-}
-
-// GetContentBlobUploadURL mocks base method.
-func (m *MockAPIInterface) GetContentBlobUploadURL(ctx context.Context, name string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContentBlobUploadURL", ctx, name)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetContentBlobUploadURL indicates an expected call of GetContentBlobUploadURL.
-func (mr *MockAPIInterfaceMockRecorder) GetContentBlobUploadURL(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentBlobUploadURL", reflect.TypeOf((*MockAPIInterface)(nil).GetContentBlobUploadURL), ctx, name)
-}
-
 // GetEnvVars mocks base method.
 func (m *MockAPIInterface) GetEnvVars(ctx context.Context) ([]*EnvVar, error) {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -194,10 +194,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getProjectEnvironmentVariables(projectId: string): Promise<ProjectEnvVar[]>;
     deleteProjectEnvironmentVariable(variableId: string): Promise<void>;
 
-    // content service
-    getContentBlobUploadUrl(name: string): Promise<string>;
-    getContentBlobDownloadUrl(name: string): Promise<string>;
-
     // Gitpod token
     getGitpodTokens(): Promise<GitpodToken[]>;
     generateNewGitpodToken(options: GitpodServer.GenerateNewGitpodTokenOptions): Promise<string>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -124,8 +124,6 @@ const defaultFunctions: FunctionsConfig = {
     triggerPrebuild: { group: "default", points: 1 },
     cancelPrebuild: { group: "default", points: 1 },
     updateProjectPartial: { group: "default", points: 1 },
-    getContentBlobUploadUrl: { group: "default", points: 1 },
-    getContentBlobDownloadUrl: { group: "default", points: 1 },
     getGitpodTokens: { group: "default", points: 1 },
     generateNewGitpodToken: { group: "default", points: 1 },
     deleteGitpodToken: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -5,12 +5,6 @@
  */
 
 import {
-    DownloadUrlRequest,
-    DownloadUrlResponse,
-    UploadUrlRequest,
-    UploadUrlResponse,
-} from "@gitpod/content-service/lib/blobs_pb";
-import {
     AppInstallationDB,
     UserDB,
     WorkspaceDB,
@@ -169,7 +163,6 @@ import { formatPhoneNumber } from "../user/phone-numbers";
 import { IDEService } from "../ide-service";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import * as grpc from "@grpc/grpc-js";
-import { CachingBlobServiceClientProvider } from "../util/content-service-sugar";
 import { CostCenterJSON } from "@gitpod/gitpod-protocol/lib/usage";
 import { createCookielessId, maskIp } from "../analytics";
 import {
@@ -269,9 +262,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     @inject(AppInstallationDB) protected readonly appInstallationDB: AppInstallationDB;
 
     @inject(AuthProviderService) protected readonly authProviderService: AuthProviderService;
-
-    @inject(CachingBlobServiceClientProvider)
-    protected readonly blobServiceClientProvider: CachingBlobServiceClientProvider;
 
     @inject(GitTokenScopeGuesser) protected readonly gitTokenScopeGuesser: GitTokenScopeGuesser;
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3325,64 +3325,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         await this.projectsService.updateProjectPartial(partial);
     }
 
-    public async getContentBlobUploadUrl(ctx: TraceContext, name: string): Promise<string> {
-        traceAPIParams(ctx, { name });
-
-        const user = await this.checkAndBlockUser("getContentBlobUploadUrl");
-        await this.guardAccess({ kind: "contentBlob", name: name, userID: user.id }, "create");
-
-        const uploadUrlRequest = new UploadUrlRequest();
-        uploadUrlRequest.setName(name);
-        uploadUrlRequest.setOwnerId(user.id);
-
-        const uploadUrlPromise = new Promise<UploadUrlResponse>((resolve, reject) => {
-            const client = this.blobServiceClientProvider.getDefault();
-            client.uploadUrl(uploadUrlRequest, (err: any, resp: UploadUrlResponse) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(resp);
-                }
-            });
-        });
-        try {
-            const resp = (await uploadUrlPromise).toObject();
-            return resp.url;
-        } catch (err) {
-            log.error("Error getting content blob upload url: ", err);
-            throw err;
-        }
-    }
-
-    public async getContentBlobDownloadUrl(ctx: TraceContext, name: string): Promise<string> {
-        traceAPIParams(ctx, { name });
-
-        const user = await this.checkAndBlockUser("getContentBlobDownloadUrl");
-        await this.guardAccess({ kind: "contentBlob", name: name, userID: user.id }, "get");
-
-        const downloadUrlRequest = new DownloadUrlRequest();
-        downloadUrlRequest.setName(name);
-        downloadUrlRequest.setOwnerId(user.id);
-
-        const downloadUrlPromise = new Promise<DownloadUrlResponse>((resolve, reject) => {
-            const client = this.blobServiceClientProvider.getDefault();
-            client.downloadUrl(downloadUrlRequest, (err: any, resp: DownloadUrlResponse) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(resp);
-                }
-            });
-        });
-        try {
-            const resp = (await downloadUrlPromise).toObject();
-            return resp.url;
-        } catch (err) {
-            log.error("Error getting content blob download url: ", err);
-            throw err;
-        }
-    }
-
     public async getGitpodTokens(ctx: TraceContext): Promise<GitpodToken[]> {
         const user = await this.checkAndBlockUser("getGitpodTokens");
         const res = (await this.userDB.findAllGitpodTokensOfUser(user.id)).filter((v) => !v.deleted);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1575,8 +1575,6 @@ export class WorkspaceStarter {
             "function:stopWorkspace",
             "function:getToken",
             "function:getGitpodTokenScopes",
-            "function:getContentBlobUploadUrl",
-            "function:getContentBlobDownloadUrl",
             "function:accessCodeSyncStorage",
             "function:guessGitTokenScopes",
             "function:getWorkspaceEnvVars",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Looks entirely unused (at least from the `server` side)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
