### PR TITLE
Revert https://github.com/gitpod-io/gitpod/pull/18158

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
     needs: [configuration, create-runner]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-build-previewctl
+      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-new-dev-image-gha.13182
@@ -129,6 +130,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.head_ref || github.ref_name }}-infrastructure
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
@@ -150,6 +152,7 @@ jobs:
       group: ${{ github.head_ref || github.ref_name }}-build-gitpod
       # For the main branch we always want the build job to run to completion
       # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
+      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
         image: mysql:5.7
@@ -336,6 +339,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-install
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Deploy Gitpod to the preview environment
@@ -379,6 +383,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-monitoring
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Deploy monitoring satellite to the preview environment
@@ -403,6 +408,7 @@ jobs:
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-integration-test
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Run integration test


### PR DESCRIPTION

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
