### PR TITLE
Fix listeners leaks – EXP-206

### DIFF
--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -33,7 +33,7 @@
     "typeorm": "0.2.38",
     "ioredis": "^5.3.2",
     "ioredis-mock": "^8.7.0",
-    "prom-client": "^13.2.0"
+    "prom-client": "^14.2.0"
   },
   "devDependencies": {
     "@testdeck/mocha": "^0.3.3",

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -60,7 +60,7 @@
         "nice-grpc-common": "^2.0.0",
         "opentracing": "^0.14.5",
         "parse-duration": "^1.0.3",
-        "prom-client": "^13.2.0",
+        "prom-client": "^14.2.0",
         "random-number-csprng": "^1.0.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -83,7 +83,7 @@
     "passport-gitlab2": "5.0.0",
     "passport-http": "^0.3.0",
     "probot": "12.1.1",
-    "prom-client": "^13.2.0",
+    "prom-client": "^14.2.0",
     "rate-limiter-flexible": "^2.3.6",
     "redlock": "^5.0.0-beta.2",
     "reflect-metadata": "^0.1.10",

--- a/components/server/src/monitoring-endpoints.ts
+++ b/components/server/src/monitoring-endpoints.ts
@@ -22,10 +22,7 @@ export class MonitoringEndpointsApp {
         // Append redis metrics to default registry
         redisMetricsRegistry()
             .getMetricsAsArray()
-            .then((metrics) => {
-                metrics.forEach((metric) => registry.registerMetric(metric as any));
-            })
-            .catch(console.error);
+            .forEach((metric) => registry.registerMetric(metric as any));
 
         const monApp = express();
         monApp.get("/metrics", async (req, res) => {

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -31,7 +31,7 @@
     "express": "^4.17.3",
     "inversify": "^6.0.1",
     "ioredis": "^5.3.2",
-    "prom-client": "^13.2.0",
+    "prom-client": "^14.2.0",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13609,7 +13609,14 @@ progress@^2.0.0:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prom-client@^13.2.0, "prom-client@~11.3.0 || ^12.0.0 || ^13.0.0":
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
+
+"prom-client@~11.3.0 || ^12.0.0 || ^13.0.0":
   version "13.2.0"
   resolved "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz"
   integrity sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==


### PR DESCRIPTION
## Description
**Before** this change, # of listeners plateaued at some level after closing all browser tabs.

<img width="727" alt="Screenshot 2023-07-28 at 10 35 51" src="https://github.com/gitpod-io/gitpod/assets/914497/d46136f5-9d27-4376-b056-888596088dcb">

**After** this change, you can see listeners going down to zero.

<img width="793" alt="Screenshot 2023-07-28 at 13 37 32" src="https://github.com/gitpod-io/gitpod/assets/914497/aa0cd19c-73d7-4e3c-8f45-acef41bd967b">

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cd5ec4</samp>

This pull request improves the efficiency and accuracy of the server's communication with browser clients and the monitoring of redis metrics. It changes the `GitpodServerImpl` class to only send updates to relevant clients and fixes a prebuild bug. It also refactors the `MonitoringEndpointsApp` class to append redis metrics to the default registry.
-->


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2cd5ec4</samp>

*  Refactor monitoring endpoints to append redis metrics to default registry instead of merging them ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-8fb753e29d055d3339227b7a7f1b768cd16c00a1c50cf6430673cd6946b492a8L16-R29))
*  Add `shouldNotifyClients` property to `GitpodServerImpl` class to control whether to send updates to clients about workspace instances and prebuilds ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479R288-R289))
*  Set `shouldNotifyClients` property based on client metadata type in `initializeClient` method of `GitpodServerImpl` class ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L312-R327))
*  Add conditions to only call `listenForWorkspaceInstanceUpdates` and `listenForPrebuildUpdates` methods if `shouldNotifyClients` property is true in `initializeClient` method of `GitpodServerImpl` class ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L312-R327))
*  Simplify `listenForPrebuildUpdates` method of `GitpodServerImpl` class by using `push` method instead of `pushAll` method to add disposables ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L334-R344))
*  Fix bug in `onWorkspaceImageBuildLogs` method of `GitpodServerImpl` class by adding `relatedPrebuildFound` variable and condition to only create and register `resetListenerFromRedis` if client exists and prebuild is related to workspace ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L456-R467))
*  Add condition to check `shouldNotifyClients` property before creating and registering `prebuildUpdateHandler` in `createProject` method of `GitpodServerImpl` class ([link](https://github.com/gitpod-io/gitpod/pull/18321/files?diff=unified&w=0#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479L3049-R3077))


</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-206

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-listeners-leak</li>
	<li><b>🔗 URL</b> - <a href="https://at-listeners-leak.preview.gitpod-dev.com/workspaces" target="_blank">at-listeners-leak.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-listeners-leak-gha.13861</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [x] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] with-monitoring
</details>

/hold
