### PR TITLE
validate: run IDE prebuild only in headless workspace

### DIFF
--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -23,6 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
@@ -241,6 +243,9 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	for _, env := range validateOpts.GitpodEnvs {
 		envs += env + "\n"
 	}
+	if validateOpts.Headless {
+		envs += "GITPOD_HEADLESS=true\n"
+	}
 	for _, env := range workspaceEnvs {
 		envs += fmt.Sprintf("%s=%s\n", env.Name, env.Value)
 	}
@@ -356,15 +361,26 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 		return err
 	}
 
-	go func() {
-		debugSupervisor.WaitForIDEReady(ctx)
-		if ctx.Err() != nil {
-			return
-		}
+	if validateOpts.Headless {
+		go func() {
+			tasks, ok := waitForAllTasksToOpen(ctx, debugSupervisor, runLog)
+			if !ok {
+				return
+			}
+			for _, task := range tasks {
+				go pipeTask(ctx, task, debugSupervisor, runLog)
+			}
+		}()
+	} else {
+		go func() {
+			debugSupervisor.WaitForIDEReady(ctx)
+			if ctx.Err() != nil {
+				return
+			}
 
-		ssh := "ssh 'debug-" + wsInfo.WorkspaceId + "@" + workspaceUrl.Host + ".ssh." + wsInfo.WorkspaceClusterHost + "'"
-		sep := strings.Repeat("=", len(ssh))
-		runLog.Infof(`The workspace is UP!
+			ssh := "ssh 'debug-" + wsInfo.WorkspaceId + "@" + workspaceUrl.Host + ".ssh." + wsInfo.WorkspaceClusterHost + "'"
+			sep := strings.Repeat("=", len(ssh))
+			runLog.Infof(`The workspace is UP!
 %s
 
 Open in Browser at:
@@ -374,11 +390,12 @@ Connect using SSH keys (https://gitpod.io/keys):
 %s
 
 %s`, sep, workspaceUrl, ssh, sep)
-		err := openWindow(ctx, workspaceUrl.String())
-		if err != nil && ctx.Err() == nil {
-			log.WithError(err).Error("failed to open window")
-		}
-	}()
+			err := openWindow(ctx, workspaceUrl.String())
+			if err != nil && ctx.Err() == nil {
+				log.WithError(err).Error("failed to open window")
+			}
+		}()
+	}
 
 	pipeLogs := func(input io.Reader, ideLevel logrus.Level) {
 		reader := bufio.NewReader(input)
@@ -487,11 +504,120 @@ func openWindow(ctx context.Context, workspaceUrl string) error {
 	return gpCmd.Run()
 }
 
+func waitForAllTasksToOpen(ctx context.Context, supervisor *supervisor.SupervisorClient, runLog *logrus.Entry) (tasks []*api.TaskStatus, allTasksOpened bool) {
+	for !allTasksOpened {
+		time.Sleep(1 * time.Second)
+		if ctx.Err() != nil {
+			return
+		}
+		listener, err := supervisor.Status.TasksStatus(ctx, &api.TasksStatusRequest{
+			Observe: true,
+		})
+		if err != nil {
+			continue
+		}
+		tasks, allTasksOpened = checkAllTasksOpened(ctx, listener, runLog)
+	}
+	return
+}
+
+func checkAllTasksOpened(ctx context.Context, listener api.StatusService_TasksStatusClient, runLog *logrus.Entry) (tasks []*api.TaskStatus, allTasksOpened bool) {
+	for !allTasksOpened {
+		resp, err := listener.Recv()
+		if err != nil {
+			return
+		}
+		tasks = resp.GetTasks()
+		allTasksOpened = areTasksOpened(tasks)
+	}
+	return
+}
+
+func areTasksOpened(tasks []*api.TaskStatus) bool {
+	for _, task := range tasks {
+		if task.State == api.TaskState_opening {
+			return false
+		}
+	}
+	return true
+}
+
+func pipeTask(ctx context.Context, task *api.TaskStatus, supervisor *supervisor.SupervisorClient, runLog *logrus.Entry) {
+	for {
+		err := listenTerminal(ctx, task, supervisor, runLog)
+		if err == nil || ctx.Err() != nil {
+			return
+		}
+		status, ok := status.FromError(err)
+		if ok && status.Code() == codes.NotFound {
+			return
+		}
+		runLog.WithError(err).Errorf("%s: failed to listen, retrying...", task.Presentation.Name)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func listenTerminal(ctx context.Context, task *api.TaskStatus, supervisor *supervisor.SupervisorClient, runLog *logrus.Entry) error {
+	listen, err := supervisor.Terminal.Listen(ctx, &api.ListenTerminalRequest{
+		Alias: task.Terminal,
+	})
+	if err != nil {
+		return err
+	}
+
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	defer pw.Close()
+
+	scanner := bufio.NewScanner(pr)
+	const maxTokenSize = 1 * 1024 * 1024 // 1 MB
+	buf := make([]byte, maxTokenSize)
+	scanner.Buffer(buf, maxTokenSize)
+
+	go func() {
+		defer pw.Close()
+		for {
+			resp, err := listen.Recv()
+			if err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+
+			title := resp.GetTitle()
+			if title != "" {
+				task.Presentation.Name = title
+			}
+
+			exitCode := resp.GetExitCode()
+			if exitCode != 0 {
+				runLog.Infof("%s: exited with code %d", task.Presentation.Name, exitCode)
+			}
+
+			data := resp.GetData()
+			if len(data) > 0 {
+				_, err := pw.Write(data)
+				if err != nil {
+					_ = pw.CloseWithError(err)
+					return
+				}
+			}
+		}
+	}()
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		runLog.Infof("%s: %s", task.Presentation.Name, line)
+	}
+
+	return scanner.Err()
+}
+
 var validateOpts struct {
 	WorkspaceFolder string
 	LogLevel        string
 	From            string
 	Prebuild        bool
+	Headless        bool
 
 	// internal
 	GitpodEnvs []string
@@ -541,9 +667,11 @@ func init() {
 		cmd.PersistentFlags().StringArrayVarP(&validateOpts.GitpodEnvs, "gitpod-env", "", nil, "")
 		cmd.PersistentFlags().StringVarP(&validateOpts.WorkspaceFolder, "workspace-folder", "w", workspaceFolder, "Path to the workspace folder.")
 		cmd.PersistentFlags().StringVarP(&validateOpts.From, "from", "", "", "Starts from 'prebuild' or 'snapshot'.")
+		cmd.PersistentFlags().BoolVarP(&validateOpts.Headless, "headless", "", false, "Starts in headless mode.")
 		_ = cmd.PersistentFlags().MarkHidden("gitpod-env")
 		_ = cmd.PersistentFlags().MarkHidden("workspace-folder")
 		_ = cmd.PersistentFlags().MarkHidden("from")
+		_ = cmd.PersistentFlags().MarkHidden("headless")
 	}
 
 	setFlags(validateCmd)

--- a/components/ide/code/codehelper/go.mod
+++ b/components/ide/code/codehelper/go.mod
@@ -38,6 +38,8 @@ replace github.com/gitpod-io/gitpod/gitpod-protocol => ../../../gitpod-protocol/
 
 replace github.com/gitpod-io/gitpod/supervisor/api => ../../../supervisor-api/go // leeway
 
+replace github.com/google/addlicense => ../../../../dev/addlicense // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Otherwise there is a race during gp validate. It does not affect the real prebuild since we don't run IDEs there at all.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Prerequisite to IDE-182

## How to test
<!-- Provide steps to test this PR -->

- Open this PR on gitpod.io with stable IntelliJ.
- checkout test repo: `cd /workspace && git clone https://github.com/gitpod-samples/spring-petclinic && cd spring-petclinic && git fetch && git checkout ak/test_warmup`
- validate prebuild without IDE: `cd /workspace/gitpod/components/supervisor && ./validate.sh --workspace-folder /workspace/spring-petclinic --prebuild --headless` - it will run headless prebuild, you won't be able to access IDE, but you will see tasks output in the terminal as well as initellij prebuild task will be triggered
- validate prebuild with IDE: `cd /workspace/gitpod/components/supervisor && ./validate.sh --workspace-folder /workspace/spring-petclinic --prebuild` - you will be able to access IDE, but intellij prebuild won't be triggered

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-validatea5a54e23f</li>
	<li><b>🔗 URL</b> - <a href="https://ak-validatea5a54e23f.preview.gitpod-dev.com/workspaces" target="_blank">ak-validatea5a54e23f.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-validate_ide_prebuild-gha.12389</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
