### PR TITLE
[server] Use our own error type

### DIFF
--- a/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
@@ -12,8 +12,7 @@ import { DBUser } from "./entity/db-user";
 import * as chai from "chai";
 import { TeamDB } from "../team-db";
 import { DBTeam } from "./entity/db-team";
-import { ResponseError } from "vscode-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 const expect = chai.expect;
 
 @suite(timeout(10000))
@@ -52,8 +51,8 @@ export class TeamDBSpec {
             await this.teamDB.createTeam(user.id, "X");
             expect.fail("Team name too short");
         } catch (error) {
-            if (error instanceof ResponseError && error.code === ErrorCodes.BAD_REQUEST) {
-                // expected ResponseError of code BAD_REQUEST
+            if (error instanceof ApplicationError && error.code === ErrorCodes.BAD_REQUEST) {
+                // expected ApplicationError of code BAD_REQUEST
             } else {
                 expect.fail("Unexpected error: " + error);
             }
@@ -65,8 +64,8 @@ export class TeamDBSpec {
             );
             expect.fail("Team name too long");
         } catch (error) {
-            if (error instanceof ResponseError && error.code === ErrorCodes.BAD_REQUEST) {
-                // expected ResponseError of code BAD_REQUEST
+            if (error instanceof ApplicationError && error.code === ErrorCodes.BAD_REQUEST) {
+                // expected ApplicationError of code BAD_REQUEST
             } else {
                 expect.fail("Unexpected error: " + error);
             }

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -4,89 +4,116 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-export namespace ErrorCodes {
-    // 400 Unauthorized
-    export const BAD_REQUEST = 400;
+import { scrubber } from "../util/scrubbing";
 
-    // 401 Unauthorized
-    export const NOT_AUTHENTICATED = 401;
+export class ApplicationError extends Error {
+    constructor(public readonly code: ErrorCode, message: string, public readonly data?: any) {
+        super(message);
+        this.data = scrubber.scrub(this.data, true);
+    }
 
-    // 403 Forbidden
-    export const PERMISSION_DENIED = 403;
+    toJson() {
+        return {
+            code: this.code,
+            message: this.message,
+            data: this.data,
+        };
+    }
+}
 
-    // 404 Not Found
-    export const NOT_FOUND = 404;
+export namespace ApplicationError {
+    export function hasErrorCode(e: any): e is Error & { code: ErrorCode } {
+        return e && e.code !== undefined;
+    }
+}
 
-    // 409 Conflict (e.g. already existing)
-    export const CONFLICT = 409;
-
-    // 411 No User
-    export const NEEDS_VERIFICATION = 411;
-
-    // 412 Precondition Failed
-    export const PRECONDITION_FAILED = 412;
-
-    // 429 Too Many Requests
-    export const TOO_MANY_REQUESTS = 429;
-
-    // 430 Repository not whitelisted (custom status code)
-    export const REPOSITORY_NOT_WHITELISTED = 430;
-
-    // 440 Prebuilds now always require a project (custom status code)
-    export const PROJECT_REQUIRED = 440;
-
-    // 451 Out of credits
-    export const PAYMENT_SPENDING_LIMIT_REACHED = 451;
-
-    // 451 Error creating a subscription
-    export const SUBSCRIPTION_ERROR = 452;
-
-    // 455 Invalid cost center (custom status code)
-    export const INVALID_COST_CENTER = 455;
-
-    // 460 Context Parse Error (custom status code)
-    export const CONTEXT_PARSE_ERROR = 460;
-
-    // 461 Invalid gitpod yml (custom status code)
-    export const INVALID_GITPOD_YML = 461;
-
-    // 470 User Blocked (custom status code)
-    export const USER_BLOCKED = 470;
-
-    // 471 User Deleted (custom status code)
-    export const USER_DELETED = 471;
-
-    // 472 Terms Acceptance Required (custom status code)
-    export const USER_TERMS_ACCEPTANCE_REQUIRED = 472;
-
-    // 481 Professional plan is required for this operation
-    export const PLAN_PROFESSIONAL_REQUIRED = 481;
-
-    // 490 Too Many Running Workspace
-    export const TOO_MANY_RUNNING_WORKSPACES = 490;
-
-    // 500 Internal Server Error
-    export const INTERNAL_SERVER_ERROR = 500;
-
-    // 501 EE Feature
-    export const EE_FEATURE = 501;
-
-    // 555 EE License Required
-    export const EE_LICENSE_REQUIRED = 555;
-
-    // 601 SaaS Feature
-    export const SAAS_FEATURE = 601;
-
-    // 630 Snapshot Error
-    export const SNAPSHOT_ERROR = 630;
-
-    // 640 Headless logs are not available (yet)
-    export const HEADLESS_LOG_NOT_YET_AVAILABLE = 640;
-
-    // 650 Invalid Value
-    export const INVALID_VALUE = 650;
-
-    export function isUserError(code: number): boolean {
+export namespace ErrorCode {
+    export function isUserError(code: number | ErrorCode) {
         return code >= 400 && code < 500;
     }
 }
+
+export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];
+
+export const ErrorCodes = {
+    // 400 Unauthorized
+    BAD_REQUEST: 400 as const,
+
+    // 401 Unauthorized
+    NOT_AUTHENTICATED: 401 as const,
+
+    // 403 Forbidden
+    PERMISSION_DENIED: 403 as const,
+
+    // 404 Not Found
+    NOT_FOUND: 404 as const,
+
+    // 409 Conflict (e.g. already existing)
+    CONFLICT: 409 as const,
+
+    // 411 No User
+    NEEDS_VERIFICATION: 411 as const,
+
+    // 412 Precondition Failed
+    PRECONDITION_FAILED: 412 as const,
+
+    // 429 Too Many Requests
+    TOO_MANY_REQUESTS: 429 as const,
+
+    // 430 Repository not whitelisted (custom status code)
+    REPOSITORY_NOT_WHITELISTED: 430 as const,
+
+    // 440 Prebuilds now always require a project (custom status code)
+    PROJECT_REQUIRED: 440 as const,
+
+    // 451 Out of credits
+    PAYMENT_SPENDING_LIMIT_REACHED: 451 as const,
+
+    // 451 Error creating a subscription
+    SUBSCRIPTION_ERROR: 452 as const,
+
+    // 455 Invalid cost center (custom status code)
+    INVALID_COST_CENTER: 455 as const,
+
+    // 460 Context Parse Error (custom status code)
+    CONTEXT_PARSE_ERROR: 460 as const,
+
+    // 461 Invalid gitpod yml (custom status code)
+    INVALID_GITPOD_YML: 461 as const,
+
+    // 470 User Blocked (custom status code)
+    USER_BLOCKED: 470 as const,
+
+    // 471 User Deleted (custom status code)
+    USER_DELETED: 471 as const,
+
+    // 472 Terms Acceptance Required (custom status code)
+    USER_TERMS_ACCEPTANCE_REQUIRED: 472 as const,
+
+    // 481 Professional plan is required for this operation
+    PLAN_PROFESSIONAL_REQUIRED: 481 as const,
+
+    // 490 Too Many Running Workspace
+    TOO_MANY_RUNNING_WORKSPACES: 490 as const,
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR: 500 as const,
+
+    // 501 EE Feature
+    EE_FEATURE: 501 as const,
+
+    // 555 EE License Required
+    EE_LICENSE_REQUIRED: 555 as const,
+
+    // 601 SaaS Feature
+    SAAS_FEATURE: 601 as const,
+
+    // 630 Snapshot Error
+    SNAPSHOT_ERROR: 630 as const,
+
+    // 640 Headless logs are not available (yet)
+    HEADLESS_LOG_NOT_YET_AVAILABLE: 640 as const,
+
+    // 650 Invalid Value
+    INVALID_VALUE: 650 as const,
+};

--- a/components/gitpod-protocol/src/messaging/proxy-factory.ts
+++ b/components/gitpod-protocol/src/messaging/proxy-factory.ts
@@ -5,11 +5,12 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { MessageConnection, ResponseError } from "vscode-jsonrpc";
+import { MessageConnection } from "vscode-jsonrpc";
 import { Event, Emitter } from "../util/event";
 import { Disposable } from "../util/disposable";
 import { ConnectionHandler } from "./handler";
 import { log } from "../util/logging";
+import { ApplicationError } from "./error";
 
 export type JsonRpcServer<Client> = Disposable & {
     /**
@@ -142,7 +143,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
         try {
             return await this.target[method](...args);
         } catch (e) {
-            if (e instanceof ResponseError) {
+            if (ApplicationError.hasErrorCode(e)) {
                 log.info(`Request ${method} unsuccessful: ${e.code}/"${e.message}"`, { method, args });
             } else {
                 log.error(`Request ${method} failed with internal server error`, e, { method, args });

--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -14,10 +14,11 @@ let component: string | undefined;
 let version: string | undefined;
 
 export interface LogContext {
-    instanceId?: string;
+    organizationId?: string;
     sessionId?: string;
     userId?: string;
     workspaceId?: string;
+    instanceId?: string;
 }
 export namespace LogContext {
     export function from(params: { userId?: string; user?: any; request?: any }) {

--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -9,7 +9,6 @@ import { TracingConfig, initTracerFromEnv } from "jaeger-client";
 import { Sampler, SamplingDecision } from "./jaeger-client-types";
 import { initGlobalTracer } from "opentracing";
 import { injectable } from "inversify";
-import { ResponseError } from "vscode-jsonrpc";
 import { log, LogContext } from "./logging";
 
 export interface TraceContext {
@@ -92,7 +91,7 @@ export namespace TraceContext {
     export function setJsonRPCError(
         ctx: TraceContext,
         method: string,
-        err: ResponseError<any>,
+        err: Error & { code: number },
         withStatusCode: boolean = false,
     ) {
         if (!ctx.span) {

--- a/components/server/src/auth/verification-service.ts
+++ b/components/server/src/auth/verification-service.ts
@@ -12,8 +12,7 @@ import { Twilio } from "twilio";
 import { ServiceContext } from "twilio/lib/rest/verify/v2/service";
 import { TeamDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { ConfigCatClientFactory } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { VerificationInstance } from "twilio/lib/rest/verify/v2/service/verification";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 
@@ -89,13 +88,13 @@ export class VerificationService {
         const isBlockedNumber = this.userDB.isBlockedPhoneNumber(phoneNumber);
         const usages = await this.userDB.countUsagesOfPhoneNumber(phoneNumber);
         if (usages > 3) {
-            throw new ResponseError(
+            throw new ApplicationError(
                 ErrorCodes.INVALID_VALUE,
                 "The given phone number has been used more than three times.",
             );
         }
         if (await isBlockedNumber) {
-            throw new ResponseError(ErrorCodes.INVALID_VALUE, "The given phone number is blocked due to abuse.");
+            throw new ApplicationError(ErrorCodes.INVALID_VALUE, "The given phone number is blocked due to abuse.");
         }
         const verification = await this.verifyService.verifications.create({ to: phoneNumber, channel });
 
@@ -138,7 +137,7 @@ export class VerificationService {
             throw new Error("No verification service configured.");
         }
         if (!uuidValidate(verificationId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Verification ID must be a valid UUID");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Verification ID must be a valid UUID");
         }
 
         const verification_check = await this.verifyService.verificationChecks.create({

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -8,8 +8,7 @@ import * as express from "express";
 import { injectable, inject } from "inversify";
 import { UserDB } from "@gitpod/gitpod-db/lib";
 import { Strategy as DummyStrategy } from "passport-dummy";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ResponseError } from "vscode-jsonrpc";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Authenticator } from "../auth/authenticator";
 import { AuthProvider } from "../auth/auth-provider";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
@@ -46,7 +45,7 @@ class DummyAuthProvider implements AuthProvider {
     readonly strategy = new DummyStrategy(async (done) => {
         const maybeUser = await this.userDb.findUserById(DevData.createTestUser().id);
         if (!maybeUser) {
-            done(new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "No dev user in DB."), undefined);
+            done(new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, "No dev user in DB."), undefined);
         }
         try {
             done(undefined, maybeUser);

--- a/components/server/src/iam/iam-oidc-create-session-payload.ts
+++ b/components/server/src/iam/iam-oidc-create-session-payload.ts
@@ -4,18 +4,17 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export namespace OIDCCreateSessionPayload {
     export function validate(payload: any): OIDCCreateSessionPayload {
         if (typeof payload !== "object") {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "OIDC Create Session Payload is not an object.");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "OIDC Create Session Payload is not an object.");
         }
 
         // validate payload.idToken
         if (!hasField(payload, "idToken")) {
-            throw new ResponseError(
+            throw new ApplicationError(
                 ErrorCodes.BAD_REQUEST,
                 "OIDC Create Session Payload does not contain idToken object.",
             );
@@ -23,29 +22,29 @@ export namespace OIDCCreateSessionPayload {
 
         // validate payload.claims
         if (!hasField(payload, "claims")) {
-            throw new ResponseError(
+            throw new ApplicationError(
                 ErrorCodes.BAD_REQUEST,
                 "OIDC Create Session Payload does not contain claims object.",
             );
         }
         if (hasEmptyField(payload.claims, "iss")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Claim 'iss' (issuer) is missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Claim 'iss' (issuer) is missing");
         }
         if (hasEmptyField(payload.claims, "sub")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Claim 'sub' (subject) is missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Claim 'sub' (subject) is missing");
         }
         if (hasEmptyField(payload.claims, "name")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Claim 'name' is missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Claim 'name' is missing");
         }
         if (hasEmptyField(payload.claims, "email")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Claim 'email' is missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Claim 'email' is missing");
         }
 
         if (hasEmptyField(payload, "organizationId")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "OrganizationId is missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "OrganizationId is missing");
         }
         if (hasEmptyField(payload, "oidcClientConfigId")) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "OIDC client config id missing");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "OIDC client config id missing");
         }
 
         return payload as OIDCCreateSessionPayload;

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -13,8 +13,8 @@ import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Identity, User } from "@gitpod/gitpod-protocol";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib";
-import { ResponseError } from "vscode-ws-jsonrpc";
 import { reportJWTCookieIssued } from "../prometheus-metrics";
+import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class IamSessionApp {
@@ -40,7 +40,7 @@ export class IamSessionApp {
                 res.status(200).json(result);
             } catch (error) {
                 log.error("Error creating session on behalf of IAM", error);
-                if (error instanceof ResponseError) {
+                if (ApplicationError.hasErrorCode(error)) {
                     res.status(error.code).json({ message: error.message });
                     return;
                 }

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -4,13 +4,12 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { LinkedInProfile, User } from "@gitpod/gitpod-protocol/lib/protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { LinkedInProfileDB } from "@gitpod/gitpod-db/lib";
 import { inject, injectable } from "inversify";
 import fetch from "node-fetch";
-import { ResponseError } from "vscode-jsonrpc";
 import { Config } from "./config";
 
 @injectable()
@@ -29,7 +28,7 @@ export class LinkedInService {
     private async getAccessToken(code: string) {
         const { clientId, clientSecret } = this.config.linkedInSecrets || {};
         if (!clientId || !clientSecret) {
-            throw new ResponseError(
+            throw new ApplicationError(
                 ErrorCodes.INTERNAL_SERVER_ERROR,
                 "LinkedIn is not properly configured (no Client ID or Client Secret)",
             );

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -38,8 +38,7 @@ import { asyncHandler } from "../express-util";
 import { ContextParser } from "../workspace/context-parser-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { RepoURL } from "../repohost";
-import { ResponseError } from "vscode-ws-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ApplicationError, ErrorCode } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 /**
  * GitHub app urls:
@@ -678,8 +677,8 @@ export class GithubApp {
 function catchError<R>(p: Promise<R>): void {
     p.catch((err) => {
         let logger = log.error;
-        if (err instanceof ResponseError) {
-            logger = ErrorCodes.isUserError(err.code) ? log.info : log.error;
+        if (ApplicationError.hasErrorCode(err)) {
+            logger = ErrorCode.isUserError(err.code) ? log.info : log.error;
         }
 
         logger("Failed to handle github event", err);

--- a/components/server/src/prebuilds/start-prebuild-context-parser.ts
+++ b/components/server/src/prebuilds/start-prebuild-context-parser.ts
@@ -5,9 +5,8 @@
  */
 
 import { User, WorkspaceContext, ContextURL } from "@gitpod/gitpod-protocol";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { injectable } from "inversify";
-import { ResponseError } from "vscode-ws-jsonrpc";
 import { IPrefixContextParser } from "../workspace/context-parser";
 
 @injectable()
@@ -21,7 +20,7 @@ export class StartPrebuildContextParser implements IPrefixContextParser {
     }
 
     public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
-        throw new ResponseError(
+        throw new ApplicationError(
             ErrorCodes.PROJECT_REQUIRED,
             `Running prebuilds without a project is no longer supported. Please add your repository as a project in a team.`,
         );

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -22,8 +22,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { PartialProject, ProjectUsage } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { Config } from "../config";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
-import { ResponseError } from "vscode-ws-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { URL } from "url";
 import { Authorizer } from "../authorization/authorizer";
 
@@ -121,13 +120,13 @@ export class ProjectsService {
         installer: User,
     ): Promise<Project> {
         if (cloneUrl.length >= 1000) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Clone URL must be less than 1k characters.");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Clone URL must be less than 1k characters.");
         }
 
         try {
             new URL(cloneUrl);
         } catch (err) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Clone URL must be a valid URL.");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Clone URL must be a valid URL.");
         }
 
         const projects = await this.getProjectsByCloneUrls([cloneUrl]);

--- a/components/server/src/user/stripe-service.ts
+++ b/components/server/src/user/stripe-service.ts
@@ -14,8 +14,7 @@ import {
     stripeClientRequestsCompletedDurationSeconds,
 } from "../prometheus-metrics";
 import { BillingServiceClient, BillingServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/billing.pb";
-import { ResponseError } from "vscode-ws-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class StripeService {
@@ -53,7 +52,7 @@ export class StripeService {
     async getPortalUrlForAttributionId(attributionId: string, returnUrl: string): Promise<string> {
         const customerId = await this.findCustomerByAttributionId(attributionId);
         if (!customerId) {
-            throw new ResponseError(
+            throw new ApplicationError(
                 ErrorCodes.NOT_FOUND,
                 `No Stripe Customer ID for attribution ID '${attributionId}'`,
             );

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -15,8 +15,7 @@ import { TokenService } from "./token-service";
 import { EmailAddressAlreadyTakenException, SelectAccountException } from "../auth/errors";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { ResponseError } from "vscode-ws-jsonrpc";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { UsageService } from "./usage-service";
 
 export interface CreateUserParams {
@@ -122,7 +121,7 @@ export class UserService {
     async blockUser(targetUserId: string, block: boolean): Promise<User> {
         const target = await this.userDb.findUserById(targetUserId);
         if (!target) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "not found");
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "not found");
         }
 
         target.blocked = !!block;
@@ -277,7 +276,7 @@ export class UserService {
     async updateUser(userID: string, update: Partial<User>): Promise<User> {
         const user = await this.userDb.findUserById(userID);
         if (!user) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "User does not exist.");
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "User does not exist.");
         }
 
         const allowedFields: (keyof User)[] = ["fullName", "additionalData"];

--- a/components/server/src/workspace/workspace-factory.ts
+++ b/components/server/src/workspace/workspace-factory.ts
@@ -22,12 +22,11 @@ import {
     Workspace,
     WorkspaceContext,
 } from "@gitpod/gitpod-protocol";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { generateWorkspaceID } from "@gitpod/gitpod-protocol/lib/util/generate-workspace-id";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { inject, injectable } from "inversify";
-import { ResponseError } from "vscode-jsonrpc";
 import { RepoURL } from "../repohost";
 import { ConfigProvider } from "./config-provider";
 import { ImageSourceProvider } from "./image-source-provider";
@@ -315,7 +314,7 @@ export class WorkspaceFactory {
         try {
             const snapshot = await this.db.trace({ span }).findSnapshotById(context.snapshotId);
             if (!snapshot) {
-                throw new ResponseError(
+                throw new ApplicationError(
                     ErrorCodes.NOT_FOUND,
                     "No snapshot with id '" + context.snapshotId + "' found.",
                 );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We want to go away from json-rpc so it doesn't make sense to reuse its ResponseError in our code base.

This PR introduces a compatible Error and replaces the usages.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-application-error</li>
	<li><b>🔗 URL</b> - <a href="https://se-application-error.preview.gitpod-dev.com/workspaces" target="_blank">se-application-error.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-application-error-gha.12347</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
