### PR TITLE
[ci] Remove license header check, already done in pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,18 +192,6 @@ jobs:
             echo "::error title=The Pre-Commit Checks Failed.::Please run 'pre-commit run --show-diff-on-failure'"
           fi
           exit "$RESULT"
-      - name: Check License Headers
-        shell: bash
-        env:
-          LEEWAY_SEGMENT_KEY: ""
-        run: |
-          export LEEWAY_WORKSPACE_ROOT="${{ env.GITHUB_WORKSPACE }}"
-          RESULT=0
-          LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || RESULT=$?
-          if [ $RESULT -ne 0 ]; then
-            echo "::error title=There are some license headers missing.::Please run 'leeway run components:update-license-header'"
-          fi
-          exit "$RESULT"
       - name: Get Secrets from GCP
         id: "secrets"
         uses: "google-github-actions/get-secretmanager-secrets@v1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Not needed, as the `pre-commit` check already executes this

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
