### PR TITLE
[alerts] Add JsonRpcApiErrorRates and WebAppServicesCrashlooping to Dedicated

### DIFF
--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -46,13 +46,12 @@ spec:
 
     # Rollout alerts
     - alert: JsonRpcApiErrorRates
-      # Reasoning: the values are taken from past data
       expr: sum(rate(gitpod_server_api_calls_total{statusCode!~"2.*|3.*|4.*"}[5m])) by (cluster) / sum(rate(gitpod_server_api_calls_total[5m])) by (cluster) > 0.04
       for: 5m
       labels:
-        # sent to the team internal channel until we fine tuned it
-        severity: warning
+        severity: critical
         team: webapp
+        dedicated: included
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodApiErrorRate.md
         summary: The error rate of the JSON RPC API is high on {{ $labels.cluster }}. Investigation required.
@@ -105,6 +104,7 @@ spec:
       labels:
         severity: critical
         team: webapp
+        dedicated: included
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesCrashlooping.md
         summary: Pod is crash looping in {{ $labels.cluster }}.


### PR DESCRIPTION
## Description

This is the first stab at setting up alerts for Dedicated, after following [this guide](https://github.com/gitpod-io/gitpod-dedicated/tree/main/ops/telemetry/alerts).

More alerts blocked by:
 - cannot setup alerts with `warning`, yet
 - cannot setup alerts only for Dedicated, yet
/cc @kylos101 

As a result, I took the super-conservative path and only added the minimal set.




## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-583

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
