### PR TITLE
Move Gitpod icon away from the navigation

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -6,11 +6,9 @@
 
 import { User } from "@gitpod/gitpod-protocol";
 import { FC, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import { useLocation } from "react-router";
 import { Location } from "history";
 import { countries } from "countries-list";
-import gitpodIcon from "../icons/gitpod.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
@@ -73,10 +71,6 @@ export default function Menu() {
             <header className="app-container flex flex-col pt-4" data-analytics='{"button_type":"menu"}'>
                 <div className="flex justify-between h-10 mb-3 w-full">
                     <div className="flex items-center">
-                        {/* hidden on smaller screens */}
-                        <Link to="/" className="hidden md:inline pr-3 w-10">
-                            <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
-                        </Link>
                         <OrganizationSelector />
                         {/* hidden on smaller screens (in it's own menu below on smaller screens) */}
                         <div className="hidden md:block pl-2">


### PR DESCRIPTION
## Description

Experiment with moving the Gitpod icon away from the navigation to avoid clashing with the organization icon.

For more context, we also hide the Gitpod icon on smaller viewports, see https://github.com/gitpod-io/gitpod/pull/16618.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPNBD0/p1688739652960249?thread_ts=1687263225.734219&cid=C01KPEPNBD0) (internal). Cc @jankeromnes @svenefftinge @mbrevoort

| BEFORE | AFTER |
|-|-|
| <img width="1126" alt="Frame 1637" src="https://github.com/gitpod-io/gitpod/assets/120486/06a1d09a-5bd5-42c9-a40f-1f13a9e9b868"> | <img width="1126" alt="Frame 1638" src="https://github.com/gitpod-io/gitpod/assets/120486/bd84a7eb-2bb4-41d6-aa1e-a871a0d57b70"> |

## How to test
1. Log in and see how the Gitpod logo is no longer clashing with the organization logo in the navigation.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-move-gitpod-icon</li>
	<li><b>🔗 URL</b> - <a href="https://gt-move-gitpod-icon.preview.gitpod-dev.com/workspaces" target="_blank">gt-move-gitpod-icon.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-move-gitpod-icon-gha.13030</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
