### PR TITLE
Add longest running reconcile to dashboards

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/components/ws-daemon.json
+++ b/operations/observability/mixins/workspace/dashboards/components/ws-daemon.json
@@ -85,7 +85,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -183,7 +183,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -301,7 +301,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -363,7 +363,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -662,7 +662,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -681,6 +681,152 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*requeue.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 78,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, max(workqueue_longest_running_processor_seconds{job=\"ws-daemon\", pod=~\"$pod\", name=~\"$controller\"}) by (cluster, pod, name))",
+          "hide": false,
+          "legendFormat": "{{cluster}} - {{pod}} - {{name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Longest running reconciliation",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "datasource": {
         "type": "datasource",
@@ -690,7 +836,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 28
       },
       "id": 52,
       "panels": [
@@ -1057,7 +1203,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 29
       },
       "id": 16,
       "panels": [],
@@ -1133,7 +1279,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 21
+        "y": 30
       },
       "id": 63,
       "options": {
@@ -1179,7 +1325,7 @@
         "h": 7,
         "w": 7,
         "x": 10,
-        "y": 21
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 2,
@@ -1202,7 +1348,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1271,7 +1417,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 21
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1291,7 +1437,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1372,7 +1518,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 37
       },
       "hiddenSeries": false,
       "id": 6,
@@ -1393,7 +1539,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1460,7 +1606,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 37
       },
       "hiddenSeries": false,
       "id": 8,
@@ -1481,7 +1627,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1547,7 +1693,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1568,7 +1714,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1643,7 +1789,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 35
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 44,
@@ -1665,7 +1811,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1741,7 +1887,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 46,
@@ -1762,7 +1908,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1840,7 +1986,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 42
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 36,
@@ -1929,7 +2075,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 42
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 42,
@@ -2036,7 +2182,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 42
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 40,
@@ -2138,7 +2284,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 60
       },
       "id": 22,
       "panels": [

--- a/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
+++ b/operations/observability/mixins/workspace/dashboards/components/ws-manager-mk2.json
@@ -582,7 +582,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "repeatDirection": "h",
       "targets": [
         {
@@ -672,7 +672,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "repeatDirection": "h",
       "targets": [
         {
@@ -762,7 +762,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "repeatDirection": "h",
       "targets": [
         {
@@ -938,7 +938,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -952,10 +952,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(workqueue_adds_total{job=\"ws-manager-mk2\", pod=~\"$pod\", name=~\"$controller\"}[5m])) by (pod, name)",
+          "expr": "sum(rate(workqueue_adds_total{job=\"ws-manager-mk2\", pod=~\"$pod\", name=~\"$controller\"}[5m])) by (cluster, pod, name)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{pod}} {{name}}",
+          "legendFormat": "{{cluster}} {{pod}} {{name}}",
           "range": true,
           "refId": "A"
         }
@@ -1036,7 +1036,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1050,10 +1050,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(workqueue_depth{job=\"ws-manager-mk2\", pod=~\"$pod\", name=~\"$controller\"}) by (pod, name)",
+          "expr": "sum(workqueue_depth{job=\"ws-manager-mk2\", pod=~\"$pod\", name=~\"$controller\"}) by (cluster, pod, name)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{pod}} {{name}}",
+          "legendFormat": "{{cluster}} {{pod}} {{name}}",
           "range": true,
           "refId": "A"
         }
@@ -1154,7 +1154,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -1216,7 +1216,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1353,7 +1353,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1440,10 +1441,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(rate(controller_runtime_reconcile_total{job=\"ws-manager-mk2\", pod=~\"$pod\", controller=~\"$controller\"}[5m])) by (pod, controller, result)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{job=\"ws-manager-mk2\", pod=~\"$pod\", controller=~\"$controller\"}[5m])) by (cluster, pod, controller, result)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{pod}} {{controller}} {{result}}",
+          "legendFormat": "{{cluster}} {{pod}} {{controller}} {{result}}",
           "range": true,
           "refId": "A"
         }
@@ -1514,7 +1515,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "targets": [
         {
           "datasource": {
@@ -1534,6 +1535,152 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*requeue.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 40
+      },
+      "id": 183,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, max(workqueue_longest_running_processor_seconds{job=\"ws-manager-mk2\", pod=~\"$pod\", name=~\"$controller\"}) by (cluster, pod, name))",
+          "hide": false,
+          "legendFormat": "{{cluster}} - {{pod}} - {{name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Longest running reconciliation",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "datasource",
@@ -1543,7 +1690,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 49
       },
       "id": 65,
       "panels": [],
@@ -1581,7 +1728,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 66,
@@ -1603,7 +1750,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1682,7 +1829,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 67,
@@ -1704,7 +1851,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1796,7 +1943,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 68,
@@ -1819,7 +1966,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "9.5.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1923,7 +2070,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 113
       },
       "id": 16,
       "panels": [],
@@ -1999,7 +2146,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 105
+        "y": 114
       },
       "id": 76,
       "options": {
@@ -2047,7 +2194,7 @@
         "h": 7,
         "w": 7,
         "x": 10,
-        "y": 105
+        "y": 114
       },
       "hiddenSeries": false,
       "id": 2,
@@ -2139,7 +2286,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 105
+        "y": 114
       },
       "hiddenSeries": false,
       "id": 4,
@@ -2243,7 +2390,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 121
       },
       "hiddenSeries": false,
       "id": 6,
@@ -2333,7 +2480,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 121
       },
       "hiddenSeries": false,
       "id": 8,
@@ -2422,7 +2569,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 119
+        "y": 128
       },
       "hiddenSeries": false,
       "id": 10,
@@ -2520,7 +2667,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 119
+        "y": 128
       },
       "hiddenSeries": false,
       "id": 57,
@@ -2618,7 +2765,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 119
+        "y": 128
       },
       "hiddenSeries": false,
       "id": 59,
@@ -2717,7 +2864,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 126
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2808,7 +2955,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 126
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 55,
@@ -2918,7 +3065,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 126
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 40,
@@ -3028,7 +3175,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 135
+        "y": 144
       },
       "id": 22,
       "panels": [],
@@ -3059,7 +3206,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 136
+        "y": 145
       },
       "hiddenSeries": false,
       "id": 32,
@@ -3153,7 +3300,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 136
+        "y": 145
       },
       "hiddenSeries": false,
       "id": 34,
@@ -3253,7 +3400,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 145
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 26,
@@ -3350,7 +3497,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 145
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 61,
@@ -3447,7 +3594,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 154
+        "y": 163
       },
       "hiddenSeries": false,
       "id": 24,
@@ -3538,7 +3685,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 154
+        "y": 163
       },
       "hiddenSeries": false,
       "id": 63,


### PR DESCRIPTION
## Description

Add panels for longest running reconciliation to the ws-manager-mk2 and ws-daemon dashboards.

Lets us observe when a reconciliation gets stuck or is running longer than expected.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-263

## How to test
<!-- Provide steps to test this PR -->

See linear issue for screenshots

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
