### PR TITLE
update dev image

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
 
 USER root
 ENV OCI_TOOL_VERSION="0.2.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: [ self-hosted ]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
@@ -155,7 +155,7 @@ jobs:
         ports:
           - 23306:23306
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
       volumes:
         - /var/tmp/${{ needs.configuration.outputs.leeway_cache_bucket }}:/var/tmp
         - /tmp:/tmp
@@ -389,7 +389,7 @@ jobs:
     needs: [ configuration, build-previewctl, build-gitpod, infrastructure, install ]
     runs-on: [ self-hosted ]
     container:
-        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
         volumes:
           - /var/tmp:/var/tmp
           - /tmp:/tmp

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
         name: Configuration
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
         outputs:
             name: ${{ steps.configuration.outputs.name }}
             version: ${{ steps.configuration.outputs.version }}
@@ -91,7 +91,7 @@ jobs:
         needs: [configuration, infrastructure]
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
             volumes:
               - /var/tmp:/var/tmp
               - /tmp:/tmp

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ needs.configuration.outputs.skip == 'false' }}
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
             volumes:
                 - /var/tmp:/var/tmp
                 - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -8,7 +8,7 @@ jobs:
         name: "Find stale preview environments"
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
         outputs:
             names: ${{ steps.set-matrix.outputs.names }}
             count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
         name: Configuration
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
             volumes:
                 - /var/tmp:/var/tmp
                 - /tmp:/tmp
@@ -113,7 +113,7 @@ jobs:
         needs: [configuration, infrastructure]
         runs-on: [self-hosted]
         container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
             volumes:
                 - /var/tmp:/var/tmp
                 - /tmp:/tmp
@@ -226,7 +226,7 @@ jobs:
       if: github.event.inputs.skip_delete != 'true' && always()
       runs-on: [ self-hosted ]
       container:
-        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+        image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
         volumes:
           - /var/tmp:/var/tmp
           - /tmp:/tmp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -64,7 +64,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -48,7 +48,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-prebuild-jam-gha.5832
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-dev-image-gha.12149
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -252,6 +252,10 @@ RUN brew install tmux tmuxinator
 # Install redis-server
 RUN brew install redis@7.0
 
+# Install zed & spicedb CLI
+RUN brew install authzed/tap/zed
+RUN brew install authzed/tap/spicedb
+
 # Copy our own tools
 ENV NEW_KUBECDL=2
 COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the dev image to include `zed` and `spicedb`CLI

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-478

## How to test
<!-- Provide steps to test this PR -->

start a workspace on this PR and verify the 
 - `zed` command is available
 - `spicedb` command is available

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
