### PR TITLE
[server, papi] Track login completed metrics by outcome, type WEB-461

### DIFF
--- a/components/public-api-server/pkg/oidc/metrics.go
+++ b/components/public-api-server/pkg/oidc/metrics.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package oidc
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	loginCompletedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitpod",
+		Name:      "login_completed_total",
+		Help:      "Total number of logins completed into gitpod, by status",
+	}, []string{"status", "type"})
+)
+
+func RegisterMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(loginCompletedTotal)
+}
+
+func reportLoginCompleted(status string, typez string) {
+	loginCompletedTotal.WithLabelValues(status, typez).Inc()
+}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -174,6 +174,7 @@ type registerDependencies struct {
 
 func register(srv *baseserver.Server, deps *registerDependencies) error {
 	proxy.RegisterMetrics(srv.MetricsRegistry())
+	oidc.RegisterMetrics(srv.MetricsRegistry())
 
 	connectMetrics := NewConnectMetrics()
 	err := connectMetrics.Register(srv.MetricsRegistry())

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -16,8 +16,8 @@ import { AuthFlow, AuthProvider } from "./auth-provider";
 import { TokenProvider } from "../user/token-provider";
 import { AuthProviderService } from "./auth-provider-service";
 import { UserAuthentication } from "../user/user-authentication";
-import { increaseLoginCounter } from "../prometheus-metrics";
 import { SignInJWT } from "./jwt";
+import { reportLoginCompleted } from "../prometheus-metrics";
 
 @injectable()
 export class Authenticator {
@@ -165,8 +165,8 @@ export class Authenticator {
         }
 
         if (!authProvider.info.verified) {
-            increaseLoginCounter("failed", authProvider.info.host);
-            log.info(`Login with "${host}" is not permitted.`, {
+            reportLoginCompleted("failed_client", "git");
+            log.warn(`Login with "${host}" is not permitted as the provider has not been verified.`, {
                 "login-flow": true,
                 ap: authProvider.info,
             });

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -11,7 +11,7 @@ import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
 import { HostContextProvider } from "./host-context-provider";
 import { AuthProviderService } from "./auth-provider-service";
-import { increaseLoginCounter, reportJWTCookieIssued } from "../prometheus-metrics";
+import { reportJWTCookieIssued, reportLoginCompleted } from "../prometheus-metrics";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { trackLogin } from "../analytics";
 import { SessionHandler } from "../session-handler";
@@ -47,10 +47,8 @@ export class LoginCompletionHandler {
                 });
             });
         } catch (err) {
-            if (authHost) {
-                increaseLoginCounter("failed", authHost);
-            }
-            log.error(logContext, `Redirect to /sorry on login`, err, { err });
+            reportLoginCompleted("failed", "git");
+            log.error(logContext, `Failed to login user. Redirecting to /sorry on login.`, err);
             response.redirect(this.config.hostUrl.asSorry("Oops! Something went wrong during login.").toString());
             return;
         }
@@ -75,8 +73,6 @@ export class LoginCompletionHandler {
         }
 
         if (authHost) {
-            increaseLoginCounter("succeeded", authHost);
-
             /** no await */ trackLogin(user, request, authHost, this.analytics).catch((err) =>
                 log.error({ userId: user.id }, "Failed to track Login.", err),
             );
@@ -87,6 +83,7 @@ export class LoginCompletionHandler {
         reportJWTCookieIssued();
 
         log.info(logContext, `User is logged in successfully. Redirect to: ${returnTo}`);
+        reportLoginCompleted("succeeded", "git");
         response.redirect(returnTo);
     }
 

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -7,7 +7,7 @@
 import * as prometheusClient from "prom-client";
 
 export function registerServerMetrics(registry: prometheusClient.Registry) {
-    registry.registerMetric(loginCounter);
+    registry.registerMetric(loginCompletedTotal);
     registry.registerMetric(apiConnectionCounter);
     registry.registerMetric(apiConnectionClosedCounter);
     registry.registerMetric(apiCallCounter);
@@ -35,11 +35,15 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(updateSubscribersRegistered);
 }
 
-const loginCounter = new prometheusClient.Counter({
-    name: "gitpod_server_login_requests_total",
-    help: "Total amount of login requests",
-    labelNames: ["status", "auth_host"],
+const loginCompletedTotal = new prometheusClient.Counter({
+    name: "gitpod_login_completed_total",
+    help: "Total number of logins completed into gitpod, by status",
+    labelNames: ["status", "type"],
 });
+
+export function reportLoginCompleted(status: LoginCounterStatus, type: "git" | "sso") {
+    loginCompletedTotal.labels(status, type).inc();
+}
 
 type LoginCounterStatus =
     // The login attempt failed due to a system error (picked up by alerts)
@@ -48,13 +52,6 @@ type LoginCounterStatus =
     | "succeeded"
     // The login attempt failed, because the client failed to provide complete session information, for instance.
     | "failed_client";
-
-export function increaseLoginCounter(status: LoginCounterStatus, auth_host: string) {
-    loginCounter.inc({
-        status,
-        auth_host,
-    });
-}
 
 const apiConnectionCounter = new prometheusClient.Counter({
     name: "gitpod_server_api_connections_total",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-257

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-login-c1443c82549</li>
	<li><b>🔗 URL</b> - <a href="https://mp-login-c1443c82549.preview.gitpod-dev.com/workspaces" target="_blank">mp-login-c1443c82549.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - mp-login-completed-metrics-gha.14155</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
