### PR TITLE
[server] Remove hasPermission from go API client

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -38,7 +38,6 @@ type APIInterface interface {
 	GetToken(ctx context.Context, query *GetTokenSearchOptions) (res *Token, err error)
 	DeleteAccount(ctx context.Context) (err error)
 	GetClientRegion(ctx context.Context) (res string, err error)
-	HasPermission(ctx context.Context, permission *PermissionName) (res bool, err error)
 	GetWorkspaces(ctx context.Context, options *GetWorkspacesOptions) (res []*WorkspaceInfo, err error)
 	GetWorkspaceOwner(ctx context.Context, workspaceID string) (res *UserInfo, err error)
 	GetWorkspaceUsers(ctx context.Context, workspaceID string) (res []*WorkspaceInstanceUser, err error)
@@ -137,8 +136,6 @@ const (
 	FunctionDeleteAccount FunctionName = "deleteAccount"
 	// FunctionGetClientRegion is the name of the getClientRegion function
 	FunctionGetClientRegion FunctionName = "getClientRegion"
-	// FunctionHasPermission is the name of the hasPermission function
-	FunctionHasPermission FunctionName = "hasPermission"
 	// FunctionGetWorkspaces is the name of the getWorkspaces function
 	FunctionGetWorkspaces FunctionName = "getWorkspaces"
 	// FunctionGetWorkspaceOwner is the name of the getWorkspaceOwner function
@@ -619,26 +616,6 @@ func (gp *APIoverJSONRPC) GetClientRegion(ctx context.Context) (res string, err 
 
 	var result string
 	err = gp.C.Call(ctx, "getClientRegion", _params, &result)
-	if err != nil {
-		return
-	}
-	res = result
-
-	return
-}
-
-// HasPermission calls hasPermission on the server
-func (gp *APIoverJSONRPC) HasPermission(ctx context.Context, permission *PermissionName) (res bool, err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	var _params []interface{}
-
-	_params = append(_params, permission)
-
-	var result bool
-	err = gp.C.Call(ctx, "hasPermission", _params, &result)
 	if err != nil {
 		return
 	}

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -761,21 +761,6 @@ func (mr *MockAPIInterfaceMockRecorder) GuessGitTokenScopes(ctx, params interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GuessGitTokenScopes), ctx, params)
 }
 
-// HasPermission mocks base method.
-func (m *MockAPIInterface) HasPermission(ctx context.Context, permission *PermissionName) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", ctx, permission)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HasPermission indicates an expected call of HasPermission.
-func (mr *MockAPIInterfaceMockRecorder) HasPermission(ctx, permission interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAPIInterface)(nil).HasPermission), ctx, permission)
-}
-
 // HasSSHPublicKey mocks base method.
 func (m *MockAPIInterface) HasSSHPublicKey(ctx context.Context) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

forgot to remove in previous PR https://github.com/gitpod-io/gitpod/pull/17981/files

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
