### PR TITLE
[db] some cleanups for db impls

### DIFF
--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -5,55 +5,56 @@
  */
 
 import {
+    OrganizationSettings,
     Team,
     TeamMemberInfo,
     TeamMemberRole,
     TeamMembershipInvite,
-    OrganizationSettings,
     User,
 } from "@gitpod/gitpod-protocol";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { randomBytes } from "crypto";
 import { inject, injectable, optional } from "inversify";
+import slugify from "slugify";
 import { EntityManager, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
-import { randomBytes } from "crypto";
+import { ResponseError } from "vscode-jsonrpc";
 import { TeamDB } from "../team-db";
 import { DBTeam } from "./entity/db-team";
 import { DBTeamMembership } from "./entity/db-team-membership";
-import { DBUser } from "./entity/db-user";
 import { DBTeamMembershipInvite } from "./entity/db-team-membership-invite";
-import { ResponseError } from "vscode-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import slugify from "slugify";
 import { DBOrgSettings } from "./entity/db-team-settings";
-import { TransactionalDBImpl, UndefinedEntityManager } from "./transactional-db-impl";
+import { DBUser } from "./entity/db-user";
+import { TransactionalDBImpl } from "./transactional-db-impl";
+import { TypeORM } from "./typeorm";
 
 @injectable()
 export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
-    constructor(@inject(UndefinedEntityManager) @optional() transactionalEM: EntityManager | undefined) {
-        super(transactionalEM);
+    constructor(@inject(TypeORM) typeorm: TypeORM, @optional() transactionalEM?: EntityManager) {
+        super(typeorm, transactionalEM);
     }
 
     protected createTransactionalDB(transactionalEM: EntityManager): TeamDB {
-        return new TeamDBImpl(transactionalEM);
+        return new TeamDBImpl(this.typeorm, transactionalEM);
     }
 
-    protected async getTeamRepo(): Promise<Repository<DBTeam>> {
+    private async getTeamRepo(): Promise<Repository<DBTeam>> {
         return (await this.getEntityManager()).getRepository<DBTeam>(DBTeam);
     }
 
-    protected async getMembershipRepo(): Promise<Repository<DBTeamMembership>> {
+    private async getMembershipRepo(): Promise<Repository<DBTeamMembership>> {
         return (await this.getEntityManager()).getRepository<DBTeamMembership>(DBTeamMembership);
     }
 
-    protected async getMembershipInviteRepo(): Promise<Repository<DBTeamMembershipInvite>> {
+    private async getMembershipInviteRepo(): Promise<Repository<DBTeamMembershipInvite>> {
         return (await this.getEntityManager()).getRepository<DBTeamMembershipInvite>(DBTeamMembershipInvite);
     }
 
-    protected async getOrgSettingsRepo(): Promise<Repository<DBOrgSettings>> {
+    private async getOrgSettingsRepo(): Promise<Repository<DBOrgSettings>> {
         return (await this.getEntityManager()).getRepository<DBOrgSettings>(DBOrgSettings);
     }
 
-    protected async getUserRepo(): Promise<Repository<DBUser>> {
+    private async getUserRepo(): Promise<Repository<DBUser>> {
         return (await this.getEntityManager()).getRepository<DBUser>(DBUser);
     }
 

--- a/components/gitpod-db/src/typeorm/transactional-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/transactional-db-impl.ts
@@ -12,15 +12,11 @@ export interface TransactionalDB<DB> {
     transaction<R>(code: (db: DB) => Promise<R>): Promise<R>;
 }
 
-// A symbol we never bind to
-export const UndefinedEntityManager = Symbol("UndefinedEntityManager");
-
 @injectable()
 export abstract class TransactionalDBImpl<DB> implements TransactionalDB<DB> {
-    @inject(TypeORM) protected readonly typeorm: TypeORM;
-
     constructor(
-        @optional() protected transactionalEM: EntityManager | undefined, // will be undefined when constructed with inversify, which is inteded
+        @inject(TypeORM) protected readonly typeorm: TypeORM,
+        @optional() private transactionalEM?: EntityManager,
     ) {}
 
     protected async getEntityManager(): Promise<EntityManager> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some minor cleanups in the db-impls.
 - remove unnecessary undefined symbol
 - made members private where there very unnecessarily protected
 - removed unused code

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
