### PR TITLE
[ws-daemon] Add reconcile timeout

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -265,7 +265,7 @@ func RunInitializer(ctx context.Context, destination string, initializer *csapi.
 	}()
 
 	var cmdOut bytes.Buffer
-	cmd := exec.Command("runc", args...)
+	cmd := exec.CommandContext(ctx, "runc", args...)
 	cmd.Dir = tmpdir
 	cmd.Stdout = &cmdOut
 	cmd.Stderr = os.Stderr
@@ -406,7 +406,7 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 		"-o", tempFile.Name(),
 	}
 
-	cmd := exec.Command("aria2c", args...)
+	cmd := exec.CommandContext(ctx, "aria2c", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")

--- a/components/ws-daemon/pkg/controller/suite_test.go
+++ b/components/ws-daemon/pkg/controller/suite_test.go
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	ctx, cancel = context.WithCancel(context.Background())
 
-	workspaceCtrl, err = NewWorkspaceController(k8sClient, record.NewFakeRecorder(100), NodeName, secretsNamespace, 5, nil, ctrl_metrics.Registry)
+	workspaceCtrl, err = NewWorkspaceController(k8sClient, record.NewFakeRecorder(100), NodeName, secretsNamespace, 5, nil, ctrl_metrics.Registry, 40*time.Minute)
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(workspaceCtrl.SetupWithManager(k8sManager)).To(Succeed())

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -34,6 +34,7 @@ type Config struct {
 
 type WorkspaceControllerConfig struct {
 	MaxConcurrentReconciles int `json:"maxConcurrentReconciles,omitempty"`
+	ReconcileTimeoutMinutes int `json:"reconcileTimeoutMinutes,omitempty"`
 }
 
 type RuntimeConfig struct {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -200,7 +200,7 @@ func NewDaemon(config Config) (*Daemon, error) {
 	}
 
 	wsctrl, err := controller.NewWorkspaceController(
-		mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), nodename, config.Runtime.SecretsNamespace, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps, wrappedReg)
+		mgr.GetClient(), mgr.GetEventRecorderFor("workspace"), nodename, config.Runtime.SecretsNamespace, config.WorkspaceController.MaxConcurrentReconciles, workspaceOps, wrappedReg, time.Minute*time.Duration(config.WorkspaceController.ReconcileTimeoutMinutes))
 	if err != nil {
 		return nil, err
 	}

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -105,6 +105,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		procLimit = ucfg.Workspace.ProcLimit
 
 		wscontroller.MaxConcurrentReconciles = 15
+		wscontroller.ReconcileTimeoutMinutes = 40
 
 		if ucfg.Workspace.WorkspaceCIDR != "" {
 			workspaceCIDR = ucfg.Workspace.WorkspaceCIDR


### PR DESCRIPTION
## Description

Add reconcile timeout to ws-daemon.
Set to 40 minutes, which is e.g. longer than a workspace's grace period of 30 minutes.

See https://linear.app/gitpod/issue/WKS-243#comment-53c175c7 for context.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-243

## How to test
<!-- Provide steps to test this PR -->



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
