### PR TITLE
[ws-man-bridge] Publish ws-instance-update - WEB-592

### DIFF
--- a/components/gitpod-protocol/src/index.ts
+++ b/components/gitpod-protocol/src/index.ts
@@ -17,3 +17,4 @@ export * from "./context-url";
 export * from "./teams-projects-protocol";
 export * from "./snapshot-url";
 export * from "./webhook-event";
+export * from "./redis";

--- a/components/gitpod-protocol/src/redis.ts
+++ b/components/gitpod-protocol/src/redis.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export const WorkspaceInstanceUpdatesChannel = "chan:workspace-instances";
+
+export type WorkspaceInstanceUpdate = {
+    instanceID: string;
+    workspaceID: string;
+};

--- a/components/gitpod-protocol/src/redis.ts
+++ b/components/gitpod-protocol/src/redis.ts
@@ -6,7 +6,7 @@
 
 export const WorkspaceInstanceUpdatesChannel = "chan:workspace-instances";
 
-export type WorkspaceInstanceUpdate = {
+export type RedisWorkspaceInstanceUpdate = {
     instanceID: string;
     workspaceID: string;
 };

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -52,6 +52,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.4.0",
     "typescript": "~4.4.2",
-    "watch": "^1.0.2"
+    "watch": "^1.0.2",
+    "ioredis-mock": "^8.7.0"
   }
 }

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -364,7 +364,10 @@ export class WorkspaceManagerBridge implements Disposable {
                 await lifecycleHandler();
             }
             await this.messagebus.notifyOnInstanceUpdate(ctx, userId, instance);
-            await this.publisher.publishInstanceUpdate();
+            await this.publisher.publishInstanceUpdate({
+                instanceID: instance.id,
+                workspaceID: instance.workspaceId,
+            });
         } catch (e) {
             TraceContext.setError({ span }, e);
             throw e;

--- a/components/ws-manager-bridge/src/redis/publisher.spec.ts
+++ b/components/ws-manager-bridge/src/redis/publisher.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import { RedisPublisher } from "./publisher";
+import { Metrics } from "../metrics";
+import { RedisClient } from "./client";
+import { Container, ContainerModule } from "inversify";
+
+const expect = chai.expect;
+const Redis = require("ioredis-mock");
+
+@suite
+class TestRedisPublisher {
+    protected container: Container;
+
+    public before() {
+        const client = {
+            get: () => new Redis(),
+        } as RedisClient;
+
+        this.container = new Container();
+        this.container.load(
+            new ContainerModule((bind) => {
+                bind(Metrics).toSelf().inSingletonScope();
+                bind(RedisClient).toConstantValue(client);
+                bind(RedisPublisher).toSelf().inSingletonScope();
+            }),
+        );
+    }
+
+    @test public publishInstanceUpdate() {
+        const publisher = this.container.get(RedisPublisher);
+        expect(() => {
+            publisher.publishInstanceUpdate({
+                instanceID: "123",
+                workspaceID: "foo-bar-123",
+            });
+        }).not.to.throw;
+    }
+}
+module.exports = new TestRedisPublisher();

--- a/components/ws-manager-bridge/src/redis/publisher.ts
+++ b/components/ws-manager-bridge/src/redis/publisher.ts
@@ -7,19 +7,33 @@
 import { inject, injectable } from "inversify";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Metrics } from "../metrics";
+import { RedisClient } from "./client";
+import { WorkspaceInstanceUpdate, WorkspaceInstanceUpdatesChannel } from "@gitpod/gitpod-protocol";
 
 @injectable()
 export class RedisPublisher {
-    constructor(@inject(Metrics) private readonly metrics: Metrics) {}
+    constructor(
+        @inject(RedisClient) private readonly client: RedisClient,
+        @inject(Metrics) private readonly metrics: Metrics,
+    ) {}
 
     async publishPrebuildUpdate(): Promise<void> {
         log.debug("[redis] Publish prebuild udpate invoked.");
         this.metrics.reportUpdatePublished("prebuild");
     }
 
-    async publishInstanceUpdate(): Promise<void> {
-        log.debug("[redis] Publish instance udpate invoked.");
-        this.metrics.reportUpdatePublished("workspace-instance");
+    async publishInstanceUpdate(update: WorkspaceInstanceUpdate): Promise<void> {
+        let err: Error | undefined;
+        try {
+            const serialized = JSON.stringify(update);
+            await this.client.get().publish(WorkspaceInstanceUpdatesChannel, serialized);
+            log.debug("[redis] Succesfully published instance update.", update);
+        } catch (e) {
+            err = e;
+            log.error("[redis] Failed to publish instance update.", e, update);
+        } finally {
+            this.metrics.reportUpdatePublished("workspace-instance", err);
+        }
     }
 
     async publishHeadlessUpdate(): Promise<void> {

--- a/components/ws-manager-bridge/src/redis/publisher.ts
+++ b/components/ws-manager-bridge/src/redis/publisher.ts
@@ -8,7 +8,7 @@ import { inject, injectable } from "inversify";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Metrics } from "../metrics";
 import { RedisClient } from "./client";
-import { WorkspaceInstanceUpdate, WorkspaceInstanceUpdatesChannel } from "@gitpod/gitpod-protocol";
+import { RedisWorkspaceInstanceUpdate, WorkspaceInstanceUpdatesChannel } from "@gitpod/gitpod-protocol";
 
 @injectable()
 export class RedisPublisher {
@@ -22,7 +22,7 @@ export class RedisPublisher {
         this.metrics.reportUpdatePublished("prebuild");
     }
 
-    async publishInstanceUpdate(update: WorkspaceInstanceUpdate): Promise<void> {
+    async publishInstanceUpdate(update: RedisWorkspaceInstanceUpdate): Promise<void> {
         let err: Error | undefined;
         try {
             const serialized = JSON.stringify(update);

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -274,7 +274,10 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         await this.onStopped(ctx, info.workspace.ownerId, info.latestInstance);
 
         await this.messagebus.notifyOnInstanceUpdate(ctx, info.workspace.ownerId, info.latestInstance);
-        await this.publisher.publishInstanceUpdate();
+        await this.publisher.publishInstanceUpdate({
+            instanceID: info.latestInstance.id,
+            workspaceID: info.workspace.id,
+        });
 
         await this.prebuildUpdater.stopPrebuildInstance(ctx, info.latestInstance);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Publishes the instance ID and workspace ID to redis. Currently there are no consumers, but we can observe metrics to verify the publishing works.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-ws-man-d3e5aaf871</li>
	<li><b>🔗 URL</b> - <a href="https://mp-ws-man-d3e5aaf871.preview.gitpod-dev.com/workspaces" target="_blank">mp-ws-man-d3e5aaf871.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - mp-ws-man-redis-publish-instance-update-gha.12681</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
