### PR TITLE
[dashboard] retry useUserQuery if error code is not 401 – WEB-560

### DIFF
--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -11,6 +11,7 @@ import { trackLocation } from "../Analytics";
 import { refreshSearchData } from "../components/RepositoryFinder";
 import { useQuery } from "@tanstack/react-query";
 import { noPersistence } from "../data/setup";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export const useUserLoader = () => {
     const { user, setUser } = useContext(UserContext);
@@ -27,8 +28,9 @@ export const useUserLoader = () => {
         // We'll let an ErrorBoundary catch the error
         useErrorBoundary: true,
         // It's important we don't retry as we want to show the login screen as quickly as possible if a 401
-        // TODO: In the future we can consider retrying for non 401 errors
-        retry: false,
+        retry: (_failureCount: number, error: Error & { code?: number }) => {
+            return error.code !== ErrorCodes.NOT_AUTHENTICATED;
+        },
         cacheTime: 1000 * 60 * 60 * 1, // 1 hour
         staleTime: 1000 * 60 * 60 * 1, // 1 hour
         onSuccess: (loadedUser) => {


### PR DESCRIPTION


## How to test
🤷🏻‍♂️ and this is why it's a draft still

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-retry-on-non-401</li>
	<li><b>🔗 URL</b> - <a href="https://at-retry-on-non-401.preview.gitpod-dev.com/workspaces" target="_blank">at-retry-on-non-401.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
