### PR TITLE
[obs] add node variable and update panels in Node PSI dashboard to use it

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/node-psi.json
+++ b/operations/observability/mixins/workspace/dashboards/node-psi.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 80,
+  "id": 86,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -60,6 +60,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "Nodes with a high normalized load average do not represent a real problem, it only means that pods should probably not be scheduled to them.\n\nIf you'd like to see more details about resource consumption of a particular node, you can do so by clicking at the node name.\n",
@@ -67,7 +68,7 @@
       "fillGradient": 5,
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 12,
         "x": 0,
         "y": 1
       },
@@ -92,7 +93,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "9.5.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -112,10 +113,12 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "topk(5, sum(nodepool:node_load1:normalized{cluster=~\"$cluster\", nodepool=~\".*workspace.*\"}) by (node))\n",
+          "editorMode": "code",
+          "expr": "topk(5, sum(nodepool:node_load1:normalized{cluster=~\"$cluster\", nodepool=~\".*workspace.*\", node=~\"$node\"}) by (node))\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
+          "range": true,
           "refId": "A"
         },
         {
@@ -169,7 +172,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 8
       },
       "id": 86,
       "panels": [],
@@ -236,9 +239,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 12,
         "x": 0,
-        "y": 16
+        "y": 9
       },
       "id": 49,
       "options": {
@@ -262,7 +265,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(5, rate(node_pressure_cpu_waiting_seconds_total{cluster=\"$cluster\"}[30s]))",
+          "expr": "topk(5, rate(node_pressure_cpu_waiting_seconds_total{cluster=\"$cluster\",node=~\"$node\"}[30s]))",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
@@ -277,7 +280,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 17
       },
       "id": 165,
       "panels": [],
@@ -344,9 +347,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 12,
         "x": 0,
-        "y": 33
+        "y": 18
       },
       "id": 133,
       "options": {
@@ -370,7 +373,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(5, rate(node_pressure_memory_waiting_seconds_total{cluster=\"$cluster\"}[30s]))",
+          "expr": "topk(5, rate(node_pressure_memory_waiting_seconds_total{cluster=\"$cluster\",node=~\"$node\"}[30s]))",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
@@ -385,7 +388,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 26
       },
       "id": 224,
       "panels": [],
@@ -452,9 +455,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 12,
         "x": 0,
-        "y": 50
+        "y": 27
       },
       "id": 197,
       "options": {
@@ -478,7 +481,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(5, rate(node_pressure_io_waiting_seconds_total{cluster=\"$cluster\"}[30s]))",
+          "expr": "topk(5, rate(node_pressure_io_waiting_seconds_total{cluster=\"$cluster\",node=~\"$node\"}[30s]))",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
@@ -489,7 +492,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -506,6 +509,7 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -542,6 +546,36 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(node_pressure_memory_waiting_seconds_total,node)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(node_pressure_memory_waiting_seconds_total,node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -577,6 +611,6 @@
   "timezone": "utc",
   "title": "Node Pressure Stall Information",
   "uid": "T7pAXoVVk",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Make it easier to observe PSI for one or more nodes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to WKS-303

## How to test
<!-- Provide steps to test this PR -->
Run CPU burn on many workspaces from a preview environment.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-2t04q5vxdek</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-2t04q5vxdek.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-2t04q5vxdek.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-2t04q5VxDek-gha.13309</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
