### PR TITLE
Change gh runners concurrency rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,6 +61,7 @@ gitpod:summary
       If enabled this will create the environment on GCE infra
 - [ ] with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
+- [ ] with-monitoring
 </details>
 
 /hold

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
       with_werft: ${{ steps.output.outputs.with-werft }}
       with_integration_tests: ${{ steps.output.outputs.with_integration_tests }}
+      with_monitoring: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-monitoring') }}
       latest_ide_version: ${{ contains( steps.pr-details.outputs.pr_body, '[x] latest-ide-version=true') }}
       leeway_cache_bucket: ${{ steps.output.outputs.leeway_cache_bucket }}
       pr_number: ${{ steps.pr-details.outputs.number }}
@@ -372,6 +373,7 @@ jobs:
     name: "Install Monitoring Satellite"
     needs: [infrastructure, build-previewctl, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
+    if: needs.configuration.outputs.with_monitoring == 'true'
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
       cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/create_runner.yml
     secrets: inherit
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-create-runner
       cancel-in-progress: false
 
   configuration:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-configuration
       cancel-in-progress: true
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
@@ -89,7 +89,7 @@ jobs:
       (needs.configuration.outputs.preview_enable == 'true')
     needs: [configuration, create-runner]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-previewctl
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
@@ -117,7 +117,7 @@ jobs:
       (needs.configuration.outputs.is_main_branch != 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -137,7 +137,7 @@ jobs:
     needs: [configuration, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-gitpod
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
@@ -329,7 +329,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     steps:
       - uses: actions/checkout@v3
@@ -373,7 +373,7 @@ jobs:
     needs: [infrastructure, build-previewctl, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -398,7 +398,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-new-dev-image-gha.13182
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-integration-test
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -444,3 +444,6 @@ jobs:
     secrets: inherit
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
+    concurrency:
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-delete-runner
+      cancel-in-progress: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,8 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     concurrency:
-      # github.head_ref is set by a pull_request event - contains the name of the source branch of the PR
-      # github.ref_name is set if the event is NOT a pull_request - it contains only the branch name.
-      group: ${{ github.head_ref || github.ref_name }}-configuration
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      cancel-in-progress: true
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
@@ -87,7 +86,7 @@ jobs:
       (needs.configuration.outputs.preview_enable == 'true')
     needs: [configuration, create-runner]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-build-previewctl
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
@@ -115,7 +114,7 @@ jobs:
       (needs.configuration.outputs.is_main_branch != 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.head_ref || github.ref_name }}-infrastructure
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -135,9 +134,7 @@ jobs:
     needs: [configuration, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.head_ref || github.ref_name }}-build-gitpod
-      # For the main branch we always want the build job to run to completion
-      # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
@@ -329,8 +326,8 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-install
-      cancel-in-progress: true
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     steps:
       - uses: actions/checkout@v3
       - name: Deploy Gitpod to the preview environment
@@ -373,7 +370,7 @@ jobs:
     needs: [infrastructure, build-previewctl, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-monitoring
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -398,7 +395,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-new-dev-image-gha.13182
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-integration-test
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
   create-runner:
     uses: ./.github/workflows/create_runner.yml
     secrets: inherit
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}
+      cancel-in-progress: false
 
   configuration:
     name: Configure job parameters


### PR DESCRIPTION

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-concurrency</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-concurrency.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-concurrency.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-concurrency-gha.13561</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
