### PR TITLE
[preview] Update infra concurrency groups to match preview name

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
         needs: [ configuration ]
         runs-on: [ self-hosted ]
         concurrency:
-            group: ${{ github.head_ref || github.ref_name }}-infrastructure
+            group: ${{ needs.configuration.outputs.name }}-infrastructure
         steps:
             - uses: actions/checkout@v3
             - name: Create preview environment infrastructure

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -53,7 +53,7 @@ jobs:
         needs: [ configuration ]
         runs-on: [ self-hosted ]
         concurrency:
-            group: ${{ github.head_ref || github.ref_name }}-infrastructure
+            group: ${{ needs.configuration.outputs.name }}-infrastructure
         steps:
             - uses: actions/checkout@v3
             - name: Create preview environment infrastructure

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -88,7 +88,7 @@ jobs:
       needs: [ configuration ]
       runs-on: [ self-hosted ]
       concurrency:
-        group: ${{ github.head_ref || github.ref_name }}-infrastructure
+        group: ${{ needs.configuration.outputs.name }}-infrastructure
       steps:
         - uses: actions/checkout@v3
         - name: Create preview environment infrastructure


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes preview env creation sometimes getting stopped for scheduled workflows on main, due to a main build cancelling the preview env creation because of matching concurrency groups (`main-infrastructure`).

See e.g. https://github.com/gitpod-io/gitpod/actions/runs/5443913650/attempts/1

The scheduled workflows should actually use the preview env's name as the concurrency group instead of the branch ref, that will prevent them from getting stopped by a main build too

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-228

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
