### PR TITLE
[perms] Implement getTeams

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2744,8 +2744,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const checkResults = await Promise.allSettled(checks);
 
         const accessibleTeams = [];
+        const errors = [];
         for (let result of checkResults) {
             if (result.status !== "fulfilled") {
+                errors.push(result.reason);
                 continue;
             }
 
@@ -2754,6 +2756,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             if (check.permitted) {
                 accessibleTeams.push(team);
             }
+        }
+
+        if (errors.length > 0) {
+            log.warn(`Failed to check for permissions on getTeams for at least one team`, { errors });
         }
 
         return accessibleTeams;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Same as https://github.com/gitpod-io/gitpod/pull/18039, but hopefylly with a working preview env..

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-perms-get-teams-2</li>
	<li><b>🔗 URL</b> - <a href="https://mp-perms-get-teams-2.preview.gitpod-dev.com/workspaces" target="_blank">mp-perms-get-teams-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
