### PR TITLE
[preview] Disable fail-fast and limit parallel jobs to 1

### DIFF
--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -46,6 +46,8 @@ jobs:
         runs-on: [self-hosted]
         if: ${{ needs.stale.outputs.count > 0 }}
         strategy:
+            fail-fast: false
+            max-parallel: 1
             matrix:
                 name: ${{ fromJSON(needs.stale.outputs.names) }}
         steps:

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -47,7 +47,6 @@ jobs:
         if: ${{ needs.stale.outputs.count > 0 }}
         strategy:
             fail-fast: false
-            max-parallel: 1
             matrix:
                 name: ${{ fromJSON(needs.stale.outputs.names) }}
         steps:


### PR DESCRIPTION
## Description

When one of the delete jobs fails they cancel the other ongoing deletion jobs in the matrix, setting `fail-fast` to false prevents that. Also limiting the concurrency to 1, as some are failing to acquire the TF lock (presumably cause multiple jobs in the matrix are trying that at the same time)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Related: https://github.com/gitpod-io/gitpod/pull/18025#issuecomment-1602765618

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
