### PR TITLE
[test] Add network limiting e2e test

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-github/v42 v42.0.0
 	github.com/google/uuid v1.3.0
 	github.com/helloyi/go-sshclient v1.1.1
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/prometheus/procfs v0.8.0
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/oauth2 v0.6.0
@@ -63,7 +64,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/cilium/ebpf v0.4.0 // indirect
+	github.com/cilium/ebpf v0.7.0 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -69,8 +69,8 @@ github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHe
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/ebpf v0.4.0 h1:QlHdikaxALkqWasW8hAC1mfR0jdmvbfaBdBPFmRSglA=
-github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
+github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
@@ -262,6 +262,8 @@ github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKU
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -414,10 +416,10 @@ golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/test/pkg/agent/daemon/api/api.go
+++ b/test/pkg/agent/daemon/api/api.go
@@ -20,3 +20,11 @@ type GetWorkspaceResourcesResponse struct {
 	CpuQuota int64
 	Found    bool
 }
+
+type GetNftRulesetsRequest struct {
+	ContainerId string
+}
+
+type GetNftRulesetsResponse struct {
+	Output string
+}

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -210,6 +210,11 @@ func (r *RpcClient) Call(serviceMethod string, args any, reply any) error {
 	for i := 0; i < connectFailureMaxTries; i++ {
 		if r != nil {
 			if err = r.client.Call(serviceMethod, args, reply); err != nil {
+				log.Warnf("rpc call %s failed (attempt %d): %v", serviceMethod, i, err)
+				if i == connectFailureMaxTries-1 {
+					return err
+				}
+
 				time.Sleep(10 * time.Second)
 				r.Close()
 				new, _, err = Instrument(r.component, r.agentName, r.namespace, r.kubeconfig, r.kclient, r.opts...)

--- a/test/tests/components/ws-daemon/network_limiting_test.go
+++ b/test/tests/components/ws-daemon/network_limiting_test.go
@@ -6,16 +6,46 @@ package wsdaemon
 
 import (
 	"context"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gitpod-io/gitpod/common-go/kubernetes"
+	daemon "github.com/gitpod-io/gitpod/test/pkg/agent/daemon/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
-func TestNetworkdLimiting(t *testing.T) {
+var (
+	expectedRules = []*regexp.Regexp{regexp.MustCompile(`(?s)table ip gitpod {
+	counter ws-connection-drop-stats {
+		packets 0 bytes 0
+	}
+
+	set ws-connections {
+		type ipv4_addr
+		size 65535
+		flags dynamic,timeout
+		elements = { 0\.0\.0\.0 limit rate over 3000\/minute burst 3000 packets timeout 1m expires [0-9a-z]+ }
+	}
+
+	chain ratelimit {
+		type filter hook postrouting priority filter; policy accept;
+		ip protocol tcp ct state new add @ws-connections { ip daddr & 0\.0\.0\.0 timeout 1m limit rate over 3000\/minute burst 3000 packets } counter name "ws-connection-drop-stats" drop
+	}
+}`),
+	}
+)
+
+func TestNetworkLimiting(t *testing.T) {
+	userToken, _ := os.LookupEnv("USER_TOKEN")
+	integration.SkipWithoutUsername(t, username)
+	integration.SkipWithoutUserToken(t, userToken)
+
 	f := features.New("network limiting").
 		WithLabel("component", "ws-daemon").
 		Assess("verify if network limiting works fine", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -29,7 +59,12 @@ func TestNetworkdLimiting(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
+			_, err := api.CreateUser(username, userToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ws, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, "https://github.com/gitpod-io/empty", username, api, integration.WithGitpodUser(username))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -48,22 +83,53 @@ func TestNetworkdLimiting(t *testing.T) {
 
 			daemonClient, daemonCloser, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), kubeconfig, cfg.Client(),
 				integration.WithWorkspacekitLift(false),
-				integration.WithContainer("ws-daemon"))
+				integration.WithContainer("ws-daemon"),
+			)
 			if err != nil {
 				t.Fatalf("unexpected error instrumenting daemon: %v", err)
 			}
 			defer daemonClient.Close()
 			integration.DeferCloser(t, daemonCloser)
 
+			t.Logf("checking if workspace pod has network limit annotation")
 			var pod corev1.Pod
-			if err := cfg.Client().Resources().Get(ctx, "ws-"+ws.Req.Id, cfg.Namespace(), &pod); err != nil {
+			if err := cfg.Client().Resources().Get(ctx, "ws-"+ws.LatestInstance.ID, cfg.Namespace(), &pod); err != nil {
 				t.Fatal(err)
 			}
+			annotation, ok := pod.Annotations[kubernetes.WorkspaceNetConnLimitAnnotation]
+			if !ok {
+				t.Fatalf("expected annotation %s to be present on workspace pod but wasn't", kubernetes.WorkspaceNetConnLimitAnnotation)
+			}
+			if annotation != "true" {
+				t.Fatalf("expected annotation %s to be true but was %s", kubernetes.WorkspaceNetConnLimitAnnotation, annotation)
+			}
 
-			// containerId := getWorkspaceContainerId(&pod)
+			t.Logf("checking nftable rules for rate limiting")
+			containerId := getCalicoContainerId(&pod)
+
+			var resp daemon.GetNftRulesetsResponse
+			err = daemonClient.Call("DaemonAgent.GetNftRulesets", daemon.GetNftRulesetsRequest{
+				ContainerId: containerId,
+			}, &resp)
+			if err != nil {
+				t.Errorf("cannot get nft rulesets for container %s: %v", containerId, err)
+			}
+			t.Logf("rulesets in workspace:")
+			println(resp.Output)
+			t.Logf("checking %d expected rulesets", len(expectedRules))
+			for _, rule := range expectedRules {
+				out := strings.ReplaceAll(resp.Output, "\r", "")
+				if !rule.MatchString(out) {
+					t.Errorf("expected the following ruleset to be present but wasn't:\n%s", rule.String())
+				}
+			}
 
 			return testCtx
 		}).Feature()
 
 	testEnv.Test(t, f)
+}
+
+func getCalicoContainerId(pod *corev1.Pod) string {
+	return pod.Annotations["cni.projectcalico.org/containerID"]
 }

--- a/test/tests/components/ws-daemon/network_limiting_test.go
+++ b/test/tests/components/ws-daemon/network_limiting_test.go
@@ -7,7 +7,10 @@ package wsdaemon
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -17,7 +20,48 @@ func TestNetworkdLimiting(t *testing.T) {
 		WithLabel("component", "ws-daemon").
 		Assess("verify if network limiting works fine", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			t.Parallel()
-			t.Skip("unimplemented")
+
+			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			daemonClient, daemonCloser, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), kubeconfig, cfg.Client(),
+				integration.WithWorkspacekitLift(false),
+				integration.WithContainer("ws-daemon"))
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting daemon: %v", err)
+			}
+			defer daemonClient.Close()
+			integration.DeferCloser(t, daemonCloser)
+
+			var pod corev1.Pod
+			if err := cfg.Client().Resources().Get(ctx, "ws-"+ws.Req.Id, cfg.Namespace(), &pod); err != nil {
+				t.Fatal(err)
+			}
+
+			// containerId := getWorkspaceContainerId(&pod)
+
 			return testCtx
 		}).Feature()
 


### PR DESCRIPTION
## Description

Add test for network limiting.

Works by:
* installing an agent in ws-daemon, with a new `GetNftRulesets` RPC
* this agent then finds the workspace container's `pid`
* then the `ring0` child process of the container process
* enters the network namespace of the ring0 process
* checks `nft list ruleset` and verifies rate limiting is present

Took a while to get this working 😄 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-223

## How to test
<!-- Provide steps to test this PR -->

```
cd test
go test -v ./... -run TestNetworkLimiting
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
