### PR TITLE
[test] Speed up setup, debug and disable k3s

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -74,7 +74,6 @@ If your integration tests depends on having having a user token available, then 
 cd test
 go test -v ./... \
     -run <test> \
-    -kubeconfig=/home/gitpod/.kube/config \
     -namespace=default \
     -username=<gitpod_user_with_oauth_setup> \
     -enterprise=<true|false> \
@@ -86,7 +85,6 @@ A concrete example would be
 ```console
 cd test
 go test -v ./... \
-    -kubeconfig=/home/gitpod/.kube/config \
     -namespace=default \
     -run TestWorkspaceInstrumentation
 ```

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -25,7 +25,8 @@ const (
 func TestK3s(t *testing.T) {
 	f := features.New("k3s").
 		WithLabel("component", "workspace").
-		Assess("it should start a k3s when cgroup v2 enable", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should start a k3s", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Skip("k3s is currently not supported in workspaces")
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(), TIME_OUT)
@@ -66,9 +67,11 @@ func TestK3s(t *testing.T) {
 			}
 
 			if !cgv2 {
-				t.Skip("This test only works for cgroup v2")
+				t.Fatalf("This test only works for cgroup v2")
 			}
 
+			k3sExit := make(chan error, 1)
+			waitForK3s := make(chan error, 1)
 			go func() {
 				var respReadyForK3s agent.ExecResponse
 				k3sUrl := fmt.Sprintf("https://github.com/k3s-io/k3s/releases/download/v%s%%2Bk3s1/k3s", K3S_VERSION)
@@ -77,9 +80,10 @@ func TestK3s(t *testing.T) {
 					Command: "bash",
 					Args: []string{
 						"-c",
-						fmt.Sprintf("curl -L %s -o /workspace/k3s && sudo chmod +x /workspace/k3s && sudo /workspace/k3s server -d /workspace/data --flannel-backend=host-gw > /dev/null 2>&1", k3sUrl),
+						fmt.Sprintf("curl -L %s -o /workspace/k3s && sudo chmod +x /workspace/k3s && sudo /workspace/k3s server -d /workspace/data --flannel-backend=host-gw", k3sUrl),
 					},
 				}, &respReadyForK3s)
+				k3sExit <- fmt.Errorf("k3s exited: %v\n%s\n%s", err, respReadyForK3s.Stdout, respReadyForK3s.Stderr)
 			}()
 
 			kubeEnv := []string{
@@ -87,21 +91,38 @@ func TestK3s(t *testing.T) {
 			}
 			var respWaitForK3s agent.ExecResponse
 			timeout := fmt.Sprintf("%.0fm", TIME_OUT.Minutes())
-			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
-				Dir:     "/",
-				Command: "bash",
-				Env:     kubeEnv,
-				Args: []string{
-					"-c",
-					fmt.Sprintf("timeout %s bash -c 'while [ ! -e /etc/rancher/k3s/k3s.yaml ]; do sleep 1; done' && sudo chmod +r /etc/rancher/k3s/k3s.yaml && timeout %s bash -c 'until /workspace/k3s kubectl wait --for=condition=Ready nodes -l node-role.kubernetes.io/master=true --timeout %s; do sleep 1; done'", timeout, timeout, timeout),
-				},
-			}, &respWaitForK3s)
-			if err != nil {
-				t.Fatalf("failed to wait for starting k3s: %v\n%s\n%s", err, respWaitForK3s.Stdout, respWaitForK3s.Stderr)
-			}
+			go func() {
+				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+					Dir:     "/",
+					Command: "bash",
+					Env:     kubeEnv,
+					Args: []string{
+						"-c",
+						fmt.Sprintf("timeout %s bash -c 'while [ ! -e /etc/rancher/k3s/k3s.yaml ]; do sleep 1; done' && sudo chmod 777 /etc/rancher/k3s/k3s.yaml && timeout %s bash -c 'until /workspace/k3s kubectl wait --for=condition=Ready nodes -l node-role.kubernetes.io/master=true --timeout %s; do sleep 1; done'", timeout, timeout, timeout),
+					},
+				}, &respWaitForK3s)
+				if err != nil {
+					waitForK3s <- fmt.Errorf("failed to wait for starting k3s: %v\n%s\n%s", err, respWaitForK3s.Stdout, respWaitForK3s.Stderr)
+					return
+				}
 
-			if respWaitForK3s.ExitCode != 0 {
-				t.Fatalf("failed to wait for starting k3s: %s\n%s", respWaitForK3s.Stdout, respWaitForK3s.Stderr)
+				if respWaitForK3s.ExitCode != 0 {
+					waitForK3s <- fmt.Errorf("failed to wait for starting k3s: %s\n%s", respWaitForK3s.Stdout, respWaitForK3s.Stderr)
+					return
+				}
+				waitForK3s <- nil
+			}()
+
+			select {
+			case err := <-waitForK3s:
+				if err != nil {
+					t.Fatalf("failed to wait for starting k3s: %v", err)
+				}
+				t.Logf("k3s is ready")
+			case err := <-k3sExit:
+				t.Fatalf("k3s exited: %v", err)
+			case <-time.After(TIME_OUT):
+				t.Fatalf("timeout waiting for k3s")
 			}
 
 			var respGetPods agent.ExecResponse


### PR DESCRIPTION
## Description

* Speed up test setup (4.5s -> 1s), makes it faster to iterate on them.
* Remove the need to specify `-kubeconfig=/home/gitpod/.kube/config` when running the tests using `go test`
* Update k3s test to fail early and log the failure when k3s fails to start in the workspace
* Skip the k3s test, as it's not supported in workspaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-153

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
