### PR TITLE
Fix preview environment delete job

### DIFF
--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -1,19 +1,34 @@
 name: "Preview environment delete"
 on:
-    workflow_dispatch:
-        inputs:
-            name:
-                required: true
-                description: "The name of the preview environment to delete"
-    delete:
+  workflow_dispatch:
+    inputs:
+      name:
+        required: true
+        description: "The name of the preview environment to delete"
+  delete:
+
 jobs:
-    delete:
-        if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
-        runs-on: ${{ needs.create-runner.outputs.label }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Delete preview environment
-              uses: ./.github/actions/delete-preview
-              with:
-                  name: ${{ github.event.inputs.name || github.event.ref}}
-                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+  create-runner:
+    uses: ./.github/workflows/create_runner.yml
+    secrets: inherit
+
+  delete:
+    if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
+    runs-on: ${{ needs.create-runner.outputs.label }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete preview environment
+        uses: ./.github/actions/delete-preview
+        with:
+          name: ${{ github.event.inputs.name || github.event.ref}}
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+
+  delete-runner:
+    if: always()
+    needs:
+      - create-runner
+      - delete
+    uses: ./.github/workflows/remove_runner.yml
+    secrets: inherit
+    with:
+      runner-label: ${{ needs.create-runner.outputs.label }}


### PR DESCRIPTION

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
