### PR TITLE
Show time taken in Workspace Integration test

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped in ${{ steps.test_summary.outputs.time }}"
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.* }}\n\n ${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped in ${{ steps.test_summary.outputs.duration }}"
 
     delete:
       name: Delete preview environment

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
               env:
                   SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}
-                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped"
+                  SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped in ${{ steps.test_summary.outputs.time }}"
 
     delete:
       name: Delete preview environment


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

a minor change to show the total time taken in workspace integration tests (in Slack message).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

_Don't 😅 ❤️_ 


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
