### PR TITLE
Fix summary length error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,19 @@ jobs:
           set +x
 
           cat report.html >> $GITHUB_STEP_SUMMARY
+
+          SUMMARY_SIZE=$(wc -c < $GITHUB_STEP_SUMMARY)
+          if [[ $SUMMARY_SIZE -gt 1000000 ]]; then
+            head -c 1000000 $GITHUB_STEP_SUMMARY > $GITHUB_STEP_SUMMARY.tmp
+            mv $GITHUB_STEP_SUMMARY.tmp $GITHUB_STEP_SUMMARY
+            (
+              echo '.....'
+              echo ''
+              echo ':x: **WARNING: Summary is too large and has been truncated.**'
+              echo ''
+            )  >> $GITHUB_STEP_SUMMARY
+          fi
+
           exit $RESULT
       - name: "Upload Test Coverage Report"
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

`GITHUB_STEP_SUMMARY` has a hard limit of 1024kb

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
