### PR TITLE
[obs] reduce noise related to GitpodWsManagerCrashLoopingMk2

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -11,24 +11,14 @@ metadata:
   name: ws-manager-monitoring-rules
 spec:
   groups:
-  - name: ws-manager
-    rules:
-    - alert: GitpodWsManagerCrashLooping
-      labels:
-        severity: critical
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
-        summary: Ws-manager is crashlooping in cluster {{ $labels.cluster }}.
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
-      expr: |
-        increase(kube_pod_container_status_restarts_total{container="ws-manager", cluster!~"ephemeral.*"}[10m]) > 0
-    - alert: GitpodWsManagerCrashLoopingMk2
-      labels:
-        severity: critical
-        dedicated: included
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
-        summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
-      expr: |
-        increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[10m]) > 0
+    - name: ws-manager
+      rules:
+      - alert: GitpodWsManagerCrashLoopingMk2
+        labels:
+          severity: warning
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
+          summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+        expr: |
+          increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[10m]) > 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When it triggers now, it's generally due to WKS-210, and is not valuable to  gitpod.io or Dedicated in it's current form.

In other words, if ws-manager-mk2 restarts, it recovers and no action is needed. If it's unable to start, we won't be able to createWorkspace (and server should emit a signal).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-288

## How to test
<!-- Provide steps to test this PR -->
n/a

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
