### PR TITLE
Fix build error undefined: scrubber.TrustedValue

### DIFF
--- a/components/blobserve/go.mod
+++ b/components/blobserve/go.mod
@@ -133,9 +133,9 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
-
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
 
 replace github.com/gitpod-io/gitpod/registry-facade => ../registry-facade // leeway
 

--- a/components/content-service/go.mod
+++ b/components/content-service/go.mod
@@ -113,6 +113,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/ee/agent-smith/go.mod
+++ b/components/ee/agent-smith/go.mod
@@ -81,6 +81,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../../content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../../gitpod-protocol/go // leeway

--- a/components/ide-service/go.mod
+++ b/components/ide-service/go.mod
@@ -79,6 +79,58 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
-replace github.com/gitpod-io/gitpod/ide-service-api => ../ide-service-api/go // leeway
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
+
+replace github.com/gitpod-io/gitpod/ide-service-api => ../ide-service-api/go // leeway
+
+replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/client-go => k8s.io/client-go v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/code-generator => k8s.io/code-generator v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-base => k8s.io/component-base v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cri-api => k8s.io/cri-api v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubelet => k8s.io/kubelet v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/metrics => k8s.io/metrics v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-helpers => k8s.io/component-helpers v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/controller-manager => k8s.io/controller-manager v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubectl => k8s.io/kubectl v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/mount-utils => k8s.io/mount-utils v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/ide/code-desktop/status/go.mod
+++ b/components/ide/code-desktop/status/go.mod
@@ -18,6 +18,58 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
+replace github.com/gitpod-io/gitpod/common-go => ../../../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/supervisor/api => ../../../supervisor-api/go // leeway
 
-replace github.com/gitpod-io/gitpod/common-go => ../../../common-go // leeway
+replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/client-go => k8s.io/client-go v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/code-generator => k8s.io/code-generator v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-base => k8s.io/component-base v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cri-api => k8s.io/cri-api v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubelet => k8s.io/kubelet v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/metrics => k8s.io/metrics v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-helpers => k8s.io/component-helpers v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/controller-manager => k8s.io/controller-manager v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubectl => k8s.io/kubectl v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/mount-utils => k8s.io/mount-utils v0.26.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/ide/code/codehelper/go.mod
+++ b/components/ide/code/codehelper/go.mod
@@ -32,6 +32,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../../../gitpod-protocol/go // leeway
 
 replace github.com/gitpod-io/gitpod/supervisor/api => ../../../supervisor-api/go // leeway

--- a/components/ide/jetbrains/launcher/go.mod
+++ b/components/ide/jetbrains/launcher/go.mod
@@ -42,9 +42,13 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../../../gitpod-protocol/go // leeway
 
 replace github.com/gitpod-io/gitpod/supervisor/api => ../../../supervisor-api/go // leeway
+
+replace github.com/google/addlicense => ../../../../dev/addlicense // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 

--- a/components/image-builder-bob/go.mod
+++ b/components/image-builder-bob/go.mod
@@ -70,6 +70,8 @@ replace github.com/docker/docker => github.com/docker/docker v20.10.3-0.20211208
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/image-builder-mk3/go.mod
+++ b/components/image-builder-mk3/go.mod
@@ -75,6 +75,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway

--- a/components/installation-telemetry/go.mod
+++ b/components/installation-telemetry/go.mod
@@ -29,6 +29,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/node-labeler/go.mod
+++ b/components/node-labeler/go.mod
@@ -73,21 +73,9 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // leeway
+replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
-replace github.com/gitpod-io/gitpod/content-service/api => ../../components/content-service-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/image-builder/api => ../../components/image-builder-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/components/public-api => ../../components/public-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/registry-facade/api => ../../components/registry-facade-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/ws-daemon/api => ../../components/ws-daemon-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/ws-manager-bridge/api => ../../components/ws-manager-bridge-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/ws-manager/api => ../../components/ws-manager-api/go // leeway
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 

--- a/components/openvsx-proxy/go.mod
+++ b/components/openvsx-proxy/go.mod
@@ -44,6 +44,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -102,11 +102,13 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
-replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
-
 replace github.com/gitpod-io/gitpod/components/gitpod-db/go => ../gitpod-db/go // leeway
 
 replace github.com/gitpod-io/gitpod/components/public-api/go => ../public-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
+replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
 
 replace github.com/gitpod-io/gitpod/usage-api => ../usage-api/go // leeway
 

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -288,9 +288,11 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
+replace github.com/ipfs/go-ipfs-config v0.5.3 => github.com/ipfs/go-ipfs-config v0.19.0
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
 
 replace github.com/gitpod-io/gitpod/registry-facade/api => ../registry-facade-api/go // leeway
 
@@ -343,5 +345,3 @@ replace k8s.io/kubectl => k8s.io/kubectl v0.26.2 // leeway indirect from compone
 replace k8s.io/mount-utils => k8s.io/mount-utils v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.2 // leeway indirect from components/common-go:lib
-
-replace github.com/ipfs/go-ipfs-config v0.5.3 => github.com/ipfs/go-ipfs-config v0.19.0

--- a/components/service-waiter/go.mod
+++ b/components/service-waiter/go.mod
@@ -40,6 +40,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -148,19 +148,21 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
-replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
-
 replace github.com/gitpod-io/gitpod/components/public-api/go => ../public-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
+replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../gitpod-protocol/go // leeway
 
+replace github.com/gitpod-io/gitpod/ide-metrics-api => ../ide-metrics-api/go // leeway
+
 replace github.com/gitpod-io/gitpod/supervisor/api => ../supervisor-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-daemon/api => ../ws-daemon-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/ide-metrics-api => ../ide-metrics-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -78,11 +78,13 @@ require (
 	gorm.io/plugin/opentelemetry v0.1.1 // indirect
 )
 
-replace github.com/gitpod-io/gitpod/components/gitpod-db/go => ../gitpod-db/go // leeway
-
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/gitpod-db/go => ../gitpod-db/go // leeway
+
 replace github.com/gitpod-io/gitpod/components/public-api/go => ../public-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 

--- a/components/workspace-rollout-job/go.mod
+++ b/components/workspace-rollout-job/go.mod
@@ -80,14 +80,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/gitpod-io/gitpod/ws-manager-bridge/api => ../ws-manager-bridge-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
-
 replace github.com/gitpod-io/gitpod/gpctl => ../../dev/gpctl
-
-replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
-
-replace k8s.io/apimachinery => k8s.io/apimachinery v0.26.2 // leeway indirect from components/common-go:lib
-
-replace k8s.io/client-go => k8s.io/client-go v0.26.2 // leeway indirect from components/common-go:lib

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -51,6 +51,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-daemon/api => ../ws-daemon-api/go // leeway

--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -187,6 +187,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway

--- a/components/ws-daemon/nsinsider/go.mod
+++ b/components/ws-daemon/nsinsider/go.mod
@@ -40,6 +40,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../../content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-daemon/api => ../../ws-daemon-api/go // leeway

--- a/components/ws-manager-mk2/go.mod
+++ b/components/ws-manager-mk2/go.mod
@@ -103,15 +103,17 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.8 // track bre
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
+replace github.com/gitpod-io/gitpod/image-builder/api => ../image-builder-api/go // leeway
+
 replace github.com/gitpod-io/gitpod/registry-facade/api => ../registry-facade-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../ws-manager-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/image-builder/api => ../image-builder-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -98,6 +98,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service => ../content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway

--- a/dev/gp-gcloud/go.mod
+++ b/dev/gp-gcloud/go.mod
@@ -35,6 +35,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../components/scrubber // leeway
+
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.2 // leeway indirect from components/common-go:lib

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -99,6 +99,8 @@ replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // l
 
 replace github.com/gitpod-io/gitpod/components/public-api/go => ../../components/public-api/go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../components/scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../../components/content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../../components/gitpod-protocol/go // leeway

--- a/dev/loadgen/go.mod
+++ b/dev/loadgen/go.mod
@@ -39,6 +39,8 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../../components/scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service/api => ../../components/content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../../components/ws-manager-api/go // leeway

--- a/test/go.mod
+++ b/test/go.mod
@@ -173,19 +173,21 @@ require (
 
 replace github.com/gitpod-io/gitpod/common-go => ../components/common-go // leeway
 
+replace github.com/gitpod-io/gitpod/components/scrubber => ../components/scrubber // leeway
+
 replace github.com/gitpod-io/gitpod/content-service => ../components/content-service // leeway
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../components/content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../components/gitpod-protocol/go // leeway
 
+replace github.com/gitpod-io/gitpod/ide-service-api => ../components/ide-service-api/go // leeway
+
 replace github.com/gitpod-io/gitpod/image-builder/api => ../components/image-builder-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/supervisor/api => ../components/supervisor-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../components/ws-manager-api/go // leeway
-
-replace github.com/gitpod-io/gitpod/ide-service-api => ../components/ide-service-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.26.2 // leeway indirect from components/common-go:lib
 


### PR DESCRIPTION
## Description
```
# [github.com/gitpod-io/gitpod/common-go/log](http://github.com/gitpod-io/gitpod/common-go/log)
../../../common-go/log/log.go:150:17: undefined: scrubber.TrustedValue
```


#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
