### PR TITLE
[alerts] Reduce the threshold for WebAppServicesCrashlooping

### DIFF
--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -98,17 +98,32 @@ spec:
         dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default
 
     - alert: WebAppServicesCrashlooping
-      # Reasoning: alert if any pod is restarting more than 3 times / 5 minutes.
-      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster) > 3
+      # Reasoning: alert if any pod is stuck in crashlooping more than 5 minute.
+      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 1
+      # Five minutes sound high, but that's the only value that's higher than recent history
       for: 5m
       labels:
-        # sent to the team internal channel until we fine tuned it
+        severity: critical
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesCrashlooping.md
+        summary: Pod is crash looping in {{ $labels.cluster }}.
+        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is stuck in crashlooping for at least 5 minutes
+
+    - alert: WebAppServicesCrashloopingInternal
+      # Reasoning: alert if any pod is stuck in crashlooping more than 1 minute.
+      # Used for fine tuning the alert above (WebAppServicesCrashlooping)!
+      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 1
+      # Let's be more ambitious than 5m
+      for: 1m
+      labels:
+        # sent to the team internal channel until we can propagate these values to CRITICAL
         severity: warning
         team: webapp
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesCrashlooping.md
         summary: Pod is crash looping in {{ $labels.cluster }}.
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes
+        description: "FINE TUNE: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is stuck in crashlooping for at least 1 minutes"
 
     - alert: StartWorkspace_InternalErrors
       expr: sum(increase(gitpod_server_api_calls_total{method="startWorkspace", statusCode=~"5.*"}[1m])) by (cluster) > 5

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -113,7 +113,7 @@ spec:
     - alert: WebAppServicesCrashloopingInternal
       # Reasoning: alert if any pod is stuck in crashlooping more than 1 minute.
       # Used for fine tuning the alert above (WebAppServicesCrashlooping)!
-      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 1
+      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 0
       # Let's be more ambitious than 5m
       for: 1m
       labels:

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -123,7 +123,7 @@ spec:
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesCrashlooping.md
         summary: Pod is crash looping in {{ $labels.cluster }}.
-        description: "FINE TUNE: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is stuck in crashlooping for at least 1 minutes"
+        description: "FINE TUNE: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is stuck in crashlooping for at least 1 minute"
 
     - alert: StartWorkspace_InternalErrors
       expr: sum(increase(gitpod_server_api_calls_total{method="startWorkspace", statusCode=~"5.*"}[1m])) by (cluster) > 5

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -99,7 +99,7 @@ spec:
 
     - alert: WebAppServicesCrashlooping
       # Reasoning: alert if any pod is stuck in crashlooping more than 5 minute.
-      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 1
+      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 0
       # Five minutes sound high, but that's the only value that's higher than recent history
       for: 5m
       labels:


### PR DESCRIPTION
and add an internal version with even lower threshold for further improvements

Situation that we are trying to detect:
![image](https://github.com/gitpod-io/gitpod/assets/32448529/261bdc1a-09f5-48ad-878b-26ec824ad15c)


## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/WEB-607/bridge-crash-incident-crashloop-alert-did-not-fire

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
