### PR TITLE
[supervisor] correct CreateSSHKeyPair error code

### DIFF
--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -737,7 +737,7 @@ func (c *ControlService) ExposePort(ctx context.Context, req *api.ExposePortRequ
 }
 
 // CreateSSHKeyPair create a ssh key pair for the workspace.
-func (ss *ControlService) CreateSSHKeyPair(ctx context.Context, api *api.CreateSSHKeyPairRequest) (response *api.CreateSSHKeyPairResponse, err error) {
+func (ss *ControlService) CreateSSHKeyPair(ctx context.Context, req *api.CreateSSHKeyPairRequest) (response *api.CreateSSHKeyPairResponse, err error) {
 	home := "/home/gitpod/"
 	if ss.privateKey != "" && ss.publicKey != "" {
 		checkKey := func() error {

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -737,7 +737,7 @@ func (c *ControlService) ExposePort(ctx context.Context, req *api.ExposePortRequ
 }
 
 // CreateSSHKeyPair create a ssh key pair for the workspace.
-func (ss *ControlService) CreateSSHKeyPair(context.Context, *api.CreateSSHKeyPairRequest) (response *api.CreateSSHKeyPairResponse, err error) {
+func (ss *ControlService) CreateSSHKeyPair(ctx context.Context, api *api.CreateSSHKeyPairRequest) (response *api.CreateSSHKeyPairResponse, err error) {
 	home := "/home/gitpod/"
 	if ss.privateKey != "" && ss.publicKey != "" {
 		checkKey := func() error {
@@ -758,40 +758,48 @@ func (ss *ControlService) CreateSSHKeyPair(context.Context, *api.CreateSSHKeyPai
 		}
 		log.WithError(err).Error("check authorized_keys failed, will recreate")
 	}
-	dir, err := os.MkdirTemp(os.TempDir(), "ssh-key-*")
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create tmpfile: %w", err)
+	type keyPair struct{ PublicKey, PrivateKey []byte }
+	createRandomSSHKeyPair := func(ctx context.Context, home string) (*keyPair, error) {
+		dir, err := os.MkdirTemp(os.TempDir(), "ssh-key-*")
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create tmpfile: %w", err)
+		}
+		err = prepareSSHKey(ctx, filepath.Join(dir, "ssh"))
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create ssh key pair: %w", err)
+		}
+		bPublic, err := os.ReadFile(filepath.Join(dir, "ssh.pub"))
+		if err != nil {
+			return nil, xerrors.Errorf("cannot read publickey: %w", err)
+		}
+		bPrivate, err := os.ReadFile(filepath.Join(dir, "ssh"))
+		if err != nil {
+			return nil, xerrors.Errorf("cannot read privatekey: %w", err)
+		}
+		err = os.MkdirAll(filepath.Join(home, ".ssh"), 0o700)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot create dir ~/.ssh/: %w", err)
+		}
+		f, err := os.OpenFile(filepath.Join(home, ".ssh/authorized_keys"), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot open file ~/.ssh/authorized_keys: %w", err)
+		}
+		_, err = f.Write(bPublic)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot write file ~.ssh/authorized_keys: %w", err)
+		}
+		err = os.Chown(filepath.Join(home, ".ssh/authorized_keys"), gitpodUID, gitpodGID)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot chown SSH authorized_keys file: %w", err)
+		}
+		return &keyPair{PublicKey: bPublic, PrivateKey: bPrivate}, nil
 	}
-	err = prepareSSHKey(context.Background(), filepath.Join(dir, "ssh"))
+	generated, err := createRandomSSHKeyPair(ctx, home)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot create ssh key pair: %w", err)
+		return nil, status.Errorf(codes.Internal, "cannot create ssh key pair: %v", err)
 	}
-	bPublic, err := os.ReadFile(filepath.Join(dir, "ssh.pub"))
-	if err != nil {
-		return nil, xerrors.Errorf("cannot read publickey: %w", err)
-	}
-	bPrivate, err := os.ReadFile(filepath.Join(dir, "ssh"))
-	if err != nil {
-		return nil, xerrors.Errorf("cannot read privatekey: %w", err)
-	}
-	err = os.MkdirAll(filepath.Join(home, ".ssh"), 0o700)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create dir ~/.ssh/: %w", err)
-	}
-	f, err := os.OpenFile(filepath.Join(home, ".ssh/authorized_keys"), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot open file ~/.ssh/authorized_keys: %w", err)
-	}
-	_, err = f.Write(bPublic)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot write file ~.ssh/authorized_keys: %w", err)
-	}
-	err = os.Chown(filepath.Join(home, ".ssh/authorized_keys"), gitpodUID, gitpodGID)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot chown SSH authorized_keys file: %w", err)
-	}
-	ss.privateKey = string(bPrivate)
-	ss.publicKey = string(bPublic)
+	ss.privateKey = string(generated.PrivateKey)
+	ss.publicKey = string(generated.PublicKey)
 	return &api.CreateSSHKeyPairResponse{
 		PrivateKey: ss.privateKey,
 	}, err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C045J13P8A1/p1689145467120339?thread_ts=1688971512.520299&cid=C045J13P8A1)

## How to test
<!-- Provide steps to test this PR -->

It should be able to connect with VS Code Desktop

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-correct88dd91db0a</li>
	<li><b>🔗 URL</b> - <a href="https://hw-correct88dd91db0a.preview.gitpod-dev.com/workspaces" target="_blank">hw-correct88dd91db0a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-correct-errror-code-gha.13357</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
