### PR TITLE
[ws-man-bridge] Rename metric label to workspace-instance

### DIFF
--- a/components/ws-manager-bridge/src/metrics.ts
+++ b/components/ws-manager-bridge/src/metrics.ts
@@ -98,7 +98,7 @@ export class Metrics {
         });
     }
 
-    reportUpdatePublished(type: "wsinstance" | "prebuild" | "headless", err?: Error): void {
+    reportUpdatePublished(type: "workspace-instance" | "prebuild" | "headless", err?: Error): void {
         this.updatesPublishedTotal.inc({ type, error: err ? "true" : "false" });
     }
 

--- a/components/ws-manager-bridge/src/redis/publisher.ts
+++ b/components/ws-manager-bridge/src/redis/publisher.ts
@@ -19,7 +19,7 @@ export class RedisPublisher {
 
     async publishInstanceUpdate(): Promise<void> {
         log.debug("[redis] Publish instance udpate invoked.");
-        this.metrics.reportUpdatePublished("wsinstance");
+        this.metrics.reportUpdatePublished("workspace-instance");
     }
 
     async publishHeadlessUpdate(): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to https://github.com/gitpod-io/gitpod/pull/18156#discussion_r1251937757

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
