### PR TITLE
Remove settings menu in the admin dashboard

### DIFF
--- a/components/dashboard/src/admin/admin.routes.ts
+++ b/components/dashboard/src/admin/admin.routes.ts
@@ -32,19 +32,5 @@ export function getAdminTabs(): TabEntry[] {
             title: "Blocked Email Domains",
             link: "/admin/blocked-email-domains",
         },
-        {
-            title: "Settings",
-            link: "/admin/settings",
-            alternatives: getAdminSettingsMenu().flatMap((e) => e.link),
-        },
-    ];
-}
-
-export function getAdminSettingsMenu() {
-    return [
-        {
-            title: "General",
-            link: ["/admin/settings"],
-        },
     ];
 }


### PR DESCRIPTION
## Description

Follow-up from WEB-171 and https://github.com/gitpod-io/gitpod/pull/17342, this will remove the remaining admin menu that has no child pages anymore.

Cc @easyCZ @geropl 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-171

## How to test

1. Login
2. Make your user admin
3. Go to the admin dashboard
4. Notice there's no settings menu

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-remove-71543b03eb</li>
	<li><b>🔗 URL</b> - <a href="https://gt-remove-71543b03eb.preview.gitpod-dev.com/workspaces" target="_blank">gt-remove-71543b03eb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-remove-admin-settings-tab-gha.13331</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
