### PR TITLE
[spicedb] Setup empty migrations job

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -58,6 +58,11 @@ export type Config = Omit<
             cookie: CookieConfig;
         };
     };
+
+    permissionsMigration: {
+        frequencySeconds: number;
+        enabled: boolean;
+    };
 };
 
 export interface WorkspaceDefaults {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -132,6 +132,7 @@ import { SnapshotsJob } from "./jobs/snapshots";
 import { OrgOnlyMigrationJob } from "./jobs/org-only-migration-job";
 import { APIStatsService } from "./api/stats";
 import { FixStripeJob } from "./jobs/fix-stripe-job";
+import { SpiceDBMigrationJob } from "./jobs/spicedb-migration";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -360,6 +361,7 @@ export const productionContainerModule = new ContainerModule(
         bind(OrgOnlyMigrationJob).toSelf().inSingletonScope();
         bind(FixStripeJob).toSelf().inSingletonScope();
         bind(JobRunner).toSelf().inSingletonScope();
+        bind(SpiceDBMigrationJob).toSelf().inSingletonScope();
 
         // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129
         rebind(UsageService)

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -19,6 +19,7 @@ import { WorkspaceGarbageCollector } from "./workspace-gc";
 import { SnapshotsJob } from "./snapshots";
 import { OrgOnlyMigrationJob } from "./org-only-migration-job";
 import { FixStripeJob } from "./fix-stripe-job";
+import { SpiceDBMigrationJob } from "./spicedb-migration";
 
 export const Job = Symbol("Job");
 
@@ -41,6 +42,7 @@ export class JobRunner {
     @inject(SnapshotsJob) protected snapshotsJob: SnapshotsJob;
     @inject(OrgOnlyMigrationJob) protected orgOnlyMigrationJob: OrgOnlyMigrationJob;
     @inject(FixStripeJob) protected fixStripeJob: FixStripeJob;
+    @inject(SpiceDBMigrationJob) protected spicedbMigrationJob: SpiceDBMigrationJob;
 
     public start(): DisposableCollection {
         const disposables = new DisposableCollection();
@@ -54,6 +56,7 @@ export class JobRunner {
             this.snapshotsJob,
             this.orgOnlyMigrationJob,
             this.fixStripeJob,
+            this.spicedbMigrationJob,
         ];
 
         for (let job of jobs) {

--- a/components/server/src/jobs/spicedb-migration.ts
+++ b/components/server/src/jobs/spicedb-migration.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Job } from "./runner";
+import { Config } from "../config";
+import { SpiceDBClient } from "../authorization/spicedb";
+
+@injectable()
+export class SpiceDBMigrationJob implements Job {
+    @inject(SpiceDBClient) spicedbClient: SpiceDBClient;
+    @inject(Config) protected readonly config: Config;
+
+    public name = "spicedb";
+    public frequencyMs = 5 * 60 * 1000; // every 5 minutes
+
+    public async run(): Promise<void> {
+        if (this.config.permissionsMigration.enabled) {
+            log.info("spicedb-migrations: Job disabled.");
+            return;
+        }
+
+        if (!this.spicedbClient) {
+            log.info("spicedb-migrations: No client exists.");
+            return;
+        }
+
+        log.info("spicedb-migrations: Would start migrations, but currently none defined.");
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Basic setup for the migrations job. We still don't have 100 clarity on the details, but this at least allows us to have something which we can play with

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
