### PR TITLE
[test] E2e test fixes and improvements

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -209,6 +209,7 @@ jobs:
               with:
                   name: test-results
                   paths: "test/tests/**/TEST-*.xml"
+              if: always()
             - name: Test Summary
               id: test_summary
               uses: test-summary/action@v2

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -205,6 +205,10 @@ jobs:
                   done
 
                   exit $FAILURE_COUNT
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: test-results
+                  paths: "test/tests/**/TEST-*.xml"
             - name: Test Summary
               id: test_summary
               uses: test-summary/action@v2

--- a/dev/preview/infrastructure/modules/gce/vm.tf
+++ b/dev/preview/infrastructure/modules/gce/vm.tf
@@ -14,7 +14,7 @@ resource "google_compute_instance" "default" {
     initialize_params {
       image = "projects/workspace-clusters/global/images/${var.vm_image}"
       type  = "pd-ssd"
-      size  = 512
+      size  = 256
     }
   }
 

--- a/dev/preview/infrastructure/modules/gce/vm.tf
+++ b/dev/preview/infrastructure/modules/gce/vm.tf
@@ -14,6 +14,7 @@ resource "google_compute_instance" "default" {
     initialize_params {
       image = "projects/workspace-clusters/global/images/${var.vm_image}"
       type  = "pd-ssd"
+      size  = 512
     }
   }
 

--- a/dev/preview/previewctl/cmd/report.go
+++ b/dev/preview/previewctl/cmd/report.go
@@ -21,10 +21,12 @@ var tmplString = `
 	<li><b>🏷️ Name</b> - {{ .Name }}</li>
 	<li><b>🔗 URL</b> - <a href="https://{{ .Name }}.preview.gitpod-dev.com/workspaces" target="_blank">{{ .Name }}.preview.gitpod-dev.com/workspaces</a>.</li>
 	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
+	<li><b>📦 Version</b> - {{ .Version }}</li>
 </ul>
 `
 
 func newReportNameCmd() *cobra.Command {
+	var version string
 	cmd := &cobra.Command{
 		Use:   "report",
 		Short: "Writes an HTML report to stdout with information about the current preview environment.",
@@ -39,6 +41,7 @@ func newReportNameCmd() *cobra.Command {
 			vars := make(map[string]interface{})
 			vars["Name"] = previewName
 			vars["Url"] = previewName
+			vars["Version"] = version
 
 			err = tmpl.Execute(os.Stdout, vars)
 			if err != nil {
@@ -48,6 +51,8 @@ func newReportNameCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&version, "installer-version", os.Getenv("VERSION"), "Deployed installer version")
 
 	return cmd
 }

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -819,7 +819,7 @@ func (c *ComponentAPI) DB(options ...DBOpt) (*sql.DB, error) {
 
 	// if configured: setup local port-forward to DB pod
 	if config.ForwardPort != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 		err = c.portFwdWithRetry(ctx, common.ForwardPortOfPod, config.ForwardPort.PodName, int(config.Port), int(config.ForwardPort.RemotePort))
 		if err != nil {
 			cancel()

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -832,6 +832,9 @@ func (c *ComponentAPI) DB(options ...DBOpt) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Hack: to fix new DB connections occasionally failing with `[mysql] packets.go:33: unexpected EOF` due
+	// to getting an idle connection from the pool which has for some reason been closed.
+	db.SetMaxIdleConns(0)
 
 	cachedDBs[opts.Database] = db
 	c.appendCloser(func() error {

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -74,13 +74,8 @@ func NewPodExec(config rest.Config, clientset *kubernetes.Clientset) *PodExec {
 func (p *PodExec) PodCopyFile(src string, dst string, containername string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	var in, out, errOut *bytes.Buffer
 	var ioStreams genericclioptions.IOStreams
-	log.Infof("%v start copy file", time.Now())
-	defer func() {
-		log.Infof("%v end copy file", time.Now())
-	}()
 	for count := 0; ; count++ {
-		// ioStreams, in, out, errOut = genericclioptions.NewTestIOStreams()
-		ioStreams = genericclioptions.NewTestIOStreamsDiscard()
+		ioStreams, in, out, errOut = genericclioptions.NewTestIOStreams()
 		copyOptions := kubectlcp.NewCopyOptions(ioStreams)
 		copyOptions.ClientConfig = p.RestConfig
 		copyOptions.Container = containername

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -99,7 +99,7 @@ func (p *PodExec) PodCopyFile(src string, dst string, containername string) (*by
 		err = copyOptions.Run()
 		if err != nil {
 			if !shouldRetry(count, err) {
-				return nil, nil, nil, fmt.Errorf("could not run copy operation: %v", err)
+				return nil, nil, nil, fmt.Errorf("could not run copy operation: %v. Stdout: %v, Stderr: %v", err, out.String(), errOut.String())
 			}
 			time.Sleep(10 * time.Second)
 			continue

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -243,7 +243,7 @@ func isComponentReady(client klient.Client, namespace, component string) (ready 
 			if cond.Type == corev1.PodReady {
 				isReady = cond.Status == corev1.ConditionTrue
 				if !isReady {
-					reason = fmt.Sprintf("status: %s, reason: %s, message: %s", cond.Status, cond.Reason, cond.Message)
+					reason = fmt.Sprintf("status: %v", p.Status)
 				}
 				break
 			}

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -706,6 +706,11 @@ func WaitForWorkspaceStart(t *testing.T, ctx context.Context, instanceID string,
 			return nil, false, err
 		}
 
+		if desc == nil || desc.Status == nil {
+			t.Logf("describe status is nil: %s", instanceID)
+			return nil, false, nil
+		}
+
 		t.Logf("describe status: %s, %s", desc.Status.Id, desc.Status.Phase)
 
 		done, err := checkStatus(desc.Status)

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -304,6 +304,13 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	t.Log("wait for workspace to be fully up and running")
 	lastStatus, err := WaitForWorkspaceStart(t, ctx, req.Id, req.Metadata.MetaId, api, options.WaitForOpts...)
 	if err != nil {
+		// Check if the preview env is in a good state, and log details if not.
+		previewReady, reason, err := isPreviewReady(api.client, api.namespace)
+		if err != nil {
+			t.Logf("error checking if preview is ready: %v", err)
+		} else if !previewReady {
+			t.Logf("preview env is not ready: %s", reason)
+		}
 		return nil, nil, xerrors.Errorf("cannot wait for workspace start: %w", err)
 	}
 	t.Log("successful launch of the workspace")

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -698,6 +698,10 @@ func WaitForWorkspaceStart(t *testing.T, ctx context.Context, instanceID string,
 		if err != nil {
 			scode := status.Code(err)
 			if scode == codes.NotFound || strings.Contains(err.Error(), "not found") {
+				if cfg.WaitForStopped {
+					t.Logf("describe: workspace couldn't be found, but we're expecting it to stop, so wait for subscribe to give us the last status")
+					return nil, false, nil
+				}
 				if !cfg.CanFail {
 					return nil, true, xerrors.New("the workspace couldn't be found")
 				}

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -305,9 +305,9 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	lastStatus, err := WaitForWorkspaceStart(t, ctx, req.Id, req.Metadata.MetaId, api, options.WaitForOpts...)
 	if err != nil {
 		// Check if the preview env is in a good state, and log details if not.
-		previewReady, reason, err := isPreviewReady(api.client, api.namespace)
-		if err != nil {
-			t.Logf("error checking if preview is ready: %v", err)
+		previewReady, reason, previewErr := isPreviewReady(api.client, api.namespace)
+		if previewErr != nil {
+			t.Logf("error checking if preview is ready: %v", previewErr)
 		} else if !previewReady {
 			t.Logf("preview env is not ready: %s", reason)
 		}

--- a/test/run.sh
+++ b/test/run.sh
@@ -114,7 +114,7 @@ if [ "$TEST_SUITE" == "workspace" ]; then
 
   set +e
   # shellcheck disable=SC2086
-  go test -parallel 1 -v $TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
+  go test -parallel 4 -v $TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
   RC=${PIPESTATUS[0]}
   set -e
 

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -112,7 +112,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 		WithLabel("component", "server").
 		Assess("should run context tests", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 
-			sctx, scancel := context.WithTimeout(testCtx, time.Duration(5*len(tests))*time.Minute)
+			sctx, scancel := context.WithTimeout(testCtx, time.Duration(10*len(tests))*time.Minute)
 			defer scancel()
 
 			api := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -52,7 +52,7 @@ func TestGitHooks(t *testing.T) {
 
 			for _, ff := range ffs {
 				func() {
-					ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
+					ctx, cancel := context.WithTimeout(testCtx, 10*time.Minute)
 					defer cancel()
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())

--- a/test/tests/workspace/gp_top_test.go
+++ b/test/tests/workspace/gp_top_test.go
@@ -23,7 +23,7 @@ func TestGpTop(t *testing.T) {
 		Assess("it can run gp top and retrieve cpu/memory usage", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			t.Parallel()
 
-			ctx, cancel := context.WithTimeout(testCtx, time.Duration(5*time.Minute))
+			ctx, cancel := context.WithTimeout(testCtx, time.Duration(10*time.Minute))
 			defer cancel()
 
 			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())


### PR DESCRIPTION
## Description
* Increase node disk size to 512Gi, as node is running out of ephemeral storage quite often.
* Upload test results as artefact, allows inspecting the results of a GHA run in more details (e.g. time it takes to run each test)
* Print the preview env's installer version to the GHA summary
* Increase DB port-forward to 60 minutes. Fixes flake where the DB connection got closed due to the port-forward timing out
* Only build each instrumentation agent once (and reuse for following tests)
* Add additional logging. E.g. preview env health when workspace start times out
* Fix nil-pointer
* Increase some timeouts that are commonly reached

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to WKS-153

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
