### PR TITLE
Fix LinkedIn connection bugs and surface errors

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -12,8 +12,10 @@ import { useAnalyticsTracking } from "./hooks/use-analytics-tracking";
 import { useUserLoader } from "./hooks/use-user-loader";
 import { Login } from "./Login";
 import { AppBlockingFlows } from "./app/AppBlockingFlows";
-import { Route, Switch, useHistory } from "react-router";
+import { Route, Switch, useHistory, useLocation } from "react-router";
 import { ErrorPages } from "./error-pages/ErrorPages";
+import { LinkedInCallback } from "react-linkedin-login-oauth2";
+import { useQueryParams } from "./hooks/use-query-params";
 
 export const StartWorkspaceModalKeyBinding = `${/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? "⌘" : "Ctrl﹢"}O`;
 
@@ -22,6 +24,8 @@ const App: FC = () => {
     const { user, loading } = useUserLoader();
     const currentOrgQuery = useCurrentOrg();
     const history = useHistory();
+    const location = useLocation();
+    const search = useQueryParams();
 
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
@@ -38,6 +42,10 @@ const App: FC = () => {
 
     // Setup analytics/tracking
     useAnalyticsTracking();
+
+    if (location.pathname === "/linkedin" && search.get("code") && search.get("state")) {
+        return <LinkedInCallback />;
+    }
 
     if (loading) {
         return <AppLoading />;

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -34,12 +34,10 @@ import { Blocked } from "./Blocked";
 // TODO: Can we bundle-split/lazy load these like other pages?
 import { BlockedRepositories } from "../admin/BlockedRepositories";
 import { Heading1, Subheading } from "../components/typography/headings";
-import { useQueryParams } from "../hooks/use-query-params";
 import { useCurrentUser } from "../user-context";
 import PersonalAccessTokenCreateView from "../user-settings/PersonalAccessTokensCreateView";
 import { CreateWorkspacePage } from "../workspaces/CreateWorkspacePage";
 import { WebsocketClients } from "./WebsocketClients";
-import { LinkedInCallback } from "react-linkedin-login-oauth2";
 import { BlockedEmailDomains } from "../admin/BlockedEmailDomains";
 
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));
@@ -83,7 +81,6 @@ export const AppRoutes = () => {
     const user = useCurrentUser();
     const [isWhatsNewShown, setWhatsNewShown] = useState(user && shouldSeeWhatsNew(user));
     const location = useLocation();
-    const search = useQueryParams();
 
     // TODO: Add a Route for this instead of inspecting location manually
     if (location.pathname.startsWith("/blocked")) {
@@ -97,10 +94,6 @@ export const AppRoutes = () => {
 
     if (isWhatsNewShown) {
         return <WhatsNew onClose={() => setWhatsNewShown(false)} />;
-    }
-
-    if (location.pathname === "/linkedin" && search.get("code") && search.get("state")) {
-        return <LinkedInCallback />;
     }
 
     // TODO: Try and encapsulate this in a route for "/" (check for hash in route component, render or redirect accordingly)

--- a/components/dashboard/src/onboarding/LinkedInBanner.tsx
+++ b/components/dashboard/src/onboarding/LinkedInBanner.tsx
@@ -48,7 +48,7 @@ export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
                     toast(
                         <>
                             <span>Error connecting with LinkedIn</span>
-                            {error.message && <span className="font-mono text-xs">{error.message}</span>}
+                            {error.message && <pre className="mt-2 whitespace-normal text-xs">{error.message}</pre>}
                         </>,
                     );
                 });

--- a/components/dashboard/src/onboarding/LinkedInBanner.tsx
+++ b/components/dashboard/src/onboarding/LinkedInBanner.tsx
@@ -13,11 +13,13 @@ import { Button } from "../components/Button";
 import SignInWithLinkedIn from "../images/sign-in-with-linkedin.svg";
 import { getGitpodService } from "../service/service";
 import { LinkedInProfile } from "@gitpod/gitpod-protocol";
+import { useToast } from "../components/toasts/Toasts";
 
 type Props = {
     onSuccess(profile: LinkedInProfile): void;
 };
 export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
+    const { toast } = useToast();
     const {
         data: clientID,
         isLoading,
@@ -43,6 +45,13 @@ export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
                 })
                 .catch((error) => {
                     console.error("LinkedIn connection failed", error);
+
+                    toast(
+                        <>
+                            <span>Error connecting with LinkedIn</span>
+                            {error.message && <span className="font-mono text-sm">{error.message}</span>}
+                        </>,
+                    );
                 });
         },
         onError: (error) => {

--- a/components/dashboard/src/onboarding/LinkedInBanner.tsx
+++ b/components/dashboard/src/onboarding/LinkedInBanner.tsx
@@ -37,7 +37,6 @@ export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
         redirectUri: `${window.location.origin}/linkedin`,
         scope: "r_liteprofile r_emailaddress",
         onSuccess: (code) => {
-            console.log("success", code);
             getGitpodService()
                 .server.connectWithLinkedIn(code)
                 .then((profile) => {
@@ -49,7 +48,7 @@ export const LinkedInBanner: FC<Props> = ({ onSuccess }) => {
                     toast(
                         <>
                             <span>Error connecting with LinkedIn</span>
-                            {error.message && <span className="font-mono text-sm">{error.message}</span>}
+                            {error.message && <span className="font-mono text-xs">{error.message}</span>}
                         </>,
                     );
                 });

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -54,8 +54,8 @@ export class LinkedInService {
     private async getLinkedInProfile(accessToken: string): Promise<LinkedInProfile> {
         // TODO: update these to use newer versioned apis
         const profileUrl =
-            "https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
-        const emailUrl = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
+            "https://api.linkedin.com/rest/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
+        const emailUrl = "https://api.linkedin.com/rest/emailAddress?q=members&projection=(elements*(handle~))";
 
         // Fetch both the user's profile and email address in parallel
         const [profileResponse, emailResponse] = await Promise.all([
@@ -63,12 +63,14 @@ export class LinkedInService {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
+                    "LinkedIn-Version": "202306",
                 },
             }),
             fetch(emailUrl, {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
+                    "LinkedIn-Version": "202306",
                 },
             }),
         ]);

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -34,6 +34,7 @@ export class LinkedInService {
             );
         }
         const redirectUri = this.config.hostUrl.with({ pathname: "/linkedin" }).toString();
+        // TODO: update this to use newer versioned apis if needed
         const url = `https://www.linkedin.com/oauth/v2/accessToken?grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&client_id=${clientId}&client_secret=${clientSecret}`;
         const response = await fetch(url, {
             method: "POST",
@@ -51,6 +52,7 @@ export class LinkedInService {
     // Retrieve the user's profile from LinkedIn using the following API:
     // https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin
     private async getLinkedInProfile(accessToken: string): Promise<LinkedInProfile> {
+        // TODO: update these to use newer versioned apis
         const profileUrl =
             "https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
         const emailUrl = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -54,7 +54,7 @@ export class LinkedInService {
     private async getLinkedInProfile(accessToken: string): Promise<LinkedInProfile> {
         // TODO: update these to use newer versioned apis
         const profileUrl =
-            "https://api.linkedin.com/rest/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
+            "https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
         const emailUrl = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
 
         // Fetch both the user's profile and email address in parallel
@@ -63,7 +63,7 @@ export class LinkedInService {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
-                    "LinkedIn-Version": "202306",
+                    // "LinkedIn-Version": "202306",
                 },
             }),
             fetch(emailUrl, {

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -34,7 +34,6 @@ export class LinkedInService {
             );
         }
         const redirectUri = this.config.hostUrl.with({ pathname: "/linkedin" }).toString();
-        // TODO: update this to use newer versioned apis if needed
         const url = `https://www.linkedin.com/oauth/v2/accessToken?grant_type=authorization_code&code=${code}&redirect_uri=${redirectUri}&client_id=${clientId}&client_secret=${clientSecret}`;
         const response = await fetch(url, {
             method: "POST",
@@ -52,7 +51,6 @@ export class LinkedInService {
     // Retrieve the user's profile from LinkedIn using the following API:
     // https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin
     private async getLinkedInProfile(accessToken: string): Promise<LinkedInProfile> {
-        // TODO: update these to use newer versioned apis
         const profileUrl =
             "https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
         const emailUrl = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
@@ -63,7 +61,6 @@ export class LinkedInService {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
-                    // "LinkedIn-Version": "202306",
                 },
             }),
             fetch(emailUrl, {
@@ -75,7 +72,6 @@ export class LinkedInService {
         ]);
 
         const profileData = await profileResponse.json();
-        console.log("profileData", profileData);
         if (profileData.error) {
             throw new Error("Could not get LinkedIn lite profile: " + profileData.error_description);
         }
@@ -84,7 +80,6 @@ export class LinkedInService {
         }
 
         const emailData = await emailResponse.json();
-        console.log("emailData", emailData);
         if (emailData.error) {
             throw new Error("Could not get LinkedIn email address: " + emailData.error_description);
         }

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -75,6 +75,7 @@ export class LinkedInService {
         ]);
 
         const profileData = await profileResponse.json();
+        console.log("profileData", profileData);
         if (profileData.error) {
             throw new Error("Could not get LinkedIn lite profile: " + profileData.error_description);
         }
@@ -83,6 +84,7 @@ export class LinkedInService {
         }
 
         const emailData = await emailResponse.json();
+        console.log("emailData", emailData);
         if (emailData.error) {
             throw new Error("Could not get LinkedIn email address: " + emailData.error_description);
         }

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -55,7 +55,7 @@ export class LinkedInService {
         // TODO: update these to use newer versioned apis
         const profileUrl =
             "https://api.linkedin.com/rest/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))";
-        const emailUrl = "https://api.linkedin.com/rest/emailAddress?q=members&projection=(elements*(handle~))";
+        const emailUrl = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
 
         // Fetch both the user's profile and email address in parallel
         const [profileResponse, emailResponse] = await Promise.all([
@@ -70,7 +70,6 @@ export class LinkedInService {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
-                    "LinkedIn-Version": "202306",
                 },
             }),
         ]);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This surfaces errors during the Connect w/ LinkedIn flow to the user via a toast vs. not showing them anything. It also fixes a bug where the `<LinkedInCallback/>` should be moved up to the top of the render tree so it's not prevented by any other blocking flows.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-341

## How to test
<!-- Provide steps to test this PR -->
This one is tricky to test as it depends on an environment setup w/ the right secrets setup. Currently the preview environment for this PR has them setup, so you should be able to onboard and try to connect with linked in. Verify the flow works.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-3c8ac4154b2</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-3c8ac4154b2.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-3c8ac4154b2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-web-341-update-deprecated-linkedin-api-methods-gha.12349</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
