### PR TITLE
[test] Disable spot instances for ws e2e tests

### DIFF
--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -29,6 +29,7 @@ TF_VAR_preview_name="$(previewctl get-name --branch "${INPUT_NAME}")"
 export TF_VAR_preview_name
 export TF_VAR_infra_provider="${INPUT_INFRASTRUCTURE_PROVIDER}"
 export TF_VAR_with_large_vm="${INPUT_LARGE_VM}"
+export TF_VAR_gce_use_spot="${INPUT_USE_SPOT:-true}"
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true
 leeway run dev/preview:create-preview

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -99,6 +99,8 @@ jobs:
             sa_key: ${{ secrets.GCP_CREDENTIALS }}
             infrastructure_provider: gce
             large_vm: true
+            # Disable spot, to prevent the e2e tests from failing due to VM preemption.
+            use_spot: false
         - name: Deploy Gitpod to the preview environment
           if: github.event.inputs.skip_deploy != 'true'
           id: deploy-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We sometimes see the e2e tests failing due to the preview env VM disappearing, the additional cost of disabling spot should be worth the time saved in having more stable tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-228

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
