### PR TITLE
[server] Use relative path for spicedb schema

### DIFF
--- a/.github/workflows/authorization.yml
+++ b/.github/workflows/authorization.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     paths:
-      - install/installer/pkg/components/spicedb/data/**
+      - components/spicedb/**
       - .github/workflows/authorization.yml
 
 name: SpiceDB
@@ -16,4 +16,4 @@ jobs:
       - name: Validate SpiceDB schema
         uses: authzed/action-spicedb-validate@v1.0.1
         with:
-          validationfile: "install/installer/pkg/components/spicedb/data/schema.yaml"
+          validationfile: "components/spicedb/schema.yaml"

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -8,7 +8,6 @@ packages:
       - .eslintrc
       - package.json
       - mocha.opts
-      - ../../install/installer/pkg/components/spicedb/data/schema.yaml
     deps:
       - components/content-service-api/typescript:lib
       - components/gitpod-db:lib
@@ -21,6 +20,7 @@ packages:
       - components/ide-service-api/typescript:lib
       - components/public-api/typescript:lib
       - components/gitpod-db:dbtest-init
+      - components/spicedb:lib
     config:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/yarn.lock

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -23,7 +23,7 @@
     "stop-services": "yarn stop-testdb && yarn stop-redis && yarn stop-spicedb",
     "start-testdb": "leeway run components/gitpod-db:init-testdb",
     "stop-testdb": "docker stop test-mysql || true && docker rm test-mysql || true",
-    "start-spicedb": "if netstat -tuln | grep ':50051 '; then echo '`spicedb serve-testing` is already running.'; else spicedb serve-testing --load-configs ../../install/installer/pkg/components/spicedb/data/schema.yaml & fi",
+    "start-spicedb": "if netstat -tuln | grep ':50051 '; then echo '`spicedb serve-testing` is already running.'; else spicedb serve-testing --load-configs components-spicedb/schema.yaml & fi",
     "stop-spicedb": "PID=$(lsof -t -i:50051); if [ -z \"$PID\" ]; then echo '`spicedb serve-testing` is not running'; else kill -INT $PID && echo 'Stopped `spicedb serve-testing`'; fi",
     "start-redis": "if netstat -tuln | grep ':6379 '; then echo 'Redis is already running.'; else docker run --name test-redis -p 6379:6379 -d redis; fi",
     "stop-redis": "docker stop test-redis || true && docker stop test-redis && docker rm test-redis",

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -23,7 +23,7 @@
     "stop-services": "yarn stop-testdb && yarn stop-redis && yarn stop-spicedb",
     "start-testdb": "leeway run components/gitpod-db:init-testdb",
     "stop-testdb": "docker stop test-mysql || true && docker rm test-mysql || true",
-    "start-spicedb": "if netstat -tuln | grep ':50051 '; then echo '`spicedb serve-testing` is already running.'; else spicedb serve-testing --load-configs /workspace/gitpod/install/installer/pkg/components/spicedb/data/schema.yaml & fi",
+    "start-spicedb": "if netstat -tuln | grep ':50051 '; then echo '`spicedb serve-testing` is already running.'; else spicedb serve-testing --load-configs ../../install/installer/pkg/components/spicedb/data/schema.yaml & fi",
     "stop-spicedb": "PID=$(lsof -t -i:50051); if [ -z \"$PID\" ]; then echo '`spicedb serve-testing` is not running'; else kill -INT $PID && echo 'Stopped `spicedb serve-testing`'; fi",
     "start-redis": "if netstat -tuln | grep ':6379 '; then echo 'Redis is already running.'; else docker run --name test-redis -p 6379:6379 -d redis; fi",
     "stop-redis": "docker stop test-redis || true && docker stop test-redis && docker rm test-redis",

--- a/components/spicedb/BUILD.yaml
+++ b/components/spicedb/BUILD.yaml
@@ -1,0 +1,5 @@
+packages:
+  - name: lib
+    type: generic
+    srcs:
+      - "schema.yaml"

--- a/components/spicedb/schema.yaml
+++ b/components/spicedb/schema.yaml
@@ -1,0 +1,167 @@
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+schema: |-
+  definition user {}
+
+  // There's only one global installation
+  definition installation {
+
+    // only users that are not owned by an org are considered installation-level users
+    relation user: user
+    relation admin: user
+
+    // orgs can only be created by installation-level users
+    permission create_organization = user
+
+  }
+
+  definition organization {
+    relation installation: installation
+
+    // Every user in an organization is automatically a member
+    relation member: user
+    // Some users in an organization may additionally have the `owner` role
+    relation owner: user
+
+    // synthetic permission for installation->admin (because https://github.com/authzed/spicedb/issues/15)
+    permission installation_admin = installation->admin
+
+    // General operations on organization
+    permission read_info = member + owner + installation->admin
+    permission write_info = owner + installation->admin
+    permission delete = owner + installation->admin
+
+    permission read_settings = owner + installation->admin
+    permission write_settings = owner + installation->admin
+
+    // Operations on Organization's Members
+    permission read_members = member + owner + installation->admin
+    permission invite_members = member + owner + installation->admin
+    permission write_members = owner + installation->admin
+    permission leave = owner + member + installation->admin
+
+    permission create_project = member + owner + installation->admin
+
+    permission read_git_provider = owner + member + installation->admin
+    permission write_git_provider = owner + installation->admin
+
+    permission read_billing = member + owner + installation->admin
+    permission write_billing = owner + installation->admin
+  }
+
+  definition project {
+    relation org: organization
+
+    relation editor: user
+
+    // A subject is a viewer, if:
+    //  * the user is directly assigned as a viewer
+    //  * the project has granted access to everyone in an organization
+    relation viewer: user | organization#member
+
+    permission write_info = org->owner + editor + org->installation_admin
+    permission read_info = write_info + viewer + org->member + org->installation_admin
+    permission delete = org->owner + editor + org->installation_admin
+  }
+# relationships to be used for assertions & validation
+relationships: |-
+  // we have one installation
+  installation:installation_0#user@user:user_0
+  installation:installation_0#admin@user:user_admin
+
+  // We have an organization org_1, which has some members & owners
+  organization:org_1#installation@installation:installation_0
+  organization:org_1#member@user:user_0
+  organization:org_1#owner@user:user_0
+  organization:org_1#member@user:user_1
+  organization:org_1#member@user:user_2
+
+  // org_1 has a project
+  project:project_1#org@organization:org_1
+  // project_1 can be accessed by anyone in the organization - it's visibility is public
+  project:project_1#viewer@organization:org_1#member
+
+  // We have another organization org_2, which has some users, some of which are also members of org_1
+  organization:org_2#member@user:user_0
+  organization:org_2#owner@user:user_0
+  organization:org_2#member@user:user_1
+  organization:org_2#member@user:user_10
+
+  // org_2 has a project project_2
+  project:project_2#org@organization:org_2
+  // user_1 is viewer of project_2
+  project:project_2#viewer@user:user_1
+
+# validation should assert that a particular relation exists between an entity, and a subject
+# validations are not used to assert that a permission exists
+validation:
+  installation:installation_0#user:
+    - "[user:user_0] is <installation:installation_0#user>"
+  installation:installation_0#admin:
+    - "[user:user_admin] is <installation:installation_0#admin>"
+  organization:org_1#member:
+    - "[user:user_0] is <organization:org_1#member>"
+    - "[user:user_1] is <organization:org_1#member>"
+    - "[user:user_2] is <organization:org_1#member>"
+  organization:org_1#owner:
+    - "[user:user_0] is <organization:org_1#owner>"
+  project:project_1#org:
+    - "[organization:org_1] is <project:project_1#org>"
+
+
+# assertions should assert that a particular permission holds, or not
+assertions:
+  assertTrue:
+    # user 0 can read org_1 because they are a member
+    - organization:org_1#read_info@user:user_0
+    # user 1 can read git providers because they are a member
+    - organization:org_1#read_git_provider@user:user_1
+    # user 0 can edit project_0, because they are the Org Owner
+    - project:project_1#write_info@user:user_0
+    - organization:org_1#write_settings@user:user_0
+    - organization:org_1#write_git_provider@user:user_0
+    # user 0 can invite members to the organization
+    - organization:org_1#read_members@user:user_0
+    - organization:org_1#write_members@user:user_0
+    - organization:org_1#invite_members@user:user_0
+    # user 1 can read and invite members to the organization
+    - organization:org_1#read_members@user:user_1
+    - organization:org_1#invite_members@user:user_1
+    # Org owner can delete the organization
+    - organization:org_1#delete@user:user_0
+    # Org owner can delete projects
+    - project:project_1#delete@user:user_0
+    # Org member can view projects
+    - project:project_1#read_info@user:user_1
+    # Org member can create projects
+    - organization:org_1#create_project@user:user_1
+    # installation user can create orgs
+    - installation:installation_0#create_organization@user:user_0
+    # Installation admin can do what org owners can
+    - project:project_1#delete@user:user_admin
+    - organization:org_1#delete@user:user_admin
+    - organization:org_1#write_settings@user:user_admin
+    - organization:org_1#write_git_provider@user:user_admin
+  assertFalse:
+    # user 10 cannot access project_1
+    - project:project_1#read_info@user:user_10
+    - project:project_2#write_info@user:user_10
+    # non-member/owner cannot access organization
+    - organization:org_1#read_info@user:user_3
+    - organization:org_1#write_info@user:user_3
+    - organization:org_1#write_settings@user:user_1
+    - organization:org_1#read_members@user:user_3
+    - organization:org_1#write_members@user:user_3
+    - organization:org_1#invite_members@user:user_3
+    # user 1 (member) can not write members
+    - organization:org_1#write_members@user:user_1
+    # members are not allowed to:
+    - organization:org_1#write_git_provider@user:user_1
+    # org member can not delete org
+    - organization:org_1#delete@user:user_1
+    # org members can not delete project
+    - project:project_1#delete@user:user_1
+    # installation admin can not create an org
+    - installation:installation_0#create_organization@user:user_admin


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
