### PR TITLE
[ws-man-bridge] Publish ownerID for WorkspaceInstance updates WEB-597

### DIFF
--- a/components/gitpod-protocol/src/redis.ts
+++ b/components/gitpod-protocol/src/redis.ts
@@ -7,6 +7,7 @@
 export const WorkspaceInstanceUpdatesChannel = "chan:workspace-instances";
 
 export type RedisWorkspaceInstanceUpdate = {
+    ownerID: string;
     instanceID: string;
     workspaceID: string;
 };

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -365,6 +365,7 @@ export class WorkspaceManagerBridge implements Disposable {
             }
             await this.messagebus.notifyOnInstanceUpdate(ctx, userId, instance);
             await this.publisher.publishInstanceUpdate({
+                ownerID: userId,
                 instanceID: instance.id,
                 workspaceID: instance.workspaceId,
             });

--- a/components/ws-manager-bridge/src/redis/publisher.spec.ts
+++ b/components/ws-manager-bridge/src/redis/publisher.spec.ts
@@ -37,6 +37,7 @@ class TestRedisPublisher {
         const publisher = this.container.get(RedisPublisher);
         expect(() => {
             publisher.publishInstanceUpdate({
+                ownerID: "123-owner",
                 instanceID: "123",
                 workspaceID: "foo-bar-123",
             });

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -275,6 +275,7 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
 
         await this.messagebus.notifyOnInstanceUpdate(ctx, info.workspace.ownerId, info.latestInstance);
         await this.publisher.publishInstanceUpdate({
+            ownerID: info.workspace.ownerId,
             instanceID: info.latestInstance.id,
             workspaceID: info.workspace.id,
         });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This will allow us to filter out the events if there are no subscribers for these, before we perform DB lookups for the data.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
