### PR TITLE
[rabbitmq] 3.11.16 with chainguard

### DIFF
--- a/components/service-waiter/cmd/messagebus.go
+++ b/components/service-waiter/cmd/messagebus.go
@@ -88,7 +88,7 @@ Optionally, TLS can be used to create the connection.`,
 					break
 				}
 				if err == amqp.ErrCredentials {
-					fail(fmt.Sprintf("Invalid credentials for the messagebus. Check MESSAGEBUS_USERNAME and MESSAGEBUS_PASSWORD. dsn: %s", dsn))
+					fail("Invalid credentials for the messagebus. Check MESSAGEBUS_USERNAME and MESSAGEBUS_PASSWORD.")
 				}
 
 				<-time.After(time.Second)

--- a/components/service-waiter/cmd/messagebus.go
+++ b/components/service-waiter/cmd/messagebus.go
@@ -88,7 +88,7 @@ Optionally, TLS can be used to create the connection.`,
 					break
 				}
 				if err == amqp.ErrCredentials {
-					fail("Invalid credentials for the messagebus. Check MESSAGEBUS_USERNAME and MESSAGEBUS_PASSWORD.")
+					fail(fmt.Sprintf("Invalid credentials for the messagebus. Check MESSAGEBUS_USERNAME and MESSAGEBUS_PASSWORD. dsn: %s", dsn))
 				}
 
 				<-time.After(time.Second)

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -17,6 +17,7 @@ const (
 	BlobServeServicePort        = 4000
 	CertManagerCAIssuer         = "gitpod-ca-issuer"
 	DockerRegistryURL           = "docker.io"
+	ChainguardRegistryURL       = "cgr.dev"
 	DockerRegistryName          = "registry"
 	GitpodContainerRegistry     = "eu.gcr.io/gitpod-core-dev/build"
 	InClusterDbSecret           = "mysql"

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -17,7 +17,6 @@ const (
 	BlobServeServicePort        = 4000
 	CertManagerCAIssuer         = "gitpod-ca-issuer"
 	DockerRegistryURL           = "docker.io"
-	ChainguardRegistryURL       = "cgr.dev"
 	DockerRegistryName          = "registry"
 	GitpodContainerRegistry     = "eu.gcr.io/gitpod-core-dev/build"
 	InClusterDbSecret           = "mysql"

--- a/install/installer/pkg/components/rabbitmq/helm.go
+++ b/install/installer/pkg/components/rabbitmq/helm.go
@@ -5,6 +5,7 @@
 package rabbitmq
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -76,6 +77,10 @@ var Helm = common.CompositeHelmFunc(
 
 		loadDefinitionsFile := "/gitpod-config/load_definition.json"
 
+		hasher := sha256.New()
+		hasher.Write([]byte("uq4KxOLtrA-QsDTfuwQ-"))
+		sum := hasher.Sum(nil)
+
 		// Create an init container to convert the password variable to the password value
 		// This is so we can use a secret for the custom message bus password in the config
 		initContainer := []corev1.Container{
@@ -85,7 +90,7 @@ var Helm = common.CompositeHelmFunc(
 				Args: []string{
 					"sh",
 					"-c",
-					fmt.Sprintf(`HASHED_PW=$(echo $PASSWORD | sha256sum); sed "s/%s/${HASHED_PW}/" /app/load_definition.json > %s`, passwordReplaceString, loadDefinitionsFile),
+					fmt.Sprintf(`sed "s/%s/%s/" /app/load_definition.json > %s`, passwordReplaceString, string(sum), loadDefinitionsFile),
 				},
 				Env: []corev1.EnvVar{
 					{

--- a/install/installer/pkg/components/rabbitmq/helm.go
+++ b/install/installer/pkg/components/rabbitmq/helm.go
@@ -123,7 +123,7 @@ var Helm = common.CompositeHelmFunc(
 			return nil, err
 		}
 
-		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.ChainguardRegistryURL)
+		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
 
 		// Add pod annotation in case config/secrets change
 		var hashObj []runtime.Object

--- a/install/installer/pkg/components/rabbitmq/helm.go
+++ b/install/installer/pkg/components/rabbitmq/helm.go
@@ -85,7 +85,7 @@ var Helm = common.CompositeHelmFunc(
 				Args: []string{
 					"sh",
 					"-c",
-					fmt.Sprintf(`sed "s/%s/${PASSWORD}/" /app/load_definition.json > %s`, passwordReplaceString, loadDefinitionsFile),
+					fmt.Sprintf(`HASHED_PW=$(echo $PASSWORD | sha256sum); sed "s/%s/${HASHED_PW}/" /app/load_definition.json > %s`, passwordReplaceString, loadDefinitionsFile),
 				},
 				Env: []corev1.EnvVar{
 					{

--- a/install/installer/pkg/components/rabbitmq/helm.go
+++ b/install/installer/pkg/components/rabbitmq/helm.go
@@ -123,7 +123,7 @@ var Helm = common.CompositeHelmFunc(
 			return nil, err
 		}
 
-		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
+		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.ChainguardRegistryURL)
 
 		// Add pod annotation in case config/secrets change
 		var hashObj []runtime.Object

--- a/install/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/install/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -8,5 +8,5 @@ name: rabbitmq
 version: 1.0.0
 dependencies:
   - name: rabbitmq
-    version: 11.3.0
+    version: 11.16.1
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/install/installer/third_party/charts/rabbitmq/values.yaml
+++ b/install/installer/third_party/charts/rabbitmq/values.yaml
@@ -9,7 +9,7 @@ rabbitmq:
   image:
     registry: cgr.dev
     repository: chainguard/rabbitmq
-    digest: sha256:cbc1a72dfc0f1e874d5f95360a548f3e786a718393dc1e8c869c735c002a63ca
+    digest: sha256:0789ae3045e86393a03718ea9d74d68161f4d9bf56ef08e537945e4908d04ae0
   enabled: true
   fullnameOverride: "messagebus"
   persistence:

--- a/install/installer/third_party/charts/rabbitmq/values.yaml
+++ b/install/installer/third_party/charts/rabbitmq/values.yaml
@@ -6,6 +6,10 @@ global:
   kubeVersion: 1.21.0
 
 rabbitmq:
+  image:
+    registry: cgr.dev
+    repository: chainguard/rabbitmq
+    digest: sha256:2dbccc1c5082e9f901c620dba178614b708a3ccebdd9de12187581df2a2dc669
   enabled: true
   fullnameOverride: "messagebus"
   persistence:

--- a/install/installer/third_party/charts/rabbitmq/values.yaml
+++ b/install/installer/third_party/charts/rabbitmq/values.yaml
@@ -6,6 +6,10 @@ global:
   kubeVersion: 1.21.0
 
 rabbitmq:
+  image:
+    registry: cgr.dev
+    repository: chainguard/rabbitmq
+    digest: sha256:cbc1a72dfc0f1e874d5f95360a548f3e786a718393dc1e8c869c735c002a63ca
   enabled: true
   fullnameOverride: "messagebus"
   persistence:

--- a/install/installer/third_party/charts/rabbitmq/values.yaml
+++ b/install/installer/third_party/charts/rabbitmq/values.yaml
@@ -6,10 +6,6 @@ global:
   kubeVersion: 1.21.0
 
 rabbitmq:
-  image:
-    registry: cgr.dev
-    repository: chainguard/rabbitmq
-    digest: sha256:0789ae3045e86393a03718ea9d74d68161f4d9bf56ef08e537945e4908d04ae0
   enabled: true
   fullnameOverride: "messagebus"
   persistence:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Based on https://github.com/gitpod-io/gitpod/pull/18137, but with a chainguard image

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
