### PR TITLE
[public-api] align context url with server

### DIFF
--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -317,20 +317,14 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.Workspace, error) 
 	if err != nil {
 		return nil, err
 	}
-	// Align to https://github.com/gitpod-io/gitpod/blob/0bb6aaad9d4923d5510de865437f22c7f726833f/components/server/src/workspace/workspace-starter.ts#L1375-L1378
-	contextUrl := input.Workspace.ContextURL
-	if input.Workspace.Context != nil && len(input.Workspace.Context.NormalizedContextURL) > 0 {
-		contextUrl = input.Workspace.Context.NormalizedContextURL
-	}
-
 	return &v1.Workspace{
 		WorkspaceId: input.Workspace.ID,
 		OwnerId:     input.Workspace.OwnerID,
 		ProjectId:   "",
 		Context: &v1.WorkspaceContext{
-			ContextUrl: contextUrl,
+			ContextUrl: input.Workspace.ContextURL,
 			Details: &v1.WorkspaceContext_Git_{Git: &v1.WorkspaceContext_Git{
-				NormalizedContextUrl: input.Workspace.ContextURL,
+				NormalizedContextUrl: input.Workspace.Context.NormalizedContextURL,
 				Commit:               "",
 			}},
 		},

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -317,12 +317,18 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.Workspace, error) 
 	if err != nil {
 		return nil, err
 	}
+	// Align to https://github.com/gitpod-io/gitpod/blob/0bb6aaad9d4923d5510de865437f22c7f726833f/components/server/src/workspace/workspace-starter.ts#L1375-L1378
+	contextUrl := input.Workspace.ContextURL
+	if input.Workspace.Context != nil && len(input.Workspace.Context.NormalizedContextURL) > 0 {
+		contextUrl = input.Workspace.Context.NormalizedContextURL
+	}
+
 	return &v1.Workspace{
 		WorkspaceId: input.Workspace.ID,
 		OwnerId:     input.Workspace.OwnerID,
 		ProjectId:   "",
 		Context: &v1.WorkspaceContext{
-			ContextUrl: input.Workspace.ContextURL,
+			ContextUrl: contextUrl,
 			Details: &v1.WorkspaceContext_Git_{Git: &v1.WorkspaceContext_Git{
 				NormalizedContextUrl: input.Workspace.ContextURL,
 				Commit:               "",

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -662,7 +662,7 @@ var workspaceTestData = []workspaceTestDataEntry{
 				ContextUrl: "https://github.com/gitpod-io/gitpod",
 				Details: &v1.WorkspaceContext_Git_{
 					Git: &v1.WorkspaceContext_Git{
-						NormalizedContextUrl: "https://github.com/gitpod-io/gitpod",
+						NormalizedContextUrl: "https://github.com/gitpod-io/protocol.git",
 					},
 				},
 			},

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -613,9 +613,9 @@ var workspaceTestData = []workspaceTestDataEntry{
 				BaseImageNameResolved: "foo:bar",
 				ID:                    "gitpodio-gitpod-isq6xj458lj",
 				OwnerID:               "fake-owner-id",
-				ContextURL:            "https://github.com/gitpod-io/gitpod",
+				ContextURL:            "open-prebuild/126ac54a-5922-4a45-9a18-670b057bf540/https://github.com/gitpod-io/gitpod/pull/18291",
 				Context: &protocol.WorkspaceContext{
-					NormalizedContextURL: "https://github.com/gitpod-io/protocol.git",
+					NormalizedContextURL: "https://github.com/gitpod-io/gitpod/pull/18291",
 					Title:                "tes ttitle",
 					Repository: &protocol.Repository{
 						Host: "github.com",
@@ -659,10 +659,10 @@ var workspaceTestData = []workspaceTestDataEntry{
 			WorkspaceId: "gitpodio-gitpod-isq6xj458lj",
 			OwnerId:     "fake-owner-id",
 			Context: &v1.WorkspaceContext{
-				ContextUrl: "https://github.com/gitpod-io/gitpod",
+				ContextUrl: "open-prebuild/126ac54a-5922-4a45-9a18-670b057bf540/https://github.com/gitpod-io/gitpod/pull/18291",
 				Details: &v1.WorkspaceContext_Git_{
 					Git: &v1.WorkspaceContext_Git{
-						NormalizedContextUrl: "https://github.com/gitpod-io/protocol.git",
+						NormalizedContextUrl: "https://github.com/gitpod-io/gitpod/pull/18291",
 					},
 				},
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See for context: https://gitpod.slack.com/archives/C03QM0ZHF5Z/p1689583726280819?thread_ts=1689581295.424429&cid=C03QM0ZHF5Z

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
It should able to start a workspace from prebuild with VS Code Desktop

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-ctx</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-ctx.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-ctx.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-ctx-gha.13658</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
