### PR TITLE
[dashboard] Only show /billing links for UBP

### DIFF
--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -11,11 +11,13 @@ import { useCurrentUser } from "../user-context";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { useLocation } from "react-router";
 import { User } from "@gitpod/gitpod-protocol";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 
 export default function OrganizationSelector() {
     const user = useCurrentUser();
     const orgs = useOrganizations();
     const currentOrg = useCurrentOrg();
+    const { data: billingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
 
     // we should have an API to ask for permissions, until then we duplicate the logic here
@@ -72,13 +74,15 @@ export default function OrganizationSelector() {
 
     // Show billing & settings if user is an owner of current org
     if (currentOrg.data && currentOrg.data.isOwner) {
-        linkEntries.push({
-            title: "Billing",
-            customContent: <LinkEntry>Billing</LinkEntry>,
-            active: false,
-            separator: false,
-            link: "/billing",
-        });
+        if (billingMode?.mode === "usage-based") {
+            linkEntries.push({
+                title: "Billing",
+                customContent: <LinkEntry>Billing</LinkEntry>,
+                active: false,
+                separator: false,
+                link: "/billing",
+            });
+        }
         linkEntries.push({
             title: "Settings",
             customContent: <LinkEntry>Settings</LinkEntry>,

--- a/components/dashboard/src/usage/UsageSummary.tsx
+++ b/components/dashboard/src/usage/UsageSummary.tsx
@@ -8,12 +8,14 @@ import { FC } from "react";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { Subheading } from "../components/typography/headings";
 import { Link } from "react-router-dom";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 
 type Props = {
     creditsUsed?: number;
 };
 export const UsageSummaryData: FC<Props> = ({ creditsUsed }) => {
     const currentOrg = useCurrentOrg();
+    const { data: billingMode } = useOrgBillingMode();
 
     return (
         <div className="flex flex-row">
@@ -24,7 +26,7 @@ export const UsageSummaryData: FC<Props> = ({ creditsUsed }) => {
                         {creditsUsed !== undefined ? creditsUsed.toLocaleString() : "-"}
                     </span>
                 </div>
-                {currentOrg.data && currentOrg.data.isOwner && (
+                {currentOrg.data && currentOrg.data.isOwner && billingMode?.mode === "usage-based" && (
                     <div className="flex text-xs text-gray-600">
                         <span className="dark:text-gray-500 text-gray-400">
                             <Link to="/billing" className="gp-link">


### PR DESCRIPTION
## Description
Fixes a regression from https://github.com/gitpod-io/gitpod/pull/17621.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-421

## How to test
 - setup Dedicated
 - note that you don't see /billing links in:
   - the usage view
   - the org menu

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-org-bm</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-org-bm.preview.gitpod-dev.com/workspaces" target="_blank">gpl-org-bm.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
