### PR TITLE
[usage] cleanup after org-only mig

### DIFF
--- a/components/gitpod-db/go/dbtest/cost_center.go
+++ b/components/gitpod-db/go/dbtest/cost_center.go
@@ -18,7 +18,7 @@ func NewCostCenter(t *testing.T, record db.CostCenter) db.CostCenter {
 	t.Helper()
 
 	result := db.CostCenter{
-		ID:                db.NewUserAttributionID(uuid.New().String()),
+		ID:                db.NewTeamAttributionID(uuid.New().String()),
 		CreationTime:      db.NewVarCharTime(time.Now()),
 		SpendingLimit:     100,
 		BillingStrategy:   db.CostCenter_Stripe,

--- a/components/gitpod-db/go/dbtest/stripe_customer.go
+++ b/components/gitpod-db/go/dbtest/stripe_customer.go
@@ -20,7 +20,7 @@ func NewStripeCustomer(t *testing.T, customer db.StripeCustomer) db.StripeCustom
 
 	result := db.StripeCustomer{
 		StripeCustomerID: fmt.Sprintf("cus_%s", uuid.New().String()),
-		AttributionID:    db.NewUserAttributionID(uuid.New().String()),
+		AttributionID:    db.NewTeamAttributionID(uuid.New().String()),
 		CreationTime:     db.NewVarCharTime(time.Now()),
 	}
 

--- a/components/gitpod-db/go/dbtest/usage.go
+++ b/components/gitpod-db/go/dbtest/usage.go
@@ -21,7 +21,7 @@ func NewUsage(t *testing.T, record db.Usage) db.Usage {
 
 	result := db.Usage{
 		ID:                  uuid.New(),
-		AttributionID:       db.NewUserAttributionID(uuid.New().String()),
+		AttributionID:       db.NewTeamAttributionID(uuid.New().String()),
 		Description:         "some description",
 		CreditCents:         42,
 		EffectiveTime:       db.VarcharTime{},

--- a/components/gitpod-db/go/dbtest/workspace_instance.go
+++ b/components/gitpod-db/go/dbtest/workspace_instance.go
@@ -67,7 +67,7 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 		status = instance.Status
 	}
 
-	attributionID := db.NewUserAttributionID(uuid.New().String())
+	attributionID := db.NewTeamAttributionID(uuid.New().String())
 	if instance.UsageAttributionID != "" {
 		attributionID = instance.UsageAttributionID
 	}

--- a/components/gitpod-db/go/stripe_customer_test.go
+++ b/components/gitpod-db/go/stripe_customer_test.go
@@ -21,7 +21,7 @@ func TestCreateStripeCustomer(t *testing.T) {
 
 	customer := db.StripeCustomer{
 		StripeCustomerID: "cus_1234",
-		AttributionID:    db.NewUserAttributionID(uuid.New().String()),
+		AttributionID:    db.NewTeamAttributionID(uuid.New().String()),
 		CreationTime:     db.NewVarCharTime(time.Now()),
 	}
 	t.Cleanup(func() {

--- a/components/gitpod-db/go/usage_test.go
+++ b/components/gitpod-db/go/usage_test.go
@@ -300,7 +300,7 @@ func TestCreditCents(t *testing.T) {
 
 func TestListBalance(t *testing.T) {
 	teamAttributionID := db.NewTeamAttributionID(uuid.New().String())
-	userAttributionID := db.NewUserAttributionID(uuid.New().String())
+	teamAttributionID2 := db.NewTeamAttributionID(uuid.New().String())
 
 	conn := dbtest.ConnectForTests(t)
 	dbtest.CreateUsageRecords(t, conn,
@@ -313,11 +313,11 @@ func TestListBalance(t *testing.T) {
 			CreditCents:   900,
 		}),
 		dbtest.NewUsage(t, db.Usage{
-			AttributionID: userAttributionID,
+			AttributionID: teamAttributionID2,
 			CreditCents:   450,
 		}),
 		dbtest.NewUsage(t, db.Usage{
-			AttributionID: userAttributionID,
+			AttributionID: teamAttributionID2,
 			CreditCents:   -500,
 			Kind:          db.InvoiceUsageKind,
 		}),
@@ -330,15 +330,15 @@ func TestListBalance(t *testing.T) {
 		CreditCents:   1000,
 	})
 	require.Contains(t, balances, db.Balance{
-		AttributionID: userAttributionID,
+		AttributionID: teamAttributionID2,
 		CreditCents:   -50,
 	})
 }
 
 func TestGetBalance(t *testing.T) {
 	teamAttributionID := db.NewTeamAttributionID(uuid.New().String())
-	userAttributionID := db.NewUserAttributionID(uuid.New().String())
-	noUsageAttributionID := db.NewUserAttributionID(uuid.New().String())
+	teamAttributionID2 := db.NewTeamAttributionID(uuid.New().String())
+	noUsageAttributionID := db.NewTeamAttributionID(uuid.New().String())
 
 	conn := dbtest.ConnectForTests(t)
 	dbtest.CreateUsageRecords(t, conn,
@@ -351,11 +351,11 @@ func TestGetBalance(t *testing.T) {
 			CreditCents:   900,
 		}),
 		dbtest.NewUsage(t, db.Usage{
-			AttributionID: userAttributionID,
+			AttributionID: teamAttributionID2,
 			CreditCents:   450,
 		}),
 		dbtest.NewUsage(t, db.Usage{
-			AttributionID: userAttributionID,
+			AttributionID: teamAttributionID2,
 			CreditCents:   -500,
 			Kind:          db.InvoiceUsageKind,
 		}),
@@ -365,7 +365,7 @@ func TestGetBalance(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1000, int(teamBalance))
 
-	userBalance, err := db.GetBalance(context.Background(), conn, userAttributionID)
+	userBalance, err := db.GetBalance(context.Background(), conn, teamAttributionID2)
 	require.NoError(t, err)
 	require.EqualValues(t, -50, int(userBalance))
 

--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -149,20 +149,11 @@ func queryWorkspaceInstanceForUsage(ctx context.Context, conn *gorm.DB) *gorm.DB
 }
 
 const (
-	AttributionEntity_User = "user"
-	AttributionEntity_Team = "team"
+	attributionEntity_Team = "team"
 )
 
-func newAttributionID(entity, identifier string) AttributionID {
-	return AttributionID(fmt.Sprintf("%s:%s", entity, identifier))
-}
-
-func NewUserAttributionID(userID string) AttributionID {
-	return newAttributionID(AttributionEntity_User, userID)
-}
-
 func NewTeamAttributionID(teamID string) AttributionID {
-	return newAttributionID(AttributionEntity_Team, teamID)
+	return AttributionID(fmt.Sprintf("%s:%s", attributionEntity_Team, teamID))
 }
 
 // AttributionID consists of an entity, and an identifier in the form:
@@ -171,16 +162,11 @@ type AttributionID string
 
 func (a AttributionID) Values() (entity string, identifier string) {
 	tokens := strings.Split(string(a), ":")
-	if len(tokens) != 2 {
+	if len(tokens) != 2 || tokens[0] != attributionEntity_Team || tokens[1] == "" {
 		return "", ""
 	}
 
 	return tokens[0], tokens[1]
-}
-
-func (a AttributionID) IsEntity(entity string) bool {
-	e, _ := a.Values()
-	return e == entity
 }
 
 func ParseAttributionID(s string) (AttributionID, error) {
@@ -194,10 +180,8 @@ func ParseAttributionID(s string) (AttributionID, error) {
 	}
 
 	switch tokens[0] {
-	case AttributionEntity_Team:
+	case attributionEntity_Team:
 		return NewTeamAttributionID(tokens[1]), nil
-	case AttributionEntity_User:
-		return NewUserAttributionID(tokens[1]), nil
 	default:
 		return "", fmt.Errorf("unknown attribution ID type: %s", s)
 	}

--- a/components/gitpod-db/go/workspace_instance_test.go
+++ b/components/gitpod-db/go/workspace_instance_test.go
@@ -103,8 +103,9 @@ func TestAttributionID_Values(t *testing.T) {
 		ExpectedEntity string
 		ExpectedID     string
 	}{
-		{Input: "team:123", ExpectedEntity: db.AttributionEntity_Team, ExpectedID: "123"},
-		{Input: "user:123", ExpectedEntity: db.AttributionEntity_User, ExpectedID: "123"},
+		{Input: "team:123", ExpectedEntity: "team", ExpectedID: "123"},
+		{Input: "user:123", ExpectedEntity: "", ExpectedID: ""},
+		{Input: "foo:123", ExpectedEntity: "", ExpectedID: ""},
 		{Input: "user:123:invalid", ExpectedEntity: "", ExpectedID: ""},
 		{Input: "invalid:123:", ExpectedEntity: "", ExpectedID: ""},
 		{Input: "", ExpectedEntity: "", ExpectedID: ""},

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -156,7 +156,7 @@ func (s *StubUserService) BlockUser(ctx context.Context, req *connect.Request[ex
 }
 
 func TestBalancesForStripeCostCenters(t *testing.T) {
-	attributionIDForStripe := db.NewUserAttributionID(uuid.New().String())
+	attributionIDForStripe := db.NewTeamAttributionID(uuid.New().String())
 	attributionIDForOther := db.NewTeamAttributionID(uuid.New().String())
 	dbconn := dbtest.ConnectForTests(t)
 
@@ -249,7 +249,7 @@ var IndiInvoiceTestData = `{
 	  },
 	  "livemode": false,
 	  "metadata": {
-		"attributionId": "user:12345678-1234-1234-1234-123456789abc",
+		"attributionId": "team:12345678-1234-1234-1234-123456789abc",
 		"preferredCurrency": "USD"
 	  },
 	  "name": "user-name",

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -184,7 +184,7 @@ func TestReconcile(t *testing.T) {
 		// we do this to test that the fields in the usage records get updated to reflect the true values from the source of truth - instances.
 		draft := dbtest.NewUsage(t, db.Usage{
 			ID:                  uuid.New(),
-			AttributionID:       db.NewUserAttributionID(uuid.New().String()),
+			AttributionID:       db.NewTeamAttributionID(uuid.New().String()),
 			Description:         "Some description",
 			CreditCents:         1,
 			EffectiveTime:       db.VarcharTime{},
@@ -253,12 +253,12 @@ func TestGetAndSetCostCenter(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 	costCenterUpdates := []*v1.CostCenter{
 		{
-			AttributionId:   string(db.NewUserAttributionID(uuid.New().String())),
+			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
 			SpendingLimit:   8000,
 			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_STRIPE,
 		},
 		{
-			AttributionId:   string(db.NewUserAttributionID(uuid.New().String())),
+			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
 			SpendingLimit:   500,
 			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_OTHER,
 		},

--- a/components/usage/pkg/stripe/stripe_test.go
+++ b/components/usage/pkg/stripe/stripe_test.go
@@ -29,9 +29,9 @@ func TestQueriesForCustomersWithAttributionID_Single(t *testing.T) {
 			Name: "1 team id, 1 user id",
 			AttributionIDs: map[db.AttributionID]int64{
 				db.NewTeamAttributionID("abcd-123"): 1,
-				db.NewUserAttributionID("abcd-456"): 1,
+				db.NewTeamAttributionID("abcd-456"): 1,
 			},
-			ExpectedQueries: []string{"metadata['attributionId']:'team:abcd-123' OR metadata['attributionId']:'user:abcd-456'"},
+			ExpectedQueries: []string{"metadata['attributionId']:'team:abcd-123' OR metadata['attributionId']:'team:abcd-456'"},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes user attribution from the usage components

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
