### PR TITLE
[workspace] Update regular not active alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -28,9 +28,9 @@ spec:
         summary: too many running but inactive workspaces
         description: too many running but inactive workspaces.
       expr: |
-        gitpod_workspace_regular_not_active_percentage_mk2 > 0.10
+        gitpod_workspace_regular_not_active_percentage_mk2 > 0.08
         AND
-        sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 20
+        sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 25
 
     - alert: GitpodWorkspacesNotStartingMk2
       labels:


### PR DESCRIPTION
## Description
Decrease the percentage of regular not active workspace that we get notified earlier. At the same time ensure that we do not get paged if we only have a low number of workspaces.

## Related Issue(s)
Fixes WKS-261

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
