### PR TITLE
[test] Fix disk pressure, run in parallel

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -183,17 +183,7 @@ jobs:
 
                   cd "${GITHUB_WORKSPACE}/test"
                   set +e
-                  go test -p 4 -v $WORKSPACE_TEST_LIST "${args[@]}" -run '.*SerialOnly$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-SERIAL.xml" -iocopy
-                  RC=${PIPESTATUS[0]}
-                  set -e
-
-                  if [ "${RC}" -ne "0" ]; then
-                    FAILURE_COUNT=$((FAILURE_COUNT+1))
-                  fi
-
-                  set +e
-                  # running tests in parallel saves time, but is flakey.
-                  go test -p 1 --parallel 1 -v $WORKSPACE_TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
+                  go test -p 5 -v $WORKSPACE_TEST_LIST "${args[@]}" -args --parallel 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}.xml" -iocopy
                   RC=${PIPESTATUS[0]}
                   set -e
 

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -177,32 +177,29 @@ jobs:
 
                   FAILURE_COUNT=0
 
-                  WORKSPACE_TEST_LIST=("$CONTENT_SERVICE_TESTS" "$IMAGE_BUILDER_TESTS" "$WS_DAEMON_TESTS" "$WS_MANAGER_TESTS" "$WORKSPACE_TESTS")
-                  for TEST_PATH in "${WORKSPACE_TEST_LIST[@]}"
-                  do
-                      TEST_NAME=$(basename "${TEST_PATH}")
-                      echo "running integration for ${TEST_NAME}"
+                  WORKSPACE_TEST_LIST="$CONTENT_SERVICE_TESTS $IMAGE_BUILDER_TESTS $WS_DAEMON_TESTS $WS_MANAGER_TESTS $WORKSPACE_TESTS"
+                  TEST_NAME="workspace"
+                  echo "running integration for ${TEST_NAME}-parallel"
 
-                      cd "${TEST_PATH}"
-                      set +e
-                      go test -p 1 -v ./... "${args[@]}" -run '.*SerialOnly$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-SERIAL.xml" -iocopy
-                      RC=${PIPESTATUS[0]}
-                      set -e
+                  cd "${GITHUB_WORKSPACE}/test"
+                  set +e
+                  go test -p 4 -v $WORKSPACE_TEST_LIST "${args[@]}" -run '.*SerialOnly$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-SERIAL.xml" -iocopy
+                  RC=${PIPESTATUS[0]}
+                  set -e
 
-                      if [ "${RC}" -ne "0" ]; then
-                        FAILURE_COUNT=$((FAILURE_COUNT+1))
-                      fi
+                  if [ "${RC}" -ne "0" ]; then
+                    FAILURE_COUNT=$((FAILURE_COUNT+1))
+                  fi
 
-                      set +e
-                      # running tests in parallel saves time, but is flakey.
-                      go test -p 1 --parallel 1 -v ./... "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
-                      RC=${PIPESTATUS[0]}
-                      set -e
+                  set +e
+                  # running tests in parallel saves time, but is flakey.
+                  go test -p 1 --parallel 1 -v $WORKSPACE_TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
+                  RC=${PIPESTATUS[0]}
+                  set -e
 
-                      if [ "${RC}" -ne "0" ]; then
-                        FAILURE_COUNT=$((FAILURE_COUNT+1))
-                      fi
-                  done
+                  if [ "${RC}" -ne "0" ]; then
+                    FAILURE_COUNT=$((FAILURE_COUNT+1))
+                  fi
 
                   exit $FAILURE_COUNT
             - uses: actions/upload-artifact@v3

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -205,7 +205,7 @@ jobs:
             - uses: actions/upload-artifact@v3
               with:
                   name: test-results
-                  paths: "test/tests/**/TEST-*.xml"
+                  path: "test/tests/**/TEST-*.xml"
               if: always()
             - name: Test Summary
               id: test_summary

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -183,7 +183,7 @@ jobs:
 
                   cd "${GITHUB_WORKSPACE}/test"
                   set +e
-                  go test -p 5 -v $WORKSPACE_TEST_LIST "${args[@]}" -args --parallel 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}.xml" -iocopy
+                  go test -p 10 -v $WORKSPACE_TEST_LIST "${args[@]}" -parallel-features=true 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}.xml" -iocopy
                   RC=${PIPESTATUS[0]}
                   set -e
 

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -195,13 +195,13 @@ jobs:
             - uses: actions/upload-artifact@v3
               with:
                   name: test-results
-                  path: "test/tests/**/TEST-*.xml"
+                  path: "test/**/TEST-*.xml"
               if: always()
             - name: Test Summary
               id: test_summary
               uses: test-summary/action@v2
               with:
-                  paths: "test/tests/**/TEST-*.xml"
+                  paths: "test/**/TEST-*.xml"
                   show: "all"
               if: always()
             - name: Slack Notification

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202306121532"
+  default     = "gitpod-k3s-202306301112"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/gce/vm.tf
+++ b/dev/preview/infrastructure/modules/gce/vm.tf
@@ -18,11 +18,15 @@ resource "google_compute_instance" "default" {
     }
   }
 
-  scratch_disk {
-    interface = "NVME"
-  }
-  scratch_disk {
-    interface = "NVME"
+  # Attach two local SSDs when large VM is enabled.
+  # These increase the containerd and workspace lvm volume sizes,
+  # allowing us to e.g. run more e2e tests in parallel without
+  # running into node disk pressure.
+  dynamic "scratch_disk" {
+    for_each = var.with_large_vm == true ? [1, 2] : []
+    content {
+      interface = "NVME"
+    }
   }
 
   tags = ["preview"]

--- a/test/README.md
+++ b/test/README.md
@@ -38,6 +38,9 @@ werft job run github -a with-preview=true -a with-integration-tests=webapp -f
 
 You may want to run tests to assert whether a Gitpod installation is successfully integrated.
 
+> Use a preview environment with a large VM to run the tests. The tests run in parallel and can consume a large amount of recources. Create one as follows:
+> `TF_VAR_with_large_vm=true leeway run dev:preview`
+
 ### Go test
 
 This is best for when you're actively developing Gitpod.

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -92,7 +92,7 @@ func Setup(ctx context.Context) (string, string, env.Environment, bool, string, 
 	flagset.StringVar(&username, "username", os.Getenv("USER_NAME"), "username to execute the tests with. Chooses one automatically if left blank.")
 	flagset.BoolVar(&enterprise, "enterprise", false, "whether to test enterprise features. requires enterprise lisence installed.")
 	flagset.BoolVar(&gitlab, "gitlab", false, "whether to test gitlab integration.")
-	flagset.BoolVar(&parallel, "parallel", false, "Run test features in parallel")
+	flagset.BoolVar(&parallel, "parallel-features", false, "Run test features in parallel")
 	flagset.DurationVar(&waitGitpodReady, "wait-gitpod-timeout", 5*time.Minute, `wait time for Gitpod components before starting integration test`)
 	flagset.StringVar(&namespace, "namespace", "", "Kubernetes cluster namespaces to use")
 	flagset.StringVar(&kubeconfig, "kubeconfig", defaultKubeConfig, "The path to the kubeconfig file")

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -30,7 +30,7 @@ import (
 const (
 	gitpodBuiltinUserID             = "builtin-user-workspace-probe-0000000"
 	perCallTimeout                  = 5 * time.Minute
-	ParallelLunchableWorkspaceLimit = 4
+	ParallelLunchableWorkspaceLimit = 10
 )
 
 var (

--- a/test/run.sh
+++ b/test/run.sh
@@ -113,7 +113,7 @@ if [ "$TEST_SUITE" == "workspace" ]; then
 
   set +e
   # shellcheck disable=SC2086
-  go test -parallel 5 -v $TEST_LIST "${args[@]}" -args --parallel 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
+  go test -p 10 -v $TEST_LIST "${args[@]}" -parallel-features=true 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
   RC=${PIPESTATUS[0]}
   set -e
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -81,7 +81,6 @@ fi
 args+=( "-kubeconfig=${KUBECONFIG:-/home/gitpod/.kube/config}" )
 args+=( "-namespace=${NAMESPACE:-default}" )
 args+=( "-timeout=60m" )
-args+=( "-p=2" )
 
 if [[ "${GITPOD_REPO_ROOT:-}" != "" ]]; then
   echo "Running in Gitpod workspace. Fetching USERNAME and USER_TOKEN"
@@ -110,22 +109,11 @@ if [ "$TEST_SUITE" == "workspace" ]; then
   LOG_FILE="${LOGS_DIR}/${TEST_NAME}.log"
 
   cd "$THIS_DIR"
-  echo "running integration for ${TEST_NAME}-parallel"
+  echo "running integration for ${TEST_NAME}"
 
   set +e
   # shellcheck disable=SC2086
-  go test -parallel 4 -v $TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}-PARALLEL.xml" -iocopy
-  RC=${PIPESTATUS[0]}
-  set -e
-
-  if [ "${RC}" -ne "0" ]; then
-    FAILURE_COUNT=$((FAILURE_COUNT+1))
-  fi
-
-  echo "running integration for ${TEST_NAME}-serial-only"
-  set +e
-  # shellcheck disable=SC2086
-  go test --parallel 1 -v $TEST_LIST "${args[@]}" -run '.*SerialOnly$' 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}-SERIAL.xml" -iocopy
+  go test -parallel 5 -v $TEST_LIST "${args[@]}" -args --parallel 2>&1  | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
   RC=${PIPESTATUS[0]}
   set -e
 

--- a/test/tests/components/content-service/content-service_test.go
+++ b/test/tests/components/content-service/content-service_test.go
@@ -66,6 +66,8 @@ func TestUploadUrl(t *testing.T) {
 	f := features.New("UploadUrlRequest").
 		WithLabel("component", "content-service").
 		Assess("it should run content-service tests", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
 			defer cancel()
 
@@ -126,6 +128,8 @@ func TestDownloadUrl(t *testing.T) {
 	f := features.New("DownloadUrl").
 		WithLabel("component", "server").
 		Assess("it should pass download URL tests", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
 			defer cancel()
 
@@ -172,6 +176,8 @@ func TestUploadDownloadBlob(t *testing.T) {
 	f := features.New("UploadDownloadBlob").
 		WithLabel("component", "server").
 		Assess("it should upload and download blob", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/components/image-builder/builder_test.go
+++ b/test/tests/components/image-builder/builder_test.go
@@ -27,6 +27,8 @@ func TestBaseImageBuild(t *testing.T) {
 	f := features.New("database").
 		WithLabel("component", "image-builder").
 		Assess("it should build a base image", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
 			defer cancel()
 
@@ -107,6 +109,8 @@ func TestParallelBaseImageBuild(t *testing.T) {
 	f := features.New("image-builder").
 		WithLabel("component", "image-builder").
 		Assess("it should allow parallel build of images", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(testCtx, 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/components/ws-daemon/storage_test.go
+++ b/test/tests/components/ws-daemon/storage_test.go
@@ -21,6 +21,8 @@ func TestCreateBucket(t *testing.T) {
 	f := features.New("DaemonAgent.CreateBucket").
 		WithLabel("component", "ws-daemon").
 		Assess("it should create a bucket", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), kubeconfig, cfg.Client(),
 				integration.WithWorkspacekitLift(false),
 				integration.WithContainer("ws-daemon"),

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -207,6 +207,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 			}
 
 			for _, test := range tests {
+				test := test
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -187,7 +187,7 @@ const (
 // - stop the regular workspace
 // - relaunch the regular workspace
 // - make sure the file foobar.txt exists
-func TestOpenWorkspaceFromPrebuildSerialOnly(t *testing.T) {
+func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
 		Assess("it should open workspace from prebuild successfully", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -208,6 +208,7 @@ func TestOpenWorkspaceFromPrebuildSerialOnly(t *testing.T) {
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
 
 					ctx, cancel := context.WithTimeout(testCtx, time.Duration(10*len(tests))*time.Minute)
 					defer cancel()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Run e2e tests in parallel
* Add 2 local SSDs to the preview VM if `with-large-vm` is enabled, which together with [this change](https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/240) removes node disk pressure issues, which were causing the tests to fail
* Some other fixes + improvements, see self review

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-228 WKS-153 WKS-227

## How to test
<!-- Provide steps to test this PR -->

Create preview env with large vm:
```
TF_VAR_with_large_vm=true leeway run dev:preview
```

Run tests:
```
cd test
./run.sh -s workspace
```

See also two successful GHA runs:
* https://github.com/gitpod-io/gitpod/actions/runs/5442586097
* https://github.com/gitpod-io/gitpod/actions/runs/5443292092

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
