### PR TITLE
`gp ssh`

### DIFF
--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -10,25 +10,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
-	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
-	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/xerrors"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
-
-var accessToken bool
 
 // sshCmd commands collection
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Show the SSH connection command for the current workspace",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Long: `The command which is outputted requires SSH keys to be configured with Gitpod.
+See https://www.gitpod.io/docs/configure/user-settings/ssh for a guide on setting them up.
+`, RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer cancel()
 
@@ -41,47 +34,6 @@ var sshCmd = &cobra.Command{
 		sshKeyHost := fmt.Sprintf(`%s@%s`, wsInfo.WorkspaceId, host)
 
 		sshHost := sshKeyHost
-
-		if accessToken {
-			var err error
-
-			supervisorConn, err := grpc.Dial(util.GetSupervisorAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-			if err != nil {
-				return xerrors.Errorf("failed connecting to supervisor: %w", err)
-			}
-			defer supervisorConn.Close()
-			clientToken, err := supervisor.NewTokenServiceClient(supervisorConn).GetToken(ctx, &supervisor.GetTokenRequest{
-				Host: wsInfo.GitpodApi.Host,
-				Kind: "gitpod",
-				Scope: []string{
-					"function:getOwnerToken",
-				},
-			})
-			if err != nil {
-				return xerrors.Errorf("failed getting token from supervisor: %w", err)
-			}
-
-			serverLog := log.NewEntry(log.StandardLogger())
-
-			client, err := serverapi.ConnectToServer(wsInfo.GitpodApi.Endpoint, serverapi.ConnectToServerOpts{
-				Token:   clientToken.Token,
-				Context: ctx,
-				Log:     serverLog,
-			})
-			if err != nil {
-				return xerrors.Errorf("failed connecting to server: %w", err)
-			}
-
-			ownerToken, err := client.GetOwnerToken(ctx, wsInfo.WorkspaceId)
-			if err != nil {
-				fmt.Println("failed getting owner token from server: %w", err)
-			}
-
-			fmt.Println(ownerToken)
-
-			sshHost = fmt.Sprintf(`%s#%s@%s`, wsInfo.WorkspaceId, ownerToken, host)
-		}
-
 		sshCommand := fmt.Sprintf(`ssh '%s'`, sshHost)
 		fmt.Println(sshCommand)
 
@@ -91,5 +43,4 @@ var sshCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(sshCmd)
-	sshCmd.Flags().BoolVar(&accessToken, "access-token", false, "Show the SSH access token command instead")
 }

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -37,8 +37,7 @@ See %s/user/keys for a guide on setting them up.
 		host := strings.Replace(wsInfo.WorkspaceUrl, wsInfo.WorkspaceId, wsInfo.WorkspaceId+".ssh", -1)
 		sshKeyHost := fmt.Sprintf(`%s@%s`, wsInfo.WorkspaceId, host)
 
-		sshHost := sshKeyHost
-		sshCommand := fmt.Sprintf(`ssh '%s'`, sshHost)
+		sshCommand := fmt.Sprintf(`ssh '%s'`, sshKeyHost)
 		fmt.Println(sshCommand)
 
 		return nil

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -19,7 +19,8 @@ import (
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Show the SSH connection command for the current workspace",
-	Long: `The command which is outputted requires SSH keys to be configured with Gitpod.
+	Long: `Displays a command with which you can connect to the current workspace.
+The returned command requires SSH keys to be configured with Gitpod.
 See https://www.gitpod.io/docs/configure/user-settings/ssh for a guide on setting them up.
 `, RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var accessKey bool
+var accessToken bool
 
 // sshCmd commands collection
 var sshCmd = &cobra.Command{
@@ -42,7 +42,7 @@ var sshCmd = &cobra.Command{
 
 		sshHost := sshKeyHost
 
-		if accessKey {
+		if accessToken {
 			var err error
 
 			supervisorConn, err := grpc.Dial(util.GetSupervisorAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -91,5 +91,5 @@ var sshCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(sshCmd)
-	sshCmd.Flags().BoolVar(&accessKey, "access-key", false, "Show the ssh access token command")
+	sshCmd.Flags().BoolVar(&accessToken, "access-token", false, "Show the SSH access token command instead")
 }

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -10,8 +10,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
+
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var accessKey bool
@@ -21,7 +29,7 @@ var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Show the SSH connection command for the current workspace",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer cancel()
 
 		wsInfo, err := gitpod.GetWSInfo(ctx)
@@ -30,15 +38,48 @@ var sshCmd = &cobra.Command{
 		}
 
 		host := strings.Replace(wsInfo.WorkspaceUrl, wsInfo.WorkspaceId, wsInfo.WorkspaceId+".ssh", -1)
-		//sshAccessTokenHost := fmt.Sprintf(`ssh '%s#%s@%s'`, wsInfo.WorkspaceId, wsInfo.Own, host)
-		sshAccessTokenHost := fmt.Sprintf(`%s#%s@%s`, wsInfo.WorkspaceId, "ownerToken", host)
 		sshKeyHost := fmt.Sprintf(`%s@%s`, wsInfo.WorkspaceId, host)
 
-		// ssh command depends on the flags
 		sshHost := sshKeyHost
+
 		if accessKey {
-			// todo(ft): implement getting Owner Token
-			sshHost = sshAccessTokenHost
+			var err error
+
+			supervisorConn, err := grpc.Dial(util.GetSupervisorAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				return xerrors.Errorf("failed connecting to supervisor: %w", err)
+			}
+			defer supervisorConn.Close()
+			clientToken, err := supervisor.NewTokenServiceClient(supervisorConn).GetToken(ctx, &supervisor.GetTokenRequest{
+				Host: wsInfo.GitpodApi.Host,
+				Kind: "gitpod",
+				Scope: []string{
+					"function:getOwnerToken",
+				},
+			})
+			if err != nil {
+				return xerrors.Errorf("failed getting token from supervisor: %w", err)
+			}
+
+			serverLog := log.NewEntry(log.StandardLogger())
+
+			client, err := serverapi.ConnectToServer(wsInfo.GitpodApi.Endpoint, serverapi.ConnectToServerOpts{
+				Token:   clientToken.Token,
+				Context: ctx,
+				Log:     serverLog,
+			})
+			if err != nil {
+				return xerrors.Errorf("failed connecting to server: %w", err)
+			}
+
+			ownerToken, err := client.GetOwnerToken(ctx, wsInfo.WorkspaceId)
+			if err != nil {
+				fmt.Println("failed getting owner token from server: %w", err)
+			}
+
+			fmt.Println(ownerToken)
+
+			sshHost = fmt.Sprintf(`%s#%s@%s`, wsInfo.WorkspaceId, ownerToken, host)
 		}
 
 		sshCommand := fmt.Sprintf(`ssh '%s'`, sshHost)

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// todo(ft): distribute this common metadata from the root command to all subcommands to reduce latency
 var gitpodHost = os.Getenv("GITPOD_HOST")
 
 // sshCmd represents the ssh command

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -7,6 +7,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -15,14 +17,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var gitpodHost = os.Getenv("GITPOD_HOST")
+
 // sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Show the SSH connection command for the current workspace",
-	Long: `Displays a command with which you can connect to the current workspace.
+	Long: fmt.Sprintf(`Displays a command with which you can connect to the current workspace.
 The returned command requires SSH keys to be configured with Gitpod.
-See https://www.gitpod.io/docs/configure/user-settings/ssh for a guide on setting them up.
-`, RunE: func(cmd *cobra.Command, args []string) error {
+See %s/user/keys for a guide on setting them up.
+`, gitpodHost), RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer cancel()
 

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sshCmd commands collection
+// sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
 	Short: "Show the SSH connection command for the current workspace",
@@ -28,7 +28,7 @@ See https://www.gitpod.io/docs/configure/user-settings/ssh for a guide on settin
 
 		wsInfo, err := gitpod.GetWSInfo(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot get workspace info: %w", err)
 		}
 
 		host := strings.Replace(wsInfo.WorkspaceUrl, wsInfo.WorkspaceId, wsInfo.WorkspaceId+".ssh", -1)

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/spf13/cobra"
+)
+
+var accessKey bool
+
+// sshCmd commands collection
+var sshCmd = &cobra.Command{
+	Use:   "ssh",
+	Short: "Show the SSH connection command for the current workspace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			return err
+		}
+
+		host := strings.Replace(wsInfo.WorkspaceUrl, wsInfo.WorkspaceId, wsInfo.WorkspaceId+".ssh", -1)
+		//sshAccessTokenHost := fmt.Sprintf(`ssh '%s#%s@%s'`, wsInfo.WorkspaceId, wsInfo.Own, host)
+		sshAccessTokenHost := fmt.Sprintf(`%s#%s@%s`, wsInfo.WorkspaceId, "ownerToken", host)
+		sshKeyHost := fmt.Sprintf(`%s@%s`, wsInfo.WorkspaceId, host)
+
+		// ssh command depends on the flags
+		sshHost := sshKeyHost
+		if accessKey {
+			// todo(ft): implement getting Owner Token
+			sshHost = sshAccessTokenHost
+		}
+
+		sshCommand := fmt.Sprintf(`ssh '%s'`, sshHost)
+		fmt.Println(sshCommand)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sshCmd)
+	sshCmd.Flags().BoolVar(&accessKey, "access-key", false, "Show the ssh access token command")
+}


### PR DESCRIPTION
## Description

Adds a `gp ssh` command for printing the SSH command used to access the workspace. This relies on having SSH keys setup.
## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/11415

## How to test

```bash
go run /workspace/gitpod/components/gitpod-cli ssh
```

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
