### PR TITLE
Remove page title suffix

### DIFF
--- a/components/dashboard/public/index.html
+++ b/components/dashboard/public/index.html
@@ -18,7 +18,7 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Dashboard — Gitpod</title>
+    <title>Dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -92,7 +92,7 @@ export interface StartWorkspaceError {
 export function StartPage(props: StartPageProps) {
     const { phase, error } = props;
     let title = props.title || getPhaseTitle(phase, error);
-    useDocumentTitle("Starting — Gitpod");
+    useDocumentTitle("Starting");
     return (
         <div className="w-screen h-screen align-middle">
             <div className="flex flex-col mx-auto items-center text-center h-screen">

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -38,7 +38,7 @@ export default function NewTeamPage() {
         }
     };
 
-    useDocumentTitle("New Organization — Gitpod");
+    useDocumentTitle("New Organization");
 
     return (
         <div className="flex flex-col w-96 mt-24 mx-auto items-center">


### PR DESCRIPTION
## Description

This will remove the — Gitpod suffix from all dashboard pages. Cc @chrifro 

| BEFORE | AFTER |
|--------|--------|
| <img width="1070" alt="Frame 1698" src="https://github.com/gitpod-io/gitpod/assets/120486/b6ef5fd5-8a8c-4579-a94e-e60d890af68b"> | <img width="1070" alt="Frame 1699" src="https://github.com/gitpod-io/gitpod/assets/120486/9f5cc1b2-49c6-42fd-b21b-848e2afe1df1"> | 

VS Code on Browser is still using `— Gitpod Code` as a suffix which coule be probably also nice to remove.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-626

## How to test
Navigate through the dashboard and notice there's no `— Gitpod` suffix anywhere in the pages.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-remove-8f99d3421b</li>
	<li><b>🔗 URL</b> - <a href="https://gt-remove-8f99d3421b.preview.gitpod-dev.com/workspaces" target="_blank">gt-remove-8f99d3421b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-remove-page-title-suffix-gha.13436</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
