### PR TITLE
[db] allow nesting transactions

### DIFF
--- a/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
@@ -88,4 +88,26 @@ export class TeamDBSpec {
         const team3 = await this.teamDB.updateTeam(team2.id, team2);
         expect(team3.slug).to.match(/^my-team-[a-zA-Z0-9_-]{8}$/);
     }
+
+    @test()
+    async testNoSlugDuplicates(): Promise<void> {
+        const user = await this.userDB.newUser();
+
+        const team1 = await this.teamDB.createTeam(user.id, "My Team");
+        expect(team1.slug).to.be.eq("my-team");
+        const team2 = await this.teamDB.createTeam(user.id, "My Team");
+        expect(team2.slug).to.match(/my-team-[a-f0-9]{4}/);
+    }
+
+    @test()
+    async testNestedTransaction(): Promise<void> {
+        const user = await this.userDB.newUser();
+
+        const team1 = await this.teamDB.transaction(async (db) => {
+            return await db.transaction(async (db) => {
+                return await db.createTeam(user.id, "My Team");
+            });
+        });
+        expect(team1.slug).to.be.eq("my-team");
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The implementation of a db method should be able to use transactions
when it makes sense without assumptions of whether the code
is called from a running transaction or not.

TypeORM actually does support this in a newer version. But they essentially [do the same](https://github.com/typeorm/typeorm/pull/8541/files#diff-78ff8320cc81d7f789d6ee8fa43c23fb755e01dc3d7f13d5e5fda1b85e6e5e56) as what this PR does.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
