### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,117 +4,117 @@
 #
 /.github/CODEOWNERS
 
-/components/blobserve @gitpod-io/engineering-ide
+/components/blobserve @gitpod-io/team-experience
 /components/common-go @gitpod-io/engineering-staff-engineers
 /components/components/scrubber @gitpod-io/engineering-staff-engineers
-/components/content-service-api @gitpod-io/engineering-workspace
-/components/content-service @gitpod-io/engineering-workspace
-/components/dashboard @gitpod-io/engineering-webapp @gtsiolis
-/components/docker-up @gitpod-io/engineering-workspace
-/components/ee/agent-smith @gitpod-io/engineering-workspace
-/components/gitpod-cli @gitpod-io/engineering-ide
-/components/gitpod-db @gitpod-io/engineering-webapp
-/components/gitpod-messagebus @gitpod-io/engineering-webapp
-/components/gitpod-protocol @gitpod-io/engineering-webapp
-/components/gitpod-protocol/java @gitpod-io/engineering-ide
-/components/gitpod-protocol/src/typings/globals.ts @gitpod-io/engineering-ide
-/components/ide @gitpod-io/engineering-ide
-/components/ide-metrics @gitpod-io/engineering-ide
-/components/ide-metrics-api @gitpod-io/engineering-ide
-/components/ide-service @gitpod-io/engineering-ide
-/components/ide-service-api @gitpod-io/engineering-ide
-/components/ide-proxy @gitpod-io/engineering-ide
-/components/image-builder-api @gitpod-io/engineering-workspace
-/components/image-builder-bob @gitpod-io/engineering-workspace
-/components/image-builder-mk3 @gitpod-io/engineering-workspace
-/components/installation-telemetry @gitpod-io/engineering-security-infrastructure-and-delivery
-/install @gitpod-io/engineering-security-infrastructure-and-delivery
+/components/content-service-api @gitpod-io/team-engine
+/components/content-service @gitpod-io/team-engine
+/components/dashboard @gitpod-io/team-experience
+/components/docker-up @gitpod-io/team-engine
+/components/ee/agent-smith @gitpod-io/team-engine
+/components/gitpod-cli @gitpod-io/team-experience
+/components/gitpod-db @gitpod-io/team-experience
+/components/gitpod-messagebus @gitpod-io/team-experience
+/components/gitpod-protocol @gitpod-io/team-experience
+/components/gitpod-protocol/java @gitpod-io/team-experience
+/components/gitpod-protocol/src/typings/globals.ts @gitpod-io/team-experience
+/components/ide @gitpod-io/team-experience
+/components/ide-metrics @gitpod-io/team-experience
+/components/ide-metrics-api @gitpod-io/team-experience
+/components/ide-service @gitpod-io/team-experience
+/components/ide-service-api @gitpod-io/team-experience
+/components/ide-proxy @gitpod-io/team-experience
+/components/image-builder-api @gitpod-io/team-engine
+/components/image-builder-bob @gitpod-io/team-engine
+/components/image-builder-mk3 @gitpod-io/team-engine
+/components/installation-telemetry @gitpod-io/team-engine
+/install @gitpod-io/team-engine
 # By default anything in in /install/installer is shared.
 /install/installer
-/install/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
-/install/installer/pkg/components/blobserve @gitpod-io/engineering-ide
-/install/installer/pkg/components/components-ide @gitpod-io/engineering-ide
-/install/installer/pkg/components/components-webapp @gitpod-io/engineering-webapp
-/install/installer/pkg/components/components-workspace @gitpod-io/engineering-workspace
-/install/installer/pkg/components/content-service @gitpod-io/engineering-workspace
-/install/installer/pkg/components/dashboard @gitpod-io/engineering-webapp
-/install/installer/pkg/components/ide-metrics @gitpod-io/engineering-ide
-/install/installer/pkg/components/ide-service @gitpod-io/engineering-ide
-/install/installer/pkg/components/ide-proxy @gitpod-io/engineering-ide
-/install/installer/pkg/components/image-builder-mk3 @gitpod-io/engineering-workspace
-/install/installer/pkg/components/image-builder-mk3-wsman @gitpod-io/engineering-workspace
-/install/installer/pkg/components/openvsx-proxy @gitpod-io/engineering-ide
-/install/installer/pkg/components/proxy @gitpod-io/engineering-webapp
-/install/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
-/install/installer/pkg/components/spicedb @gitpod-io/engineering-webapp
-/install/installer/pkg/components/public-api-server @gitpod-io/engineering-webapp
-/install/installer/pkg/components/server @gitpod-io/engineering-webapp
-/install/installer/pkg/components/server/ide @gitpod-io/engineering-ide
-/install/installer/pkg/components/usage @gitpod-io/engineering-webapp
-/install/installer/pkg/components/usage-api @gitpod-io/engineering-webapp
-/install/installer/pkg/components/workspace @gitpod-io/engineering-workspace
-/install/installer/pkg/components/workspace/ide @gitpod-io/engineering-ide
-/install/installer/pkg/components/ws-daemon @gitpod-io/engineering-workspace
-/install/installer/pkg/components/ws-manager-mk2 @gitpod-io/engineering-workspace
-/install/installer/pkg/components/ws-manager-bridge @gitpod-io/engineering-webapp
-/install/installer/pkg/components/ws-proxy @gitpod-io/engineering-workspace
-/install/installer/pkg/config/versions @gitpod-io/engineering-ide
-/components/local-app-api @csweichel @akosyakov
-/components/local-app @gitpod-io/engineering-ide
-/components/openvsx-proxy @gitpod-io/engineering-ide
-/components/proxy @gitpod-io/engineering-webapp
-/components/public-api @gitpod-io/engineering-webapp
+/install/installer/pkg/components/agent-smith @gitpod-io/team-engine
+/install/installer/pkg/components/blobserve @gitpod-io/team-experience
+/install/installer/pkg/components/components-ide @gitpod-io/team-experience
+/install/installer/pkg/components/components-webapp @gitpod-io/team-experience
+/install/installer/pkg/components/components-workspace @gitpod-io/team-engine
+/install/installer/pkg/components/content-service @gitpod-io/team-engine
+/install/installer/pkg/components/dashboard @gitpod-io/team-experience
+/install/installer/pkg/components/ide-metrics @gitpod-io/team-experience
+/install/installer/pkg/components/ide-service @gitpod-io/team-experience
+/install/installer/pkg/components/ide-proxy @gitpod-io/team-experience
+/install/installer/pkg/components/image-builder-mk3 @gitpod-io/team-engine
+/install/installer/pkg/components/image-builder-mk3-wsman @gitpod-io/team-engine
+/install/installer/pkg/components/openvsx-proxy @gitpod-io/team-experience
+/install/installer/pkg/components/proxy @gitpod-io/team-experience
+/install/installer/pkg/components/registry-facade @gitpod-io/team-engine
+/install/installer/pkg/components/spicedb @gitpod-io/team-experience
+/install/installer/pkg/components/public-api-server @gitpod-io/team-experience
+/install/installer/pkg/components/server @gitpod-io/team-experience
+/install/installer/pkg/components/server/ide @gitpod-io/team-experience
+/install/installer/pkg/components/usage @gitpod-io/team-experience
+/install/installer/pkg/components/usage-api @gitpod-io/team-experience
+/install/installer/pkg/components/workspace @gitpod-io/team-engine
+/install/installer/pkg/components/workspace/ide @gitpod-io/team-experience
+/install/installer/pkg/components/ws-daemon @gitpod-io/team-engine
+/install/installer/pkg/components/ws-manager-mk2 @gitpod-io/team-engine
+/install/installer/pkg/components/ws-manager-bridge @gitpod-io/team-experience
+/install/installer/pkg/components/ws-proxy @gitpod-io/team-engine
+/install/installer/pkg/config/versions @gitpod-io/team-experience
+/components/local-app-api @gitpod-io/team-experience
+/components/local-app @gitpod-io/team-experience
+/components/openvsx-proxy @gitpod-io/team-experience
+/components/proxy @gitpod-io/team-experience
+/components/public-api @gitpod-io/team-experience
 # Any team can make changes to the experimental package
-/components/public-api/gitpod/experimental @gitpod-io/engineering-webapp
-/components/public-api-server @gitpod-io/engineering-webapp
-/components/registry-facade-api @gitpod-io/engineering-workspace
-/components/registry-facade @gitpod-io/engineering-workspace
-/components/server @gitpod-io/engineering-webapp
-/components/server/src/ide-service.* @gitpod-io/engineering-ide
-/components/service-waiter @gitpod-io/engineering-webapp
-/components/supervisor-api/*.proto @csweichel @akosyakov
-/components/supervisor @gitpod-io/engineering-ide
-/components/usage @gitpod-io/engineering-webapp
-/components/usage-api @gitpod-io/engineering-webapp
-/components/workspacekit @gitpod-io/engineering-workspace
-/components/ws-daemon-api @gitpod-io/engineering-workspace
-/components/ws-daemon @gitpod-io/engineering-workspace
-/components/ws-manager-api @gitpod-io/engineering-workspace
-/components/ws-manager-bridge-api @gitpod-io/engineering-webapp
-/components/ws-manager-bridge @gitpod-io/engineering-webapp
-/components/ws-manager-mk2 @gitpod-io/engineering-workspace
-/components/ws-proxy @gitpod-io/engineering-workspace
-/components/node-labeler @gitpod-io/engineering-workspace
-/install/installer/pkg/components/node-labeler @gitpod-io/engineering-workspace
-/dev/gpctl @gitpod-io/engineering-workspace
-/dev/gpctl/api/ @gitpod-io/engineering-webapp
-/dev/loadgen @gitpod-io/engineering-workspace
+/components/public-api/gitpod/experimental @gitpod-io/team-experience
+/components/public-api-server @gitpod-io/team-experience
+/components/registry-facade-api @gitpod-io/team-engine
+/components/registry-facade @gitpod-io/team-engine
+/components/server @gitpod-io/team-experience
+/components/server/src/ide-service.* @gitpod-io/team-experience
+/components/service-waiter @gitpod-io/team-experience
+/components/supervisor-api/*.proto @gitpod-io/team-experience
+/components/supervisor @gitpod-io/team-experience
+/components/usage @gitpod-io/team-experience
+/components/usage-api @gitpod-io/team-experience
+/components/workspacekit @gitpod-io/team-engine
+/components/ws-daemon-api @gitpod-io/team-engine
+/components/ws-daemon @gitpod-io/team-engine
+/components/ws-manager-api @gitpod-io/team-engine
+/components/ws-manager-bridge-api @gitpod-io/team-experience
+/components/ws-manager-bridge @gitpod-io/team-experience
+/components/ws-manager-mk2 @gitpod-io/team-engine
+/components/ws-proxy @gitpod-io/team-engine
+/components/node-labeler @gitpod-io/team-engine
+/install/installer/pkg/components/node-labeler @gitpod-io/team-engine
+/dev/gpctl @gitpod-io/team-engine
+/dev/gpctl/api/ @gitpod-io/team-experience
+/dev/loadgen @gitpod-io/team-engine
 
 # Preview is shared between all teams.
 /dev/preview
 
 # Operations is shared between all teams
 /operations
-/operations/observability/mixins/IDE @gitpod-io/engineering-ide
-/operations/observability/mixins/meta @gitpod-io/engineering-webapp
-/operations/observability/mixins/workspace @gitpod-io/engineering-workspace
+/operations/observability/mixins/IDE @gitpod-io/team-experience
+/operations/observability/mixins/meta @gitpod-io/team-experience
+/operations/observability/mixins/workspace @gitpod-io/team-engine
 # a single review should be enough
 /operations/observability/mixins/cross-teams
 
 # werft is shared between all teams
 /.werft
-/.werft/ide-* @gitpod-io/engineering-ide
-/.werft/platform-* @gitpod-io/engineering-security-infrastructure-and-delivery
-/.werft/webapp-* @gitpod-io/engineering-webapp
-/.werft/workspace-* @gitpod-io/engineering-workspace
-/.werft/self-hosted-* @gitpod-io/engineering-security-infrastructure-and-delivery
-/.werft/*installer-tests* @gitpod-io/engineering-security-infrastructure-and-delivery
-/.werft/jobs/build/self-hosted-* @gitpod-io/engineering-security-infrastructure-and-delivery
+/.werft/ide-* @gitpod-io/team-experience
+/.werft/platform-* @gitpod-io/team-engine
+/.werft/webapp-* @gitpod-io/team-experience
+/.werft/workspace-* @gitpod-io/team-engine
+/.werft/self-hosted-* @gitpod-io/team-engine
+/.werft/*installer-tests* @gitpod-io/team-engine
+/.werft/jobs/build/self-hosted-* @gitpod-io/team-engine
 
-.github/workflows/ide-*.yml @gitpod-io/engineering-ide
-.github/workflows/jetbrains-*.yml @gitpod-io/engineering-ide
-.github/workflows/code-nightly.yml @gitpod-io/engineering-ide
-.github/workflows/workspace-*.yml @gitpod-io/engineering-workspace
+.github/workflows/ide-*.yml @gitpod-io/team-experience
+.github/workflows/jetbrains-*.yml @gitpod-io/team-experience
+.github/workflows/code-nightly.yml @gitpod-io/team-experience
+.github/workflows/workspace-*.yml @gitpod-io/team-engine
 
 #
 # Automation
@@ -128,14 +128,14 @@
 
 #
 # Add so that teams assert we're not breaking each other's integration tests
-/test/pkg/agent @gitpod-io/engineering-workspace
-/test/pkg/integration @gitpod-io/engineering-ide @gitpod-io/engineering-workspace
-/test/pkg/report @gitpod-io/engineering-workspace
-/test/tests/workspace @gitpod-io/engineering-workspace
-/test/tests/smoke-test @gitpod-io/engineering-ide @gitpod-io/engineering-workspace
-/test/tests/ide @gitpod-io/engineering-ide
-/test/tests/components/content-service @gitpod-io/engineering-workspace
-/test/tests/components/database @gitpod-io/engineering-webapp
-/test/tests/components/image-builder @gitpod-io/engineering-workspace
-/test/tests/components/server @gitpod-io/engineering-webapp
-/test/tests/components/ws-daemon @gitpod-io/engineering-workspace
+/test/pkg/agent @gitpod-io/team-engine
+/test/pkg/integration @gitpod-io/team-experience @gitpod-io/team-engine
+/test/pkg/report @gitpod-io/team-engine
+/test/tests/workspace @gitpod-io/team-engine
+/test/tests/smoke-test @gitpod-io/team-experience @gitpod-io/team-engine
+/test/tests/ide @gitpod-io/team-experience
+/test/tests/components/content-service @gitpod-io/team-engine
+/test/tests/components/database @gitpod-io/team-experience
+/test/tests/components/image-builder @gitpod-io/team-engine
+/test/tests/components/server @gitpod-io/team-experience
+/test/tests/components/ws-daemon @gitpod-io/team-engine


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request updates the code owners file to reflect the new engineering team structure. It assigns the @gitpod-io/team-experience and @gitpod-io/team-engine teams to the folders and files they are responsible for in the Gitpod repository. This change helps to ensure that the appropriate reviewers are notified and involved in the code review process.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
