### PR TITLE
[perms] Implement getTeams WEB-501

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2695,10 +2695,27 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return fromDB.value;
     }
 
-    public async getTeams(ctx: TraceContext): Promise<Team[]> {
+    public async getTeams(ctx: TraceContext): Promise<Organization[]> {
         // Note: this operation is per-user only, hence needs no resource guard
-        const user = await this.checkUser("getTeams");
-        return this.teamDB.findTeamsByUser(user.id);
+        const user = await this.checkUser("getOrganizations");
+        const orgs = await this.teamDB.findTeamsByUser(user.id);
+
+        const filterOrg = async (org: Organization): Promise<Organization | undefined> => {
+            const members = await this.teamDB.findMembersByTeam(org.id);
+            if (!(await this.hasOrgOperationPermission(org, members, "get", "read_info"))) {
+                return undefined;
+            }
+            return org;
+        };
+
+        const accessibleOrgs = [];
+        for (const check of orgs.map(filterOrg)) {
+            const org = await check;
+            if (org) {
+                accessibleOrgs.push(org);
+            }
+        }
+        return accessibleOrgs;
     }
 
     public async getTeam(ctx: TraceContext, teamId: string): Promise<Team> {


### PR DESCRIPTION
## Description

Adds permission checks for getTeams call

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-501

## How to test
<!-- Provide steps to test this PR -->
1. Start with feature flag disabled
	* Create an org
2. Enable feature flag
	* Create another org
	* You should now see both Orgs
3. Disable feature flag
	* You should see both orgs

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-perms-list-teams</li>
	<li><b>🔗 URL</b> - <a href="https://se-perms-list-teams.preview.gitpod-dev.com/workspaces" target="_blank">se-perms-list-teams.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
