### PR TITLE
[server, bridge] Small messagebus cleanup

### DIFF
--- a/components/gitpod-protocol/src/headless-workspace-log.ts
+++ b/components/gitpod-protocol/src/headless-workspace-log.ts
@@ -26,7 +26,6 @@ export namespace HeadlessWorkspaceEventType {
 
 export interface HeadlessWorkspaceEvent {
     workspaceID: string;
-    text: string;
     type: HeadlessWorkspaceEventType;
 }
 

--- a/components/server/src/workspace/messagebus-integration.ts
+++ b/components/server/src/workspace/messagebus-integration.ts
@@ -199,15 +199,8 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
             throw new Error("Not connected to message bus");
         }
 
-        const topic = this.messageBusHelper.getWsTopicForPublishing(userId, workspaceId, "headless-log");
-        const msg = Buffer.from(JSON.stringify(evt));
-        await this.messageBusHelper.assertWorkspaceExchange(this.channel);
-        await super.publish(MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL, topic, msg, {
-            trace: ctx,
-        });
-
         // Prebuild updatables use a single queue to implement round-robin handling of updatables.
-        // We need to write to that queue in addition to the regular log exchange.
+        const msg = Buffer.from(JSON.stringify(evt));
         if (!HeadlessWorkspaceEventType.isRunning(evt.type)) {
             await MessageBusHelperImpl.assertPrebuildWorkspaceUpdatableQueue(this.channel!);
             await super.publishToQueue(MessageBusHelperImpl.PREBUILD_UPDATABLE_QUEUE, msg, {

--- a/components/ws-manager-bridge/src/messagebus-integration.ts
+++ b/components/ws-manager-bridge/src/messagebus-integration.ts
@@ -62,15 +62,8 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
             throw new Error("Not connected to message bus");
         }
 
-        const topic = this.messageBusHelper.getWsTopicForPublishing(userId, workspaceId, "headless-log");
-        const msg = Buffer.from(JSON.stringify(evt));
-        await this.messageBusHelper.assertWorkspaceExchange(this.channel);
-        await super.publish(MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL, topic, msg, {
-            trace: ctx,
-        });
-
         // Prebuild updatables use a single queue to implement round-robin handling of updatables.
-        // We need to write to that queue in addition to the regular log exchange.
+        const msg = Buffer.from(JSON.stringify(evt));
         if (!HeadlessWorkspaceEventType.isRunning(evt.type)) {
             await MessageBusHelperImpl.assertPrebuildWorkspaceUpdatableQueue(this.channel!);
             await super.publishToQueue(MessageBusHelperImpl.PREBUILD_UPDATABLE_QUEUE, msg, {

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -91,7 +91,6 @@ export class PrebuildUpdater {
                 await this.messagebus.notifyHeadlessUpdate({ span }, userId, workspaceId, {
                     type: update.type,
                     workspaceID: workspaceId,
-                    text: "",
                 });
 
                 // prebuild info


### PR DESCRIPTION
## Description
 
Cleanup after we talked in sync, as preparation for the redis work.

I don't think it's worth replacing the UPDATEABLE_QUEUE, yet, as we use the GitHub API to update, not only the DB, and we call it from server and bridge ([source](https://github.com/gitpod-io/gitpod/blob/638ec536e0d273686f485ac305c643363ea61e79/components/server/src/prebuilds/prebuilt-status-maintainer.ts#L164-L176)).
Let's make this a separate queue for, the shape is an ID plus status ([source](https://github.com/gitpod-io/gitpod/blob/f1d2a38dc7e8bf2042692e4ff440091879a62d4d/components/gitpod-protocol/src/headless-workspace-log.ts#L27-L30)).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
