### PR TITLE
Fix build previewctl step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,10 +101,14 @@ jobs:
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
-          PREVIEW_ENV_DEV_SA_KEY_PATH: ${{ env.GITHUB_WORKSPACE }}/.config/gcloud/preview-environment-dev-sa.json
           PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
         run: |
+          export PREVIEW_ENV_DEV_SA_KEY_PATH="$GITHUB_WORKSPACE/.config/gcloud/preview-environment-dev-sa.json"
+          echo "LEEWAY_WORKSPACE_ROOT: $LEEWAY_WORKSPACE_ROOT"
+          echo "PREVIEW_ENV_DEV_SA_KEY_PATH: $PREVIEW_ENV_DEV_SA_KEY_PATH"
+
           # Authenticate with GCP so we can use the Leeway cache
+          mkdir -p "$(dirname "$PREVIEW_ENV_DEV_SA_KEY_PATH")"
           echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,10 +103,10 @@ jobs:
         id: build
         shell: bash
         env:
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
           PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           export PREVIEW_ENV_DEV_SA_KEY_PATH="$GITHUB_WORKSPACE/.config/gcloud/preview-environment-dev-sa.json"
           echo "LEEWAY_WORKSPACE_ROOT: $LEEWAY_WORKSPACE_ROOT"
           echo "PREVIEW_ENV_DEV_SA_KEY_PATH: $PREVIEW_ENV_DEV_SA_KEY_PATH"
@@ -179,9 +179,9 @@ jobs:
       - name: Leeway Vet
         shell: bash
         env:
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           leeway vet --ignore-warnings
       - name: Pre-Commit Checks
         shell: bash
@@ -195,9 +195,9 @@ jobs:
       - name: Check License Headers
         shell: bash
         env:
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           RESULT=0
           LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || RESULT=$?
           if [ $RESULT -ne 0 ]; then
@@ -218,10 +218,10 @@ jobs:
         env:
           JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
           VERSION: ${{needs.configuration.outputs.version}}
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
         shell: bash
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           RESULT=0
           set -x
           leeway build dev:all \
@@ -259,9 +259,9 @@ jobs:
           JB_MARKETPLACE_PUBLISH_TOKEN: "${{ steps.secrets.outputs.jb-marketplace-publish-token }}"
           PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
           CODECOV_TOKEN: "${{ steps.secrets.outputs.codecov-token }}"
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
           [[ "${PUBLISH_TO_NPM}" = 'true' ]] && NPM_PUBLISH_TRIGGER=$(date +%s%3N) || NPM_PUBLISH_TRIGGER="false"
@@ -427,9 +427,9 @@ jobs:
           TEST_BUILD_ID: ${{ github.run_id }}
           TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
           LEEWAY_SEGMENT_KEY: ""
         run: |
+          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
           set -euo pipefail
 
           echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
           PREVIEW_ENV_DEV_SA_KEY_PATH: ${{ env.GITHUB_WORKSPACE }}/.config/gcloud/preview-environment-dev-sa.json
           PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
         run: |
@@ -172,7 +172,7 @@ jobs:
         shell: bash
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
         run: |
           leeway vet --ignore-warnings
       - name: Pre-Commit Checks
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
         run: |
           RESULT=0
           LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || RESULT=$?
@@ -211,7 +211,7 @@ jobs:
           JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
           VERSION: ${{needs.configuration.outputs.version}}
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
         shell: bash
         run: |
           RESULT=0
@@ -252,7 +252,7 @@ jobs:
           PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
           CODECOV_TOKEN: "${{ steps.secrets.outputs.codecov-token }}"
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
@@ -420,7 +420,7 @@ jobs:
           TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
-          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          LEEWAY_SEGMENT_KEY: ""
         run: |
           set -euo pipefail
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,6 @@ jobs:
         env:
           PR_DESC: "${{ steps.pr-details.outputs.pr_body }}"
           MAIN_BRANCH: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
-          LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
         shell: bash
         run: |
           {
@@ -100,12 +99,12 @@ jobs:
         id: build
         shell: bash
         env:
-          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-          LEEWAY_SEGMENT_KEY: "${{ secrets.LEEWAY_SEGMENT_KEY }}"
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: ${{ env.GITHUB_WORKSPACE }}/.config/gcloud/preview-environment-dev-sa.json
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
         run: |
           # Authenticate with GCP so we can use the Leeway cache
-          export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
           echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
@@ -171,10 +170,11 @@ jobs:
           password: "${{ steps.auth.outputs.access_token }}"
       - name: Leeway Vet
         shell: bash
-        run: |
-          leeway vet --ignore-warnings
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+        run: |
+          leeway vet --ignore-warnings
       - name: Pre-Commit Checks
         shell: bash
         run: |
@@ -188,6 +188,7 @@ jobs:
         shell: bash
         env:
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
         run: |
           RESULT=0
           LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || RESULT=$?
@@ -209,8 +210,8 @@ jobs:
         env:
           JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
           VERSION: ${{needs.configuration.outputs.version}}
-          LEEWAY_SEGMENT_KEY: "${{ secrets.LEEWAY_SEGMENT_KEY }}"
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
         shell: bash
         run: |
           RESULT=0
@@ -250,8 +251,8 @@ jobs:
           JB_MARKETPLACE_PUBLISH_TOKEN: "${{ steps.secrets.outputs.jb-marketplace-publish-token }}"
           PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
           CODECOV_TOKEN: "${{ steps.secrets.outputs.codecov-token }}"
-          LEEWAY_SEGMENT_KEY: "${{ secrets.LEEWAY_SEGMENT_KEY }}"
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
@@ -329,13 +330,11 @@ jobs:
   install:
     name: "Install Gitpod"
     needs:
-      [
-        configuration,
-        build-previewctl,
-        build-gitpod,
-        infrastructure,
-        create-runner,
-      ]
+      - configuration
+      - build-previewctl
+      - build-gitpod
+      - infrastructure
+      - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-install
@@ -394,14 +393,12 @@ jobs:
   integration-test:
     name: "Run integration test"
     needs:
-      [
-        configuration,
-        build-previewctl,
-        build-gitpod,
-        infrastructure,
-        install,
-        create-runner,
-      ]
+      - configuration
+      - build-previewctl
+      - build-gitpod
+      - infrastructure
+      - install
+      - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway-075-gha.12686
@@ -416,15 +413,14 @@ jobs:
           ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
           INTEGRATION_TEST_USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
-          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
           PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
           TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
           TEST_USE_LATEST_VERSION: ${{ needs.configuration.outputs.latest_ide_version }}
           TEST_BUILD_ID: ${{ github.run_id }}
           TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
-          PREVIEW_ENV_DEV_SA_KEY_PATH: ${{ env.GITHUB_WORKSPACE }}"/.config/gcloud/preview-environment-dev-sa.json"
           LEEWAY_WORKSPACE_ROOT: ${{ env.GITHUB_WORKSPACE }}
+          LEEWAY_SEGMENT_KEY: ${{ secrets.LEEWAY_SEGMENT_KEY }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,10 @@ jobs:
       previewctl_hash: ${{ steps.build.outputs.previewctl_hash }}
     steps:
       - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
       - name: Build previewctl
         id: build
         shell: bash


### PR DESCRIPTION
## Description


Based on https://github.com/gitpod-io/gitpod/pull/18228/.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
