### PR TITLE
[server] Make parallel ws limit configurable

### DIFF
--- a/components/server/src/billing/entitlement-service-ubp.ts
+++ b/components/server/src/billing/entitlement-service-ubp.ts
@@ -26,9 +26,6 @@ import { BillingModes } from "./billing-mode";
 import { CostCenter_BillingStrategy } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 import { UsageService } from "../user/usage-service";
 
-const MAX_PARALLEL_WORKSPACES_FREE = 4;
-const MAX_PARALLEL_WORKSPACES_PAID = 16;
-
 /**
  * EntitlementService implementation for Usage-Based Pricing (UBP)
  */
@@ -84,9 +81,9 @@ export class EntitlementServiceUBP implements EntitlementService {
 
     protected async getMaxParallelWorkspaces(user: User, date: Date): Promise<number> {
         if (await this.hasPaidSubscription(user, date)) {
-            return MAX_PARALLEL_WORKSPACES_PAID;
+            return this.config.maxParallelWorkspacesPaid;
         } else {
-            return MAX_PARALLEL_WORKSPACES_FREE;
+            return this.config.maxParallelWorkspacesFree;
         }
     }
 

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -149,6 +149,9 @@ export interface ConfigSerialized {
     /** maxConcurrentPrebuildsPerRef is the maximum number of prebuilds we allow per ref type at any given time */
     maxConcurrentPrebuildsPerRef: number;
 
+    maxParallelWorkspacesFree: number;
+    maxParallelWorkspacesPaid: number;
+
     incrementalPrebuilds: {
         repositoryPasslist: string[];
         commitHistory: number;

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -258,6 +258,7 @@ yq w -i "${INSTALLER_CONFIG_PATH}" workspace.resources.requests.memory "256Mi"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.procLimit 1000
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.ioLimits.writeBandwidthPerSecond "250Mi"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.ioLimits.readBandwidthPerSecond "300Mi"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.server.maxParallelWorkspacesFree 16
 
 # create two workspace classes (g1-standard and g1-small) in server-config configmap
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-standard"

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -192,6 +192,21 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	_, _, authCfg := auth.GetConfig(ctx)
 
+	maxParallelWorkspacesFree := 4
+	maxParallelWorkspacesPaid := 16
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp == nil || cfg.WebApp.Server == nil {
+			return nil
+		}
+		if cfg.WebApp.Server.MaxParallelWorkspacesFree != nil {
+			maxParallelWorkspacesFree = *cfg.WebApp.Server.MaxParallelWorkspacesFree
+		}
+		if cfg.WebApp.Server.MaxParallelWorkspacesPaid != nil {
+			maxParallelWorkspacesPaid = *cfg.WebApp.Server.MaxParallelWorkspacesPaid
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -242,6 +257,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		DisableDynamicAuthProviderLogin:   disableDynamicAuthProviderLogin,
 		MaxEnvvarPerUserCount:             4048,
 		MaxConcurrentPrebuildsPerRef:      10,
+		MaxParallelWorkspacesFree:         int32(maxParallelWorkspacesFree),
+		MaxParallelWorkspacesPaid:         int32(maxParallelWorkspacesPaid),
 		IncrementalPrebuilds:              IncrementalPrebuilds{CommitHistory: 100, RepositoryPasslist: []string{}},
 		BlockNewUsers:                     ctx.Config.BlockNewUsers,
 		DefaultBaseImageRegistryWhitelist: defaultBaseImageRegistryWhitelist,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -26,6 +26,8 @@ type ConfigSerialized struct {
 	DisableDynamicAuthProviderLogin   bool        `json:"disableDynamicAuthProviderLogin"`
 	MaxEnvvarPerUserCount             int32       `json:"maxEnvvarPerUserCount"`
 	MaxConcurrentPrebuildsPerRef      int32       `json:"maxConcurrentPrebuildsPerRef"`
+	MaxParallelWorkspacesFree         int32       `json:"maxParallelWorkspacesFree"`
+	MaxParallelWorkspacesPaid         int32       `json:"maxParallelWorkspacesPaid"`
 	MakeNewUsersAdmin                 bool        `json:"makeNewUsersAdmin"`
 	DefaultBaseImageRegistryWhitelist []string    `json:"defaultBaseImageRegistryWhitelist"`
 	RunDbDeleter                      bool        `json:"runDbDeleter"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -253,6 +253,8 @@ type ServerConfig struct {
 	InactivityPeriodForReposInDays    *int              `json:"inactivityPeriodForReposInDays"`
 	ShowSetupModal                    *bool             `json:"showSetupModal"`
 	IsSingleOrgInstallation           bool              `json:"isSingleOrgInstallation"`
+	MaxParallelWorkspacesFree         *int              `json:"maxParallelWorkspacesFree"`
+	MaxParallelWorkspacesPaid         *int              `json:"maxParallelWorkspacesPaid"`
 
 	// @deprecated use containerRegistry.privateBaseImageAllowList instead
 	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`


### PR DESCRIPTION
## Description

Make parallel free/paid workspace limit configurable, and set the free limit to 16 in preview envs to support running more tests in parallel

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to WKS-153

## How to test
<!-- Provide steps to test this PR -->

Created a preview env, and tested I could create max 16 workspaces in parallel as a free user.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
