### PR TITLE
Keep search input visible when scrolling on the repository and editor dropdown

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -154,7 +154,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                 </div>
             </div>
             {showDropDown && (
-                <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 max-h-72 overflow-auto rounded-b-lg mt-3 z-50 p-2 filter drop-shadow-xl">
+                <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 rounded-b-lg mt-3 z-50 p-2 filter drop-shadow-xl">
                     {!props.disableSearch && (
                         <div className="h-12">
                             <input
@@ -167,7 +167,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                             />
                         </div>
                     )}
-                    <ul>
+                    <ul className="max-h-60 overflow-auto">
                         {filteredOptions.length > 0 ? (
                             filteredOptions.map((element) => {
                                 let selectionClasses = `dark:bg-gray-800 cursor-pointer`;


### PR DESCRIPTION
## Description

Fix the location of the search input in the dropdown2 component, on the new workspace page.

Thanks @aledbf for re-surfacing this UX issue. 🙇 

## How to test

1. Go to `/new` and click on the **repository** or the **editor** dropdown.
2. Scroll down and notice how the search input is always fixed at the top.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-keep-se9c004c10e4</li>
	<li><b>🔗 URL</b> - <a href="https://gt-keep-se9c004c10e4.preview.gitpod-dev.com/workspaces" target="_blank">gt-keep-se9c004c10e4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
