### PR TITLE
[ws-daemon] Add OWI to logs

### DIFF
--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"golang.org/x/xerrors"
+	"k8s.io/klog/v2"
 
 	"github.com/bombsimon/logrusr/v2"
 	"github.com/heptiolabs/healthcheck"
@@ -40,7 +41,10 @@ var runCmd = &cobra.Command{
 
 		createLVMDevices()
 
-		ctrl.SetLogger(logrusr.New(log.Log))
+		baseLogger := logrusr.New(log.Log)
+		ctrl.SetLogger(baseLogger)
+		// Set the logger used by k8s (e.g. client-go).
+		klog.SetLogger(baseLogger)
 
 		dmn, err := daemon.NewDaemon(cfg.Daemon)
 		if err != nil {

--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
@@ -58,11 +58,11 @@ func (c *IOLimiterV2) Apply(ctx context.Context, opts *PluginOptions) error {
 	}()
 
 	go func() {
-		log.WithField("cgroupPath", opts.CgroupPath).Debug("starting io limiting")
+		log.WithFields(log.OWI("", "", opts.InstanceId)).WithField("cgroupPath", opts.CgroupPath).Debug("starting io limiting")
 
 		_, err := v2.NewManager(opts.BasePath, filepath.Join("/", opts.CgroupPath), c.limits)
 		if err != nil {
-			log.WithError(err).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Warn("cannot write IO limits")
+			log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Warn("cannot write IO limits")
 		}
 
 		for {
@@ -70,7 +70,7 @@ func (c *IOLimiterV2) Apply(ctx context.Context, opts *PluginOptions) error {
 			case <-update:
 				_, err := v2.NewManager(opts.BasePath, filepath.Join("/", opts.CgroupPath), c.limits)
 				if err != nil {
-					log.WithError(err).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write IO limits")
+					log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write IO limits")
 				}
 			case <-ctx.Done():
 				// Prior to shutting down though, we need to reset the IO limits to ensure we don't have
@@ -78,9 +78,9 @@ func (c *IOLimiterV2) Apply(ctx context.Context, opts *PluginOptions) error {
 				// workspace pod from shutting down.
 				_, err := v2.NewManager(opts.BasePath, filepath.Join("/", opts.CgroupPath), &v2.Resources{})
 				if err != nil {
-					log.WithError(err).WithField("cgroupPath", opts.CgroupPath).Error("cannot write IO limits")
+					log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("cgroupPath", opts.CgroupPath).Error("cannot write IO limits")
 				}
-				log.WithField("cgroupPath", opts.CgroupPath).Debug("stopping io limiting")
+				log.WithFields(log.OWI("", "", opts.InstanceId)).WithField("cgroupPath", opts.CgroupPath).Debug("stopping io limiting")
 				return
 			}
 		}

--- a/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
@@ -57,7 +57,7 @@ func (c *ProcLimiterV2) Apply(ctx context.Context, opts *PluginOptions) error {
 
 		_, err := v2.NewManager(opts.BasePath, filepath.Join("/", opts.CgroupPath), c.limits)
 		if err != nil {
-			log.WithError(err).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
+			log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
 		}
 
 		for {
@@ -65,7 +65,7 @@ func (c *ProcLimiterV2) Apply(ctx context.Context, opts *PluginOptions) error {
 			case <-update:
 				_, err := v2.NewManager(opts.BasePath, filepath.Join("/", opts.CgroupPath), c.limits)
 				if err != nil {
-					log.WithError(err).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
+					log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("basePath", opts.BasePath).WithField("cgroupPath", opts.CgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
 				}
 			case <-ctx.Done():
 				return

--- a/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
@@ -78,7 +78,7 @@ func (c *ProcessPriorityV2) Apply(ctx context.Context, opts *PluginOptions) erro
 			// the target cgroup/workspace has gone
 			return nil
 		} else if err != nil {
-			log.WithField("path", fullCgroupPath).WithError(err).Errorf("cannot read cgroup.procs file")
+			log.WithFields(log.OWI("", "", opts.InstanceId)).WithField("path", fullCgroupPath).WithError(err).Errorf("cannot read cgroup.procs file")
 			return err
 		}
 
@@ -92,7 +92,7 @@ func (c *ProcessPriorityV2) Apply(ctx context.Context, opts *PluginOptions) erro
 
 			pid, err := strconv.ParseInt(line, 10, 64)
 			if err != nil {
-				log.WithError(err).WithField("line", line).Warn("cannot parse pid")
+				log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("line", line).Warn("cannot parse pid")
 				continue
 			}
 
@@ -102,7 +102,7 @@ func (c *ProcessPriorityV2) Apply(ctx context.Context, opts *PluginOptions) erro
 					continue
 				}
 
-				log.WithError(err).WithField("pid", pid).Warn("cannot get process")
+				log.WithError(err).WithFields(log.OWI("", "", opts.InstanceId)).WithField("pid", pid).Warn("cannot get process")
 				continue
 			}
 

--- a/components/ws-daemon/pkg/cgroup/plugin_psi.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_psi.go
@@ -91,20 +91,20 @@ func (p *PSIMetrics) scrape(cpu *cgroups.Cpu, memory *cgroups.Memory, io *cgroup
 		p.cpu.WithLabelValues(p.nodeName, instanceID, "some").Set(float64(psi.Some))
 		p.cpu.WithLabelValues(p.nodeName, instanceID, "full").Set(float64(psi.Full))
 	} else if !os.IsNotExist(err) {
-		log.WithError(err).Warn("could not retrieve cpu psi")
+		log.WithError(err).WithFields(log.OWI("", "", instanceID)).Warn("could not retrieve cpu psi")
 	}
 
 	if psi, err := memory.PSI(); err == nil {
 		p.memory.WithLabelValues(p.nodeName, instanceID, "some").Set(float64(psi.Some))
 		p.memory.WithLabelValues(p.nodeName, instanceID, "full").Set(float64(psi.Full))
 	} else if !os.IsNotExist(err) {
-		log.WithError(err).Warn("could not retrieve memory psi")
+		log.WithError(err).WithFields(log.OWI("", "", instanceID)).Warn("could not retrieve memory psi")
 	}
 
 	if psi, err := io.PSI(); err == nil {
 		p.io.WithLabelValues(p.nodeName, instanceID, "some").Set(float64(psi.Some))
 		p.io.WithLabelValues(p.nodeName, instanceID, "full").Set(float64(psi.Full))
 	} else if !os.IsNotExist(err) {
-		log.WithError(err).Warn("could not retrieve io psi")
+		log.WithError(err).WithFields(log.OWI("", "", instanceID)).Warn("could not retrieve io psi")
 	}
 }

--- a/components/ws-daemon/pkg/container/containerd.go
+++ b/components/ws-daemon/pkg/container/containerd.go
@@ -300,7 +300,7 @@ func (s *Containerd) handleNewTask(cid string, rootfs []*types.Mount, pid uint32
 		mnts, err := s.Client.SnapshotService(info.Snapshotter).Mounts(ctx, info.SnapshotKey)
 		cancel()
 		if err != nil {
-			log.WithError(err).Warnf("cannot get mounts for container %v", cid)
+			log.WithError(err).WithFields(log.OWI(info.OwnerID, info.WorkspaceID, info.InstanceID)).Warnf("cannot get mounts for container %v", cid)
 		}
 		for _, m := range mnts {
 			rootfs = append(rootfs, &types.Mount{

--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -91,7 +91,7 @@ func hookSetupWorkspaceLocation(ctx context.Context, ws *session.Workspace) (err
 		// in the very unlikely event that the workspace Pod did not mount (and thus create) the workspace directory, create it
 		err = os.Mkdir(location, 0755)
 		if os.IsExist(err) {
-			log.WithError(err).WithField("location", location).Debug("ran into non-atomic workspace location existence check")
+			log.WithError(err).WithFields(ws.OWI()).WithField("location", location).Debug("ran into non-atomic workspace location existence check")
 		} else if err != nil {
 			return xerrors.Errorf("cannot create workspace: %w", err)
 		}

--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -123,7 +123,7 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	glog.WithField("workspace", req.NamespacedName).WithField("phase", workspace.Status.Phase).Info("reconciling workspace")
+	glog.WithFields(workspace.OWI()).WithField("workspace", req.NamespacedName).WithField("phase", workspace.Status.Phase).Info("reconciling workspace")
 
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseCreating ||
 		workspace.Status.Phase == workspacev1.WorkspacePhaseInitializing {
@@ -155,7 +155,7 @@ func (wsc *WorkspaceController) latestWorkspace(ctx context.Context, ws *workspa
 
 	err := wsc.Client.Status().Update(ctx, ws)
 	if err != nil && !errors.IsConflict(err) {
-		glog.Warnf("could not refresh workspace: %v", err)
+		glog.WithFields(ws.OWI()).Warnf("could not refresh workspace: %v", err)
 	}
 
 	return err
@@ -409,7 +409,7 @@ func (m *workspaceMetrics) recordInitializeTime(duration float64, ws *workspacev
 
 	hist, err := m.initializeTimeHistVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
-		glog.WithError(err).WithField("type", tpe).WithField("class", class).Infof("could not retrieve initialize metric")
+		glog.WithError(err).WithFields(ws.OWI()).WithField("type", tpe).WithField("class", class).Infof("could not retrieve initialize metric")
 	}
 
 	hist.Observe(duration)
@@ -421,7 +421,7 @@ func (m *workspaceMetrics) recordFinalizeTime(duration float64, ws *workspacev1.
 
 	hist, err := m.finalizeTimeHistVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
-		glog.WithError(err).WithField("type", tpe).WithField("class", class).Infof("could not retrieve finalize metric")
+		glog.WithError(err).WithFields(ws.OWI()).WithField("type", tpe).WithField("class", class).Infof("could not retrieve finalize metric")
 	}
 
 	hist.Observe(duration)

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -169,12 +169,12 @@ func (wso *DefaultWorkspaceOperations) InitWorkspace(ctx context.Context, option
 
 	err = ensureCleanSlate(ws.Location)
 	if err != nil {
-		glog.Warnf("cannot ensure clean slate for workspace %s (this might break content init): %v", ws.InstanceID, err)
+		glog.WithFields(ws.OWI()).Warnf("cannot ensure clean slate for workspace %s (this might break content init): %v", ws.InstanceID, err)
 	}
 
 	err = content.RunInitializer(ctx, ws.Location, options.Initializer, remoteContent, opts)
 	if err != nil {
-		glog.Infof("error running initializer %v", err)
+		glog.WithFields(ws.OWI()).Infof("error running initializer %v", err)
 		return err.Error(), err
 	}
 
@@ -234,7 +234,7 @@ func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts
 		err := wso.uploadWorkspaceLogs(ctx, opts)
 		if err != nil {
 			// we do not fail the workspace yet because we still might succeed with its content!
-			glog.WithError(err).Error("log backup failed")
+			glog.WithError(err).WithFields(ws.OWI()).Error("log backup failed")
 		}
 	}
 
@@ -253,7 +253,7 @@ func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts
 			// which can happen for various reasons, including user corrupting his .git folder somehow
 			// instead we log the error and continue cleaning up workspace
 			// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
-			glog.WithError(err).Warn("cannot get git status")
+			glog.WithError(err).WithFields(ws.OWI()).Warn("cannot get git status")
 		}
 	}
 
@@ -267,13 +267,13 @@ func (wso *DefaultWorkspaceOperations) DeleteWorkspace(ctx context.Context, inst
 	}
 
 	if err = ws.Dispose(ctx, wso.provider.hooks[session.WorkspaceDisposed]); err != nil {
-		glog.WithError(err).Error("cannot dispose session")
+		glog.WithError(err).WithFields(ws.OWI()).Error("cannot dispose session")
 		return err
 	}
 
 	// remove workspace daemon directory in the node
 	if err := os.RemoveAll(ws.ServiceLocDaemon); err != nil {
-		glog.WithError(err).Error("cannot delete workspace daemon directory")
+		glog.WithError(err).WithFields(ws.OWI()).Error("cannot delete workspace daemon directory")
 		return err
 	}
 	wso.provider.Remove(ctx, instanceID)
@@ -369,12 +369,13 @@ func (wso *DefaultWorkspaceOperations) uploadWorkspaceLogs(ctx context.Context, 
 
 	for _, absLogPath := range logFiles {
 		taskID, parseErr := logs.ParseTaskIDFromPrebuildLogFilePath(absLogPath)
+		owi := glog.OWI(opts.Meta.Owner, opts.Meta.WorkspaceID, opts.Meta.InstanceID)
 		if parseErr != nil {
-			glog.WithError(parseErr).Warn("cannot parse headless workspace log file name")
+			glog.WithError(parseErr).WithFields(owi).Warn("cannot parse headless workspace log file name")
 			continue
 		}
 
-		err = retryIfErr(ctx, 5, glog.WithField("op", "upload log"), func(ctx context.Context) (err error) {
+		err = retryIfErr(ctx, 5, glog.WithField("op", "upload log").WithFields(owi), func(ctx context.Context) (err error) {
 			_, _, err = rs.UploadInstance(ctx, absLogPath, logs.UploadedHeadlessLogPath(taskID))
 			if err != nil {
 				return

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -111,7 +111,7 @@ func (s *Workspace) Dispose(ctx context.Context, hooks []WorkspaceLivecycleHook)
 	err = os.Remove(s.persistentStateLocation())
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			log.WithError(err).Warn("workspace persistent state location not exist")
+			log.WithError(err).WithFields(s.OWI()).Warn("workspace persistent state location not exist")
 			err = nil
 		} else {
 			return xerrors.Errorf("cannot remove workspace persistent state location: %w", err)

--- a/components/ws-daemon/pkg/netlimit/netlimit.go
+++ b/components/ws-daemon/pkg/netlimit/netlimit.go
@@ -157,7 +157,7 @@ func (c *ConnLimiter) limitWorkspace(ctx context.Context, ws *dispatch.Workspace
 			case <-ticker.C:
 				counter, err := c.GetConnectionDropCounter(pid)
 				if err != nil {
-					log.WithError(err).Errorf("could not get connection drop stats for %s", ws.WorkspaceID)
+					log.WithFields(ws.OWI()).WithError(err).Errorf("could not get connection drop stats for %s", ws.WorkspaceID)
 					continue
 				}
 

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -6,6 +6,8 @@ package v1
 
 import (
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -435,6 +437,12 @@ func (w *Workspace) IsHeadless() bool {
 
 func (w *Workspace) IsConditionTrue(condition WorkspaceCondition) bool {
 	return wsk8s.ConditionPresentAndTrue(w.Status.Conditions, string(condition))
+}
+
+// OWI produces the owner, workspace, instance log metadata from the information
+// of this workspace.
+func (w *Workspace) OWI() logrus.Fields {
+	return log.OWI(w.Spec.Ownership.Owner, w.Spec.Ownership.WorkspaceID, w.Name)
 }
 
 func init() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add OWI to ws-daemon logs that didn't have it yet, to help debug specific workspace logs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Open a workspace in a preview env, check the logs for OWI info.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
