### PR TITLE
Hide Invite Members button from non-owners – WEB-611

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -69,6 +69,11 @@ export default function MembersPage() {
         return owners?.length === 1 && owners[0].userId === user?.id;
     }, [org.data?.members, user?.id]);
 
+    const isOwner = useMemo(() => {
+        const owners = org.data?.members.filter((m) => m.role === "owner");
+        return !!owners?.some((o) => o.userId === user?.id);
+    }, [org.data?.members, user?.id]);
+
     const filteredMembers =
         org.data?.members.filter((m) => {
             if (!!roleFilter && m.role !== roleFilter) {
@@ -122,17 +127,19 @@ export default function MembersPage() {
                             ]}
                         />
                     </div>
-                    <button
-                        onClick={() => {
-                            trackEvent("invite_url_requested", {
-                                invite_url: inviteUrl || "",
-                            });
-                            setShowInviteModal(true);
-                        }}
-                        className="ml-2"
-                    >
-                        Invite Members
-                    </button>
+                    {isOwner && (
+                        <button
+                            onClick={() => {
+                                trackEvent("invite_url_requested", {
+                                    invite_url: inviteUrl || "",
+                                });
+                                setShowInviteModal(true);
+                            }}
+                            className="ml-2"
+                        >
+                            Invite Members
+                        </button>
+                    )}
                 </div>
                 <ItemsList className="mt-2">
                     <Item header={true} className="grid grid-cols-3">

--- a/components/public-api-server/pkg/apiv1/team.go
+++ b/components/public-api-server/pkg/apiv1/team.go
@@ -282,7 +282,7 @@ func (s *TeamService) toTeamAPIResponse(ctx context.Context, conn protocol.APIIn
 	if err != nil {
 		convertedError := proxy.ConvertError(err)
 		// code not found is expected if the organization is SSO-enabled
-		if connectError, ok := convertedError.(*connect.Error); !ok || connectError.Code() != connect.CodeNotFound {
+		if connectError, ok := convertedError.(*connect.Error); !ok || !(connectError.Code() == connect.CodeNotFound || connectError.Code() == connect.CodePermissionDenied) {
 			logger.WithError(err).Error("Failed to get generic invite")
 			return nil, convertedError
 		}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2851,7 +2851,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         const user = await this.checkUser("getGenericInvite");
-        await this.guardTeamOperation(teamId, "get", "write_members");
+        await this.guardTeamOperation(teamId, "update", "write_members");
 
         return this.organizationService.getOrCreateInvite(user.id, teamId);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67c4669</samp>

Restrict team invitation feature to owners. Hide `Invite Members` button from non-owners in `Members.tsx`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67c4669</samp>

*  Add `isOwner` variable to check if the current user is an owner of the organization ([link](https://github.com/gitpod-io/gitpod/pull/18320/files?diff=unified&w=0#diff-53ff0bdfe65ca0d0e6a4af4ac305ab6a4f94c852f14e509b915659e8d653c820R72-R76))
*  Hide `Invite Members` button for non-owners using `isOwner` variable ([link](https://github.com/gitpod-io/gitpod/pull/18320/files?diff=unified&w=0#diff-53ff0bdfe65ca0d0e6a4af4ac305ab6a4f94c852f14e509b915659e8d653c820L125-R142))

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-611

## How to test
Invite a second test user to an Org of yours and see that there is no Invite Member button rendered on the Members page for the non-owner.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-invite-button</li>
	<li><b>🔗 URL</b> - <a href="https://at-invite-button.preview.gitpod-dev.com/workspaces" target="_blank">at-invite-button.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-invite-button-gha.14032</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
