### PR TITLE
[ws-proxy] Remove pod info provider

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -73,24 +73,14 @@ var runCmd = &cobra.Command{
 		}
 
 		var infoprov proxy.CompositeInfoProvider
-		podInfoProv := proxy.NewRemoteWorkspaceInfoProvider(mgr.GetClient(), mgr.GetScheme())
-		if err = podInfoProv.SetupWithManager(mgr); err != nil {
-			log.WithError(err).Fatal(err, "unable to create controller", "controller", "Pod")
+		crdInfoProv, err := proxy.NewCRDWorkspaceInfoProvider(mgr.GetClient(), mgr.GetScheme())
+		if err != nil {
+			log.WithError(err).Fatal("cannot create CRD-based info provider")
 		}
-		infoprov = append(infoprov, podInfoProv)
-
-		if cfg.EnableWorkspaceCRD {
-			crdInfoProv, err := proxy.NewCRDWorkspaceInfoProvider(mgr.GetClient(), mgr.GetScheme())
-			if err == nil {
-				if err = crdInfoProv.SetupWithManager(mgr); err != nil {
-					log.WithError(err).Warn(err, "unable to create CRD-based info provider", "controller", "Workspace")
-				} else {
-					infoprov = append(infoprov, crdInfoProv)
-				}
-			} else {
-				log.WithError(err).Warn("cannot create CRD-based info provider")
-			}
+		if err = crdInfoProv.SetupWithManager(mgr); err != nil {
+			log.WithError(err).Fatal(err, "unable to create CRD-based info provider", "controller", "Workspace")
 		}
+		infoprov = append(infoprov, crdInfoProv)
 
 		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 			log.WithError(err).Fatal("unable to set up health check")

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -8,25 +8,21 @@ import (
 	"context"
 	"encoding/base64"
 	"net/url"
-	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
-	regapi "github.com/gitpod-io/gitpod/registry-facade/api"
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	wsapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
@@ -72,122 +68,9 @@ type WorkspaceInfo struct {
 	IsRunning     bool
 }
 
-// RemoteWorkspaceInfoProvider provides (cached) infos about running workspaces that it queries from ws-manager.
-type RemoteWorkspaceInfoProvider struct {
-	client.Client
-	Scheme *runtime.Scheme
-
-	store cache.ThreadSafeStore
-}
-
 const (
 	workspaceIndex = "workspaceIndex"
 )
-
-// NewRemoteWorkspaceInfoProvider creates a fresh WorkspaceInfoProvider.
-func NewRemoteWorkspaceInfoProvider(client client.Client, scheme *runtime.Scheme) *RemoteWorkspaceInfoProvider {
-	// create custom indexer for searches
-	indexers := cache.Indexers{
-		workspaceIndex: func(obj interface{}) ([]string, error) {
-			if workspaceInfo, ok := obj.(*WorkspaceInfo); ok {
-				return []string{workspaceInfo.WorkspaceID}, nil
-			}
-
-			return nil, xerrors.Errorf("object is not a WorkspaceInfo")
-		},
-	}
-
-	return &RemoteWorkspaceInfoProvider{
-		Client: client,
-		Scheme: scheme,
-
-		store: cache.NewThreadSafeStore(indexers, cache.Indices{}),
-	}
-}
-
-func (r *RemoteWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var pod corev1.Pod
-	err := r.Client.Get(context.Background(), req.NamespacedName, &pod)
-	if errors.IsNotFound(err) {
-		// pod is gone - that's ok
-		r.store.Delete(req.Name)
-		log.WithField("workspace", req.Name).Debug("removing workspace from store")
-
-		return reconcile.Result{}, nil
-	}
-
-	// extract workspace details from pod and store
-	workspaceInfo := mapPodToWorkspaceInfo(&pod)
-	r.store.Update(req.Name, workspaceInfo)
-	log.WithField("workspace", req.Name).WithField("details", workspaceInfo).Debug("adding/updating workspace details")
-
-	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *RemoteWorkspaceInfoProvider) SetupWithManager(mgr ctrl.Manager) error {
-	podWorkspaceSelector, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"app":       "gitpod",
-			"component": "workspace",
-			"gpwsman":   "true",
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	return ctrl.NewControllerManagedBy(mgr).
-		Named("pod").
-		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		For(
-			&corev1.Pod{},
-			builder.WithPredicates(podWorkspaceSelector),
-		).
-		Complete(r)
-}
-
-func mapPodToWorkspaceInfo(pod *corev1.Pod) *WorkspaceInfo {
-	ownerToken := pod.Annotations[kubernetes.OwnerTokenAnnotation]
-	admission := wsapi.AdmissionLevel_ADMIT_OWNER_ONLY
-	if av, ok := wsapi.AdmissionLevel_value[strings.ToUpper(pod.Annotations[kubernetes.WorkspaceAdmissionAnnotation])]; ok {
-		admission = wsapi.AdmissionLevel(av)
-	}
-
-	imageSpec, _ := regapi.ImageSpecFromBase64(pod.Annotations[kubernetes.WorkspaceImageSpecAnnotation])
-
-	workspaceURL := pod.Annotations[kubernetes.WorkspaceURLAnnotation]
-
-	return &WorkspaceInfo{
-		WorkspaceID:     pod.Labels[kubernetes.MetaIDLabel],
-		InstanceID:      pod.Labels[kubernetes.WorkspaceIDLabel],
-		URL:             workspaceURL,
-		IDEImage:        imageSpec.IdeRef,
-		IDEPublicPort:   getPortStr(workspaceURL),
-		SupervisorImage: imageSpec.SupervisorRef,
-		IPAddress:       pod.Status.PodIP,
-		Ports:           extractExposedPorts(pod).Ports,
-		Auth:            &wsapi.WorkspaceAuthentication{Admission: admission, OwnerToken: ownerToken},
-		StartedAt:       pod.CreationTimestamp.Time,
-		OwnerUserId:     pod.Labels[kubernetes.OwnerLabel],
-		SSHPublicKeys:   extractUserSSHPublicKeys(pod),
-		IsRunning:       pod.DeletionTimestamp == nil,
-	}
-}
-
-// WorkspaceInfo return the WorkspaceInfo available for the given workspaceID.
-func (r *RemoteWorkspaceInfoProvider) WorkspaceInfo(workspaceID string) *WorkspaceInfo {
-	workspaces, err := r.store.ByIndex(workspaceIndex, workspaceID)
-	if err != nil {
-		return nil
-	}
-
-	if len(workspaces) == 1 {
-		return workspaces[0].(*WorkspaceInfo)
-	}
-
-	return nil
-}
 
 // getPortStr extracts the port part from a given URL string. Returns "" if parsing fails or port is not specified.
 func getPortStr(urlStr string) string {
@@ -215,7 +98,7 @@ type CRDWorkspaceInfoProvider struct {
 	store cache.ThreadSafeStore
 }
 
-// NewRemoteWorkspaceInfoProvider creates a fresh WorkspaceInfoProvider.
+// NewCRDWorkspaceInfoProvider creates a fresh WorkspaceInfoProvider.
 func NewCRDWorkspaceInfoProvider(client client.Client, scheme *runtime.Scheme) (*CRDWorkspaceInfoProvider, error) {
 	// create custom indexer for searches
 	indexers := cache.Indexers{
@@ -298,6 +181,7 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 		Ports:           ports,
 		Auth:            &wsapi.WorkspaceAuthentication{Admission: admission, OwnerToken: ws.Status.OwnerToken},
 		StartedAt:       ws.CreationTimestamp.Time,
+		OwnerUserId:     ws.Spec.Ownership.Owner,
 		SSHPublicKeys:   ws.Spec.SshPublicKeys,
 		IsRunning:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 	}


### PR DESCRIPTION
## Description

Removes the pod info provider from ws-proxy, which is no longer used (was for ws-manager-mk1)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Test in a preview env that you can still start and connect to a workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
