### PR TITLE
Improve organization selector

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -106,7 +106,7 @@ function ContextMenu(props: ContextMenuProps) {
             </div>
             {expanded ? (
                 <div
-                    className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 filter drop-shadow-xl rounded-lg truncated ${
+                    className={`mt-2 py-1 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-50 dark:border-gray-800 filter drop-shadow-xl rounded-lg truncated ${
                         props.customClasses || "w-48 right-0"
                     }`}
                     data-analytics='{"button_type":"context_menu"}'
@@ -170,8 +170,6 @@ export const MenuEntry: FunctionComponent<MenuEntryProps> = ({
     separator = false,
     customContent,
     customFontStyle,
-    isFirst,
-    isLast,
     onClick,
 }) => {
     const clickable = href || link || onClick;
@@ -180,14 +178,12 @@ export const MenuEntry: FunctionComponent<MenuEntryProps> = ({
         <div
             title={title}
             className={cn(
-                "px-4 py-2 flex leading-1 text-sm",
-                customFontStyle || "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100",
+                "px-2 py-1 my-0.5 flex leading-1 text-sm rounded-md mx-2",
+                customFontStyle || "text-gray-600 dark:text-gray-400 rounded-md mt-1",
                 {
-                    "cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700": clickable,
-                    "bg-gray-50 dark:bg-gray-800": active,
-                    "rounded-t-lg": isFirst,
-                    "rounded-b-lg": isLast,
-                    "border-b border-gray-200 dark:border-gray-800": separator,
+                    "cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800": clickable,
+                    "dark:bg-gray-900": active,
+                    "border-0": separator,
                 },
             )}
         >

--- a/components/dashboard/src/components/org-icon/OrgIcon.tsx
+++ b/components/dashboard/src/components/org-icon/OrgIcon.tsx
@@ -9,38 +9,24 @@ import { FunctionComponent } from "react";
 import { consistentClassname } from "./consistent-classname";
 import "./styles.css";
 
-const SIZE_CLASSES = {
-    small: "w-6 h-6",
-    medium: "w-10 h-10",
-};
-
-const TEXT_SIZE_CLASSES = {
-    small: "text-sm",
-    medium: "text-xl",
-};
-
 export type OrgIconProps = {
     id: string;
     name: string;
-    size?: keyof typeof SIZE_CLASSES;
     className?: string;
 };
-export const OrgIcon: FunctionComponent<OrgIconProps> = ({ id, name, size = "medium", className }) => {
+export const OrgIcon: FunctionComponent<OrgIconProps> = ({ id, name, className }) => {
     const logoBGClass = consistentClassname(id);
     const initials = getOrgInitials(name);
-    const sizeClasses = SIZE_CLASSES[size];
-    const textClass = TEXT_SIZE_CLASSES[size];
 
     return (
         <div
             className={classNames(
-                "rounded-full flex items-center justify-center flex-shrink-0",
-                sizeClasses,
+                "rounded-full flex items-center justify-center flex-shrink-0 w-6 h-6",
                 logoBGClass,
                 className,
             )}
         >
-            <span className={`text-white font-semibold ${textClass}`}>{initials}</span>
+            <span className="text-white font-semibold ">{initials}</span>
         </div>
     );
 };

--- a/components/dashboard/src/dedicated-setup/SetupLayout.tsx
+++ b/components/dashboard/src/dedicated-setup/SetupLayout.tsx
@@ -45,7 +45,6 @@ export const SetupLayout: FC<Props> = ({
                                 <OrgIcon
                                     id={currentOrg?.data?.id || "empty"}
                                     name={currentOrg.data?.name || ""}
-                                    size="small"
                                     className="mr-2"
                                 />
                                 {currentOrg.data?.name}

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -6,7 +6,7 @@
 
 import { FunctionComponent, useCallback } from "react";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
-import { OrgIcon, OrgIconProps } from "../components/org-icon/OrgIcon";
+import { OrgIcon } from "../components/org-icon/OrgIcon";
 import { useCurrentUser } from "../user-context";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { useLocation } from "react-router";
@@ -28,7 +28,7 @@ export default function OrganizationSelector() {
     let activeOrgEntry = !currentOrg.data
         ? {
               title: userFullName,
-              customContent: <CurrentOrgEntry title={userFullName} subtitle="Personal Account" />,
+              customContent: <CurrentOrgEntry id={`1`} title={userFullName} subtitle="Personal Account" />,
               active: false,
               separator: false,
               tight: true,
@@ -37,6 +37,7 @@ export default function OrganizationSelector() {
               title: currentOrg.data.name,
               customContent: (
                   <CurrentOrgEntry
+                      id={currentOrg.data.id}
                       title={currentOrg.data.name}
                       subtitle={
                           !!currentOrg.data.members
@@ -113,29 +114,21 @@ export default function OrganizationSelector() {
             ),
             // marking as active for styles
             active: true,
-            separator: true,
+            separator: false,
             link: getOrgURL(org.id),
         }));
 
     const entries = [
         activeOrgEntry,
-        ...linkEntries,
         ...otherOrgEntries,
+        ...linkEntries,
         ...(canCreateOrgs
             ? [
                   {
                       title: "Create a new organization",
                       customContent: (
-                          <div className="w-full text-gray-500 flex items-center">
+                          <div className="w-full text-gray-400 dark:text-gray-500 flex items-center">
                               <span className="flex-1">New Organization</span>
-                              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5">
-                                  <path
-                                      fill="currentColor"
-                                      fillRule="evenodd"
-                                      d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z"
-                                      clipRule="evenodd"
-                                  />
-                              </svg>
                           </div>
                       ),
                       link: "/orgs/new",
@@ -148,17 +141,12 @@ export default function OrganizationSelector() {
 
     const selectedTitle = currentOrg?.data ? currentOrg.data.name : userFullName;
     const classes =
-        "flex h-full text-base py-0 text-gray-500 bg-gray-50  dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
+        "flex h-full text-base py-0 text-gray-500 bg-gray-50 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
                 <div className="py-1 pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
-                    <OrgIcon
-                        id={currentOrg?.data?.id || user?.id || "empty"}
-                        name={selectedTitle}
-                        size="small"
-                        className="mr-2"
-                    />
+                    <OrgIcon id={currentOrg?.data?.id || user?.id || "empty"} name={selectedTitle} className="mr-2" />
                     {selectedTitle}
                 </div>
                 <div className="flex h-full pl-0 pr-1 py-1.5 text-gray-50">
@@ -189,31 +177,30 @@ type OrgEntryProps = {
     id: string;
     title: string;
     subtitle: string;
-    iconSize?: OrgIconProps["size"];
 };
-export const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle, iconSize }) => {
+export const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title }) => {
     return (
         <div className="w-full text-gray-400 flex items-center">
-            <OrgIcon id={id} name={title} className="mr-4" size={iconSize} />
+            <OrgIcon id={id} name={title} className="mr-2" />
             <div className="flex flex-col">
-                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
-                <span>{subtitle}</span>
+                <span className="text-gray-600 dark:text-gray-300 text-sm font-semibold">{title}</span>
             </div>
         </div>
     );
 };
 
 type CurrentOrgEntryProps = {
+    id: string;
     title: string;
     subtitle: string;
 };
-const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ title, subtitle }) => {
+const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ id, title }) => {
     return (
-        <div className="w-full text-gray-400 flex items-center justify-between">
-            <div className="flex flex-col">
-                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
-                <span>{subtitle}</span>
-            </div>
+        <div className="w-full text-gray-400 flex items-center">
+            <OrgIcon id={id} name={title} className="mr-2 shrink-0" />
+            <span className="flex-auto">
+                <span className="text-gray-600 dark:text-gray-300 text-sm font-semibold">{title}</span>
+            </span>
 
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" className="dark:hidden" fill="none">
                 <path


### PR DESCRIPTION
## Description

An attempt to imporve the organization selector UX.

⚠️ It’s still missing the following from implementation side:
1. ~~Thinner menu entries and rounded with margin on hover. :leftwards_arrow_with_hook: I'd like to apply this to all context menus in the dropdown component, as seen in the dropdown2 component.~~
1. A separator after the list of orgs.
1. ~~The avatar of the active org.~~
1. Keep the list of orgs regardless which one is active.

☝️  Once we make these, we could move the Log out action + User Settings there and completely remove the user menu, merging the org and user menu. Maybe also merging settings as described in [UX-37](https://linear.app/gitpod/issue/UX-37/improve-ux-for-organization-and-account-settings).

👋 Any hints or commits appreciated. 🙇 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes UX-25

## How to test

Test clarity and UX on the changes around the organization selector.

| BEFORE | AFTER |
|--------|--------|
| <img width="530" alt="Frame 1705" src="https://github.com/gitpod-io/gitpod/assets/120486/9a3a2454-3678-4e8e-9033-d27bbcd81e1b"> | <img width="530" alt="Frame 1706" src="https://github.com/gitpod-io/gitpod/assets/120486/151ff13d-4a43-48d7-83cf-ac54953182ef"> |
| <img width="530" alt="Frame 1703" src="https://github.com/gitpod-io/gitpod/assets/120486/9e68c0dc-3e2c-405e-9553-aab2a1f14c4e"> | <img width="530" alt="Frame 1704" src="https://github.com/gitpod-io/gitpod/assets/120486/965983fa-a73f-4fdb-9b9c-0dd15ff55b84"> |
| <img width="530" alt="Frame 1707" src="https://github.com/gitpod-io/gitpod/assets/120486/1cbb3a75-b7d8-4870-bbf7-db0eb4a5f743"> | <img width="530" alt="Frame 1708" src="https://github.com/gitpod-io/gitpod/assets/120486/440cd359-8505-49ee-b54f-12a57ea870ac"> |


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-improvef143127353</li>
	<li><b>🔗 URL</b> - <a href="https://gt-improvef143127353.preview.gitpod-dev.com/workspaces" target="_blank">gt-improvef143127353.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-improve-org-selector-gha.13447</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
