### PR TITLE
Fix: Authorize with undefined – WEB-613

### DIFF
--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -22,7 +22,7 @@ export class ApplicationError extends Error {
 }
 
 export namespace ApplicationError {
-    export function hasErrorCode(e: any): e is Error & { code: ErrorCode } {
+    export function hasErrorCode(e: any): e is Error & { code: ErrorCode; data?: any } {
         return e && e.code !== undefined;
     }
 }

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -434,7 +434,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
                         message: e.message,
                     },
                 );
-                throw new ResponseError(e.code, e.message);
+                throw new ResponseError(e.code, e.message, e.data);
             } else {
                 TraceContext.setError(ctx, e); // this is a "real" error
 


### PR DESCRIPTION
This fixes an issue with missing `data` attribute propagation introduced in [PR 18113](https://github.com/gitpod-io/gitpod/pull/18113/files#r1268153249).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-613

## How to test
* given the current preview env, you should be able to see the link `Authorize with gitlab.gitpod-dev.com` if you follow https://at-fix-auth-with.preview.gitpod-dev.com/#https://gitlab.gitpod-dev.com/george/gitpod-spring-petclinic

<img width="1497" alt="Screenshot 2023-07-19 at 16 40 43" src="https://github.com/gitpod-io/gitpod/assets/914497/f1b6ee99-b656-4e80-a91f-43682ed8c020">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-fix-auth-with</li>
	<li><b>🔗 URL</b> - <a href="https://at-fix-auth-with.preview.gitpod-dev.com/workspaces" target="_blank">at-fix-auth-with.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-fix-auth-with-gha.13762</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
