### PR TITLE
[public-api] Remove db debug from OIDC tests

### DIFF
--- a/components/public-api-server/pkg/apiv1/oidc_test.go
+++ b/components/public-api-server/pkg/apiv1/oidc_test.go
@@ -747,7 +747,7 @@ func TestOIDCService_SetClientConfigActivation_WithFeatureFlagEnabled(t *testing
 func setupOIDCService(t *testing.T, expClient experiments.Client) (*protocol.MockAPIInterface, v1connect.OIDCServiceClient, *gorm.DB) {
 	t.Helper()
 
-	dbConn := dbtest.ConnectForTests(t).Debug()
+	dbConn := dbtest.ConnectForTests(t)
 
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)

--- a/components/public-api-server/pkg/apiv1/oidc_test.go
+++ b/components/public-api-server/pkg/apiv1/oidc_test.go
@@ -151,7 +151,6 @@ func TestOIDCService_CreateClientConfig_FeatureFlagEnabled(t *testing.T) {
 			Config: config,
 		}))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such host")
 		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 	})
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove debug logging of db ops

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
