### PR TITLE
Show `gp idp` in the CLI help menu

### DIFF
--- a/components/gitpod-cli/cmd/idp.go
+++ b/components/gitpod-cli/cmd/idp.go
@@ -9,8 +9,8 @@ import (
 )
 
 var idpCmd = &cobra.Command{
-	Use:    "idp",
-	Short:  "Interact Gitpod's OIDC identity provider",
+	Use:   "idp",
+	Short: "Interact with Gitpod's OIDC identity provider",
 }
 
 func init() {

--- a/components/gitpod-cli/cmd/idp.go
+++ b/components/gitpod-cli/cmd/idp.go
@@ -11,7 +11,6 @@ import (
 var idpCmd = &cobra.Command{
 	Use:    "idp",
 	Short:  "Interact Gitpod's OIDC identity provider",
-	Hidden: true,
 }
 
 func init() {

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -68,6 +68,8 @@ replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
 replace github.com/gitpod-io/gitpod/components/public-api/go => ../public-api/go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
 
 replace github.com/gitpod-io/gitpod/ide-metrics-api => ../ide-metrics-api/go // leeway


### PR DESCRIPTION
## Description

Make the command appear and do not hide it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes IDE-190

## How to test

```
gp --help
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
