### PR TITLE
[dashboard] remember options by cloneURL & orgID

### DIFF
--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -258,14 +258,17 @@ const useGetOrgURL = () => {
             // Default to root path when switching orgs
             let path = "/";
             let hash = "";
+            const search = new URLSearchParams();
+            search.append("org", orgID);
 
             // If we're on the new workspace page, try to maintain the location and context url
             if (/^\/new(\/$)?$/.test(location.pathname)) {
                 path = `/new`;
                 hash = location.hash;
+                search.append("autostart", "false");
             }
 
-            return `${path}?org=${encodeURIComponent(orgID)}${hash}`;
+            return `${path}?${search.toString()}${hash}`;
         },
         [location.hash, location.pathname],
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This removes the auto-switching to other orgs and allows to store autostart options per repo and org.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-586

## How to test
<!-- Provide steps to test this PR -->
Store autostart options for a repo in your org.
Create a second org and verify that no autostart options are considered.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-store-oe5edc4a2a9</li>
	<li><b>🔗 URL</b> - <a href="https://se-store-oe5edc4a2a9.preview.gitpod-dev.com/workspaces" target="_blank">se-store-oe5edc4a2a9.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-store-options-by-org-gha.12427</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
