### PR TITLE
Revert "[perms] Implement getTeams WEB-501 (#18039)"

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2748,35 +2748,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     public async getTeams(ctx: TraceContext): Promise<Team[]> {
         // Note: this operation is per-user only, hence needs no resource guard
         const user = await this.checkUser("getTeams");
-        const teams = await this.teamDB.findTeamsByUser(user.id);
-
-        // We need to check each team individually against our permission system.
-        // checks are promises, which resolve to { team, check } object
-        const checks = teams.map((team) =>
-            this.authorizer.check(ReadOrganizationInfo(user.id, team.id)).then((check) => ({ team, check })),
-        );
-        const checkResults = await Promise.allSettled(checks);
-
-        const accessibleTeams = [];
-        const errors = [];
-        for (let result of checkResults) {
-            if (result.status !== "fulfilled") {
-                errors.push(result.reason);
-                continue;
-            }
-
-            const { team, check } = result.value;
-
-            if (check.permitted) {
-                accessibleTeams.push(team);
-            }
-        }
-
-        if (errors.length > 0) {
-            log.warn(`Failed to check for permissions on getTeams for at least one team`, { errors });
-        }
-
-        return accessibleTeams;
+        return this.teamDB.findTeamsByUser(user.id);
     }
 
     public async getTeam(ctx: TraceContext, teamId: string): Promise<Team> {


### PR DESCRIPTION
This reverts commit 01117568d7f49971572cf588ea8f8b78035090ff.

## Description
Incident: https://stspg.io/lzd5wlknj7yc

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-revert-getteams</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-revert-getteams.preview.gitpod-dev.com/workspaces" target="_blank">gpl-revert-getteams.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
