### PR TITLE
[usage] less expensive reconcilation

### DIFF
--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -74,7 +74,7 @@ func FindStoppedWorkspaceInstancesInRange(ctx context.Context, conn *gorm.DB, fr
 	return instances, nil
 }
 
-// FindRunningWorkspaceInstances finds WorkspaceInstanceForUsage that are running at the point in time the querty is executed.
+// FindRunningWorkspaceInstances finds WorkspaceInstanceForUsage that are running at the point in time the query is executed.
 func FindRunningWorkspaceInstances(ctx context.Context, conn *gorm.DB) ([]WorkspaceInstanceForUsage, error) {
 	var instances []WorkspaceInstanceForUsage
 	var instancesInBatch []WorkspaceInstanceForUsage
@@ -82,8 +82,8 @@ func FindRunningWorkspaceInstances(ctx context.Context, conn *gorm.DB) ([]Worksp
 	tx := queryWorkspaceInstanceForUsage(ctx, conn).
 		Where("wsi.stoppingTime = ?", "").
 		Where("wsi.usageAttributionId != ?", "").
-		// We cannot guarantee data quality before this date
-		Where("wsi.startedTime > ?", TimeToISO8601(time.Date(2022, 8, 1, 0, 0, 0, 0, time.UTC))).
+		// We are only interested in instances that have been started within the last 10 days.
+		Where("wsi.startedTime > ?", TimeToISO8601(time.Now().Add(-10*24*time.Hour))).
 		FindInBatches(&instancesInBatch, 1000, func(_ *gorm.DB, _ int) error {
 			instances = append(instances, instancesInBatch...)
 			return nil

--- a/components/gitpod-db/go/workspace_instance_test.go
+++ b/components/gitpod-db/go/workspace_instance_test.go
@@ -124,29 +124,33 @@ func TestFindRunningWorkspace(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 
 	workspace := dbtest.CreateWorkspaces(t, conn, dbtest.NewWorkspace(t, db.Workspace{}))[0]
+	now := time.Now()
+	fiveMinAgo := now.Add(-5 * time.Minute)
+	tenMinAgo := now.Add(-10 * time.Minute)
+	moreThan10DaysAgo := now.Add(-11 * 24 * time.Hour)
 
 	all := []db.WorkspaceInstance{
 		// one stopped instance
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			WorkspaceID:  workspace.ID,
-			StartedTime:  db.NewVarCharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
-			StoppingTime: db.NewVarCharTime(time.Date(2022, 05, 15, 13, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarCharTime(tenMinAgo),
+			StoppingTime: db.NewVarCharTime(fiveMinAgo),
 		}),
-		// one before August 2022, excluded
+		// one unstopped before 10 days ago
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
+			StartedTime: db.NewVarCharTime(moreThan10DaysAgo),
 		}),
 		// Two running instances
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:          uuid.New(),
 			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(time.Date(2022, 9, 1, 0, 00, 00, 00, time.UTC)),
+			StartedTime: db.NewVarCharTime(tenMinAgo),
 		}),
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:          uuid.New(),
 			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(time.Date(2022, 9, 30, 23, 00, 00, 00, time.UTC)),
+			StartedTime: db.NewVarCharTime(tenMinAgo),
 		}),
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The query to find running instances does a scan on all instances since August 2022. [The query gets slower and slower](https://console.cloud.google.com/sql/instances/gitpod-prod-us-west1/insights;database=gitpod;duration=PT1H;query_hash=2850358609397758774;sort_by=TOTAL_EXEC_TIME?project=gitpod-191109) and it is unnecessary to recheck such old instances, as instances can run at most 36 hours and it is not the responsibility of this control loop to handle when this is not the case.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-571

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
