### PR TITLE
[server] Report client-side metrics for all spicedb operations

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -238,17 +238,12 @@ export function reportCentralizedPermsValidation(operation: string, matches: boo
 export const spicedbClientLatency = new prometheusClient.Histogram({
     name: "gitpod_spicedb_client_requests_completed_seconds",
     help: "Histogram of completed spicedb client requests",
-    labelNames: ["operation", "permission", "outcome"],
+    labelNames: ["operation", "outcome"],
 });
 
-export function observespicedbClientLatency(
-    operation: string,
-    permission: string,
-    outcome: Error | undefined,
-    durationInSeconds: number,
-) {
+export function observespicedbClientLatency(operation: string, outcome: Error | undefined, durationInSeconds: number) {
     spicedbClientLatency.observe(
-        { operation, permission, outcome: outcome === undefined ? "success" : "error" },
+        { operation, outcome: outcome === undefined ? "success" : "error" },
         durationInSeconds,
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
