### PR TITLE
[perms] Compose org updates

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -52,14 +52,8 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-                    }),
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-                    }),
+                    ...this.removeOrganizationOwnerRoleUpdates(orgID, userID),
+                    ...this.addOrganizationMemberRoleUpdates(orgID, userID),
                 ],
             }),
             {
@@ -71,12 +65,7 @@ export class Authorizer {
     async addOrganizationMemberRole(orgID: string, userID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-                    }),
-                ],
+                updates: this.addOrganizationMemberRoleUpdates(orgID, userID),
             }),
             {
                 orgID,
@@ -87,12 +76,7 @@ export class Authorizer {
     async removeOrganizationOwnerRole(orgID: string, userID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-                    }),
-                ],
+                updates: this.removeOrganizationOwnerRoleUpdates(orgID, userID),
             }),
             {
                 orgID,
@@ -104,14 +88,8 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-                    }),
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-                    }),
+                    ...this.removeOrganizationMemberRoleUpdates(orgID, userID),
+                    ...this.removeOrganizationOwnerRoleUpdates(orgID, userID),
                 ],
             }),
             {
@@ -123,16 +101,7 @@ export class Authorizer {
     async addProjectToOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(
-                            objectRef("project", projectID),
-                            "org",
-                            subject("organization", orgID),
-                        ),
-                    }),
-                ],
+                updates: this.addProjectToOrgUpdates(orgID, projectID),
             }),
             {
                 orgID,
@@ -143,21 +112,57 @@ export class Authorizer {
     async removeProjectFromOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(
-                            objectRef("project", projectID),
-                            "org",
-                            subject("organization", orgID),
-                        ),
-                    }),
-                ],
+                updates: this.removeProjectFromOrgUpdates(orgID, projectID),
             }),
             {
                 orgID,
             },
         );
+    }
+
+    private addOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
+        return [
+            v1.RelationshipUpdate.create({
+                operation: v1.RelationshipUpdate_Operation.TOUCH,
+                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
+            }),
+        ];
+    }
+
+    private removeOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
+        return [
+            v1.RelationshipUpdate.create({
+                operation: v1.RelationshipUpdate_Operation.DELETE,
+                relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
+            }),
+        ];
+    }
+
+    private removeOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
+        return [
+            v1.RelationshipUpdate.create({
+                operation: v1.RelationshipUpdate_Operation.DELETE,
+                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
+            }),
+        ];
+    }
+
+    private removeProjectFromOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
+        return [
+            v1.RelationshipUpdate.create({
+                operation: v1.RelationshipUpdate_Operation.DELETE,
+                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
+            }),
+        ];
+    }
+
+    private addProjectToOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
+        return [
+            v1.RelationshipUpdate.create({
+                operation: v1.RelationshipUpdate_Operation.TOUCH,
+                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
+            }),
+        ];
     }
 }
 

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -52,7 +52,7 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [
-                    this.removeOrganizationOwnerRoleUpdates(orgID, userID),
+                    this.addOrganizationOwnerRoleUpdates(orgID, userID),
                     this.addOrganizationMemberRoleUpdates(orgID, userID),
                 ],
             }),
@@ -124,6 +124,13 @@ export class Authorizer {
         return v1.RelationshipUpdate.create({
             operation: v1.RelationshipUpdate_Operation.TOUCH,
             relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
+        });
+    }
+
+    private addOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.TOUCH,
+            relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
         });
     }
 

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -52,8 +52,8 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [
-                    ...this.removeOrganizationOwnerRoleUpdates(orgID, userID),
-                    ...this.addOrganizationMemberRoleUpdates(orgID, userID),
+                    this.removeOrganizationOwnerRoleUpdates(orgID, userID),
+                    this.addOrganizationMemberRoleUpdates(orgID, userID),
                 ],
             }),
             {
@@ -65,7 +65,7 @@ export class Authorizer {
     async addOrganizationMemberRole(orgID: string, userID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: this.addOrganizationMemberRoleUpdates(orgID, userID),
+                updates: [this.addOrganizationMemberRoleUpdates(orgID, userID)],
             }),
             {
                 orgID,
@@ -76,7 +76,7 @@ export class Authorizer {
     async removeOrganizationOwnerRole(orgID: string, userID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: this.removeOrganizationOwnerRoleUpdates(orgID, userID),
+                updates: [this.removeOrganizationOwnerRoleUpdates(orgID, userID)],
             }),
             {
                 orgID,
@@ -88,8 +88,8 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [
-                    ...this.removeOrganizationMemberRoleUpdates(orgID, userID),
-                    ...this.removeOrganizationOwnerRoleUpdates(orgID, userID),
+                    this.removeOrganizationMemberRoleUpdates(orgID, userID),
+                    this.removeOrganizationOwnerRoleUpdates(orgID, userID),
                 ],
             }),
             {
@@ -101,7 +101,7 @@ export class Authorizer {
     async addProjectToOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: this.addProjectToOrgUpdates(orgID, projectID),
+                updates: [this.addProjectToOrgUpdates(orgID, projectID)],
             }),
             {
                 orgID,
@@ -112,7 +112,7 @@ export class Authorizer {
     async removeProjectFromOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
-                updates: this.removeProjectFromOrgUpdates(orgID, projectID),
+                updates: [this.removeProjectFromOrgUpdates(orgID, projectID)],
             }),
             {
                 orgID,
@@ -120,49 +120,39 @@ export class Authorizer {
         );
     }
 
-    private addOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-            }),
-        ];
+    private addOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.TOUCH,
+            relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
+        });
     }
 
-    private removeOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-            }),
-        ];
+    private removeOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.DELETE,
+            relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
+        });
     }
 
-    private removeOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-            }),
-        ];
+    private removeOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.DELETE,
+            relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
+        });
     }
 
-    private removeProjectFromOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
-            }),
-        ];
+    private removeProjectFromOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.DELETE,
+            relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
+        });
     }
 
-    private addProjectToOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
-            }),
-        ];
+    private addProjectToOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate {
+        return v1.RelationshipUpdate.create({
+            operation: v1.RelationshipUpdate_Operation.TOUCH,
+            relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
+        });
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is a pre-PR for implementation of `leaveTeam`. 

This change composes individual relationship updates - allows us to reuse the relationships in bigger (public signature) methods to be used outside of the authorizer.

As it stands, the change is semantically equivalent to the current implementation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
