### PR TITLE
allow disconnect for org owned users

### DIFF
--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { AuthProviderEntry, AuthProviderInfo } from "@gitpod/gitpod-protocol";
+import { AuthProviderEntry, AuthProviderInfo, User } from "@gitpod/gitpod-protocol";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { useQuery } from "@tanstack/react-query";
 import React, { useCallback, useContext, useEffect, useState } from "react";
@@ -98,10 +98,12 @@ function GitProviders() {
                     separator: true,
                 });
             }
-            const connectedWithSecondProvider = authProviders.data?.some(
-                (p) => p.authProviderId !== provider.authProviderId && isConnected(p.authProviderId),
-            );
-            if (connectedWithSecondProvider) {
+            const canDisconnect =
+                (user && User.isOrganizationOwned(user)) ||
+                authProviders.data?.some(
+                    (p) => p.authProviderId !== provider.authProviderId && isConnected(p.authProviderId),
+                );
+            if (canDisconnect) {
                 result.push({
                     title: "Disconnect",
                     customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allow org owned users to disconnect all git providers.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-619

## How to test
<!-- Provide steps to test this PR -->
To test this you can join my org on the preview env. w/ your google login by following this link:

https://brad-web-6a8b1c5163c.preview.gitpod-dev.com/login/brad

* Go to User Settings / Git Providers and connect to a provider.
* Verify you can disconnect from that provider even though it's the only connection you have.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-web-6a8b1c5163c</li>
	<li><b>🔗 URL</b> - <a href="https://brad-web-6a8b1c5163c.preview.gitpod-dev.com/workspaces" target="_blank">brad-web-6a8b1c5163c.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-web-619-allow-sso-users-to-remove-all-their-git-provider-connections-gha.13125</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
