### PR TITLE
[server] add organization service

### DIFF
--- a/components/gitpod-protocol/src/experiments/configcat-server.ts
+++ b/components/gitpod-protocol/src/experiments/configcat-server.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Client } from "./types";
+import { Attributes, Client } from "./types";
 import * as configcat from "configcat-node";
 import { LogLevel } from "configcat-common";
 import { ConfigCatClient } from "./configcat";
@@ -14,6 +14,22 @@ let client: Client | undefined;
 
 export type ConfigCatClientFactory = () => Client;
 export const ConfigCatClientFactory = Symbol("ConfigCatClientFactory");
+export namespace Experiments {
+    export function configureTestingClient(config: Record<string, any>): void {
+        client = {
+            getValueAsync<T>(experimentName: string, defaultValue: T, attributes: Attributes): Promise<T> {
+                if (config.hasOwnProperty(experimentName)) {
+                    return Promise.resolve(config[experimentName] as T);
+                }
+                return Promise.resolve(defaultValue);
+            },
+
+            dispose(): void {
+                // there is nothing to dispose, no-op.
+            },
+        };
+    }
+}
 
 export function getExperimentsClientForBackend(): Client {
     // We have already instantiated a client, we can just re-use it.

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -17,7 +17,9 @@
     "purge": "yarn clean && yarn clean:node && yarn run rimraf yarn.lock",
     "lint": "yarn tslint -p .",
     "test": ". $(leeway run components/gitpod-db:db-test-env) && TS_NODE_FILES=true mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
-    "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
+    "spicedb-testing": "if netstat -tuln | grep ':50051 '; then echo '`spicedb serve-testing` is already running.'; else spicedb serve-testing --load-configs /workspace/gitpod/install/installer/pkg/components/spicedb/data/schema.yaml; fi",
+    "stop-spicedb-testing": "PID=$(lsof -t -i:50051); if [ -z \"$PID\" ]; then echo '`spicedb serve-testing` is not running'; else kill -INT $PID && echo 'Stopped `spicedb serve-testing`'; fi",
+    "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn spicedb-testing & yarn db-test-run; yarn stop-spicedb-testing; };r",
     "db-test-run": "TS_NODE_FILES=true mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",
     "telepresence": "telepresence --swap-deployment server --method inject-tcp --run yarn start-inspect"
   },

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -17,6 +17,7 @@ export type OrganizationPermission =
     | "read_info"
     | "write_info"
     | "read_members"
+    | "invite_members"
     | "write_members"
     | "leave"
     | "delete"

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -29,14 +29,14 @@ export class SpiceDBAuthorizer {
         },
     ): Promise<boolean> {
         if (!this.client) {
-            return false;
+            return true;
         }
 
         const featureEnabled = await getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
             teamId: experimentsFields?.orgID,
         });
         if (!featureEnabled) {
-            return false;
+            return true;
         }
 
         const timer = spicedbClientLatency.startTimer();

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -129,6 +129,7 @@ import { WorkspaceDownloadService } from "./workspace/workspace-download-service
 import { WorkspaceFactory } from "./workspace/workspace-factory";
 import { WorkspaceStarter } from "./workspace/workspace-starter";
 import { SpiceDBAuthorizer } from "./authorization/spicedb-authorizer";
+import { OrganizationService } from "./orgs/organization-service";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -253,6 +254,7 @@ export const productionContainerModule = new ContainerModule(
         bind(HeadlessLogService).toSelf().inSingletonScope();
         bind(HeadlessLogController).toSelf().inSingletonScope();
 
+        bind(OrganizationService).toSelf().inSingletonScope();
         bind(ProjectsService).toSelf().inSingletonScope();
         bind(EnvVarService).toSelf().inSingletonScope();
 

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { v1 } from "@authzed/authzed-node";
+import { DBUser, TypeORM, UserDB, testContainer } from "@gitpod/gitpod-db/lib";
+import { DBTeam } from "@gitpod/gitpod-db/lib/typeorm/entity/db-team";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { User } from "@gitpod/ide-service-api/lib/ide.pb";
+import { fail } from "assert";
+import * as chai from "chai";
+import { Container, ContainerModule } from "inversify";
+import "mocha";
+import { v4 as uuidv4 } from "uuid";
+import { Authorizer } from "../authorization/authorizer";
+import { SpiceDBClient } from "../authorization/spicedb";
+import { SpiceDBAuthorizer } from "../authorization/spicedb-authorizer";
+import { OrganizationService } from "./organization-service";
+
+const expect = chai.expect;
+
+describe("OrganizationService", async () => {
+    let container: Container;
+    let owner: User;
+    let stranger: User;
+
+    beforeEach(async () => {
+        container = testContainer.createChild();
+        container.load(
+            new ContainerModule((bind) => {
+                bind(OrganizationService).toSelf().inSingletonScope();
+                bind(SpiceDBClient)
+                    .toDynamicValue(() => {
+                        const token = uuidv4();
+                        return v1.NewClient(token, "localhost:50051", v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS)
+                            .promises;
+                    })
+                    .inSingletonScope();
+                bind(SpiceDBAuthorizer).toSelf().inSingletonScope();
+                bind(Authorizer).toSelf().inSingletonScope();
+            }),
+        );
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+        const userDB = container.get<UserDB>(UserDB);
+        owner = await userDB.newUser();
+        stranger = await userDB.newUser();
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        const typeorm = container.get(TypeORM);
+        const dbConn = await typeorm.getConnection();
+        await dbConn.getRepository(DBTeam).delete({});
+        await (await typeorm.getConnection()).getRepository(DBUser).delete(owner.id);
+    });
+
+    it("should allow owners to get an invite", async () => {
+        const os = container.get(OrganizationService);
+        const org = await os.createOrganization(owner.id, "myorg");
+        expect(org.name).to.equal("myorg");
+
+        const invite = await os.getOrCreateInvite(owner.id, org.id);
+        expect(invite).to.not.be.undefined;
+
+        const invite2 = await os.getOrCreateInvite(owner.id, org.id);
+        expect(invite2.id).to.equal(invite.id);
+
+        const invite3 = await os.resetInvite(owner.id, org.id);
+        expect(invite3.id).to.not.equal(invite.id);
+    });
+
+    //TODO it("should not allow members to get an invite", async () => { once the organizationService can maintain members
+
+    it("should not allow strangers to get an invite", async () => {
+        const os = container.get(OrganizationService);
+        const org = await os.createOrganization(owner.id, "myorg");
+        expect(org.name).to.equal("myorg");
+
+        try {
+            await os.getOrCreateInvite(stranger.id, org.id);
+            fail("should have thrown");
+        } catch (e) {
+            expect(e.message).to.contain("not found");
+        }
+
+        // let's nmake sure an invite is created by the owner
+        const invite = await os.getOrCreateInvite(owner.id, org.id);
+        expect(invite).to.not.be.undefined;
+
+        // still the invite should not be accessible to strangers
+        try {
+            await os.getOrCreateInvite(stranger.id, org.id);
+            fail("should have thrown");
+        } catch (e) {
+            expect(e.message).to.contain("not found");
+        }
+    });
+});

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TeamDB } from "@gitpod/gitpod-db/lib";
+import { Organization, TeamMembershipInvite } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { Authorizer } from "../authorization/authorizer";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { OrganizationPermission } from "../authorization/definitions";
+
+@injectable()
+export class OrganizationService {
+    constructor(
+        @inject(TeamDB) private readonly teamDB: TeamDB,
+        @inject(Authorizer) private readonly auth: Authorizer,
+    ) {}
+    /**
+     * createOrganization creates a new organization
+     */
+    async createOrganization(userId: string, name: string): Promise<Organization> {
+        let result: Organization;
+        try {
+            result = await this.teamDB.transaction(async (db) => {
+                result = await db.createTeam(userId, name);
+                await this.auth.addOrganizationOwnerRole(result.id, userId);
+                return result;
+            });
+        } catch (err) {
+            if (result! && result.id) {
+                await this.auth.removeUserFromOrg(result.id, userId);
+            }
+
+            throw err;
+        }
+        return result;
+    }
+
+    /**
+     * getGenericInvite returns the generic invite for the given organization or creates one if no invite exists.
+     *
+     * @param userId
+     * @param orgID
+     * @returns
+     */
+    public async getOrCreateInvite(userId: string, orgID: string): Promise<TeamMembershipInvite> {
+        await this.checkPermissionAndThrow(userId, "invite_members", orgID);
+        const invite = await this.teamDB.findGenericInviteByTeamId(orgID);
+        if (invite) {
+            if (await this.teamDB.hasActiveSSO(orgID)) {
+                throw new ApplicationError(ErrorCodes.NOT_FOUND, "Invites are disabled for SSO-enabled organizations.");
+            }
+            return invite;
+        }
+        return this.resetInvite(userId, orgID);
+    }
+
+    public async resetInvite(userId: string, orgID: string): Promise<TeamMembershipInvite> {
+        await this.checkPermissionAndThrow(userId, "invite_members", orgID);
+        if (await this.teamDB.hasActiveSSO(orgID)) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Invites are disabled for SSO-enabled organizations.");
+        }
+        return this.teamDB.resetGenericInvite(orgID);
+    }
+
+    private async checkPermissionAndThrow(userId: string, permission: OrganizationPermission, orgID: string) {
+        if (await this.auth.hasPermissionOnOrganization(userId, permission, orgID)) {
+            return;
+        }
+        // check if the user has read permission
+        if ("read_info" === permission || !(await this.auth.hasPermissionOnOrganization(userId, "read_info", orgID))) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, `Organization ${orgID} not found.`);
+        }
+
+        throw new ApplicationError(
+            ErrorCodes.PERMISSION_DENIED,
+            `You do not have ${permission} on organization ${orgID}`,
+        );
+    }
+}

--- a/install/installer/pkg/components/spicedb/data/schema.yaml
+++ b/install/installer/pkg/components/spicedb/data/schema.yaml
@@ -18,7 +18,8 @@ schema: |-
 
     // Operations on Organization's Members
     permission read_members = member + owner
-    permission write_members = member + owner
+    permission invite_members = member + owner
+    permission write_members = owner
 
     // Any user in the organization can try to leave their organization
     permission leave = owner + member
@@ -100,6 +101,13 @@ assertions:
     - project:project_1#write_info@user:user_0
     - organization:org_1#write_settings@user:user_0
     - organization:org_1#write_git_provider@user:user_0
+    # user 0 can invite members to the organization
+    - organization:org_1#read_members@user:user_0
+    - organization:org_1#write_members@user:user_0
+    - organization:org_1#invite_members@user:user_0
+    # user 1 can read and invite members to the organization
+    - organization:org_1#read_members@user:user_1
+    - organization:org_1#invite_members@user:user_1
     # Org Owner can delete the organization
     - organization:org_1#delete@user:user_0
   assertFalse:
@@ -109,9 +117,12 @@ assertions:
     # non-member/owner cannot access organization
     - organization:org_1#read_info@user:user_3
     - organization:org_1#write_info@user:user_3
+    - organization:org_1#write_settings@user:user_1
     - organization:org_1#read_members@user:user_3
     - organization:org_1#write_members@user:user_3
-    - organization:org_1#write_settings@user:user_1
+    - organization:org_1#invite_members@user:user_3
+    # user 1 (member) can not write members
+    - organization:org_1#write_members@user:user_1
     # members are not allowed to:
     - organization:org_1#write_git_provider@user:user_1
 # validation should assert that a particular relation exists between an entity, and a subject
@@ -149,3 +160,13 @@ validation:
   - "[user:user_0] is <organization:org_1#owner>"
   organization:org_1#delete:
   - "[user:user_0] is <organization:org_1#owner>"
+  organization:org_1#read_members:
+  - "[user:user_0] is <organization:org_1#member>/<organization:org_1#owner>"
+  - "[user:user_1] is <organization:org_1#member>"
+  - "[user:user_2] is <organization:org_1#member>"
+  organization:org_1#write_members:
+  - "[user:user_0] is <organization:org_1#owner>"
+  organization:org_1#invite_members:
+  - "[user:user_0] is <organization:org_1#member>/<organization:org_1#owner>"
+  - "[user:user_1] is <organization:org_1#member>"
+  - "[user:user_2] is <organization:org_1#member>"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds an orgaization service and corresponding test, which includes testing spicedb permissions.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
 - review unit tests
 - play around with the preview env, e.g. join my org https://se-add-org-service.preview.gitpod-dev.com/login/sven's-org?org=551f2a25-602a-42f4-b5cf-da8008ed0f49

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-add-org-service</li>
	<li><b>🔗 URL</b> - <a href="https://se-add-org-service.preview.gitpod-dev.com/workspaces" target="_blank">se-add-org-service.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-add-org-service-gha.12301</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
