### PR TITLE
[configcat] use internal route

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -146,6 +146,13 @@
 	}
 }
 
+# Internal configcat endpoint
+:9547 {
+	handle /configcat* {
+		gitpod.configcat
+	}
+}
+
 # public-api
 api.{$GITPOD_DOMAIN} {
 	log {

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -431,7 +431,7 @@ func ConfigcatEnv(ctx *RenderContext) []corev1.EnvVar {
 		},
 		{
 			Name:  "CONFIGCAT_BASE_URL",
-			Value: "https://" + ctx.Config.Domain + "/configcat",
+			Value: ClusterURL("http", ProxyComponent, ctx.Namespace, ProxyConfigcatPort) + "/configcat",
 		},
 	}
 }

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -28,6 +28,7 @@ const (
 	MinioServiceAPIPort         = 9000
 	MonitoringChart             = "monitoring"
 	ProxyComponent              = "proxy"
+	ProxyConfigcatPort          = 9547
 	ProxyContainerHTTPPort      = 80
 	ProxyContainerHTTPName      = "http"
 	ProxyContainerHTTPSPort     = 443
@@ -61,6 +62,8 @@ const (
 	AnnotationConfigChecksum    = "gitpod.io/checksum_config"
 	DatabaseConfigMountPath     = "/secrets/database-config"
 	AuthPKISecretName           = "auth-pki"
+	IDEServiceComponent         = "ide-service"
+	OpenVSXProxyComponent       = "openvsx-proxy"
 )
 
 var (

--- a/install/installer/pkg/components/ide-service/constants.go
+++ b/install/installer/pkg/components/ide-service/constants.go
@@ -4,8 +4,10 @@
 
 package ide_service
 
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
 const (
-	Component    = "ide-service"
+	Component    = common.IDEServiceComponent
 	VolumeConfig = "config"
 
 	GRPCPortName    = "grpc"

--- a/install/installer/pkg/components/openvsx-proxy/constants.go
+++ b/install/installer/pkg/components/openvsx-proxy/constants.go
@@ -4,8 +4,10 @@
 
 package openvsx_proxy
 
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
 const (
-	Component     = "openvsx-proxy"
+	Component     = common.OpenVSXProxyComponent
 	ContainerPort = 8080
 	ServicePort   = 8080
 	PortName      = "http"

--- a/install/installer/pkg/components/proxy/constants.go
+++ b/install/installer/pkg/components/proxy/constants.go
@@ -24,4 +24,6 @@ const (
 	RegistryTLSCertSecret  = common.RegistryTLSCertSecret
 	ContainerAnalyticsPort = 9546
 	ContainerAnalyticsName = "analytics"
+	ContainerConfigcatPort = common.ProxyConfigcatPort
+	ContainerConfigcatName = "configcat"
 )

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -238,6 +238,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							}, prometheusPort, {
 								ContainerPort: ContainerAnalyticsPort,
 								Name:          ContainerAnalyticsName,
+							}, {
+								ContainerPort: ContainerConfigcatPort,
+								Name:          ContainerConfigcatName,
 							}},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               pointer.Bool(false),

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -71,6 +71,36 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 						"component": common.WSProxyComponent,
 					}},
 				}},
+			}, {
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: common.TCPProtocol,
+					Port:     &intstr.IntOrString{IntVal: ContainerConfigcatPort},
+				}},
+				From: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.ServerComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.WSManagerBridgeComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.IDEServiceComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.PublicApiComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.UsageComponent,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.OpenVSXProxyComponent,
+					}},
+				}},
 			}},
 		},
 	}}, nil

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -75,6 +75,11 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ContainerPort: ContainerAnalyticsPort,
 			ServicePort:   ContainerAnalyticsPort,
 		},
+		{
+			Name:          ContainerConfigcatName,
+			ContainerPort: ContainerConfigcatPort,
+			ServicePort:   ContainerConfigcatPort,
+		},
 	}
 	if ctx.Config.SSHGatewayHostKey != nil {
 		ports = append(ports, common.ServicePort{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix IDE-185

## How to test
<!-- Provide steps to test this PR -->

- Check logs of all dependent components that they can resolve feature flag.
- Try to change some feature flags and see whether changes are picked up.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-ide-185</li>
	<li><b>🔗 URL</b> - <a href="https://ak-ide-185.preview.gitpod-dev.com/workspaces" target="_blank">ak-ide-185.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
