### PR TITLE
[server] Broadcast prebuild updates from redis WEB-599, WEB-593

### DIFF
--- a/components/gitpod-protocol/src/redis.ts
+++ b/components/gitpod-protocol/src/redis.ts
@@ -4,10 +4,21 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { PrebuiltWorkspaceState } from "./protocol";
+
 export const WorkspaceInstanceUpdatesChannel = "chan:workspace-instances";
+export const PrebuildUpdatesChannel = "chan:prebuilds";
 
 export type RedisWorkspaceInstanceUpdate = {
     ownerID: string;
     instanceID: string;
     workspaceID: string;
+};
+
+export type RedisPrebuildUpdate = {
+    status: PrebuiltWorkspaceState;
+    prebuildID: string;
+    workspaceID: string;
+    instanceID: string;
+    projectID: string;
 };

--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -168,7 +168,7 @@ export class RedisSubscriber implements LocalMessageBroker {
     }
 
     listenForPrebuildUpdates(projectId: string, listener: PrebuildUpdateListener): Disposable {
-        return this.doRegister(projectId, listener, this.prebuildUpdateListeners);
+        return this.doRegister(projectId, listener, this.prebuildUpdateListeners, "prebuild");
     }
 
     listenForPrebuildUpdatableEvents(listener: HeadlessWorkspaceEventListener): Disposable {

--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -214,6 +214,7 @@ export class RedisSubscriber implements LocalMessageBroker {
             "none",
             {},
         );
+        log.debug("Enabled types in redis publisher:", enabledTypes);
         return enabledTypes.indexOf(type) >= 0;
     }
 }

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -95,7 +95,13 @@ export class PrebuildUpdater {
                 const info = (await this.workspaceDB.trace({ span }).findPrebuildInfos([updatedPrebuild.id]))[0];
                 if (info) {
                     await this.messagebus.notifyOnPrebuildUpdate({ info, status: updatedPrebuild.state });
-                    await this.publisher.publishPrebuildUpdate();
+                    await this.publisher.publishPrebuildUpdate({
+                        instanceID: instanceId,
+                        projectID: prebuild.projectId || "",
+                        prebuildID: updatedPrebuild.id,
+                        status: updatedPrebuild.state,
+                        workspaceID: workspaceId,
+                    });
                 }
             }
         } catch (e) {
@@ -120,7 +126,13 @@ export class PrebuildUpdater {
                 const info = (await this.workspaceDB.trace({ span }).findPrebuildInfos([prebuild.id]))[0];
                 if (info) {
                     await this.messagebus.notifyOnPrebuildUpdate({ info, status: prebuild.state });
-                    await this.publisher.publishPrebuildUpdate();
+                    await this.publisher.publishPrebuildUpdate({
+                        instanceID: instance.id,
+                        projectID: prebuild.projectId || "",
+                        prebuildID: prebuild.id,
+                        status: prebuild.state,
+                        workspaceID: instance.workspaceId,
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/18212

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-server-2a7cce3eb6</li>
	<li><b>🔗 URL</b> - <a href="https://mp-server-2a7cce3eb6.preview.gitpod-dev.com/workspaces" target="_blank">mp-server-2a7cce3eb6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - mp-server-prebuild-update-gha.13043</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
