### PR TITLE
[usage] reduce log noise

### DIFF
--- a/components/usage/pkg/scheduler/scheduler.go
+++ b/components/usage/pkg/scheduler/scheduler.go
@@ -70,7 +70,7 @@ func (c *Scheduler) Start() {
 				return jobErr
 			})
 			if err != nil {
-				if errors.Is(err, redsync.ErrFailed) {
+				if errors.Is(err, redsync.ErrTaken{}) {
 					logger.WithError(err).Info("Failed to acquire lock, another instance holds the lock already.")
 					return
 				}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes [this log message](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-06-26T07:05:24.002063499Z;pinnedLogId=2023-06-26T07:05:24.002063499Z%2Fzprf54b5vovdbce3;query=resource.labels.container_name%3D%22usage%22%0A%22reset_usage%22%0Atimestamp%3D%222023-06-26T07:05:24.002063499Z%22%0AinsertId%3D%22zprf54b5vovdbce3%22?project=gitpod-191109) become info severity

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
