### PR TITLE
[obs] further restrict NodePoolLoad to avoid false positives

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -62,7 +62,7 @@ spec:
                 for: 60m
                 annotations:
                     runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodePoolLoad.md
-                    summary: Node pool load is high
+                    summary: Node pool load has been high for too long for 4 or more nodes
                     description: Node pool {{ $labels.nodepool }} in cluster {{ $labels.cluster }} has high, sustained load
                 expr: |
-                    sum by(nodepool, cluster) (nodepool:node_load1:normalized{nodepool=~".*workspace.*",cluster!~"ephemeral.*"}) > 30
+                    sum by(nodepool) (count by(node, nodepool) (sum by(node, nodepool) (nodepool:node_load1:normalized{nodepool=~".*workspace.*", cluster!~"ephemeral.*"}) >= 1)) >= 4


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Only trigger alerts when 2 or more nodes have high load average that is sustained over 1 for 60m.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WKS-301

## How to test
<!-- Provide steps to test this PR -->
We don't actually have data for when [this](https://grafana.gitpod.io/explore?left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22expr%22:%22sum%20by%28nodepool%29%20%28count%20by%28node,%20nodepool%29%20%28sum%20by%28node,%20nodepool%29%20%28nodepool:node_load1:normalized%7Bnodepool%3D~%5C%22.%2Aworkspace.%2A%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%29%20%3E%3D%201%29%29%20%3E%3D%202%22,%22format%22:%22time_series%22,%22intervalFactor%22:2,%22refId%22:%22A%22,%22interval%22:%22%22,%22editorMode%22:%22builder%22,%22range%22:true,%22instant%22:true,%22hide%22:false,%22legendFormat%22:%22__auto%22%7D,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22expr%22:%22sum%20by%28nodepool%29%20%28count%20by%28node,%20nodepool%29%20%28sum%20by%28node,%20nodepool%29%20%28nodepool:node_load1:normalized%7Bnodepool%3D~%5C%22.%2Aworkspace.%2A%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%29%20%3E%3D%202%29%29%20%3E%201%22,%22format%22:%22time_series%22,%22intervalFactor%22:2,%22refId%22:%22B%22,%22interval%22:%22%22,%22editorMode%22:%22builder%22,%22range%22:true,%22instant%22:true,%22hide%22:true,%22legendFormat%22:%22%7B%7Bnodepool%7D%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D&orgId=1) would have triggered, because that was before June 9.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
