### PR TITLE
Log network link state

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -471,6 +471,22 @@ func main() {
 				},
 			},
 			{
+				Name:  "dump-network-info",
+				Usage: "dump network info",
+				Action: func(c *cli.Context) error {
+					links, err := netlink.LinkList()
+					if err != nil {
+						return xerrors.Errorf("cannot list network links: %v", err)
+					}
+
+					for _, link := range links {
+						fmt.Printf("%v", link)
+					}
+
+					return nil
+				},
+			},
+			{
 				Name:  "setup-connection-limit",
 				Usage: "set up network connection rate limiting",
 				Flags: []cli.Flag{

--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -473,14 +473,42 @@ func main() {
 			{
 				Name:  "dump-network-info",
 				Usage: "dump network info",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name: "tag",
+					},
+				},
 				Action: func(c *cli.Context) error {
 					links, err := netlink.LinkList()
 					if err != nil {
 						return xerrors.Errorf("cannot list network links: %v", err)
 					}
 
+					tag := c.String("tag")
+
 					for _, link := range links {
-						fmt.Printf("%v", link)
+						attrs := link.Attrs()
+
+						ip4, _ := netlink.AddrList(link, netlink.FAMILY_V4)
+						ip6, _ := netlink.AddrList(link, netlink.FAMILY_V6)
+
+						log.Infof("%v", struct {
+							Tag   string
+							Name  string
+							Type  string
+							Ip4   []netlink.Addr
+							Ip6   []netlink.Addr
+							Flags net.Flags
+							MTU   int
+						}{
+							Tag:   tag,
+							Name:  attrs.Name,
+							Type:  link.Type(),
+							Ip4:   ip4,
+							Ip6:   ip6,
+							Flags: attrs.Flags,
+							MTU:   attrs.MTU,
+						})
 					}
 
 					return nil

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -382,6 +382,17 @@ func (wbs *InWorkspaceServiceServer) SetupPairVeths(ctx context.Context, req *ap
 	}, nsi.EnterMountNS(true), nsi.EnterPidNS(true), nsi.EnterNetNS(true))
 	if err != nil {
 		log.WithError(err).WithFields(wbs.Session.OWI()).Error("SetupPairVeths: cannot setup a peer veths")
+
+		nsi.Nsinsider(wbs.Session.InstanceID, int(containerPID), func(c *exec.Cmd) {
+			c.Args = append(c.Args, "dump-network-info",
+				fmt.Sprintf("--tag=%v", "pod"))
+		}, nsi.EnterMountNS(true), nsi.EnterPidNS(true), nsi.EnterNetNS(true))
+
+		nsi.Nsinsider(wbs.Session.InstanceID, int(pid), func(c *exec.Cmd) {
+			c.Args = append(c.Args, "dump-network-info",
+				fmt.Sprintf("--tag=%v", "workspace"))
+		}, nsi.EnterMountNS(true), nsi.EnterPidNS(true), nsi.EnterNetNS(true))
+
 		return nil, status.Errorf(codes.Internal, "cannot setup a peer veths")
 	}
 


### PR DESCRIPTION
## Description
Log network link state in case we cannot set up the workspace network

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-279

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
