### PR TITLE
[server] use org service in iam-session-app

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -18,13 +18,21 @@ import {
 import { SpiceDBAuthorizer } from "./spicedb-authorizer";
 import { Organization, TeamMemberInfo, Project, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class Authorizer {
     constructor(
         @inject(SpiceDBAuthorizer)
         private authorizer: SpiceDBAuthorizer,
-    ) {}
+    ) {
+        this.initialize().catch((err) => log.error("Failed to add installation admin", err));
+    }
+
+    private async initialize(): Promise<void> {
+        await this.addAdminRole(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+    }
 
     async hasPermissionOnOrganization(
         userId: string,

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -18,8 +18,8 @@ import * as request from "supertest";
 
 import * as chai from "chai";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
-import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib";
-import { TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
+import { TeamMemberInfo, TeamMemberRole, User } from "@gitpod/gitpod-protocol";
+import { OrganizationService } from "../orgs/organization-service";
 const expect = chai.expect;
 
 @suite(timeout(10000))
@@ -55,18 +55,13 @@ class TestIamSessionApp {
         },
     };
 
-    protected teamDbMock: Partial<TeamDB> & { memberships: Set<string> } = {
+    protected orgServiceMock: Partial<OrganizationService> & { memberships: Set<string> } = {
         memberships: new Set<string>(), // simply assuming single org here!
-        findMembersByTeam: async (teamId: string): Promise<TeamMemberInfo[]> => {
+        listMembers: async (teamId: string): Promise<TeamMemberInfo[]> => {
             return [];
         },
-        async addMemberToTeam(userId: string, teamId: string): Promise<"added" | "already_member"> {
-            this.memberships.add(userId);
-            return "added";
-        },
-        setTeamMemberRole: async (userId, teamId, role): Promise<void> => {},
-        async removeMemberFromTeam(userId, teamId): Promise<void> {
-            this.memberships.delete(userId);
+        async addOrUpdateMember(userId: string, teamId: string, memberId: string, role: TeamMemberRole): Promise<void> {
+            this.memberships.add(memberId);
         },
     };
 
@@ -90,7 +85,7 @@ class TestIamSessionApp {
     };
 
     public before() {
-        this.teamDbMock.memberships.clear();
+        this.orgServiceMock.memberships.clear();
         this.knownUser.identities = [];
 
         const container = new Container();
@@ -114,7 +109,7 @@ class TestIamSessionApp {
                 bind(Authenticator).toConstantValue(<any>{}); // unused
                 bind(Config).toConstantValue(<any>{}); // unused
                 bind(UserService).toConstantValue(this.userServiceMock as any);
-                bind(TeamDB).toConstantValue(this.teamDbMock as TeamDB);
+                bind(OrganizationService).toConstantValue(this.orgServiceMock as any);
             }),
         );
         this.app = container.get(IamSessionApp);
@@ -200,24 +195,6 @@ class TestIamSessionApp {
 
         expect(result.statusCode, JSON.stringify(result.body)).to.equal(400);
         expect(result.body?.message).to.equal("OIDC client config id missing");
-    }
-
-    @test public async testSessionRequest_createUser_removes_admin() {
-        // assert only admin is member of the org
-        await this.teamDbMock.addMemberToTeam!(BUILTIN_INSTLLATION_ADMIN_USER_ID, "test-org");
-        expect(this.teamDbMock.memberships.has(BUILTIN_INSTLLATION_ADMIN_USER_ID)).to.be.true;
-        expect(this.teamDbMock.memberships.has("id-new-user")).to.be.false;
-
-        const result = await request(this.app.create())
-            .post("/session")
-            .set("Content-Type", "application/json")
-            .send(JSON.stringify(this.payload));
-
-        expect(result.statusCode, JSON.stringify(result.body)).to.equal(200);
-
-        // assert no admin is member of the org
-        expect(this.teamDbMock.memberships.has(BUILTIN_INSTLLATION_ADMIN_USER_ID)).to.be.false;
-        expect(this.teamDbMock.memberships.has("id-new-user")).to.be.true;
     }
 
     @test public async testSessionRequest_updates_existing_user() {

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import {
     OrgMemberInfo,
     OrgMemberRole,
@@ -17,6 +17,7 @@ import { Authorizer } from "../authorization/authorizer";
 import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { ProjectsService } from "../projects/projects-service";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class OrganizationService {
@@ -171,7 +172,7 @@ export class OrganizationService {
         }
     }
 
-    public async setOrganizationMemberRole(
+    public async addOrUpdateMember(
         userId: string,
         orgId: string,
         memberId: string,
@@ -184,16 +185,35 @@ export class OrganizationService {
                 throw new ApplicationError(ErrorCodes.CONFLICT, "Cannot remove the last owner of an organization.");
             }
         }
+        const members = await this.teamDB.findMembersByTeam(orgId);
+        const firstMember = members.filter((m) => m.userId !== BUILTIN_INSTLLATION_ADMIN_USER_ID).length === 0;
+        if (firstMember) {
+            // first member (that is not an admin) is going to be an owner
+            role = "owner";
+            log.info({ userId: memberId }, "First member of organization, setting role to owner.");
+        }
 
         try {
             await this.teamDB.transaction(async (db) => {
+                await db.addMemberToTeam(memberId, orgId);
                 await db.setTeamMemberRole(memberId, orgId, role);
                 await this.auth.addOrganizationRole(orgId, memberId, role);
+                if (role === "member") {
+                    await this.auth.removeOrganizationOwnerRole(orgId, memberId);
+                }
             });
         } catch (err) {
+            //TODO simply removing the user is not necessarily the right thing to do here, as the user might have been a member before
             await this.auth.removeUserFromOrg(orgId, memberId);
-
             throw err;
+        }
+        // we can remove the built-in installation admin now
+        if (firstMember) {
+            try {
+                await this.removeOrganizationMember(memberId, orgId, BUILTIN_INSTLLATION_ADMIN_USER_ID);
+            } catch (error) {
+                log.warn("Failed to remove built-in installation admin from organization.", error);
+            }
         }
     }
 

--- a/components/server/src/orgs/usage-service.spec.db.ts
+++ b/components/server/src/orgs/usage-service.spec.db.ts
@@ -4,8 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { DBUser, TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
-import { DBTeam } from "@gitpod/gitpod-db/lib/typeorm/entity/db-team";
+import { TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
 import { Organization, User } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
@@ -26,6 +25,7 @@ import { createTestContainer } from "../test/service-testing-container-module";
 import { UserService } from "../user/user-service";
 import { OrganizationService } from "./organization-service";
 import { UsageService } from "./usage-service";
+import { resetDB } from "../test/reset-db";
 
 const expect = chai.expect;
 
@@ -71,9 +71,7 @@ describe("UsageService", async () => {
     afterEach(async () => {
         // Clean-up database
         const typeorm = container.get(TypeORM);
-        const conn = await typeorm.getConnection();
-        await conn.getRepository(DBTeam).clear();
-        await conn.getRepository(DBUser).clear();
+        await resetDB(typeorm);
     });
 
     it("getCostCenter permissions", async () => {

--- a/components/server/src/test/reset-db.ts
+++ b/components/server/src/test/reset-db.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { DBUser, TypeORM, isBuiltinUser } from "@gitpod/gitpod-db/lib";
+import { DBProject } from "@gitpod/gitpod-db/lib/typeorm/entity/db-project";
+import { DBTeam } from "@gitpod/gitpod-db/lib/typeorm/entity/db-team";
+import { DBTeamMembership } from "@gitpod/gitpod-db/lib/typeorm/entity/db-team-membership";
+
+export async function resetDB(typeorm: TypeORM) {
+    const conn = await typeorm.getConnection();
+    await conn.getRepository(DBTeam).clear();
+    await conn.getRepository(DBTeamMembership).clear();
+    await conn.getRepository(DBProject).clear();
+    // delete all users except the builtin users
+    const users = await conn.getRepository(DBUser).find();
+    await conn.getRepository(DBUser).remove(users.filter((u) => !isBuiltinUser(u.id)));
+}

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -9,7 +9,8 @@ import * as chai from "chai";
 import { Container } from "inversify";
 import { createTestContainer } from "../test/service-testing-container-module";
 import { UserService } from "./user-service";
-import { DBUser, TypeORM } from "@gitpod/gitpod-db/lib";
+import { TypeORM } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "../test/reset-db";
 
 const expect = chai.expect;
 
@@ -27,8 +28,7 @@ describe("UserService", async () => {
 
     afterEach(async () => {
         const typeorm = container.get(TypeORM);
-        const conn = await typeorm.getConnection();
-        await conn.getRepository(DBUser).clear();
+        await resetDB(typeorm);
     });
 
     it("updateLoggedInUser_avatarUrlNotUpdatable", async () => {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2845,7 +2845,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
 
         await this.guardTeamOperation(teamId, "update", "write_members");
-        await this.organizationService.setOrganizationMemberRole(requestor.id, teamId, userId, role);
+        await this.organizationService.addOrUpdateMember(requestor.id, teamId, userId, role);
     }
 
     public async removeTeamMember(ctx: TraceContext, orgID: string, userId: string): Promise<void> {
@@ -3497,7 +3497,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             { teamId, userId: memberId, role },
             Permission.ADMIN_WORKSPACES,
         );
-        return this.organizationService.setOrganizationMemberRole(user.id, teamId, memberId, role);
+        return this.organizationService.addOrUpdateMember(user.id, teamId, memberId, role);
     }
 
     async getOwnAuthProviders(ctx: TraceContext): Promise<AuthProviderEntry[]> {

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -9,11 +9,11 @@ schema: |-
   definition installation {
 
     // only users that are not owned by an org are considered installation-level users
-    relation user: user
+    relation member: user
     relation admin: user
 
     // orgs can only be created by installation-level users
-    permission create_organization = user
+    permission create_organization = member + admin
 
   }
 
@@ -33,7 +33,7 @@ schema: |-
     permission write_info = owner + installation->admin
     permission delete = owner + installation->admin
 
-    permission read_settings = owner + installation->admin
+    permission read_settings = member + owner + installation->admin
     permission write_settings = owner + installation->admin
 
     // Operations on Organization's Members
@@ -64,14 +64,14 @@ schema: |-
     //  * the project has granted access to everyone in an organization
     relation viewer: user | organization#member
 
-    permission write_info = org->owner + editor + org->installation_admin
-    permission read_info = write_info + viewer + org->member + org->installation_admin
-    permission delete = org->owner + editor + org->installation_admin
+    permission read_info = viewer + org->member + editor + org->owner + org->installation_admin
+    permission write_info = editor + org->owner + org->installation_admin
+    permission delete = editor + org->owner + org->installation_admin
   }
 # relationships to be used for assertions & validation
 relationships: |-
   // we have one installation
-  installation:installation_0#user@user:user_0
+  installation:installation_0#member@user:user_0
   installation:installation_0#admin@user:user_admin
 
   // We have an organization org_1, which has some members & owners
@@ -100,8 +100,8 @@ relationships: |-
 # validation should assert that a particular relation exists between an entity, and a subject
 # validations are not used to assert that a permission exists
 validation:
-  installation:installation_0#user:
-    - "[user:user_0] is <installation:installation_0#user>"
+  installation:installation_0#member:
+    - "[user:user_0] is <installation:installation_0#member>"
   installation:installation_0#admin:
     - "[user:user_admin] is <installation:installation_0#admin>"
   organization:org_1#member:
@@ -147,6 +147,8 @@ assertions:
     - organization:org_1#delete@user:user_admin
     - organization:org_1#write_settings@user:user_admin
     - organization:org_1#write_git_provider@user:user_admin
+    # installation admin can create an org
+    - installation:installation_0#create_organization@user:user_admin
   assertFalse:
     # user 10 cannot access project_1
     - project:project_1#read_info@user:user_10
@@ -166,5 +168,3 @@ assertions:
     - organization:org_1#delete@user:user_1
     # org members can not delete project
     - project:project_1#delete@user:user_1
-    # installation admin can not create an org
-    - installation:installation_0#create_organization@user:user_admin

--- a/dev/preview/previewctl/cmd/admin.go
+++ b/dev/preview/previewctl/cmd/admin.go
@@ -130,7 +130,7 @@ func createAdminCredentials(ctx context.Context, expiry time.Duration) (string, 
 			"admin.json": secretContents,
 		},
 	}
-	_, err = secretsAPI.Get(ctx, secret.ObjectMeta.Name, metav1.GetOptions{})
+	existingSecret, err := secretsAPI.Get(ctx, secret.ObjectMeta.Name, metav1.GetOptions{})
 	if err != nil {
 		// secret does not yet exist, create it
 		_, err = secretsAPI.Create(ctx, secret, metav1.CreateOptions{})
@@ -139,7 +139,8 @@ func createAdminCredentials(ctx context.Context, expiry time.Duration) (string, 
 		}
 	} else {
 		// secret exists, update it
-		_, err = secretsAPI.Update(ctx, secret, metav1.UpdateOptions{})
+		existingSecret.Data = secret.Data // Update the Data of the existing secret
+		_, err = secretsAPI.Update(ctx, existingSecret, metav1.UpdateOptions{})
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to update secret with admin credentials: %w", err)
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Replaces use of teamDb with organizationService in iam-session.app.ts

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f52115</samp>

This pull request introduces several changes to the server component of Gitpod, mainly related to the authorization and organization management features. It refactors some classes and services, updates the tests and the schema, and fixes some bugs. It also adds a new utility function for resetting the database in the test files.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4f52115</samp>

> _Sing, O Muse, of the valiant pull request_
> _That refactored the code of `IamSessionApp`_
> _And made the tests more robust and clear_
> _With `resetDB`, the helper of the gods._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f52115</samp>

*  Add `initialize` method to `Authorizer` class that assigns the installation admin role to the built-in admin user ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-63e2ba5a68d9965170e174c27650c4caed4ac91ad2e79b885e6f9f81655fe5ffR21-R22),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-63e2ba5a68d9965170e174c27650c4caed4ac91ad2e79b885e6f9f81655fe5ffL27-R36))
*  Rename `TeamDB` to `OrganizationService` and update its methods and interface ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L21-R22),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L58-R65),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L15-R28),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL7-R8),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL117-R120),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL128-R127),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL7-R7),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL174-R175),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL187-R217),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L2848-R2848),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L3500-R3500))
*  Remove `BUILTIN_INSTLLATION_ADMIN_USER_ID` from `User` interface and update imports and references ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L21-R22),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L15-R28),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL7-R8),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL7-R7))
*  Make internal methods of `IamSessionApp` class private and simplify logic of `createNewOIDCUser` method ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L56-R59),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L79-R82),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L91-R94),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L115-R118),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L129-R132),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-cc5e8c8b2a81e5a2a660fe5f6a04c00901e4c6152d70e93beb89f49778ef4272L142-R145))
*  Update logic of `addOrUpdateMember` method of `OrganizationService` class to handle first non-admin member and remove admin user from organization ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL174-R175),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a6a96347dfcaea576e1fc89c848e5a6bcc808f9afb4b071ea4bfe7583c78267aL187-R217))
*  Update schema file for `SpiceDBAuthorizer` class to rename `user` relation to `member` and update permissions and assertions ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dL12-R16),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dL36-R36),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dL67-R74),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dL103-R104),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dR150-R151),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dL169-L170))
*  Update `previewctl` command to update existing secret instead of creating a new one in `createAdminCredentials` function ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-e54d16b8ebe207eec554008726e68661aadf73c8fcc0d2e6e99c5b4c41860510L133-R133),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-e54d16b8ebe207eec554008726e68661aadf73c8fcc0d2e6e99c5b4c41860510L142-R143))
*  Add `resetDB` function to clear database tables in test files and update imports and references ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL14-R17),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-05780e0f6ab3166c26a42575490fa18c16eee36a67cb4d62264be1e4625d2995L7-R7),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-05780e0f6ab3166c26a42575490fa18c16eee36a67cb4d62264be1e4625d2995R28),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-05780e0f6ab3166c26a42575490fa18c16eee36a67cb4d62264be1e4625d2995L74-R74),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-77482d7b22000fadc710e0af7e6b89c599285aab8e7fe4a5f6db0fb3112398c2L7-R7),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-77482d7b22000fadc710e0af7e6b89c599285aab8e7fe4a5f6db0fb3112398c2R18),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-77482d7b22000fadc710e0af7e6b89c599285aab8e7fe4a5f6db0fb3112398c2L56-R56),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-3cc10f050fa6ef9c8caf51f435704d8920868a2f7d551d10ac0832953e917b5cR1-R20),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-92cdccf6d6ba3466df6c81706f564c48dcc249820ded2225071db35f5b1bd323L12-R13),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-92cdccf6d6ba3466df6c81706f564c48dcc249820ded2225071db35f5b1bd323L30-R31))
*  Update test cases to reflect changes in `OrganizationService` methods and logic ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L58-R65),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L93-R88),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-7675ac4e44d727152bb60866081791113aa49e9221fd86001f5df96947f69f18L117-R112),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL48-R56),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL117-R120),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bL128-R127),[link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-a7b0cc6b128e725c8acf08bd1a3695893b52f25d702a9611734196fa5916bd9bR194-R205))
*  Add check to `expectError` function in `ProjectsService` test file to ensure error has an error code ([link](https://github.com/gitpod-io/gitpod/pull/18280/files?diff=unified&w=0#diff-77482d7b22000fadc710e0af7e6b89c599285aab8e7fe4a5f6db0fb3112398c2R210-R212))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-624

## How to test
<!-- Provide steps to test this PR -->

Setup the preview env with SSO and verify that the first user becomes an owner and has owner privileges with spicedb as well.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-use-org-service</li>
	<li><b>🔗 URL</b> - <a href="https://se-use-org-service.preview.gitpod-dev.com/workspaces" target="_blank">se-use-org-service.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-use-org-service-gha.13528</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
