### PR TITLE
[test] Log preview env state on failure, check cpu limit config is set

### DIFF
--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -1166,6 +1166,16 @@ func (c *ComponentAPI) Done(t *testing.T) {
 			t.Logf("cleanup failed: %q", err)
 		}
 	}
+
+	if t.Failed() {
+		// Log preview env status when test fails to help debug the failure.
+		ready, reason, err := isPreviewReady(c.client, c.namespace)
+		if err != nil {
+			t.Logf("failed to check preview status: %q", err)
+		} else {
+			t.Logf("preview status: ready=%v, reason=%s", ready, reason)
+		}
+	}
 }
 
 func (c *ComponentAPI) appendCloser(closer func() error) {

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -1175,6 +1175,7 @@ func (c *ComponentAPI) Done(t *testing.T) {
 		} else {
 			t.Logf("preview status: ready=%v, reason=%s", ready, reason)
 		}
+		logGitpodStatus(t, c.client, c.namespace)
 	}
 }
 

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -304,13 +304,6 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	t.Log("wait for workspace to be fully up and running")
 	lastStatus, err := WaitForWorkspaceStart(t, ctx, req.Id, req.Metadata.MetaId, api, options.WaitForOpts...)
 	if err != nil {
-		// Check if the preview env is in a good state, and log details if not.
-		previewReady, reason, previewErr := isPreviewReady(api.client, api.namespace)
-		if previewErr != nil {
-			t.Logf("error checking if preview is ready: %v", previewErr)
-		} else if !previewReady {
-			t.Logf("preview env is not ready: %s", reason)
-		}
 		return nil, nil, xerrors.Errorf("cannot wait for workspace start: %w", err)
 	}
 	t.Log("successful launch of the workspace")

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -48,6 +48,12 @@ func TestCpuBurst(t *testing.T) {
 			return ctx
 		}
 
+		if daemonConfig.CpuLimitConfig.Limit == 0 {
+			t.Fatal("cpu limit is not set")
+		}
+		if daemonConfig.CpuLimitConfig.BurstLimit == 0 {
+			t.Fatal("cpu burst limit is not set")
+		}
 		daemonConfig.CpuLimitConfig.Limit = daemonConfig.CpuLimitConfig.Limit * 100_000
 		daemonConfig.CpuLimitConfig.BurstLimit = daemonConfig.CpuLimitConfig.BurstLimit * 100_000
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Logs the preview env status when an integration test fails, to help debug the failure.

Also add a small sanity check to assert that the cpu limit config is non-zero (not sure that would've been caught by the test otherwise). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-219

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
