### PR TITLE
Fix lacework integration workflow

### DIFF
--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -43,14 +43,13 @@ jobs:
     runs-on: [self-hosted]
     needs: [configuration]
     if: ${{ needs.configuration.outputs.skip == 'false' }}
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
     steps:
       # Most of this is taken over from the Build workflow/preview-env-check-regressions workflow
       - uses: actions/checkout@v3
       - name: Configure workspace
         run: |
-          cp -r /__w/gitpod/gitpod /workspace
-          # Needed by google-github-actions/setup-gcloud
-          sudo chown -R gitpod:gitpod /__t
           # Needed by docker/login-action
           sudo chmod goa+rw /var/run/docker.sock
       - id: auth
@@ -75,11 +74,10 @@ jobs:
       - name: Lacework Inline Scanner
         id: lacework-inline-scanner
         shell: bash
-        working-directory: /workspace/gitpod
         env:
           VERSION: ${{needs.configuration.outputs.version}}
           LW_ACCESS_TOKEN: '${{ steps.secrets.outputs.lacework-access-token }}'
           # TODO(gpl) See docker.io access above
           EXCLUDE_DOCKER_IO: true
         run: |
-          ./scripts/lw-scan-images.sh
+          $GITHUB_WORKSPACE/scripts/lw-scan-images.sh

--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "Set outputs"
         id: configuration
         run: |
-            if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+            if [[ '${{ github.event.workflow_run.run_number }}' == '' ]]; then
                 # The workflow was triggered by workflow_dispatch
                 {
                     echo "version=${{ github.event.inputs.version }}"


### PR DESCRIPTION
## Description

Hopefully last follow-up for https://github.com/gitpod-io/gitpod/pull/18178 :crossed_fingers: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Working example: https://github.com/gitpod-io/gitpod/actions/runs/5476187478/jobs/9973362193

Check results at: https://gitpod.lacework.net/ui?redirectUrl=/investigation/container/VulnerabilityDashboard and search for "All images", "Build ID = main-gha.12830"

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
