### PR TITLE
Fix disposal of VMs

### DIFF
--- a/.github/workflows/remove_runner.yml
+++ b/.github/workflows/remove_runner.yml
@@ -29,10 +29,10 @@ jobs:
             exit 0
           fi
 
+          gcloud auth activate-service-account --key-file ${{ steps.auth.outputs.credentials_file_path }}
           if [ -z "$(gcloud compute instances list | grep "${{ inputs.runner-label }}")" ]; then
             // vm is gone
             exit 0
           fi
 
-          gcloud auth activate-service-account --key-file "${{ steps.auth.outputs.credentials_file_path }}"
           gcloud compute instances delete ${{ inputs.runner-label }} --quiet --zone europe-west1-b


### PR DESCRIPTION

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
