### PR TITLE
[POC] Redis for messaging instead of rabbitmq

### DIFF
--- a/components/server/src/messaging/local-message-broker.ts
+++ b/components/server/src/messaging/local-message-broker.ts
@@ -15,6 +15,8 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { inject, injectable } from "inversify";
 import { MessageBusIntegration } from "../workspace/messagebus-integration";
+import { RedisClient } from "../redis/client";
+import { DBWorkspaceInstance, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 
 export interface PrebuildUpdateListener {
     (ctx: TraceContext, evt: PrebuildWithStatus): void;
@@ -129,6 +131,167 @@ export class LocalRabbitMQBackedMessageBroker implements LocalMessageBroker {
                 },
             ),
         );
+    }
+
+    async stop() {
+        this.disposables.dispose();
+    }
+
+    listenForPrebuildUpdates(projectId: string, listener: PrebuildUpdateListener): Disposable {
+        return this.doRegister(projectId, listener, this.prebuildUpdateListeners);
+    }
+
+    listenForPrebuildUpdatableEvents(listener: HeadlessWorkspaceEventListener): Disposable {
+        // we're being cheap here in re-using a map where it just needs to be a plain array.
+        return this.doRegister(
+            LocalRabbitMQBackedMessageBroker.UNDEFINED_KEY,
+            listener,
+            this.headlessWorkspaceEventListeners,
+        );
+    }
+
+    listenForWorkspaceInstanceUpdates(userId: string, listener: WorkspaceInstanceUpdateListener): Disposable {
+        return this.doRegister(userId, listener, this.workspaceInstanceUpdateListeners);
+    }
+
+    protected doRegister<L>(key: string, listener: L, listenersStore: Map<string, L[]>): Disposable {
+        let listeners = listenersStore.get(key);
+        if (listeners === undefined) {
+            listeners = [];
+            listenersStore.set(key, listeners);
+        }
+        listeners.push(listener);
+        return Disposable.create(() => {
+            const ls = listeners!;
+            let idx = ls.findIndex((l) => l === listener);
+            if (idx !== -1) {
+                ls.splice(idx, 1);
+            }
+            if (ls.length === 0) {
+                listenersStore.delete(key);
+            }
+        });
+    }
+}
+
+@injectable()
+export class RedisListener implements LocalMessageBroker {
+    constructor(
+        @inject(RedisClient) private readonly redis: RedisClient,
+        @inject(WorkspaceDB) private readonly workspaceDB: WorkspaceDB,
+    ) {}
+
+    protected prebuildUpdateListeners: Map<string, PrebuildUpdateListener[]> = new Map();
+    protected headlessWorkspaceEventListeners: Map<string, HeadlessWorkspaceEventListener[]> = new Map();
+    protected workspaceInstanceUpdateListeners: Map<string, WorkspaceInstanceUpdateListener[]> = new Map();
+
+    protected readonly disposables = new DisposableCollection();
+
+    async start(): Promise<void> {
+        const channels = ["chan:instances", "chan:prebuilds"];
+        const client = this.redis.get();
+
+        for (let chan of channels) {
+            await client.subscribe(chan);
+            this.disposables.push(Disposable.create(() => client.unsubscribe(chan)));
+        }
+
+        client.on("message", (channel: string, message: string) => {
+            switch (channel) {
+                case "chan:instances":
+                    const instanceID = message;
+                    return this.onInstanceUpdate(instanceID);
+                case "chan:prebuilds":
+                    const prebuildID = message;
+                    return this.onPrebuildUpdate(prebuildID);
+                default:
+                    log.error("Received message on unknown channel", { channel, message });
+            }
+        });
+
+        this.disposables.push(
+            this.messageBusIntegration.listenForPrebuildUpdatableQueue(
+                (ctx: TraceContext, evt: HeadlessWorkspaceEvent) => {
+                    TraceContext.setOWI(ctx, { workspaceId: evt.workspaceID });
+
+                    const listeners =
+                        this.headlessWorkspaceEventListeners.get(LocalRabbitMQBackedMessageBroker.UNDEFINED_KEY) || [];
+                    for (const l of listeners) {
+                        try {
+                            l(ctx, evt);
+                        } catch (err) {
+                            TraceContext.setError(ctx, err);
+                            log.error({ workspaceId: evt.workspaceID }, "listenForPrebuildUpdatableQueue", err);
+                        }
+                    }
+                },
+            ),
+        );
+    }
+
+    private async onInstanceUpdate(instanceID: string): Promise<void> {
+        const instance = await this.workspaceDB.findInstanceById(instanceID);
+        if (!instance) {
+            return;
+        }
+
+        const workspace = await this.workspaceDB.findByInstanceId(instanceID);
+        if (!workspace) {
+            return;
+        }
+
+        const ctx = {};
+        const listeners = this.workspaceInstanceUpdateListeners.get(workspace.ownerId) || [];
+        // broadcast to all subscribers
+        for (const l of listeners) {
+            try {
+                l(ctx, instance);
+            } catch (err) {
+                TraceContext.setError(ctx, err);
+                log.error(
+                    { userId: workspace.ownerId, instanceId: instance.id },
+                    "listenForWorkspaceInstanceUpdates",
+                    err,
+                );
+            }
+        }
+    }
+
+    private async onPrebuildUpdate(prebuildID: string): Promise<void> {
+        const prebuild = await this.workspaceDB.findPrebuildByID(prebuildID);
+        if (!prebuild) {
+            return;
+        }
+
+        if (!prebuild.projectId) {
+            return;
+        }
+
+        const infos = await this.workspaceDB.findPrebuildInfos([prebuildID]);
+        if (infos.length !== 1) {
+            return;
+        }
+
+        const info = infos[0];
+
+        const ctx = {};
+        const listeners = this.prebuildUpdateListeners.get(prebuild.projectId) || [];
+        for (const l of listeners) {
+            try {
+                l(ctx, {
+                    info,
+                    status: "TODO",
+                });
+            } catch (err) {
+                TraceContext.setError(ctx, err);
+                log.error(
+                    { userId: info.userId, workspaceId: info.buildWorkspaceId },
+                    "listenForPrebuildUpdates",
+                    err,
+                    { projectId: info.projectId, prebuildId: info.id },
+                );
+            }
+        }
     }
 
     async stop() {

--- a/components/server/src/messaging/local-message-broker.ts
+++ b/components/server/src/messaging/local-message-broker.ts
@@ -209,24 +209,24 @@ export class RedisListener implements LocalMessageBroker {
             }
         });
 
-        this.disposables.push(
-            this.messageBusIntegration.listenForPrebuildUpdatableQueue(
-                (ctx: TraceContext, evt: HeadlessWorkspaceEvent) => {
-                    TraceContext.setOWI(ctx, { workspaceId: evt.workspaceID });
+        // this.disposables.push(
+        //     this.messageBusIntegration.listenForPrebuildUpdatableQueue(
+        //         (ctx: TraceContext, evt: HeadlessWorkspaceEvent) => {
+        //             TraceContext.setOWI(ctx, { workspaceId: evt.workspaceID });
 
-                    const listeners =
-                        this.headlessWorkspaceEventListeners.get(LocalRabbitMQBackedMessageBroker.UNDEFINED_KEY) || [];
-                    for (const l of listeners) {
-                        try {
-                            l(ctx, evt);
-                        } catch (err) {
-                            TraceContext.setError(ctx, err);
-                            log.error({ workspaceId: evt.workspaceID }, "listenForPrebuildUpdatableQueue", err);
-                        }
-                    }
-                },
-            ),
-        );
+        //             const listeners =
+        //                 this.headlessWorkspaceEventListeners.get(LocalRabbitMQBackedMessageBroker.UNDEFINED_KEY) || [];
+        //             for (const l of listeners) {
+        //                 try {
+        //                     l(ctx, evt);
+        //                 } catch (err) {
+        //                     TraceContext.setError(ctx, err);
+        //                     log.error({ workspaceId: evt.workspaceID }, "listenForPrebuildUpdatableQueue", err);
+        //                 }
+        //             }
+        //         },
+        //     ),
+        // );
     }
 
     private async onInstanceUpdate(instanceID: string): Promise<void> {

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -31,6 +31,7 @@
     "amqplib": "^0.8.0",
     "express": "^4.17.3",
     "inversify": "^6.0.1",
+    "ioredis": "^5.3.2",
     "prom-client": "^13.2.0",
     "reflect-metadata": "^0.1.13"
   },

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -5,7 +5,7 @@
  */
 
 import { inject, injectable } from "inversify";
-import { MessageBusIntegration } from "./messagebus-integration";
+import { MessageBusIntegration, RedisPublisher } from "./messagebus-integration";
 import {
     Disposable,
     Queue,
@@ -49,26 +49,16 @@ export type WorkspaceClusterInfo = Pick<WorkspaceCluster, "name" | "url">;
 
 @injectable()
 export class WorkspaceManagerBridge implements Disposable {
-    @inject(TracedWorkspaceDB)
-    protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
-
-    @inject(MessageBusIntegration)
-    protected readonly messagebus: MessageBusIntegration;
-
-    @inject(PrometheusMetricsExporter)
-    protected readonly prometheusExporter: PrometheusMetricsExporter;
-
-    @inject(Configuration)
-    protected readonly config: Configuration;
-
-    @inject(IAnalyticsWriter)
-    protected readonly analytics: IAnalyticsWriter;
-
-    @inject(PrebuildUpdater)
-    protected readonly prebuildUpdater: PrebuildUpdater;
-
-    @inject(WorkspaceInstanceController)
-    protected readonly workspaceInstanceController: WorkspaceInstanceController; // bound in "transient" mode: we expect to receive a fresh instance here
+    constructor(
+        @inject(TracedWorkspaceDB) private readonly workspaceDB: DBWithTracing<WorkspaceDB>,
+        @inject(MessageBusIntegration) private readonly messagebus: MessageBusIntegration,
+        @inject(PrometheusMetricsExporter) private readonly prometheusExporter: PrometheusMetricsExporter,
+        @inject(Configuration) private readonly config: Configuration,
+        @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
+        @inject(PrebuildUpdater) private readonly prebuildUpdater: PrebuildUpdater,
+        @inject(WorkspaceInstanceController) private readonly workspaceInstanceController: WorkspaceInstanceController, // bound in "transient" mode: we expect to receive a fresh instance here
+        @inject(RedisPublisher) private readonly redisPublisher: RedisPublisher,
+    ) {}
 
     protected readonly disposables = new DisposableCollection();
     protected readonly queues = new Map<string, Queue>();
@@ -377,6 +367,7 @@ export class WorkspaceManagerBridge implements Disposable {
                 await lifecycleHandler();
             }
             await this.messagebus.notifyOnInstanceUpdate(ctx, userId, instance);
+            await this.redisPublisher.notifyOnInstanceUpdate(instance.id);
         } catch (e) {
             TraceContext.setError({ span }, e);
             throw e;

--- a/components/ws-manager-bridge/src/client.ts
+++ b/components/ws-manager-bridge/src/client.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { injectable, postConstruct } from "inversify";
+import { Redis } from "ioredis";
+
+@injectable()
+export class RedisClient {
+    private client: Redis;
+
+    @postConstruct()
+    protected initialize(): void {
+        const [host, port] = "redis:6379".split(":");
+        this.client = new Redis({
+            port: Number(port),
+            host,
+            enableReadyCheck: true,
+            keepAlive: 10 * 1000,
+            connectionName: "ws-man-bridge",
+        });
+    }
+
+    public get(): Redis {
+        return this.client;
+    }
+}

--- a/components/ws-manager-bridge/src/messagebus-integration.ts
+++ b/components/ws-manager-bridge/src/messagebus-integration.ts
@@ -13,6 +13,7 @@ import {
     PrebuildWithStatus,
 } from "@gitpod/gitpod-protocol";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { RedisClient } from "./client";
 
 @injectable()
 export class MessageBusIntegration extends AbstractMessageBusIntegration {
@@ -84,5 +85,22 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         if (this.channel) {
             this.channel.close();
         }
+    }
+}
+
+@injectable()
+export class RedisPublisher {
+    constructor(@inject(RedisClient) private readonly redis: RedisClient) {}
+
+    async notifyOnPrebuildUpdate(prebuildID: string) {
+        await this.redis.get().publish("chan:prebuilds", prebuildID);
+    }
+
+    async notifyOnInstanceUpdate(instanceID: string) {
+        await this.redis.get().publish("chan:instances", instanceID);
+    }
+
+    async notifyHeadlessUpdate(workspaceID: string) {
+        await this.redis.get().publish("chan:headless", workspaceID);
     }
 }

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -14,7 +14,7 @@ import { PrometheusMetricsExporter } from "./prometheus-metrics-exporter";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
 import { DBWithTracing, TracedUserDB, TracedWorkspaceDB } from "@gitpod/gitpod-db/lib/traced-db";
 import { UserDB } from "@gitpod/gitpod-db/lib/user-db";
-import { MessageBusIntegration } from "./messagebus-integration";
+import { MessageBusIntegration, RedisPublisher } from "./messagebus-integration";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { ClientProvider } from "./wsman-subscriber";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
@@ -47,25 +47,16 @@ export interface WorkspaceInstanceController {
  */
 @injectable()
 export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceController {
-    @inject(Configuration) protected readonly config: Configuration;
-
-    @inject(PrometheusMetricsExporter)
-    protected readonly prometheusExporter: PrometheusMetricsExporter;
-
-    @inject(TracedWorkspaceDB)
-    protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
-
-    @inject(TracedUserDB)
-    protected readonly userDB: DBWithTracing<UserDB>;
-
-    @inject(MessageBusIntegration)
-    protected readonly messagebus: MessageBusIntegration;
-
-    @inject(PrebuildUpdater)
-    protected readonly prebuildUpdater: PrebuildUpdater;
-
-    @inject(IAnalyticsWriter)
-    protected readonly analytics: IAnalyticsWriter;
+    constructor(
+        @inject(Configuration) private readonly config: Configuration,
+        @inject(PrometheusMetricsExporter) private readonly prometheusExporter: PrometheusMetricsExporter,
+        @inject(TracedWorkspaceDB) private readonly workspaceDB: DBWithTracing<WorkspaceDB>,
+        @inject(TracedUserDB) private readonly userDB: DBWithTracing<UserDB>,
+        @inject(MessageBusIntegration) private readonly messagebus: MessageBusIntegration,
+        @inject(PrebuildUpdater) private readonly prebuildUpdater: PrebuildUpdater,
+        @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
+        @inject(RedisPublisher) private readonly redisPublisher: RedisPublisher,
+    ) {}
 
     protected readonly disposables = new DisposableCollection();
 
@@ -282,6 +273,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         await this.onStopped(ctx, info.workspace.ownerId, info.latestInstance);
 
         await this.messagebus.notifyOnInstanceUpdate(ctx, info.workspace.ownerId, info.latestInstance);
+        await this.redisPublisher.notifyOnInstanceUpdate(info.workspace.id);
         await this.prebuildUpdater.stopPrebuildInstance(ctx, info.latestInstance);
     }
 

--- a/components/ws-manager-bridge/tsconfig.json
+++ b/components/ws-manager-bridge/tsconfig.json
@@ -21,8 +21,7 @@
         "sourceMap": true,
         "declaration": true,
         "declarationMap": true,
-        "skipLibCheck": true,
-        "useUnknownInCatchVariables": false
+        "skipLibCheck": true
     },
     "include": [
         "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10640,7 +10640,23 @@ jsonify@~0.0.0:
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonwebtoken@^8.5.1, jsonwebtoken@^9.0.0:
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
+jsonwebtoken@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
   integrity sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==
@@ -10931,10 +10947,35 @@ lodash.get@^4:
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
 lodash.isarguments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
   integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -10955,6 +10996,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.template@^4.5.0:
   version "4.5.0"
@@ -11348,14 +11394,26 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@3.0.5, minimatch@^3.0.4:
+minimatch@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
   integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@1.2.8, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
