### PR TITLE
[ws-man-bridge] Use chainguard image WEB-576

### DIFF
--- a/components/ws-manager-bridge/leeway.Dockerfile
+++ b/components/ws-manager-bridge/leeway.Dockerfile
@@ -8,13 +8,14 @@ COPY components-ws-manager-bridge--app /installer/
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:16.13.0-slim
+# NodeJS v16.19
+FROM cgr.dev/chainguard/node@sha256:95bb4763acb8e9702c956e093932be97ab118db410a0619bb3fdd334c9198006
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 # '--no-log-init': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-RUN useradd --no-log-init --create-home --uid 31002 --home-dir /app/ unode
+# RUN useradd --no-log-init --create-home --uid 31002 --home-dir /app/ unode
 COPY --from=builder /app /app/
-USER unode
+# USER unode
 WORKDIR /app/node_modules/@gitpod/ws-manager-bridge
 
 ARG __GIT_COMMIT

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -152,7 +152,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							}),
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               pointer.Bool(false),
-								RunAsUser:                pointer.Int64(31001),
 								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
