### PR TITLE
[db] directly delete code sync resources

### DIFF
--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
@@ -132,8 +132,8 @@ export class CodeSyncResourceDB {
         await connection.transaction(async (manager) => {
             await manager
                 .createQueryBuilder()
-                .update(DBCodeSyncResource)
-                .set({ deleted: true })
+                .delete()
+                .from(DBCodeSyncResource)
                 .where("userId = :userId AND kind != 'editSessions' AND collection = :collection", {
                     userId,
                     collection: uuid.NIL,
@@ -155,8 +155,8 @@ export class CodeSyncResourceDB {
             await connection.transaction(async (manager) => {
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncResource)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncResource)
                     .where("userId = :userId AND kind = :kind AND rev = :rev AND collection = :collection", {
                         userId,
                         kind,
@@ -170,8 +170,8 @@ export class CodeSyncResourceDB {
             await connection.transaction(async (manager) => {
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncResource)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncResource)
                     .where("userId = :userId AND kind = :kind AND collection = :collection", {
                         userId,
                         kind,
@@ -317,14 +317,14 @@ export class CodeSyncResourceDB {
             await connection.transaction(async (manager) => {
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncCollection)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncCollection)
                     .where("userId = :userId AND collection = :collection", { userId, collection })
                     .execute();
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncResource)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncResource)
                     .where("userId = :userId AND collection = :collection", { userId, collection })
                     .execute();
                 await doDelete(collection);
@@ -334,14 +334,14 @@ export class CodeSyncResourceDB {
             await connection.transaction(async (manager) => {
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncCollection)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncCollection)
                     .where("userId = :userId", { userId })
                     .execute();
                 await manager
                     .createQueryBuilder()
-                    .update(DBCodeSyncResource)
-                    .set({ deleted: true })
+                    .delete()
+                    .from(DBCodeSyncResource)
                     .where("userId = :userId AND collection != :collection", { userId, collection: uuid.NIL })
                     .execute();
                 await doDelete();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Delete code sync resources directly, as we don't need to the two-phase deletion anymore. Also the [deletion query is slow](https://console.cloud.google.com/sql/instances/gitpod-prod-us-west1/insights;database=gitpod;duration=PT1H;query_hash=3431532609399736197;sort_by=TOTAL_EXEC_TIME?project=gitpod-191109).

Tests are [here](https://github.com/gitpod-io/gitpod/blob/58108e58defdc9233e63f38f0057640a33df6957/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts#L242).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-570

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
