### PR TITLE
[server] Guard org authProvider-related API calls centralizedPermissions

### DIFF
--- a/components/server/src/authorization/checks.ts
+++ b/components/server/src/authorization/checks.ts
@@ -35,4 +35,7 @@ export const WriteOrganizationMembers = check("user", "write_members", "organiza
 export const ReadOrganizationSettings = check("user", "read_settings", "organization");
 export const WriteOrganizationSettings = check("user", "write_settings", "organization");
 
+export const ReadGitProvider = check("user", "read_git_provider", "organization");
+export const WriteGitProvider = check("user", "write_git_provider", "organization");
+
 export const LeaveOrganization = check("user", "leave", "organization");

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -22,6 +22,8 @@ export type OrganizationPermission =
     | "leave"
     | "read_settings"
     | "write_settings"
+    | "read_git_provider"
+    | "write_git_provider"
     | "create_project";
 export type ProjectPermission = "write_info" | "read_info";
 export type Permission = OrganizationPermission;

--- a/install/installer/pkg/components/spicedb/data/schema.yaml
+++ b/install/installer/pkg/components/spicedb/data/schema.yaml
@@ -29,6 +29,10 @@ schema: |-
     // Only owners can change settings
     permission read_settings = owner
     permission write_settings = owner
+
+    // Only owners can change Git providers
+    permission read_git_provider = owner + member
+    permission write_git_provider = owner
   }
 
   definition project {
@@ -82,9 +86,12 @@ relationships: |-
 assertions:
   assertTrue:
     - organization:org_1#read_info@user:user_0
+    # user 1 can read git providers because they are a member
+    - organization:org_1#read_git_provider@user:user_1
     # user 0 can edit project_0, because they are the Org Owner
     - project:project_1#write_info@user:user_0
     - organization:org_1#write_settings@user:user_0
+    - organization:org_1#write_git_provider@user:user_0
   assertFalse:
     # user 10 cannot access project_1
     - project:project_1#read_info@user:user_10
@@ -95,6 +102,8 @@ assertions:
     - organization:org_1#read_members@user:user_3
     - organization:org_1#write_members@user:user_3
     - organization:org_1#write_settings@user:user_1
+    # members are not allowed to:
+    - organization:org_1#write_git_provider@user:user_1
 # validation should assert that a particular relation exists between an entity, and a subject
 # validations are not used to assert that a permission exists
 validation:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-529
Fixes WEB-530
Fixes WEB-531
Fixes WEB-532

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-org-authprovider</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-org-authprovider.preview.gitpod-dev.com/workspaces" target="_blank">gpl-org-authprovider.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
