### PR TITLE
[server] Gauge for registered listeners

### DIFF
--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -96,7 +96,7 @@ export class RedisSubscriber implements LocalMessageBroker {
     }
 
     listenForWorkspaceInstanceUpdates(userId: string, listener: WorkspaceInstanceUpdateListener): Disposable {
-        return this.doRegister(userId, listener, this.workspaceInstanceUpdateListeners);
+        return this.doRegister(userId, listener, this.workspaceInstanceUpdateListeners, "workspace-instance");
     }
 
     protected doRegister<L>(

--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -19,7 +19,11 @@ import {
 } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { reportRedisUpdateCompleted, reportRedisUpdateReceived } from "../prometheus-metrics";
+import {
+    reportRedisUpdateCompleted,
+    reportRedisUpdateReceived,
+    updateSubscribersRegistered,
+} from "../prometheus-metrics";
 import { Redis } from "ioredis";
 
 @injectable()
@@ -95,18 +99,25 @@ export class RedisSubscriber implements LocalMessageBroker {
         return this.doRegister(userId, listener, this.workspaceInstanceUpdateListeners);
     }
 
-    protected doRegister<L>(key: string, listener: L, listenersStore: Map<string, L[]>): Disposable {
+    protected doRegister<L>(
+        key: string,
+        listener: L,
+        listenersStore: Map<string, L[]>,
+        type: "workspace-instance" | "prebuild" | "prebuild-updatable",
+    ): Disposable {
         let listeners = listenersStore.get(key);
         if (listeners === undefined) {
             listeners = [];
             listenersStore.set(key, listeners);
         }
         listeners.push(listener);
+        updateSubscribersRegistered.labels(type).inc();
         return Disposable.create(() => {
             const ls = listeners!;
             const idx = ls.findIndex((l) => l === listener);
             if (idx !== -1) {
                 ls.splice(idx, 1);
+                updateSubscribersRegistered.labels(type).dec();
             }
             if (ls.length === 0) {
                 listenersStore.delete(key);

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -33,6 +33,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(redisCacheRequestsTotal);
     registry.registerMetric(redisUpdatesReceived);
     registry.registerMetric(redisUpdatesCompletedTotal);
+    registry.registerMetric(updateSubscribersRegistered);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -330,3 +331,9 @@ export const redisUpdatesCompletedTotal = new prometheusClient.Counter({
 export function reportRedisUpdateCompleted(channel: string, err?: Error) {
     redisUpdatesCompletedTotal.labels(channel, err ? "true" : "false").inc();
 }
+
+export const updateSubscribersRegistered = new prometheusClient.Gauge({
+    name: "gitpod_server_subscribers_registered",
+    help: "Gauge of subscribers registered",
+    labelNames: ["type"],
+});


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
