### PR TITLE
[test] Assert cgroup v2 is enabled

### DIFF
--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -25,7 +25,7 @@ import (
 func TestCgroupV2(t *testing.T) {
 	f := features.New("cgroup v2").
 		WithLabel("component", "workspace").
-		Assess("it should create a new cgroup when cgroup v2 is enabled", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should have cgroup v2 enabled and create a new cgroup", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			report.SetupReport(t, report.FeatureResourceLimit, "this is the test for cgroup v2")
 			t.Parallel()
 
@@ -66,7 +66,7 @@ func TestCgroupV2(t *testing.T) {
 				t.Fatalf("unexpected error checking cgroup v2: %v", err)
 			}
 			if !cgv2 {
-				t.Skip("This test only works for cgroup v2")
+				t.Fatalf("expected cgroup v2 to be enabled")
 			}
 
 			cgroupBase := "/sys/fs/cgroup/test"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fail cgroupv2 test if v2 is not enabled

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-270

## How to test
<!-- Provide steps to test this PR -->

```
cd test
go test -v ./... -run TestCgroupV2
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
