### PR TITLE
[github] Basic lacework integration

### DIFF
--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -79,5 +79,7 @@ jobs:
         env:
           VERSION: ${{needs.configuration.outputs.version}}
           LW_ACCESS_TOKEN: '${{ steps.secrets.outputs.lacework-access-token }}'
+          # TODO(gpl) See docker.io access above
+          EXCLUDE_DOCKER_IO: true
         run: |
           ./scripts/lw-scan-images.sh

--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -1,0 +1,83 @@
+name: Lacework Inline Scanner
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+    branches:
+      - 'main'
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: "What Gitpod version to scan for CVEs"
+
+jobs:
+  configuration:
+    name: Configuration
+    runs-on: [self-hosted]
+    outputs:
+      skip: ${{ steps.configuration.outputs.skip }}
+      version: ${{ steps.configuration.outputs.version }}
+    steps:
+      - name: "Set outputs"
+        id: configuration
+        run: |
+            if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+                # The workflow was triggered by workflow_dispatch
+                {
+                    echo "version=${{ github.event.inputs.version }}"
+                    echo "skip=false"
+                } >> $GITHUB_OUTPUT
+            else
+                # The workflow was triggered by workflow_run
+                {
+                    echo "version=main-gha.${{ github.event.workflow_run.run_number }}"
+                    echo "skip=${{ github.event.workflow_run.conclusion == 'failure' }}"
+                } >> $GITHUB_OUTPUT
+            fi
+
+  scan-images:
+    # TODO(gpl) Could easily be run on ubuntu:latest if we pushed some bash in lw-scan-images.sh into the installer
+    runs-on: [self-hosted]
+    name: Scan all docker images for CVEs
+    # Only run if the build was successful
+    if: ${{ needs.configuration.outputs.skip == 'false' }}
+    steps:
+      # Most of this is taken over from the Build workflow/preview-env-check-regressions workflow
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      # TODO(gpl) How to configure proper docker.io access here, so that the inline scanner does not fail?
+      - uses: docker/login-action@v2
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: "${{ steps.auth.outputs.access_token }}"
+      - name: Get Secrets from GCP
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            lacework-access-token:gitpod-core-dev/lacework-access-token
+      - name: Lacework Inline Scanner
+        id: lacework-inline-scanner
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          VERSION: ${{needs.configuration.outputs.version}}
+          LW_ACCESS_TOKEN: '${{ steps.secrets.outputs.lacework-access-token }}'
+        run: |
+          ./scripts/lw-scan-images.sh

--- a/scripts/lw-scan-images.sh
+++ b/scripts/lw-scan-images.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ -z "$VERSION" ]]; then
+  echo "VERSION env var is required"
+  exit 1
+fi
+
+if [[ -z "$LW_ACCESS_TOKEN" ]]; then
+  echo "LW_ACCESS_TOKEN env var is required"
+  exit 1
+fi
+
+EXCLUDE_DOCKER_IO="${EXCLUDE_DOCKER_IO:-"false"}"
+
 TMP=$(mktemp -d)
 echo "workdir: $TMP"
 
@@ -27,11 +39,12 @@ echo "Found $(cat "$TMP/images.txt" | wc -l) images to scan"
 # There, we can see the results in the "Vulnerabilities" tab, by searching for the Gitpod version
 # Note: Does not fail on CVEs!
 while IFS= read -r IMAGE_REF; do
-  # Skip images with this prefix
-  # TODO(gpl) Unclear why we can't access the docker.io images; it works from a workspace?
-  if [[ "$IMAGE_REF" == "docker.io/"* ]]; then
-    echo "Skipping $IMAGE_REF"
-    continue
+  # TODO(gpl) Unclear why we can't access the docker.io images the GitHub workflow; it works from a workspace?
+  if [[ "$EXCLUDE_DOCKER_IO" == "true" ]]; then
+    if [[ "$IMAGE_REF" == "docker.io/"* ]]; then
+      echo "Skipping docker.io image: $IMAGE_REF"
+      continue
+    fi
   fi
 
   NAME=$(echo "$IMAGE_REF" | cut -d ":" -f 1)

--- a/scripts/lw-scan-images.sh
+++ b/scripts/lw-scan-images.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+TMP=$(mktemp -d)
+echo "workdir: $TMP"
+
+HOME="/home/gitpod"
+BIN="$HOME/bin"
+mkdir -p "$BIN"
+
+SCANNER="$BIN/lw-scanner"
+if [ ! -f "$SCANNER" ]; then
+  curl -L https://github.com/lacework/lacework-vulnerability-scanner/releases/latest/download/lw-scanner-linux-amd64 -o "$SCANNER"
+  chmod +x "$SCANNER"
+fi
+
+echo "Gathering list of _all_ images for $VERSION"
+# TODO(gpl) If we like this approach we should think about moving this into the installer as "list-images" or similar
+#           This would also remove the dependency to our dev image (yq4)
+docker run -v "$TMP":/workdir "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" config init -c "/workdir/config.yaml" --log-level=warn
+docker run -v "$TMP":/workdir "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" render -c "/workdir/config.yaml" --no-validation > "$TMP/rendered.yaml"
+yq4 --no-doc '(.. | select(key == "image" and tag == "!!str"))' "$TMP/rendered.yaml" > "$TMP/images.txt"
+# shellcheck disable=SC2002
+echo "Found $(cat "$TMP/images.txt" | wc -l) images to scan"
+
+# Scan all images, and push the result to Lacework
+# There, we can see the results in the "Vulnerabilities" tab, by searching for the Gitpod version
+# Note: Does not fail on CVEs!
+while IFS= read -r IMAGE_REF; do
+  # Skip images with this prefix
+  # TODO(gpl) Unclear why we can't access the docker.io images; it works from a workspace?
+  if [[ "$IMAGE_REF" == "docker.io/"* ]]; then
+    echo "Skipping $IMAGE_REF"
+    continue
+  fi
+
+  NAME=$(echo "$IMAGE_REF" | cut -d ":" -f 1)
+  TAG=$(echo "$IMAGE_REF" | cut -d ":" -f 2)
+  echo "Scanning $NAME : $TAG"
+  "$SCANNER" image evaluate "$NAME" "$TAG" \
+    --account-name gitpod \
+    --access-token "$LW_ACCESS_TOKEN" \
+    --build-id "$VERSION" \
+    --ci-build=true \
+    --disable-library-package-scanning=false \
+    --save=true \
+    --tags version="$VERSION" > /dev/null
+done < "$TMP/images.txt"


### PR DESCRIPTION
## Description

This PR adds:
 - `scripts/lw-scan-images.sh`: Scan all images for a given Gitpod version using the Lacework inline scanner [[1](https://www.google.de/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwisjKra4fn_AhVw0QIHHUt0DckQFnoECBUQAQ&url=https%3A%2F%2Fdocs.lacework.net%2Fonboarding%2Fintegrate-inline-scanner&usg=AOvVaw0Rvx-joprdhfQMkyiK-ln9&opi=89978449)], and send the result to lacework so we can use it in policies/alerts 
 - a new workflow `Lacework Inline Scanner` which gets trigger on each successful main build and uses that script

First I tried to hook this up to the build directly, but it slowed it down too much (~10mins).

### Todo
 - figure out how to access docker.io from GitHub actions [[2](https://github.com/gitpod-io/gitpod/blob/2882ae5e97f8d1ee389ce64df0e965eb867058e6/.github/workflows/lacework-inline-scanner.yml#L63)]
 - configure alerts (to Slack?) in Lacework

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes PDEO-67

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [x] scan-images
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
