### PR TITLE
Update top navigation

### DIFF
--- a/components/dashboard/src/components/PillMenuItem.tsx
+++ b/components/dashboard/src/components/PillMenuItem.tsx
@@ -14,10 +14,10 @@ export default function PillMenuItem(p: {
     onClick?: (event: React.MouseEvent) => void;
 }) {
     let classes =
-        "flex block font-medium dark:text-gray-400 px-3 py-1 rounded-2xl transition ease-in-out font-semibold " +
+        "flex block font-medium dark:text-gray-400 px-3 py-1 rounded-2xl transition ease-in-out " +
         (p.selected
-            ? "text-gray-50 bg-gray-800 dark:text-gray-900 dark:bg-gray-50"
-            : "hover:bg-gray-100 dark:hover:bg-gray-700");
+            ? "text-gray-500 bg-gray-50 dark:text-gray-100 dark:bg-gray-800"
+            : "hover:bg-gray-100 dark:hover:bg-gray-800");
     if (p.additionalClasses) {
         classes = classes + " " + p.additionalClasses;
     }

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -148,11 +148,11 @@ export default function OrganizationSelector() {
 
     const selectedTitle = currentOrg?.data ? currentOrg.data.name : userFullName;
     const classes =
-        "flex h-full text-base py-0 text-gray-500 bg-gray-50  dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
+        "flex h-full text-base py-0 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700";
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
-                <div className="py-1 pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
+                <div className="py-1 pr-1 flex font-medium whitespace-nowrap max-w-xs overflow-hidden">
                     <OrgIcon
                         id={currentOrg?.data?.id || user?.id || "empty"}
                         name={selectedTitle}


### PR DESCRIPTION
## Description

Reviving parts of https://github.com/gitpod-io/gitpod/pull/16433 to update the top navigation and tone down the active menu.

| BEFORE | AFTER |
|-|-|
| <img width="565" alt="Frame 1712" src="https://github.com/gitpod-io/gitpod/assets/120486/985c7336-2e4d-4595-a330-41aa37df942d"> | <img width="565" alt="Frame 1713" src="https://github.com/gitpod-io/gitpod/assets/120486/ff57ef0a-f3c6-4443-b4a0-05aac7e7b61b"> |
| <img width="565" alt="Frame 1714" src="https://github.com/gitpod-io/gitpod/assets/120486/05fe117a-ab9d-4d2b-9c7c-287e257b1c0a"> | <img width="565" alt="Frame 1715" src="https://github.com/gitpod-io/gitpod/assets/120486/41884f22-db09-4ff9-b23a-8008bf2eccce"> |
| <img width="1512" alt="Frame 1716" src="https://github.com/gitpod-io/gitpod/assets/120486/589c1cc8-a0f3-49b6-9270-580b4389ea8d"> | <img width="1512" alt="Frame 1717" src="https://github.com/gitpod-io/gitpod/assets/120486/53e7660c-1e28-4235-b83e-c00419b85613"> |

## How to test

Log in and see how the top navigation no longer stands out much, overtaking the primary action of the page.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-b2dd5edb54</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-b2dd5edb54.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-b2dd5edb54.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-update-top-navigation-gha.13570</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
</details>

/hold
