### PR TITLE
[spicedb] added installation and admin permission

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -4,15 +4,23 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+export const InstallationID = "1";
+export const InstallationResourceType = "installation";
 export const OrganizationResourceType = "organization";
 export const ProjectResourceType = "project";
 export const UserResourceType = "user";
-export type ResourceType = typeof OrganizationResourceType | typeof ProjectResourceType | typeof UserResourceType;
+export type ResourceType =
+    | typeof InstallationResourceType
+    | typeof OrganizationResourceType
+    | typeof ProjectResourceType
+    | typeof UserResourceType;
 
-export type OrganizationRelation = "owner" | "member";
-export type ProjectRelation = "org";
-export type Relation = OrganizationRelation | ProjectRelation;
+export type InstallationRelation = "user" | "admin";
+export type OrganizationRelation = "installation" | "owner" | "member";
+export type ProjectRelation = "org" | "editor" | "viewer";
+export type Relation = InstallationRelation | OrganizationRelation | ProjectRelation;
 
+export type InstallationPermission = "create_organization";
 export type OrganizationPermission =
     | "read_info"
     | "write_info"
@@ -21,12 +29,12 @@ export type OrganizationPermission =
     | "write_members"
     | "leave"
     | "delete"
+    | "create_project"
     | "read_settings"
     | "write_settings"
     | "read_git_provider"
     | "write_git_provider"
     | "read_billing"
-    | "write_billing"
-    | "create_project";
+    | "write_billing";
 export type ProjectPermission = "write_info" | "read_info" | "delete";
 export type Permission = OrganizationPermission;

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -64,7 +64,8 @@ export class OrganizationService {
         try {
             result = await this.teamDB.transaction(async (db) => {
                 result = await db.createTeam(userId, name);
-                await this.auth.addOrganizationOwnerRole(result.id, userId);
+                const members = await db.findMembersByTeam(result.id);
+                await this.auth.addOrganization(result, members, []);
                 return result;
             });
         } catch (err) {

--- a/install/installer/pkg/components/spicedb/data/schema.yaml
+++ b/install/installer/pkg/components/spicedb/data/schema.yaml
@@ -5,50 +5,55 @@
 schema: |-
   definition user {}
 
+  // There's only one global installation
+  definition installation {
+
+    // only users that are not owned by an org are considered installation-level users
+    relation user: user
+    relation admin: user
+
+    // orgs can only be created by installation-level users
+    permission create_organization = user
+
+  }
+
   definition organization {
+    relation installation: installation
+
     // Every user in an organization is automatically a member
     relation member: user
     // Some users in an organization may additionally have the `owner` role
-    // granting them more privilidges with respect to the organization.
     relation owner: user
 
+    // synthetic permission for installation->admin (because https://github.com/authzed/spicedb/issues/15)
+    permission installation_admin = installation->admin
+
     // General operations on organization
-    permission read_info = member + owner
-    permission write_info = owner
+    permission read_info = member + owner + installation->admin
+    permission write_info = owner + installation->admin
+    permission delete = owner + installation->admin
+
+    permission read_settings = owner + installation->admin
+    permission write_settings = owner + installation->admin
 
     // Operations on Organization's Members
-    permission read_members = member + owner
-    permission invite_members = member + owner
-    permission write_members = owner
+    permission read_members = member + owner + installation->admin
+    permission invite_members = member + owner + installation->admin
+    permission write_members = owner + installation->admin
+    permission leave = owner + member + installation->admin
 
-    // Any user in the organization can try to leave their organization
-    permission leave = owner + member
+    permission create_project = member + owner + installation->admin
 
-    // Owners can delete the organization,
-    // and through this process also disconnect all users from the organization
-    permission delete = owner
+    permission read_git_provider = owner + member + installation->admin
+    permission write_git_provider = owner + installation->admin
 
-    // Only owners can create new projects
-    permission create_project = member + owner
-
-    // Only owners can change settings
-    permission read_settings = owner
-    permission write_settings = owner
-
-    // Only owners can change Git providers
-    permission read_git_provider = owner + member
-    permission write_git_provider = owner
-
-    // Only owners can create and modify billing information
-    permission read_billing = member + owner
-    permission write_billing = owner
+    permission read_billing = member + owner + installation->admin
+    permission write_billing = owner + installation->admin
   }
 
   definition project {
     relation org: organization
 
-    // A subject is an editor, if:
-    //  * the user is directly assigned as an editor
     relation editor: user
 
     // A subject is a viewer, if:
@@ -56,25 +61,18 @@ schema: |-
     //  * the project has granted access to everyone in an organization
     relation viewer: user | organization#member
 
-    // Project can be modified by:
-    //  * Organization owners
-    //  * editors
-    permission write_info = org->owner + editor
-
-    // Project can be accessed by:
-    //  * Anyone with write_info permission
-    //  * viewers
-    permission read_info = write_info + viewer + org->member
-
-    // Project can be deleted by:
-    //  * Organization owners
-    //  * editors
-    permission delete = org->owner + editor
+    permission write_info = org->owner + editor + org->installation_admin
+    permission read_info = write_info + viewer + org->member + org->installation_admin
+    permission delete = org->owner + editor + org->installation_admin
   }
-
 # relationships to be used for assertions & validation
 relationships: |-
+  // we have one installation
+  installation:installation_0#user@user:user_0
+  installation:installation_0#admin@user:user_admin
+
   // We have an organization org_1, which has some members & owners
+  organization:org_1#installation@installation:installation_0
   organization:org_1#member@user:user_0
   organization:org_1#owner@user:user_0
   organization:org_1#member@user:user_1
@@ -99,6 +97,10 @@ relationships: |-
 # validation should assert that a particular relation exists between an entity, and a subject
 # validations are not used to assert that a permission exists
 validation:
+  installation:installation_0#user:
+    - "[user:user_0] is <installation:installation_0#user>"
+  installation:installation_0#admin:
+    - "[user:user_admin] is <installation:installation_0#admin>"
   organization:org_1#member:
     - "[user:user_0] is <organization:org_1#member>"
     - "[user:user_1] is <organization:org_1#member>"
@@ -112,6 +114,7 @@ validation:
 # assertions should assert that a particular permission holds, or not
 assertions:
   assertTrue:
+    # user 0 can read org_1 because they are a member
     - organization:org_1#read_info@user:user_0
     # user 1 can read git providers because they are a member
     - organization:org_1#read_git_provider@user:user_1
@@ -134,6 +137,13 @@ assertions:
     - project:project_1#read_info@user:user_1
     # Org member can create projects
     - organization:org_1#create_project@user:user_1
+    # installation user can create orgs
+    - installation:installation_0#create_organization@user:user_0
+    # Installation admin can do what org owners can
+    - project:project_1#delete@user:user_admin
+    - organization:org_1#delete@user:user_admin
+    - organization:org_1#write_settings@user:user_admin
+    - organization:org_1#write_git_provider@user:user_admin
   assertFalse:
     # user 10 cannot access project_1
     - project:project_1#read_info@user:user_10
@@ -153,3 +163,5 @@ assertions:
     - organization:org_1#delete@user:user_1
     # org members can not delete project
     - project:project_1#delete@user:user_1
+    # installation admin can not create an org
+    - installation:installation_0#create_organization@user:user_admin


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds the global installation reource and two roles as well as one permission (create_organization)

I also applied a pattern where each role gets a corresponding `is_<role>` oermission that can be composed of a relation ship and a permission, to make the permissions more readable

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-420

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
