### PR TITLE
validate jb warmup

### DIFF
--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_code.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_code.golden
@@ -10,8 +10,7 @@
             "eu.gcr.io/gitpod-core-dev/build/ide/jb-backend-plugin:commit-b38092639d1783a1957894ddd4f492b3cdc9794a-latest",
             "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest@sha256:e07524e52089829dc8d3b38f7d18fb51b24f07aed7d8e4e6e447899687978d43",
             "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest@sha256:e07524e52089829dc8d3b38f7d18fb51b24f07aed7d8e4e6e447899687978d43"
-        ],
-        "tasks": "[{\"init\":\"echo 'warming up stable release of intellij...'\\nJETBRAINS_BACKEND_QUALIFIER=stable /ide-desktop/jb-launcher warmup intellij\\n\\necho 'warming up stable release of goland...'\\nJETBRAINS_BACKEND_QUALIFIER=stable /ide-desktop/jb-launcher warmup goland\\n\\necho 'warming up latest release of goland...'\\nJETBRAINS_BACKEND_QUALIFIER=latest /ide-desktop/jb-launcher warmup goland\\n\\necho 'warming up latest release of phpstorm...'\\nJETBRAINS_BACKEND_QUALIFIER=latest /ide-desktop/jb-launcher warmup phpstorm\",\"name\":\"GITPOD_JB_WARMUP_TASK\"}]\n"
+        ]
     },
     "Err": ""
 }

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_intellij.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_intellij.golden
@@ -8,8 +8,7 @@
             "eu.gcr.io/gitpod-core-dev/build/ide/intellij:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
             "eu.gcr.io/gitpod-core-dev/build/ide/jb-backend-plugin:commit-b38092639d1783a1957894ddd4f492b3cdc9794a-latest",
             "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest@sha256:e07524e52089829dc8d3b38f7d18fb51b24f07aed7d8e4e6e447899687978d43"
-        ],
-        "tasks": "[{\"init\":\"echo 'warming up stable release of intellij...'\\nJETBRAINS_BACKEND_QUALIFIER=stable /ide-desktop/jb-launcher warmup intellij\\n\\necho 'warming up latest release of intellij...'\\nJETBRAINS_BACKEND_QUALIFIER=latest /ide-desktop/jb-launcher warmup intellij\",\"name\":\"GITPOD_JB_WARMUP_TASK\"}]\n"
+        ]
     },
     "Err": ""
 }

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_multiple_ide.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_prebuild_multiple_ide.golden
@@ -10,8 +10,7 @@
             "eu.gcr.io/gitpod-core-dev/build/ide/jb-backend-plugin:commit-b38092639d1783a1957894ddd4f492b3cdc9794a-latest",
             "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest@sha256:e07524e52089829dc8d3b38f7d18fb51b24f07aed7d8e4e6e447899687978d43",
             "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest@sha256:e07524e52089829dc8d3b38f7d18fb51b24f07aed7d8e4e6e447899687978d43"
-        ],
-        "tasks": "[{\"init\":\"echo 'warming up stable release of intellij...'\\nJETBRAINS_BACKEND_QUALIFIER=stable /ide-desktop/jb-launcher warmup intellij\\n\\necho 'warming up stable release of goland...'\\nJETBRAINS_BACKEND_QUALIFIER=stable /ide-desktop/jb-launcher warmup goland\\n\\necho 'warming up latest release of goland...'\\nJETBRAINS_BACKEND_QUALIFIER=latest /ide-desktop/jb-launcher warmup goland\\n\\necho 'warming up latest release of phpstorm...'\\nJETBRAINS_BACKEND_QUALIFIER=latest /ide-desktop/jb-launcher warmup phpstorm\",\"name\":\"GITPOD_JB_WARMUP_TASK\"}]\n"
+        ]
     },
     "Err": ""
 }

--- a/components/ide/jetbrains/image/create-supervisor-config.js
+++ b/components/ide/jetbrains/image/create-supervisor-config.js
@@ -44,6 +44,9 @@ const ideConfigs = [
     ideConfigs.forEach((ideConfig) => {
         const name = ideConfig.name + (qualifier === "stable" ? "" : "-" + qualifier);
         const template = {
+            name: ideConfig.name,
+            displayName: ideConfig.displayName,
+            version: qualifier,
             entrypoint: `/ide-desktop/jb-launcher`,
             entrypointArgs: ["{DESKTOPIDEPORT}", ideConfig.name, `Open in ${ideConfig.displayName}`],
             readinessProbe: {
@@ -63,8 +66,10 @@ const ideConfigs = [
                 GP_EXTERNAL_BROWSER: `/ide-desktop/${name}/bin/idea-cli preview`,
             },
             prebuild: {
-                name: `GITPOD_JB_WARMUP_TASK`,
-                entrypointArgs: ["warmup"],
+                args: ["warmup", ideConfig.name],
+                env: {
+                    JETBRAINS_BACKEND_QUALIFIER: qualifier,
+                },
             },
         };
         fs.writeFileSync(`supervisor-ide-config_${name}.json`, JSON.stringify(template, null, 2), "utf-8");

--- a/components/ide/jetbrains/image/create-supervisor-config.js
+++ b/components/ide/jetbrains/image/create-supervisor-config.js
@@ -62,6 +62,10 @@ const ideConfigs = [
                 GP_PREVIEW_BROWSER: `/ide-desktop/${name}/bin/idea-cli preview`,
                 GP_EXTERNAL_BROWSER: `/ide-desktop/${name}/bin/idea-cli preview`,
             },
+            prebuild: {
+                name: `GITPOD_JB_WARMUP_TASK`,
+                entrypointArgs: ["warmup"],
+            },
         };
         fs.writeFileSync(`supervisor-ide-config_${name}.json`, JSON.stringify(template, null, 2), "utf-8");
     });

--- a/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "clion",
+  "displayName": "CLion",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/clion-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "clion"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/clion-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/clion-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_clion.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_clion.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/clion/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/clion/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_clion.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_clion.json
@@ -1,4 +1,7 @@
 {
+  "name": "clion",
+  "displayName": "CLion",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/clion/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "clion"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/goland-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/goland-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "goland",
+  "displayName": "GoLand",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/goland-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "goland"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland.json
@@ -1,4 +1,7 @@
 {
+  "name": "goland",
+  "displayName": "GoLand",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/goland/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "goland"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/goland/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/goland/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/intellij-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/intellij-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "intellij",
+  "displayName": "IntelliJ IDEA",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/intellij-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "intellij"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
@@ -1,4 +1,7 @@
 {
+  "name": "intellij",
+  "displayName": "IntelliJ IDEA",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/intellij/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "intellij"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/intellij/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/intellij/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/phpstorm-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/phpstorm-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "phpstorm",
+  "displayName": "PhpStorm",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/phpstorm-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "phpstorm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
@@ -1,4 +1,7 @@
 {
+  "name": "phpstorm",
+  "displayName": "PhpStorm",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/phpstorm/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "phpstorm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/phpstorm/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/phpstorm/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/pycharm-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/pycharm-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "pycharm",
+  "displayName": "PyCharm",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/pycharm-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "pycharm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
@@ -1,4 +1,7 @@
 {
+  "name": "pycharm",
+  "displayName": "PyCharm",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/pycharm/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "pycharm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/pycharm/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/pycharm/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/rider-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rider-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "rider",
+  "displayName": "Rider",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rider-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "rider"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/rider/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rider/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider.json
@@ -1,4 +1,7 @@
 {
+  "name": "rider",
+  "displayName": "Rider",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rider/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "rider"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/rubymine-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rubymine-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "rubymine",
+  "displayName": "RubyMine",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rubymine-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "rubymine"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
@@ -1,4 +1,7 @@
 {
+  "name": "rubymine",
+  "displayName": "RubyMine",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rubymine/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "rubymine"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/rubymine/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/rubymine/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
@@ -1,4 +1,7 @@
 {
+  "name": "webstorm",
+  "displayName": "WebStorm",
+  "version": "latest",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/webstorm-latest/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "webstorm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "latest"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/webstorm-latest/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/webstorm-latest/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
@@ -1,4 +1,7 @@
 {
+  "name": "webstorm",
+  "displayName": "WebStorm",
+  "version": "stable",
   "entrypoint": "/ide-desktop/jb-launcher",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
@@ -22,9 +25,12 @@
     "GP_EXTERNAL_BROWSER": "/ide-desktop/webstorm/bin/idea-cli preview"
   },
   "prebuild": {
-    "name": "GITPOD_JB_WARMUP_TASK",
-    "entrypointArgs": [
-      "warmup"
-    ]
+    "args": [
+      "warmup",
+      "webstorm"
+    ],
+    "env": {
+      "JETBRAINS_BACKEND_QUALIFIER": "stable"
+    }
   }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
@@ -20,5 +20,11 @@
     "GIT_EDITOR": "$EDITOR --wait",
     "GP_PREVIEW_BROWSER": "/ide-desktop/webstorm/bin/idea-cli preview",
     "GP_EXTERNAL_BROWSER": "/ide-desktop/webstorm/bin/idea-cli preview"
+  },
+  "prebuild": {
+    "name": "GITPOD_JB_WARMUP_TASK",
+    "entrypointArgs": [
+      "warmup"
+    ]
   }
 }

--- a/components/ide/jetbrains/launcher/main_test.go
+++ b/components/ide/jetbrains/launcher/main_test.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -15,96 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestCollectPrebuilds(t *testing.T) {
-	tests := []struct {
-		name     string
-		config   *protocol.GitpodConfig
-		expected []string // list of expected aliases and qualifiers
-	}{
-		{
-			name: "no products",
-			config: &protocol.GitpodConfig{
-				Jetbrains: &protocol.Jetbrains{},
-			},
-			expected: []string{},
-		},
-		{
-			name: "one product, latest version",
-			config: &protocol.GitpodConfig{
-				Jetbrains: &protocol.Jetbrains{
-					Intellij: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "latest",
-						},
-					},
-				},
-			},
-			expected: []string{"intellij, latest"},
-		},
-		{
-			name: "one product, stable version",
-			config: &protocol.GitpodConfig{
-				Jetbrains: &protocol.Jetbrains{
-					Intellij: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "stable",
-						},
-					},
-				},
-			},
-			expected: []string{"intellij, stable"},
-		},
-		{
-			name: "one product, both versions",
-			config: &protocol.GitpodConfig{
-				Jetbrains: &protocol.Jetbrains{
-					Intellij: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "both",
-						},
-					},
-				},
-			},
-			expected: []string{"intellij, stable", "intellij, latest"},
-		},
-		{
-			name: "multiple products, mixed versions",
-			config: &protocol.GitpodConfig{
-				Jetbrains: &protocol.Jetbrains{
-					Intellij: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "stable",
-						},
-					},
-					Goland: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "latest",
-						},
-					},
-					Clion: &protocol.JetbrainsProduct{
-						Prebuilds: &protocol.Prebuilds{
-							Version: "both",
-						},
-					},
-				},
-			},
-			expected: []string{"clion, stable", "clion, latest", "goland, latest", "intellij, stable"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := []string{}
-			collectPrebuilds(test.config, func(alias string, qualifier string) {
-				actual = append(actual, fmt.Sprintf("%s, %s", alias, qualifier))
-			})
-			if !reflect.DeepEqual(actual, test.expected) {
-				t.Errorf("expected %v, got %v", test.expected, actual)
-			}
-		})
-	}
-}
 
 func TestGetProductConfig(t *testing.T) {
 	expectation := &protocol.JetbrainsProduct{}

--- a/components/ide/jetbrains/launcher/main_test.go
+++ b/components/ide/jetbrains/launcher/main_test.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,6 +15,96 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCollectPrebuilds(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *protocol.GitpodConfig
+		expected []string // list of expected aliases and qualifiers
+	}{
+		{
+			name: "no products",
+			config: &protocol.GitpodConfig{
+				Jetbrains: &protocol.Jetbrains{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "one product, latest version",
+			config: &protocol.GitpodConfig{
+				Jetbrains: &protocol.Jetbrains{
+					Intellij: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "latest",
+						},
+					},
+				},
+			},
+			expected: []string{"intellij, latest"},
+		},
+		{
+			name: "one product, stable version",
+			config: &protocol.GitpodConfig{
+				Jetbrains: &protocol.Jetbrains{
+					Intellij: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "stable",
+						},
+					},
+				},
+			},
+			expected: []string{"intellij, stable"},
+		},
+		{
+			name: "one product, both versions",
+			config: &protocol.GitpodConfig{
+				Jetbrains: &protocol.Jetbrains{
+					Intellij: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "both",
+						},
+					},
+				},
+			},
+			expected: []string{"intellij, stable", "intellij, latest"},
+		},
+		{
+			name: "multiple products, mixed versions",
+			config: &protocol.GitpodConfig{
+				Jetbrains: &protocol.Jetbrains{
+					Intellij: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "stable",
+						},
+					},
+					Goland: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "latest",
+						},
+					},
+					Clion: &protocol.JetbrainsProduct{
+						Prebuilds: &protocol.Prebuilds{
+							Version: "both",
+						},
+					},
+				},
+			},
+			expected: []string{"clion, stable", "clion, latest", "goland, latest", "intellij, stable"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := []string{}
+			collectPrebuilds(test.config, func(alias string, qualifier string) {
+				actual = append(actual, fmt.Sprintf("%s, %s", alias, qualifier))
+			})
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
 
 func TestGetProductConfig(t *testing.T) {
 	expectation := &protocol.JetbrainsProduct{}

--- a/components/supervisor/cmd/prepare-ide-prebuild.go
+++ b/components/supervisor/cmd/prepare-ide-prebuild.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/util"
+	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var prepareIDEPrebuildCmd = &cobra.Command{
+	Use:   "prepare-ide-prebuild",
+	Short: "awaits when it is time to run IDE prebuild",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		for {
+			conn, err := dial(ctx)
+			if err == nil {
+				err = checkTasks(ctx, conn)
+			}
+
+			if err == nil || ctx.Err() != nil {
+				return
+			}
+
+			log.WithError(err).Error("supervisor: failed to check tasks status")
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(1 * time.Second):
+			}
+		}
+	},
+}
+
+func checkTasks(ctx context.Context, conn *grpc.ClientConn) error {
+	client := supervisor.NewStatusServiceClient(conn)
+	tasksResponse, err := client.TasksStatus(ctx, &supervisor.TasksStatusRequest{Observe: true})
+	if err != nil {
+		return xerrors.Errorf("failed get tasks status client: %w", err)
+	}
+
+	for {
+		var runningTasksCounter int
+
+		resp, err := tasksResponse.Recv()
+		if err != nil {
+			return err
+		}
+
+		for _, task := range resp.Tasks {
+			idePrebuildTask := strings.Contains(task.Presentation.Name, "ide-prebuild-")
+			if task.State != supervisor.TaskState_closed && !idePrebuildTask {
+				runningTasksCounter++
+			}
+		}
+		if runningTasksCounter == 0 {
+			break
+		}
+	}
+
+	return nil
+}
+
+func dial(ctx context.Context) (*grpc.ClientConn, error) {
+	supervisorConn, err := grpc.DialContext(ctx, util.GetSupervisorAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		err = xerrors.Errorf("failed connecting to supervisor: %w", err)
+	}
+	return supervisorConn, err
+}
+
+func init() {
+	rootCmd.AddCommand(prepareIDEPrebuildCmd)
+}

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -238,7 +238,7 @@ func Run(options ...RunOption) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	internalPorts := []uint32{uint32(cfg.IDEPort), uint32(cfg.APIEndpointPort), uint32(cfg.SSHPort)}
-	if cfg.DesktopIDE != nil {
+	if cfg.GetDesktopIDE() != nil {
 		internalPorts = append(internalPorts, desktopIDEPort)
 	}
 	if cfg.isDebugWorkspace() {
@@ -271,7 +271,7 @@ func Run(options ...RunOption) {
 		}, tokenService)
 	}
 
-	if cfg.DesktopIDE != nil {
+	if cfg.GetDesktopIDE() != nil {
 		desktopIdeReady = &ideReadyState{cond: sync.NewCond(&sync.Mutex{})}
 	}
 	if !cfg.isHeadless() && !opts.RunGP && !cfg.isDebugWorkspace() {
@@ -377,9 +377,9 @@ func Run(options ...RunOption) {
 	var ideWG sync.WaitGroup
 	ideWG.Add(1)
 	go startAndWatchIDE(ctx, cfg, &cfg.IDE, &ideWG, cstate, ideReady, WebIDE, supervisorMetrics)
-	if cfg.DesktopIDE != nil {
+	if cfg.GetDesktopIDE() != nil {
 		ideWG.Add(1)
-		go startAndWatchIDE(ctx, cfg, cfg.DesktopIDE, &ideWG, cstate, desktopIdeReady, DesktopIDE, supervisorMetrics)
+		go startAndWatchIDE(ctx, cfg, cfg.GetDesktopIDE(), &ideWG, cstate, desktopIdeReady, DesktopIDE, supervisorMetrics)
 	}
 
 	var (
@@ -949,7 +949,7 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool) []string {
 	getEnv := func(name string) string {
 		return envs[name]
 	}
-	for _, ide := range []*IDEConfig{&cfg.IDE, cfg.DesktopIDE} {
+	for _, ide := range []*IDEConfig{&cfg.IDE, cfg.GetDesktopIDE()} {
 		if ide == nil || ide.Env == nil {
 			continue
 		}
@@ -1792,7 +1792,7 @@ func trackReadiness(ctx context.Context, w analytics.Writer, cfg *Config, cstate
 		<-ideReady.Wait()
 		trackFn(cfg, readinessKindIDE)
 	}()
-	if cfg.DesktopIDE != nil {
+	if cfg.GetDesktopIDE() != nil {
 		go func() {
 			<-desktopIdeReady.Wait()
 			trackFn(cfg, readinessKindDesktopIDE)

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -181,11 +181,8 @@ func (tm *tasksManager) init(ctx context.Context) {
 		log.WithError(err).Error()
 		return
 	}
-	if tasks == nil && tm.config.isHeadless() {
+	if len(tasks) == 0 && tm.config.isHeadless() {
 		return
-	}
-	if tasks == nil {
-		tasks = &[]TaskConfig{{}}
 	}
 
 	select {
@@ -200,7 +197,7 @@ func (tm *tasksManager) init(ctx context.Context) {
 	// give 1s window between content and tasks for IDE to startup, i.e. no competition for resources
 	tm.waitForIde(ctx, 1*time.Second)
 
-	for i, config := range *tasks {
+	for i, config := range tasks {
 		id := strconv.Itoa(i)
 		presentation := &api.TaskPresentation{}
 		if config.Name != nil {

--- a/components/supervisor/supervisor-config.json
+++ b/components/supervisor/supervisor-config.json
@@ -1,6 +1,6 @@
 {
   "ideConfigLocation": "/ide/supervisor-ide-config.json",
-  "desktopIdeConfigLocation": "/ide-desktop/supervisor-ide-config.json",
+  "desktopIdeRoot": "/ide-desktop",
   "frontendLocation": "/.supervisor/frontend/",
   "apiEndpointPort": 22999,
   "sshPort": 23001


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR extract JB warmup task configuration from server to JB integration itself to enable usage of `gp validate` to investigate warmup issues in the regular workspace. Composition of IDE prebuild tasks are done by supervisor, i.e. it can detect multiple desktop IDEs now. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
A prerequisite to IDE-182

## How to test
<!-- Provide steps to test this PR -->

- Create a project for https://github.com/akosyakov/spring-petclinic
- And run a prebuild
- It does not need to succeed, but just check that warmup of IntelliJ was triggered from logs
- Or test that starting IntelliJ from https://ak-validat3f63c69ca3.preview.gitpod-dev.com/projects/spring-petclinic/766afbb5-ec90-46e9-906b-d56fa6b7d9c9 works both for stable and latest.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-validat3f63c69ca3</li>
	<li><b>🔗 URL</b> - <a href="https://ak-validat3f63c69ca3.preview.gitpod-dev.com/workspaces" target="_blank">ak-validat3f63c69ca3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
