### PR TITLE
[test] Use unique users

### DIFF
--- a/test/tests/components/ws-daemon/network_limiting_test.go
+++ b/test/tests/components/ws-daemon/network_limiting_test.go
@@ -36,6 +36,7 @@ func TestNetworkLimiting(t *testing.T) {
 				api.Done(t)
 			})
 
+			username := username + "-network-limit"
 			_, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)

--- a/test/tests/ide/ssh/ssh_gateway_test.go
+++ b/test/tests/ide/ssh/ssh_gateway_test.go
@@ -38,6 +38,7 @@ func TestSSHGatewayConnection(t *testing.T) {
 				api.Done(t)
 			})
 
+			username := username + "-ssh-gateway"
 			_, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -56,6 +56,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 				api.Done(t)
 			})
 
+			username := username + "-python-extension"
 			userId, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)

--- a/test/tests/smoke-test/smoke_test.go
+++ b/test/tests/smoke-test/smoke_test.go
@@ -31,6 +31,7 @@ func TestStartWorkspaceWithImageBuild(t *testing.T) {
 				api.Done(t)
 			})
 
+			username := username + "-smoke-test"
 			_, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -118,8 +118,9 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 			api := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			defer api.Done(t)
 
-			for _, test := range tests {
+			for i, test := range tests {
 				test := test
+				i := i
 				t.Run(test.ContextURL, func(t *testing.T) {
 					report.SetupReport(t, report.FeatureContentInit, fmt.Sprintf("Test to open %v", test.ContextURL))
 					if test.Skip {
@@ -134,6 +135,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					defer api.Done(t)
 
+					username := fmt.Sprintf("%s-context-%d", username, i)
 					_, err := api.CreateUser(username, userToken)
 					if err != nil {
 						t.Fatal(err)

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -52,6 +52,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 						api.Done(t)
 					})
 
+					username := username + "-example"
 					_, err := api.CreateUser(username, userToken)
 					if err != nil {
 						t.Fatal(err)

--- a/test/tests/workspace/ports_test.go
+++ b/test/tests/workspace/ports_test.go
@@ -46,6 +46,7 @@ func TestRegularWorkspacePorts(t *testing.T) {
 				api.Done(t)
 			})
 
+			username := username + "-ports"
 			_, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Create unique users per test, to prevent running into the max (4) parallel workspaces per user, due to tests running in parallel now

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Ran `test/run.sh -s workspace` locally

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
