### PR TITLE
[installer] Optional flag to use mysql 8.0

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -493,6 +493,11 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.enforce 
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.connectionsPerMinute "3000"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.bucketSize "3000"
 
+#
+# Configure DB
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" database.inClusterMySql_8_0 "true"
+
 log_success "Generated config at $INSTALLER_CONFIG_PATH"
 
 # ========

--- a/install/installer/pkg/components/database/incluster/helm.go
+++ b/install/installer/pkg/components/database/incluster/helm.go
@@ -26,10 +26,17 @@ var Helm = common.CompositeHelmFunc(
 
 		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
 
+		// We switched to specific tags because we got subtle broken versions with just specifying major versions
+		mysqlBitnamiImageTag := "5.7.34-debian-10-r55"
+		if cfg.Config.Database.InClusterMysSQL_8_0 {
+			mysqlBitnamiImageTag = "8.0.33-debian-11-r24"
+		}
+
 		return &common.HelmConfig{
 			Enabled: true,
 			Values: &values.Options{
 				Values: []string{
+					helm.KeyValue("mysql.image.tag", mysqlBitnamiImageTag),
 					helm.KeyValue("mysql.auth.existingSecret", SQLPasswordName),
 					helm.KeyValue("mysql.auth.database", Database),
 					helm.KeyValue("mysql.auth.username", Username),

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -196,6 +196,8 @@ type Database struct {
 	External  *DatabaseExternal `json:"external,omitempty"`
 	CloudSQL  *DatabaseCloudSQL `json:"cloudSQL,omitempty"`
 	SSL       *SSLOptions       `json:"ssl,omitempty"`
+	// A temporary flag to help debug for the migration to MySQL 8.0
+	InClusterMysSQL_8_0 bool `json:"inClusterMySql_8_0,omitempty"`
 }
 
 type DatabaseExternal struct {

--- a/install/installer/third_party/charts/mysql/values.yaml
+++ b/install/installer/third_party/charts/mysql/values.yaml
@@ -5,8 +5,7 @@
 mysql:
   fullnameOverride: mysql
   image:
-    # We switched to the specific version because "5.7" was broken at least once
-    tag: 5.7.34-debian-10-r55
+    tag: "overwritten"
   primary:
     extraEnvVars:
       # We rely on this in our DB implementations: NULL (re-)sets configured columns to be initialized with CURRENT_TIMESTAMP.


### PR DESCRIPTION
## Description


Enables the use of MySql 8.0 for **all preview environments**.
Part of the effort to identify problems in migration from MySQL 5.7 to 8.0

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - start a workspace and see that it works as usual.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
