### PR TITLE
[JetBrains-plugin] Error message shouldn't be editable on Workspace Phase tray window

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -113,7 +113,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
         val phaseMessage = JLabel()
         val statusMessage = JLabel()
         val errorMessage = JBTextArea().apply {
-            isEditable = true
+            isEditable = false
             wrapStyleWord = true
             lineWrap = true
             border = null


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Preview on [this PR's dev JB plugin](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev/355030)


| Before | After |
|:--------:|:--------:|
|<video src="https://github.com/gitpod-io/gitpod/assets/55068936/8de1238a-669f-46a1-bf84-3da88b8885aa"/>|<video src="https://github.com/gitpod-io/gitpod/assets/55068936/aae4a59a-acc7-495b-8033-373c91061f54"/>|



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [IDE-189 : error message in loading dialog of JB GW should no be editable](https://linear.app/gitpod/issue/IDE-189/error-message-in-loading-dialog-of-jb-gw-should-no-be-editable)

## How to test
<!-- Provide steps to test this PR -->

- Install [JB Plugin](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev/355030)
- Start any workspace in JB IDEs
- Try to type in the Start Workspace window tray.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here
-->

No

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-fd7eaeb6d88</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-fd7eaeb6d88.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-fd7eaeb6d88.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-fix-jb-plugin-gha.12458</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
