### PR TITLE
[test] Fix RPC retries & improve logging

### DIFF
--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -208,30 +208,29 @@ func (r *RpcClient) Call(serviceMethod string, args any, reply any) error {
 	var err error
 	var new *RpcClient
 	for i := 0; i < connectFailureMaxTries; i++ {
-		if r != nil {
-			if err = r.client.Call(serviceMethod, args, reply); err != nil {
-				log.Warnf("rpc call %s failed (attempt %d): %v", serviceMethod, i, err)
-				if i == connectFailureMaxTries-1 {
-					return err
-				}
-
-				time.Sleep(10 * time.Second)
-				r.Close()
-				new, _, err = Instrument(r.component, r.agentName, r.namespace, r.kubeconfig, r.kclient, r.opts...)
-				if err != nil {
-					time.Sleep(10 * time.Second)
-					continue
-				}
-				r = new
-			}
-		} else {
+		if r == nil {
 			new, _, err = Instrument(r.component, r.agentName, r.namespace, r.kubeconfig, r.kclient, r.opts...)
 			if err != nil {
+				log.Warnf("failed to re-instrument (attempt %d): %v", i, err)
 				time.Sleep(10 * time.Second)
 				continue
 			}
 			r = new
 		}
+
+		err = r.client.Call(serviceMethod, args, reply)
+		if err == nil {
+			return nil
+		}
+
+		log.Warnf("rpc call %s failed (attempt %d): %v", serviceMethod, i, err)
+		if i == connectFailureMaxTries-1 {
+			return err
+		}
+
+		time.Sleep(10 * time.Second)
+		r.Close()
+		r = nil // Try to Instrument again next attempt
 	}
 	return err
 }
@@ -446,7 +445,10 @@ L:
 func shutdownAgent(podExec *PodExec, kubeconfig string, podName string, namespace string, containerName string) error {
 	cmd := []string{"curl", "localhost:8080/shutdown"}
 	_, _, _, err := podExec.ExecCmd(cmd, podName, namespace, containerName)
-	return err
+	if err != nil {
+		return fmt.Errorf("curl failed: %v", err)
+	}
+	return nil
 }
 
 func getFreePort() (int, error) {

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	"github.com/gitpod-io/gitpod/common-go/log"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	daemon "github.com/gitpod-io/gitpod/test/pkg/agent/daemon/api"
 	wsapi "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
@@ -140,7 +139,7 @@ func TestCpuBurst(t *testing.T) {
 			}, &cpuResp)
 
 			if err != nil && err.Error() != "unexpected EOF" {
-				log.WithError(err).Error("could not perform cpu burn")
+				t.Logf("error performing cpu burn: %q", err)
 			}
 		}()
 


### PR DESCRIPTION
## Description

* Fix rpc retries, to always `Instrument` first after closing the connection on failure, and to return when the call succeeds (was always calling the rpc 5 times before)
* Improve logging

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to WKS-153

## How to test
<!-- Provide steps to test this PR -->
https://github.com/gitpod-io/gitpod/actions/runs/5506674959

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
