### PR TITLE
[dashboard] show warning when select code desktop

### DIFF
--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -36,6 +36,7 @@ export interface AlertProps {
     onClose?: () => void;
     showIcon?: boolean;
     iconColor?: string;
+    iconSize?: string;
     icon?: React.ReactNode;
     rounded?: boolean;
     children?: React.ReactNode;
@@ -119,7 +120,7 @@ export default function Alert(props: AlertProps) {
             )}
         >
             {showIcon && (
-                <span className={`mt-1 mr-4 h-4 w-4 ${props.iconColor ?? info.iconColor}`}>
+                <span className={`mt-1 mr-4 ${props.iconSize ?? "h-4 w-4"} ${props.iconColor ?? info.iconColor}`}>
                     {props.icon ?? info.icon}
                 </span>
             )}

--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -35,6 +35,7 @@ export interface AlertProps {
     autoFocusClose?: boolean;
     onClose?: () => void;
     showIcon?: boolean;
+    iconColor?: string;
     icon?: React.ReactNode;
     rounded?: boolean;
     children?: React.ReactNode;
@@ -117,7 +118,11 @@ export default function Alert(props: AlertProps) {
                 rounded ? "rounded" : "",
             )}
         >
-            {showIcon && <span className={`mt-1 mr-4 h-4 w-4 ${info.iconColor}`}>{props.icon ?? info.icon}</span>}
+            {showIcon && (
+                <span className={`mt-1 mr-4 h-4 w-4 ${props.iconColor ?? info.iconColor}`}>
+                    {props.icon ?? info.icon}
+                </span>
+            )}
             <span className="flex-1 text-left">{props.children}</span>
             {props.closable && (
                 <span className={`mt-1 ml-4`}>

--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -35,8 +35,6 @@ export interface AlertProps {
     autoFocusClose?: boolean;
     onClose?: () => void;
     showIcon?: boolean;
-    iconColor?: string;
-    iconSize?: string;
     icon?: React.ReactNode;
     rounded?: boolean;
     children?: React.ReactNode;
@@ -119,11 +117,7 @@ export default function Alert(props: AlertProps) {
                 rounded ? "rounded" : "",
             )}
         >
-            {showIcon && (
-                <span className={`mt-1 mr-4 ${props.iconSize ?? "h-4 w-4"} ${props.iconColor ?? info.iconColor}`}>
-                    {props.icon ?? info.icon}
-                </span>
-            )}
+            {showIcon && <span className={`mt-1 mr-4 h-4 w-4 ${info.iconColor}`}>{props.icon ?? info.icon}</span>}
             <span className="flex-1 text-left">{props.children}</span>
             {props.closable && (
                 <span className={`mt-1 ml-4`}>

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -24,6 +24,8 @@ const featureFlags = {
     enableDedicatedOnboardingFlow: false,
     phoneVerificationByCall: false,
     doRetryUserLoader: true,
+    // Local SSH feature of VS Code Desktop Extension
+    gitpod_desktop_use_local_ssh_proxy: false,
 };
 
 export const useFeatureFlag = (featureFlag: keyof typeof featureFlags) => {

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -458,8 +458,8 @@ function LocalSSHWarning(props: { className: string }) {
     return (
         <div className={props.className}>
             <Alert light className="bg-gray-100 dark:bg-gray-800" type="info">
-                To make VS Code Desktop open seamlessly we will add a single entry to your local SSH configuration.
-                Gitpod does not read any of your existing SSH configurations.&nbsp;
+                Choosing VS Code for Desktop will add a single entry to your local SSH configuration.
+                Gitpod won't interfere with your existing SSH configurations.&nbsp;
                 <a
                     className="gp-link"
                     href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#ssh-configuration-modifications"

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -458,11 +458,11 @@ function LocalSSHWarning(props: { className: string }) {
     return (
         <div className={props.className}>
             <Alert light className="bg-gray-100 dark:bg-gray-800" type="info">
-                Choosing VS Code for Desktop will add a single entry to your local SSH configuration.
-                Gitpod won't interfere with your existing SSH configurations.&nbsp;
+                Choosing VS Code for Desktop will add a single entry to your local SSH configuration. Gitpod won't
+                interfere with your existing SSH configurations.&nbsp;
                 <a
                     className="gp-link"
-                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#ssh-configuration-modifications"
+                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#connecting-to-vs-code-desktop"
                     target="_blank"
                     rel="noreferrer"
                 >

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -40,9 +40,6 @@ import { useDirtyState } from "../hooks/use-dirty-state";
 import { LinkButton } from "../components/LinkButton";
 import { InputField } from "../components/forms/InputField";
 import Alert from "../components/Alert";
-import { ReactComponent as Exclamation2 } from "../images/exclamation2.svg";
-import { isGitpodIo } from "../utils";
-import FeedbackFormModal from "../feedback-form/FeedbackModal";
 import { useFeatureFlag } from "../data/featureflag-query";
 
 export function CreateWorkspacePage() {
@@ -453,7 +450,6 @@ export function CreateWorkspacePage() {
 
 function LocalSSHWarning(props: { className: string }) {
     const isLocalSSHProxyEnabled = useFeatureFlag("gitpod_desktop_use_local_ssh_proxy");
-    const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
     if (!isLocalSSHProxyEnabled) {
         return null;
@@ -461,14 +457,7 @@ function LocalSSHWarning(props: { className: string }) {
 
     return (
         <div className={props.className}>
-            <Alert
-                light
-                className="bg-gray-100 dark:bg-gray-800"
-                type="info"
-                iconSize="w-8 h-8"
-                icon={<Exclamation2 className="h-full w-full" />}
-                iconColor="text-gray-500"
-            >
+            <Alert light className="bg-gray-100 dark:bg-gray-800" type="info">
                 To make VS Code Desktop open seamlessly we will add a single entry to your local SSH configuration.
                 Gitpod does not read any of your existing SSH configurations.&nbsp;
                 <a
@@ -477,7 +466,7 @@ function LocalSSHWarning(props: { className: string }) {
                     target="_blank"
                     rel="noreferrer"
                 >
-                    More Detail
+                    Learn more
                 </a>
                 <div className="flex mt-2 text-sm">
                     Comment on&nbsp;
@@ -489,20 +478,6 @@ function LocalSSHWarning(props: { className: string }) {
                     >
                         feedback issue
                     </a>
-                    {isGitpodIo() && (
-                        <span>
-                            &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a
-                                className="gp-link"
-                                // eslint-disable-next-line no-script-url
-                                href="javascript:void(0)"
-                                onClick={() => setFeedbackFormVisible(true)}
-                            >
-                                submit feedback
-                            </a>
-                        </span>
-                    )}
-                    {isFeedbackFormVisible && <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />}
                 </div>
             </Alert>
         </div>

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -468,17 +468,15 @@ function LocalSSHWarning(props: { className: string }) {
                 >
                     Learn more
                 </a>
-                <div className="flex mt-2 text-sm">
-                    Comment on&nbsp;
-                    <a
-                        href="https://github.com/gitpod-io/gitpod/issues/18109"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="gp-link"
-                    >
-                        feedback issue
-                    </a>
-                </div>
+                &nbsp;&middot;&nbsp;
+                <a
+                    className="gp-link"
+                    href="https://github.com/gitpod-io/gitpod/issues/18109"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Send feedback
+                </a>
             </Alert>
         </div>
     );

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -40,6 +40,9 @@ import { useDirtyState } from "../hooks/use-dirty-state";
 import { LinkButton } from "../components/LinkButton";
 import { InputField } from "../components/forms/InputField";
 import Alert from "../components/Alert";
+import { ReactComponent as Exclamation2 } from "../images/exclamation2.svg";
+import { isGitpodIo } from "../utils";
+import FeedbackFormModal from "../feedback-form/FeedbackModal";
 
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
@@ -179,6 +182,8 @@ export function CreateWorkspacePage() {
         );
     }, [workspaces.data, workspaceContext.data]);
     const [selectAccountError, setSelectAccountError] = useState<SelectAccountPayload | undefined>(undefined);
+
+    const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
     const createWorkspace = useCallback(
         async (options?: Omit<GitpodServer.CreateWorkspaceOptions, "contextUrl" | "organizationId">) => {
@@ -395,6 +400,54 @@ export function CreateWorkspacePage() {
                             loading={workspaceContext.isLoading}
                         />
                     </InputField>
+
+                    {selectedIde === "code-desktop" && (
+                        <>
+                            <Alert
+                                className="mt-4"
+                                type="info"
+                                icon={<Exclamation2 className="w-4 h-4"></Exclamation2>}
+                                iconColor="text-yellow-400 dark:text-yellow-900"
+                            >
+                                To make VS Code Desktop open seamlessly we will add a single entry to your local SSH
+                                configuration. Gitpod does not read any of your existing SSH configurations.&nbsp;
+                                <a
+                                    className="gp-link"
+                                    href="https://deploy-preview-3800--gitpod-kumquat.netlify.app/docs/references/ides-and-editors/vscode-desktop-local-ssh"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    More Detail
+                                </a>
+                                <div className="flex mt-2 text-sm">
+                                    Common on&nbsp;
+                                    <a
+                                        href="https://github.com/gitpod-io/gitpod/issues/18109"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="gp-link"
+                                    >
+                                        feedback issue
+                                    </a>
+                                    {isGitpodIo() && (
+                                        <span>
+                                            &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                            <a
+                                                className="gp-link"
+                                                href="#"
+                                                onClick={() => setFeedbackFormVisible(true)}
+                                            >
+                                                submit feedback
+                                            </a>
+                                        </span>
+                                    )}
+                                    {isFeedbackFormVisible && (
+                                        <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />
+                                    )}
+                                </div>
+                            </Alert>
+                        </>
+                    )}
 
                     <InputField error={errorWsClass}>
                         <SelectWorkspaceClassComponent

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -462,7 +462,7 @@ function LocalSSHWarning(props: { className: string }) {
                 Gitpod does not read any of your existing SSH configurations.&nbsp;
                 <a
                     className="gp-link"
-                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#modify-ssh-config-file"
+                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#ssh-configuration-modifications"
                     target="_blank"
                     rel="noreferrer"
                 >

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -422,7 +422,7 @@ export function CreateWorkspacePage() {
                     </Button>
                 </div>
 
-                {selectedIde === "code-desktop" && <LocalSSHWarning className="px-6" />}
+                {selectedIde === "code-desktop" && <LocalSSHWarning className="mx-6 mt-3 rounded-lg overflow-hidden" />}
                 {workspaceContext.data && (
                     <RememberOptions
                         disabled={workspaceContext.isLoading || createWorkspaceMutation.isStarting}
@@ -463,7 +463,7 @@ function LocalSSHWarning(props: { className: string }) {
         <div className={props.className}>
             <Alert
                 light
-                className="mt-4 bg-gray-100 dark:bg-gray-800"
+                className="bg-gray-100 dark:bg-gray-800"
                 type="info"
                 iconSize="w-8 h-8"
                 icon={<Exclamation2 className="h-full w-full" />}

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -401,54 +401,6 @@ export function CreateWorkspacePage() {
                         />
                     </InputField>
 
-                    {selectedIde === "code-desktop" && (
-                        <>
-                            <Alert
-                                className="mt-4"
-                                type="info"
-                                icon={<Exclamation2 className="w-4 h-4"></Exclamation2>}
-                                iconColor="text-yellow-400 dark:text-yellow-900"
-                            >
-                                To make VS Code Desktop open seamlessly we will add a single entry to your local SSH
-                                configuration. Gitpod does not read any of your existing SSH configurations.&nbsp;
-                                <a
-                                    className="gp-link"
-                                    href="https://deploy-preview-3800--gitpod-kumquat.netlify.app/docs/references/ides-and-editors/vscode-desktop-local-ssh"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    More Detail
-                                </a>
-                                <div className="flex mt-2 text-sm">
-                                    Common on&nbsp;
-                                    <a
-                                        href="https://github.com/gitpod-io/gitpod/issues/18109"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="gp-link"
-                                    >
-                                        feedback issue
-                                    </a>
-                                    {isGitpodIo() && (
-                                        <span>
-                                            &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                            <a
-                                                className="gp-link"
-                                                href="#"
-                                                onClick={() => setFeedbackFormVisible(true)}
-                                            >
-                                                submit feedback
-                                            </a>
-                                        </span>
-                                    )}
-                                    {isFeedbackFormVisible && (
-                                        <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />
-                                    )}
-                                </div>
-                            </Alert>
-                        </>
-                    )}
-
                     <InputField error={errorWsClass}>
                         <SelectWorkspaceClassComponent
                             onSelectionChange={setSelectedWsClass}
@@ -470,6 +422,57 @@ export function CreateWorkspacePage() {
                         {createWorkspaceMutation.isStarting ? "Opening Workspace ..." : "Continue"}
                     </Button>
                 </div>
+
+                {selectedIde === "code-desktop" && (
+                    <div className="px-6">
+                        <Alert
+                            light
+                            className="mt-4 bg-gray-100 dark:bg-gray-800"
+                            type="info"
+                            iconSize="w-8 h-8"
+                            icon={<Exclamation2 className="h-full w-full" />}
+                            iconColor="text-gray-500"
+                        >
+                            To make VS Code Desktop open seamlessly we will add a single entry to your local SSH
+                            configuration. Gitpod does not read any of your existing SSH configurations.&nbsp;
+                            <a
+                                className="gp-link"
+                                href="https://deploy-preview-3800--gitpod-kumquat.netlify.app/docs/references/ides-and-editors/vscode-desktop-local-ssh"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                More Detail
+                            </a>
+                            <div className="flex mt-2 text-sm">
+                                Common on&nbsp;
+                                <a
+                                    href="https://github.com/gitpod-io/gitpod/issues/18109"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="gp-link"
+                                >
+                                    feedback issue
+                                </a>
+                                {isGitpodIo() && (
+                                    <span>
+                                        &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                        <a
+                                            className="gp-link"
+                                            // eslint-disable-next-line no-script-url
+                                            href="javascript:void(0)"
+                                            onClick={() => setFeedbackFormVisible(true)}
+                                        >
+                                            submit feedback
+                                        </a>
+                                    </span>
+                                )}
+                                {isFeedbackFormVisible && (
+                                    <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />
+                                )}
+                            </div>
+                        </Alert>
+                    </div>
+                )}
                 {workspaceContext.data && (
                     <RememberOptions
                         disabled={workspaceContext.isLoading || createWorkspaceMutation.isStarting}

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -43,6 +43,7 @@ import Alert from "../components/Alert";
 import { ReactComponent as Exclamation2 } from "../images/exclamation2.svg";
 import { isGitpodIo } from "../utils";
 import FeedbackFormModal from "../feedback-form/FeedbackModal";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
@@ -182,8 +183,6 @@ export function CreateWorkspacePage() {
         );
     }, [workspaces.data, workspaceContext.data]);
     const [selectAccountError, setSelectAccountError] = useState<SelectAccountPayload | undefined>(undefined);
-
-    const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
     const createWorkspace = useCallback(
         async (options?: Omit<GitpodServer.CreateWorkspaceOptions, "contextUrl" | "organizationId">) => {
@@ -423,56 +422,7 @@ export function CreateWorkspacePage() {
                     </Button>
                 </div>
 
-                {selectedIde === "code-desktop" && (
-                    <div className="px-6">
-                        <Alert
-                            light
-                            className="mt-4 bg-gray-100 dark:bg-gray-800"
-                            type="info"
-                            iconSize="w-8 h-8"
-                            icon={<Exclamation2 className="h-full w-full" />}
-                            iconColor="text-gray-500"
-                        >
-                            To make VS Code Desktop open seamlessly we will add a single entry to your local SSH
-                            configuration. Gitpod does not read any of your existing SSH configurations.&nbsp;
-                            <a
-                                className="gp-link"
-                                href="https://www.gitpod.io/docs/references/ides-and-editors/vscode-desktop-local-ssh"
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                More Detail
-                            </a>
-                            <div className="flex mt-2 text-sm">
-                                Common on&nbsp;
-                                <a
-                                    href="https://github.com/gitpod-io/gitpod/issues/18109"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="gp-link"
-                                >
-                                    feedback issue
-                                </a>
-                                {isGitpodIo() && (
-                                    <span>
-                                        &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                        <a
-                                            className="gp-link"
-                                            // eslint-disable-next-line no-script-url
-                                            href="javascript:void(0)"
-                                            onClick={() => setFeedbackFormVisible(true)}
-                                        >
-                                            submit feedback
-                                        </a>
-                                    </span>
-                                )}
-                                {isFeedbackFormVisible && (
-                                    <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />
-                                )}
-                            </div>
-                        </Alert>
-                    </div>
-                )}
+                {selectedIde === "code-desktop" && <LocalSSHWarning className="px-6" />}
                 {workspaceContext.data && (
                     <RememberOptions
                         disabled={workspaceContext.isLoading || createWorkspaceMutation.isStarting}
@@ -497,6 +447,64 @@ export function CreateWorkspacePage() {
                     </div>
                 )}
             </div>
+        </div>
+    );
+}
+
+function LocalSSHWarning(props: { className: string }) {
+    const isLocalSSHProxyEnabled = useFeatureFlag("gitpod_desktop_use_local_ssh_proxy");
+    const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
+
+    if (!isLocalSSHProxyEnabled) {
+        return null;
+    }
+
+    return (
+        <div className={props.className}>
+            <Alert
+                light
+                className="mt-4 bg-gray-100 dark:bg-gray-800"
+                type="info"
+                iconSize="w-8 h-8"
+                icon={<Exclamation2 className="h-full w-full" />}
+                iconColor="text-gray-500"
+            >
+                To make VS Code Desktop open seamlessly we will add a single entry to your local SSH configuration.
+                Gitpod does not read any of your existing SSH configurations.&nbsp;
+                <a
+                    className="gp-link"
+                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode-desktop-local-ssh"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    More Detail
+                </a>
+                <div className="flex mt-2 text-sm">
+                    Common on&nbsp;
+                    <a
+                        href="https://github.com/gitpod-io/gitpod/issues/18109"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="gp-link"
+                    >
+                        feedback issue
+                    </a>
+                    {isGitpodIo() && (
+                        <span>
+                            &nbsp;or {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                            <a
+                                className="gp-link"
+                                // eslint-disable-next-line no-script-url
+                                href="javascript:void(0)"
+                                onClick={() => setFeedbackFormVisible(true)}
+                            >
+                                submit feedback
+                            </a>
+                        </span>
+                    )}
+                    {isFeedbackFormVisible && <FeedbackFormModal onClose={() => setFeedbackFormVisible(false)} />}
+                </div>
+            </Alert>
         </div>
     );
 }

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -437,7 +437,7 @@ export function CreateWorkspacePage() {
                             configuration. Gitpod does not read any of your existing SSH configurations.&nbsp;
                             <a
                                 className="gp-link"
-                                href="https://deploy-preview-3800--gitpod-kumquat.netlify.app/docs/references/ides-and-editors/vscode-desktop-local-ssh"
+                                href="https://www.gitpod.io/docs/references/ides-and-editors/vscode-desktop-local-ssh"
                                 target="_blank"
                                 rel="noreferrer"
                             >

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -473,14 +473,14 @@ function LocalSSHWarning(props: { className: string }) {
                 Gitpod does not read any of your existing SSH configurations.&nbsp;
                 <a
                     className="gp-link"
-                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode-desktop-local-ssh"
+                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#modify-ssh-config-file"
                     target="_blank"
                     rel="noreferrer"
                 >
                     More Detail
                 </a>
                 <div className="flex mt-2 text-sm">
-                    Common on&nbsp;
+                    Comment on&nbsp;
                     <a
                         href="https://github.com/gitpod-io/gitpod/issues/18109"
                         target="_blank"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Blocked by https://github.com/gitpod-io/website/pull/3800

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- It should show warning when select VS Code Desktop in new workspace view https://hw-local-ssh-warning.preview.gitpod-dev.com/new
- It should hide if you add your userId to [configcat](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=97590) and disable it

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-local-ssh-warning</li>
	<li><b>🔗 URL</b> - <a href="https://hw-local-ssh-warning.preview.gitpod-dev.com/workspaces" target="_blank">hw-local-ssh-warning.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-local-ssh-warning-gha.12348</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
