### PR TITLE
[test] Use latest successful main build

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -7,7 +7,7 @@ on:
                 description: "The name of the preview environment, or leave empty to use a default name"
             version:
                 required: false
-                description: "The version of Gitpod to install (leave empty to target the latest build on main)"
+                description: "The version of Gitpod to install (leave empty to target the latest successful build on main)"
             skip_deploy:
                 required: false
                 type: boolean
@@ -65,10 +65,10 @@ jobs:
                           echo "version=${{ github.event.inputs.version }}"
                       } >> $GITHUB_OUTPUT
                   else
-                      # others
-                      RUNID=$(gh run list -R gitpod-io/gitpod -b main -w Build --limit 1 --json databaseId --jq .[0].databaseId)
-                      if ! gh run watch "$RUNID" --exit-status -R gitpod-io/gitpod >/dev/null 2>&1; then
-                        echo main branch build is failed, see https://github.com/gitpod-io/gitpod/actions/runs/"$RUNID" for detail | tee -a $GITHUB_STEP_SUMMARY
+                      # Find the most recent successful build on main. Look back up to 10 builds.
+                      RUNID=$(gh run list --repo gitpod-io/gitpod --branch main --workflow Build --limit 10 --json createdAt,conclusion,databaseId --jq 'map(select(.conclusion == "success")) | sort_by(.createdAt) | .[-1] | .databaseId')
+                      if [ "$RUNID" == "" ]; then
+                        echo no successful build found on main branch in the last 10 commits, see https://github.com/gitpod-io/gitpod/actions/workflows/build.yml for details | tee -a $GITHUB_STEP_SUMMARY
                         exit 1
                       fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Find and use the latest successful build on main by looking back 10 builds, instead of trying/waiting on the most recent build when no specific installer version is specified.

Makes it easier to iterate on the tests by removing the wait on the latest build to finish, and also prevents a main build flake from failing the periodic e2e test runs. Now it will fall back on the most recent green build.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Testing here: https://github.com/gitpod-io/gitpod/actions/runs/5388611363, and ran the `gh run list ...` commands locally to check

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
