### PR TITLE
Switch github runners

### DIFF
--- a/.github/workflows/authorization.yml
+++ b/.github/workflows/authorization.yml
@@ -6,7 +6,7 @@ on:
 name: SpiceDB
 jobs:
   scan-repo:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     name: Validate schema
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   configuration:
     name: Configure job parameters
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     concurrency:
       # github.head_ref is set by a pull_request event - contains the name of the source branch of the PR
       # github.ref_name is set if the event is NOT a pull_request - it contains only the branch name.
@@ -83,7 +83,7 @@ jobs:
     needs: [ configuration ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-build-previewctl
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
       volumes:
@@ -121,7 +121,7 @@ jobs:
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
       (needs.configuration.outputs.preview_enable == 'true') &&
       (needs.configuration.outputs.is_main_branch != 'true')
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     concurrency:
       group: ${{ github.head_ref || github.ref_name }}-infrastructure
     steps:
@@ -140,7 +140,7 @@ jobs:
   build-gitpod:
     name: Build Gitpod
     needs: [ configuration ]
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     concurrency:
       group: ${{ github.head_ref || github.ref_name }}-build-gitpod
       # For the main branch we always want the build job to run to completion
@@ -301,7 +301,7 @@ jobs:
             test-coverage-report
 
   install-app:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     needs: [ configuration, build-gitpod ]
     if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
     steps:
@@ -329,7 +329,7 @@ jobs:
   install:
     name: "Install Gitpod"
     needs: [ configuration, build-previewctl, build-gitpod, infrastructure ]
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-install
     steps:
@@ -372,7 +372,7 @@ jobs:
   monitoring:
     name: "Install Monitoring Satellite"
     needs: [ infrastructure, build-previewctl ]
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-monitoring
     steps:
@@ -387,7 +387,7 @@ jobs:
   integration-test:
     name: "Run integration test"
     needs: [ configuration, build-previewctl, build-gitpod, infrastructure, install ]
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     container:
         image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
         volumes:

--- a/.github/workflows/check-gitpodyaml.yml
+++ b/.github/workflows/check-gitpodyaml.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   notify:
     name: Build and upload model
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - name: Notify
         uses: KeisukeYamashita/create-comment@v1

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/comment-ops.yaml
+++ b/.github/workflows/comment-ops.yaml
@@ -17,7 +17,7 @@ jobs:
       (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER') &&
       (github.event.issue.pull_request && contains(github.event.comment.body, '/gh run')) &&
       (contains(github.event.comment.body, 'recreate-vm'))
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     # Technically we don't need these here, as we don't reuse them between jobs, but it's good to have them in a single place
     outputs:
       branch: ${{ steps.comment-branch.outputs.head_ref }}
@@ -101,7 +101,7 @@ jobs:
   comment-fail:
     if: (always() && contains(needs.*.result, 'failure'))
     needs: [ configure ]
-    runs-on: [ self-hosted ]
+    runs-on: gitpod-runners
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/configcat.yml
+++ b/.github/workflows/configcat.yml
@@ -5,7 +5,7 @@ on:
 name: Configcat code references
 jobs:
   scan-repo:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     name: Scan repository for configcat code references
     steps:
     - name: Checkout

--- a/.github/workflows/dashboard-sync.yml
+++ b/.github/workflows/dashboard-sync.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/.github/workflows/delete-kots-channel.yml
+++ b/.github/workflows/delete-kots-channel.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   delete:
     if: github.event.ref_type == 'branch'
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     continue-on-error: true
     steps:
       - name: Install Replicated CLI

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     configuration:
         name: Configuration
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
         outputs:
@@ -64,7 +64,7 @@ jobs:
     infrastructure:
         name: Create preview environment infrastructure
         needs: [ configuration ]
-        runs-on: [ self-hosted ]
+        runs-on: gitpod-runners
         concurrency:
             group: ${{ needs.configuration.outputs.name }}-infrastructure
         steps:
@@ -89,7 +89,7 @@ jobs:
     check:
         name: Check for regressions
         needs: [configuration, infrastructure]
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
             volumes:
@@ -177,7 +177,7 @@ jobs:
       name: Delete preview environment
       needs: [ configuration, infrastructure, check ]
       if: github.event.inputs.skip_delete != 'true' && always()
-      runs-on: [ self-hosted ]
+      runs-on: gitpod-runners
       steps:
         - uses: actions/checkout@v3
         - name: Delete preview environment

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -17,9 +17,10 @@ on:
 
 jobs:
   update-jetbrains:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
           go-version: "1.19"

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -33,7 +33,7 @@ on:
         required: true
 jobs:
   jetbrains-smoke-test-linux:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - name: Generate Summary
         if: always()

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -29,7 +29,7 @@ on:
 jobs:
     update-plugin-platform:
         name: Update Platform Version from ${{ inputs.pluginName }}
-        runs-on: ubuntu-latest
+        runs-on: gitpod-runners
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     update-jetbrains:
-        runs-on: ubuntu-latest
+        runs-on: gitpod-runners
         steps:
             - uses: actions/checkout@v3
             - name: Check for updates

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -20,7 +20,7 @@ on:
 jobs:
     configuration:
         name: Configuration
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         outputs:
             skip: ${{ steps.configuration.outputs.skip }}
             name: ${{ steps.configuration.outputs.name }}
@@ -51,7 +51,7 @@ jobs:
     infrastructure:
         name: Create preview environment infrastructure
         needs: [ configuration ]
-        runs-on: [ self-hosted ]
+        runs-on: gitpod-runners
         concurrency:
             group: ${{ needs.configuration.outputs.name }}-infrastructure
         steps:
@@ -76,7 +76,7 @@ jobs:
         name: Check for regressions
         needs: [configuration, infrastructure]
         if: ${{ needs.configuration.outputs.skip == 'false' }}
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
             volumes:
@@ -162,7 +162,7 @@ jobs:
         name: Delete preview environment
         needs: [ configuration, infrastructure, check ]
         if: always()
-        runs-on: [ self-hosted ]
+        runs-on: gitpod-runners
         steps:
             - uses: actions/checkout@v3
             - name: Delete preview environment

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     delete:
         if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         steps:
             - uses: actions/checkout@v3
             - name: Delete preview environment

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     stale:
         name: "Find stale preview environments"
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
         outputs:
@@ -43,7 +43,7 @@ jobs:
     delete:
         name: "Delete preview environment"
         needs: [stale]
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         if: ${{ needs.stale.outputs.count > 0 }}
         strategy:
             fail-fast: false

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -5,7 +5,7 @@ on:
     - components/public-api/**
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: gitpod-runners
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   label:
     name: Apply team labels
-    runs-on: ubuntu-20.04
+    runs-on: gitpod-runners
     steps:
       - name: Set team labels as output
         id: team_labels

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: gitpod-runners
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     configuration:
         name: Configuration
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
             volumes:
@@ -86,7 +86,7 @@ jobs:
 
     infrastructure:
       needs: [ configuration ]
-      runs-on: [ self-hosted ]
+      runs-on: gitpod-runners
       concurrency:
         group: ${{ needs.configuration.outputs.name }}-infrastructure
       steps:
@@ -111,7 +111,7 @@ jobs:
     check:
         name: Check for regressions
         needs: [configuration, infrastructure]
-        runs-on: [self-hosted]
+        runs-on: gitpod-runners
         container:
             image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
             volumes:
@@ -227,7 +227,7 @@ jobs:
       name: Delete preview environment
       needs: [ configuration, infrastructure, check ]
       if: github.event.inputs.skip_delete != 'true' && always()
-      runs-on: [ self-hosted ]
+      runs-on: gitpod-runners
       container:
         image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
         volumes:


### PR DESCRIPTION

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
