### PR TITLE
[dashboard] smoother loading screen

### DIFF
--- a/components/dashboard/src/app/AppLoading.tsx
+++ b/components/dashboard/src/app/AppLoading.tsx
@@ -4,19 +4,43 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FunctionComponent } from "react";
-import { Delayed } from "../components/Delayed";
+import { FunctionComponent, useEffect, useState } from "react";
 import { Heading3, Subheading } from "../components/typography/headings";
 import gitpodIcon from "../icons/gitpod.svg";
+import { Delayed } from "../components/Delayed";
+
+function useDelay(wait: number) {
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+        const timeout = setTimeout(() => setDone(true), wait);
+        return () => clearTimeout(timeout);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [wait]);
+    return done;
+}
 
 export const AppLoading: FunctionComponent = () => {
+    const done = useDelay(8000);
+    const connectionProblems = useDelay(25000);
     return (
-        // Wait 3 seconds before showing the loading screen to avoid flashing it too quickly
         <Delayed wait={3000}>
             <div className="flex flex-col justify-center items-center w-full h-screen space-y-4">
-                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0"} />
-                <Heading3>Just getting a few more things ready</Heading3>
-                <Subheading>hang in there...</Subheading>
+                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0 animate-fade-in"} />
+                {connectionProblems ? (
+                    <Heading3 className={done ? "" : "invisible"}>This is taking longer than it should</Heading3>
+                ) : (
+                    <Heading3 className={done ? "animate-fade-in" : "invisible"}>
+                        Just getting a few more things ready
+                    </Heading3>
+                )}
+                {connectionProblems ? (
+                    <Subheading className={done ? "max-w-xl text-center" : "invisible"}>
+                        It seems like you are having connection issues. Please check your network connection. Sometimes
+                        this problem can also be caused by a slow browser with too many tabs and/or extensions.
+                    </Subheading>
+                ) : (
+                    <Subheading className={done ? "animate-fade-in" : "invisible"}>hang in there...</Subheading>
+                )}
             </div>
         </Delayed>
     );

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -54,9 +54,14 @@ module.exports = {
                     from: { transform: "translateX(100%)" },
                     to: { transform: "translateX(0)" },
                 },
+                "fade-in": {
+                    "0%": { opacity: "0" },
+                    "100%": { opacity: "1" },
+                },
             },
             animation: {
                 "toast-in-right": "toast-in-right 0.3s ease-in-out",
+                "fade-in": "fade-in 3s linear",
             },
             transitionProperty: {
                 width: "width",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The loading screen is currently white for 5 sec and than immediately jumps to logo with text.

This change proposes to smoothen the experience and make it bit more gradual.
- After 1 sec the logo softly fades in
- After 6 sec the text apears
- After 20 sec we tell the user that something is off.

Here's a [loom](https://www.loom.com/share/49e9c244e6064841985e01fadaea8dfc?sid=31061572-5955-47f8-a401-07d4559cdc79).

<img width="624" alt="Screenshot 2023-06-27 at 09 30 31" src="https://github.com/gitpod-io/gitpod/assets/372735/a6df6ae7-4124-40f3-910f-cf56d6e5cd61">



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-loading</li>
	<li><b>🔗 URL</b> - <a href="https://se-loading.preview.gitpod-dev.com/workspaces" target="_blank">se-loading.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
