### PR TITLE
Prevent Input w/ Copy button from submitting forms

### DIFF
--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -12,6 +12,7 @@ export type ButtonProps = {
     type?: "primary" | "secondary" | "danger" | "danger.secondary" | "transparent";
     // TODO: determine how to handle small/medium (block does w-full atm)
     size?: "small" | "medium" | "block";
+    spacing?: "compact" | "default";
     disabled?: boolean;
     loading?: boolean;
     className?: string;
@@ -35,6 +36,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             loading = false,
             autoFocus = false,
             size,
+            spacing = "default",
             icon,
             children,
             onClick,
@@ -48,7 +50,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                     "cursor-pointer my-auto",
                     "text-sm font-medium whitespace-nowrap",
                     "rounded-md focus:outline-none focus:ring transition ease-in-out",
-                    size === "small" ? "px-0 py-0" : "px-4 py-2",
+                    spacing === "compact" ? ["px-0 py-0"] : null,
+                    spacing === "default" ? ["px-4 py-2"] : null,
                     type === "primary"
                         ? [
                               "bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600",

--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -50,7 +50,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                     "cursor-pointer my-auto",
                     "text-sm font-medium whitespace-nowrap",
                     "rounded-md focus:outline-none focus:ring transition ease-in-out",
-                    spacing === "compact" ? ["px-0 py-0"] : null,
+                    spacing === "compact" ? ["px-1 py-1"] : null,
                     spacing === "default" ? ["px-4 py-2"] : null,
                     type === "primary"
                         ? [
@@ -71,7 +71,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                               "text-red-600 hover:text-red-700",
                           ]
                         : null,
-                    type === "transparent" ? ["bg-transparent hover:bg-transparent"] : null,
+                    type === "transparent"
+                        ? [
+                              "bg-transparent hover:bg-gray-600 hover:bg-opacity-10 dark:hover:bg-gray-200 dark:hover:bg-opacity-10",
+                          ]
+                        : null,
                     {
                         "w-full": size === "block",
                         "cursor-default opacity-50 pointer-events-none": disabled || loading,

--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -48,7 +48,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                     "cursor-pointer my-auto",
                     "text-sm font-medium whitespace-nowrap",
                     "rounded-md focus:outline-none focus:ring transition ease-in-out",
-                    size === "small" ? "px-1 py-1" : "px-4 py-2",
+                    size === "small" ? "px-0 py-0" : "px-4 py-2",
                     type === "primary"
                         ? [
                               "bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600",

--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -9,8 +9,7 @@ import { FC, ForwardedRef, ReactNode, forwardRef } from "react";
 import { ReactComponent as SpinnerWhite } from "../icons/SpinnerWhite.svg";
 
 export type ButtonProps = {
-    // TODO: determine if we want danger.secondary
-    type?: "primary" | "secondary" | "danger" | "danger.secondary";
+    type?: "primary" | "secondary" | "danger" | "danger.secondary" | "transparent";
     // TODO: determine how to handle small/medium (block does w-full atm)
     size?: "small" | "medium" | "block";
     disabled?: boolean;
@@ -19,7 +18,7 @@ export type ButtonProps = {
     autoFocus?: boolean;
     htmlType?: "button" | "submit" | "reset";
     icon?: ReactNode;
-    children: ReactNode;
+    children?: ReactNode;
     onClick?: ButtonOnClickHandler;
 };
 
@@ -46,9 +45,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             <button
                 type={htmlType}
                 className={classNames(
-                    "cursor-pointer px-4 py-2 my-auto",
+                    "cursor-pointer my-auto",
                     "text-sm font-medium whitespace-nowrap",
                     "rounded-md focus:outline-none focus:ring transition ease-in-out",
+                    size === "small" ? "px-1 py-1" : "px-4 py-2",
                     type === "primary"
                         ? [
                               "bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600",
@@ -68,6 +68,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                               "text-red-600 hover:text-red-700",
                           ]
                         : null,
+                    type === "transparent" ? ["bg-transparent hover:bg-transparent"] : null,
                     {
                         "w-full": size === "block",
                         "cursor-default opacity-50 pointer-events-none": disabled || loading,
@@ -99,10 +100,10 @@ const ButtonContent: FC<ButtonContentProps> = ({ loading, icon, children }) => {
 
     return (
         <div className="flex items-center justify-center space-x-2">
-            <span className="flex items-center w-5 h-5">
+            <span className="flex justify-center items-center w-5 h-5">
                 {loading ? <SpinnerWhite className="animate-spin" /> : icon ? icon : null}
             </span>
-            <span>{children}</span>
+            {children && <span>{children}</span>}
         </div>
     );
 };

--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -6,7 +6,8 @@
 
 import { FC, useCallback } from "react";
 import Tooltip from "../components/Tooltip";
-import copy from "../images/copy.svg";
+import { ReactComponent as CopyIcon } from "../images/copy.svg";
+import { ReactComponent as CheckIcon } from "../images/check-currentColor.svg";
 import { copyToClipboard } from "../utils";
 import { Button } from "./Button";
 import { TextInput } from "./forms/TextInputField";
@@ -32,12 +33,14 @@ export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", classNa
         <div className={`w-full relative max-w-lg ${className ?? ""}`}>
             <TextInput value={value} disabled className="w-full pr-8 overscoll-none" />
 
-            <Tooltip content={copied ? "Copied" : tip} className="absolute top-2.5 right-1">
+            <Tooltip content={tip} className="absolute top-1.5 right-1">
                 <Button
                     type="transparent"
                     htmlType="button"
                     spacing="compact"
-                    icon={<img src={copy} alt="copy icon" title={tip} className="w-3.5 h-3.5" />}
+                    icon={
+                        copied ? <CheckIcon className="text-green-500 w-5 h-5" /> : <CopyIcon className="w-3.5 h-3.5" />
+                    }
                     onClick={handleCopyToClipboard}
                 />
             </Tooltip>

--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -4,34 +4,43 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useState } from "react";
+import { FC, useCallback } from "react";
 import Tooltip from "../components/Tooltip";
 import copy from "../images/copy.svg";
 import { copyToClipboard } from "../utils";
+import { Button } from "./Button";
+import { TextInput } from "./forms/TextInputField";
+import { useTemporaryState } from "../hooks/use-temporary-value";
 
-export function InputWithCopy(props: { value: string; tip?: string; className?: string }) {
-    const [copied, setCopied] = useState<boolean>(false);
-    const handleCopyToClipboard = (text: string) => {
-        copyToClipboard(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
-    const tip = props.tip ?? "Click to copy";
+type Props = { value: string; tip?: string; className?: string };
+
+export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", className }) => {
+    const [copied, setCopied] = useTemporaryState(false, 2000);
+
+    const handleCopyToClipboard = useCallback(
+        (e) => {
+            e.preventDefault();
+
+            copyToClipboard(value);
+            setCopied(true);
+        },
+        [setCopied, value],
+    );
+
     return (
-        <div className={`w-full relative ${props.className ?? ""}`}>
-            <input
-                disabled={true}
-                readOnly={true}
-                autoFocus
-                className="w-full pr-8 overscroll-none"
-                type="text"
-                value={props.value}
-            />
-            <button className="reset absolute top-1/3 right-3" onClick={() => handleCopyToClipboard(props.value)}>
-                <Tooltip content={copied ? "Copied" : tip}>
-                    <img src={copy} alt="copy icon" title={tip} />
-                </Tooltip>
-            </button>
+        // max-w-lg is to mirror width of TextInput so Tooltip is positioned correctly
+        <div className={`w-full relative max-w-lg ${className ?? ""}`}>
+            <TextInput value={value} disabled className="w-full pr-8 overscoll-none" />
+
+            <Tooltip content={copied ? "Copied" : tip} className="absolute top-2 right-1">
+                <Button
+                    type="transparent"
+                    htmlType="button"
+                    size="small"
+                    icon={<img src={copy} alt="copy icon" title={tip} className="w-4 h-4" />}
+                    onClick={handleCopyToClipboard}
+                />
+            </Tooltip>
         </div>
     );
-}
+};

--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -36,8 +36,8 @@ export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", classNa
                 <Button
                     type="transparent"
                     htmlType="button"
-                    size="small"
-                    icon={<img src={copy} alt="copy icon" title={tip} className="w-4 h-4" />}
+                    spacing="compact"
+                    icon={<img src={copy} alt="copy icon" title={tip} className="w-3.5 h-3.5" />}
                     onClick={handleCopyToClipboard}
                 />
             </Tooltip>

--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -32,7 +32,7 @@ export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", classNa
         <div className={`w-full relative max-w-lg ${className ?? ""}`}>
             <TextInput value={value} disabled className="w-full pr-8 overscoll-none" />
 
-            <Tooltip content={copied ? "Copied" : tip} className="absolute top-2 right-1">
+            <Tooltip content={copied ? "Copied" : tip} className="absolute top-2.5 right-1">
                 <Button
                     type="transparent"
                     htmlType="button"

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -6,7 +6,7 @@
 
 import { FC, FormEvent, ReactNode, useCallback } from "react";
 import { Portal } from "react-portal";
-import { AutoFocusInside, FocusOn } from "react-focus-on";
+import { FocusOn, AutoFocusInside } from "react-focus-on";
 import cn from "classnames";
 import { Heading2 } from "./typography/headings";
 import Alert, { AlertProps } from "./Alert";

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -6,7 +6,7 @@
 
 import { FC, FormEvent, ReactNode, useCallback } from "react";
 import { Portal } from "react-portal";
-import { FocusOn, AutoFocusInside } from "react-focus-on";
+import { AutoFocusInside, FocusOn } from "react-focus-on";
 import cn from "classnames";
 import { Heading2 } from "./typography/headings";
 import Alert, { AlertProps } from "./Alert";
@@ -25,8 +25,8 @@ type Props = {
     children: ReactNode;
     visible: boolean;
     closeable?: boolean;
+    autoFocus?: boolean;
     disableFocusLock?: boolean;
-    disableAutoFocus?: boolean;
     className?: string;
     onClose: () => void;
     onSubmit?: () => void | Promise<void>;
@@ -39,8 +39,8 @@ export const Modal: FC<Props> = ({
     visible,
     children,
     closeable = true,
+    autoFocus = false,
     disableFocusLock = false,
-    disableAutoFocus = false,
     className,
     onClose,
     onSubmit,
@@ -83,7 +83,7 @@ export const Modal: FC<Props> = ({
                 {/* Modal outer-container for positioning */}
                 <div className="flex justify-center items-center w-screen h-screen">
                     <FocusOn
-                        autoFocus={!disableAutoFocus}
+                        autoFocus={autoFocus}
                         onClickOutside={handleClickOutside}
                         onEscapeKey={handleEscape}
                         focusLock={!disableFocusLock}

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -26,6 +26,7 @@ type Props = {
     visible: boolean;
     closeable?: boolean;
     disableFocusLock?: boolean;
+    disableAutoFocus?: boolean;
     className?: string;
     onClose: () => void;
     onSubmit?: () => void | Promise<void>;
@@ -39,6 +40,7 @@ export const Modal: FC<Props> = ({
     children,
     closeable = true,
     disableFocusLock = false,
+    disableAutoFocus = false,
     className,
     onClose,
     onSubmit,
@@ -81,7 +83,7 @@ export const Modal: FC<Props> = ({
                 {/* Modal outer-container for positioning */}
                 <div className="flex justify-center items-center w-screen h-screen">
                     <FocusOn
-                        autoFocus
+                        autoFocus={!disableAutoFocus}
                         onClickOutside={handleClickOutside}
                         onEscapeKey={handleEscape}
                         focusLock={!disableFocusLock}

--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -9,6 +9,7 @@ import { Portal } from "react-portal";
 import { usePopper } from "react-popper";
 
 export interface TooltipProps {
+    className?: string;
     children: ReactNode;
     content: string;
     allowWrap?: boolean;
@@ -31,14 +32,14 @@ function Tooltip(props: TooltipProps) {
     }, [update, props.content]);
 
     // Adds a 500ms delay to showing tooltip so we don't show them until user pauses a bit like native browser tooltips
-    const handleMouseEnter = useCallback(() => {
+    const handlShow = useCallback(() => {
         const timeout = setTimeout(() => {
             setExpanded(true);
         }, 500);
         setShowTooltipTimeout(timeout);
     }, []);
 
-    const handleMouseLeave = useCallback(() => {
+    const handleHide = useCallback(() => {
         if (showTooltipTimeout) {
             clearTimeout(showTooltipTimeout);
         }
@@ -47,7 +48,14 @@ function Tooltip(props: TooltipProps) {
     }, [showTooltipTimeout]);
 
     return (
-        <span onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} ref={setTriggerEl}>
+        <span
+            onMouseEnter={handlShow}
+            onFocus={handlShow}
+            onMouseLeave={handleHide}
+            onBlur={handleHide}
+            ref={setTriggerEl}
+            className={props.className}
+        >
             {props.children}
             {expanded ? (
                 <Portal>

--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -32,7 +32,7 @@ function Tooltip(props: TooltipProps) {
     }, [update, props.content]);
 
     // Adds a 500ms delay to showing tooltip so we don't show them until user pauses a bit like native browser tooltips
-    const handlShow = useCallback(() => {
+    const handleShow = useCallback(() => {
         const timeout = setTimeout(() => {
             setExpanded(true);
         }, 500);
@@ -49,8 +49,8 @@ function Tooltip(props: TooltipProps) {
 
     return (
         <span
-            onMouseEnter={handlShow}
-            onFocus={handlShow}
+            onMouseEnter={handleShow}
+            onFocus={handleShow}
             onMouseLeave={handleHide}
             onBlur={handleHide}
             ref={setTriggerEl}

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -14,12 +14,13 @@ type CheckboxListFieldProps = {
     label: string;
     error?: ReactNode;
     className?: string;
+    topMargin?: boolean;
 };
 
 // CheckboxListField is a wrapper for a list of related CheckboxInputField components.
-export const CheckboxListField: FC<CheckboxListFieldProps> = ({ label, error, className, children }) => {
+export const CheckboxListField: FC<CheckboxListFieldProps> = ({ label, error, className, topMargin, children }) => {
     return (
-        <InputField label={label} className={className} error={error}>
+        <InputField label={label} className={className} error={error} topMargin={topMargin}>
             <div className="space-y-2 ml-2">{children}</div>
         </InputField>
     );
@@ -34,6 +35,7 @@ type CheckboxInputFieldProps = {
     hint?: ReactNode;
     error?: ReactNode;
     topMargin?: boolean;
+    containerClassName?: string;
     onChange: (checked: boolean) => void;
 };
 export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({
@@ -45,6 +47,7 @@ export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({
     checked,
     disabled = false,
     topMargin = true,
+    containerClassName,
     onChange,
 }) => {
     const maybeId = useId();
@@ -59,7 +62,7 @@ export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({
 
     return (
         // Intentionally not passing label and hint to InputField because we want to render them differently for checkboxes.
-        <InputField error={error} topMargin={topMargin}>
+        <InputField error={error} topMargin={topMargin} className={containerClassName}>
             <label className="flex space-x-2 justify-start items-start max-w-lg" htmlFor={elementId}>
                 <input
                     type="checkbox"

--- a/components/dashboard/src/components/forms/SelectInputField.tsx
+++ b/components/dashboard/src/components/forms/SelectInputField.tsx
@@ -17,17 +17,39 @@ type Props = {
     error?: ReactNode;
     disabled?: boolean;
     required?: boolean;
+    topMargin?: boolean;
+    containerClassName?: string;
     onChange: (newValue: string) => void;
     onBlur?: () => void;
 };
 
 export const SelectInputField: FunctionComponent<Props> = memo(
-    ({ label, value, id, hint, error, disabled = false, required = false, children, onChange, onBlur }) => {
+    ({
+        label,
+        value,
+        id,
+        hint,
+        error,
+        disabled = false,
+        required = false,
+        topMargin,
+        containerClassName,
+        children,
+        onChange,
+        onBlur,
+    }) => {
         const maybeId = useId();
         const elementId = id || maybeId;
 
         return (
-            <InputField id={elementId} label={label} hint={hint} error={error}>
+            <InputField
+                id={elementId}
+                label={label}
+                hint={hint}
+                error={error}
+                topMargin={topMargin}
+                className={containerClassName}
+            >
                 <SelectInput
                     id={elementId}
                     value={value}

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -70,7 +70,7 @@ type TextInputProps = {
     placeholder?: string;
     disabled?: boolean;
     required?: boolean;
-    onChange: (newValue: string) => void;
+    onChange?: (newValue: string) => void;
     onBlur?: () => void;
 };
 
@@ -78,7 +78,7 @@ export const TextInput: FunctionComponent<TextInputProps> = memo(
     ({ type = "text", value, className, id, placeholder, disabled = false, required = false, onChange, onBlur }) => {
         const handleChange = useCallback(
             (e) => {
-                onChange(e.target.value);
+                onChange && onChange(e.target.value);
             },
             [onChange],
         );

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -21,6 +21,7 @@ type Props = {
     placeholder?: string;
     disabled?: boolean;
     required?: boolean;
+    topMargin?: boolean;
     containerClassName?: string;
     onChange: (newValue: string) => void;
     onBlur?: () => void;
@@ -37,6 +38,7 @@ export const TextInputField: FunctionComponent<Props> = memo(
         error,
         disabled = false,
         required = false,
+        topMargin,
         containerClassName,
         onChange,
         onBlur,
@@ -45,7 +47,14 @@ export const TextInputField: FunctionComponent<Props> = memo(
         const elementId = id || maybeId;
 
         return (
-            <InputField id={elementId} label={label} hint={hint} error={error} className={containerClassName}>
+            <InputField
+                id={elementId}
+                label={label}
+                hint={hint}
+                error={error}
+                topMargin={topMargin}
+                className={containerClassName}
+            >
                 <TextInput
                     id={elementId}
                     value={value}

--- a/components/dashboard/src/images/check-currentColor.svg
+++ b/components/dashboard/src/images/check-currentColor.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.707 5.293a1 1 0 0 1 0 1.414l-8 8a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 12.586l7.293-7.293a1 1 0 0 1 1.414 0Z"/>
+</svg>

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -52,13 +52,9 @@
 }
 
 @layer components {
+    /* TODO: deprecate button styles in favor of using <Button> component and handling there */
     button {
         @apply cursor-pointer px-4 py-2 my-auto bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600 text-gray-100 dark:text-green-100 text-sm font-medium rounded-md focus:outline-none focus:ring transition ease-in-out;
-    }
-    button.reset {
-        @apply bg-transparent hover:bg-transparent font-normal rounded-none;
-        padding: unset;
-        text-align: start;
     }
     button.secondary {
         @apply bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-500 dark:text-gray-100 hover:text-gray-600;

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -189,7 +189,9 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     );
 
     return (
-        <Modal visible onClose={props.onClose} onSubmit={activate}>
+        // Don't auto-focus if editing to avoid tooltip automatically showing on redirect uri copy button
+        // TODO: determine if there's a better way to handle this 👆
+        <Modal visible onClose={props.onClose} onSubmit={activate} disableAutoFocus={!isNew}>
             <ModalHeader>{isNew ? "New Git Provider" : "Git Provider"}</ModalHeader>
             <ModalBody>
                 {isNew && (
@@ -203,6 +205,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
                         disabled={!isNew}
                         label="Provider Type"
                         value={type}
+                        topMargin={false}
                         onChange={(val) => setType(val as ProviderType)}
                     >
                         <option value="GitHub">GitHub</option>

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -189,9 +189,7 @@ export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
     );
 
     return (
-        // Don't auto-focus if editing to avoid tooltip automatically showing on redirect uri copy button
-        // TODO: determine if there's a better way to handle this 👆
-        <Modal visible onClose={props.onClose} onSubmit={activate} disableAutoFocus={!isNew}>
+        <Modal visible onClose={props.onClose} onSubmit={activate} autoFocus={isNew}>
             <ModalHeader>{isNew ? "New Git Provider" : "Git Provider"}</ModalHeader>
             <ModalBody>
                 {isNew && (

--- a/components/dashboard/src/user-settings/Account.tsx
+++ b/components/dashboard/src/user-settings/Account.tsx
@@ -17,6 +17,7 @@ import { TextInputField } from "../components/forms/TextInputField";
 import isEmail from "validator/lib/isEmail";
 import { useToast } from "../components/toasts/Toasts";
 import { InputWithCopy } from "../components/InputWithCopy";
+import { InputField } from "../components/forms/InputField";
 
 export default function Account() {
     const { user, setUser } = useContext(UserContext);
@@ -159,12 +160,9 @@ function ProfileInformation(props: {
                         }}
                     />
                     {props.user && (
-                        <div className="flex flex-col space-y-2 mt-4">
-                            <label className={"text-md font-semibold dark:text-gray-400 text-gray-600"}>User ID</label>
-                            <p className={"text-sm text-gray-500 dark:text-gray-500"}>
-                                <InputWithCopy className="max-w-md w-32" value={props.user.id} tip="Copy User ID" />
-                            </p>
-                        </div>
+                        <InputField label="User ID">
+                            <InputWithCopy value={props.user.id} tip="Copy User ID" />
+                        </InputField>
                     )}
                 </fieldset>
                 <div className="lg:pl-14">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes a bug where clicking the copy button on the InputWithCopy component would submit a form. The main reason was due to the `<button>` not having a `type` explicitly set, which would result in a form submitting if it was inside of one. To fix that I've:

* Explicitly set `button.type=button`
* Added a `preventDefault()` on the click handler as an extra measure to prevent side-effects beyond copying to the clipboard.

I've also updated a few things in the InputWithCopy component to re-use existing hooks/components. A byproduct of that was updating a couple related components.

### New `<Button>` features:
* New optional `spacing='compact|default'` prop to allow tighter padding when needed.
* Added `type='transparent'` instead of the `button.reset` global css class name

### `<Modal>` changes
* Added optional `disableAutoFocus=true|false` prop to opt-out of the modal auto-focusing the first focusable element. Useful in this particular use-case.

### Normalized `<TextInputField>`, `<SelectInputField>` & `<CheckboxInputField>`
* Each have `topMargin` and `containerClassName` for consistency

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
WEB-581

## How to test
<!-- Provide steps to test this PR -->
* Open the Git Providers Settings for your org.
* Create a new provider.
* Click the Copy icon on the Redirect URL and ensure it doesn't submit the modal/form.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-55cceb5ef3e</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-55cceb5ef3e.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-55cceb5ef3e.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-web-581-copying-gitprovider-redirect-url-triggers-activate-action-gha.12579</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
