### PR TITLE
Add Gitpod Desktop OAuth client

### DIFF
--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -82,6 +82,26 @@ function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium")
     };
 }
 
+const desktopClient: OAuthClient = {
+    id: "gitpod-desktop",
+    name: "Gitpod Deskop",
+    redirectUris: ["gitpod://complete-auth"],
+    allowedGrants: ["authorization_code"],
+    scopes: [
+        { name: "function:getGitpodTokenScopes" },
+        { name: "function:getLoggedInUser" },
+        { name: "function:accessCodeSyncStorage" },
+        { name: "function:getOwnerToken" },
+        { name: "function:getWorkspace" },
+        { name: "function:getWorkspaces" },
+        { name: "function:getSSHPublicKeys" },
+        { name: "function:startWorkspace" },
+        { name: "function:stopWorkspace" },
+        { name: "function:deleteWorkspace" },
+        { name: "resource:default" },
+    ],
+};
+
 const vscode = createVSCodeClient("vscode");
 const vscodeInsiders = createVSCodeClient("vscode-insiders");
 const vscodium = createVSCodeClient("vscodium");
@@ -93,6 +113,7 @@ export const inMemoryDatabase: InMemory = {
         [vscode.id]: vscode,
         [vscodeInsiders.id]: vscodeInsiders,
         [vscodium.id]: vscodium,
+        [desktopClient.id]: desktopClient,
     },
     tokens: {},
     scopes: {},

--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -84,7 +84,7 @@ function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium")
 
 const desktopClient: OAuthClient = {
     id: "gitpod-desktop",
-    name: "Gitpod Deskop",
+    name: "Gitpod Desktop",
     redirectUris: ["gitpod://complete-auth"],
     allowedGrants: ["authorization_code"],
     scopes: [


### PR DESCRIPTION
## Description

Adds an OAuth client for the Desktop App experiment

## Related Issue(s)

A part of IDE-229

## How to test

Try https://github.com/gitpod-io/gitpod-desktop-app-vite/pull/2 with it :)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-gitpode87057719a</li>
	<li><b>🔗 URL</b> - <a href="https://ide-gitpode87057719a.preview.gitpod-dev.com/workspaces" target="_blank">ide-gitpode87057719a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-gitpod-desktop-oauth-gha.13682</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
