### PR TITLE
Partial revert of "[server] remove definitely-gp (#18278) (#18316)"

### DIFF
--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -4,42 +4,55 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
+import fetch from "node-fetch";
 import * as path from "path";
+import * as crypto from "crypto";
 
+import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import {
-    AdditionalContentContext,
-    Commit,
+    User,
+    WorkspaceConfig,
     CommitContext,
+    Repository,
+    ImageConfigString,
     ExternalImageConfigFile,
     ImageConfigFile,
-    ImageConfigString,
+    Commit,
     NamedWorkspaceFeatureFlag,
-    ProjectConfig,
-    Repository,
-    User,
+    AdditionalContentContext,
     WithDefaultConfig,
-    WorkspaceConfig,
+    ProjectConfig,
 } from "@gitpod/gitpod-protocol";
 import { GitpodFileParser } from "@gitpod/gitpod-protocol/lib/gitpod-file-parser";
-import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 
-import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { HostContextProvider } from "../auth/host-context-provider";
-import { Config } from "../config";
+import { MaybeContent } from "../repohost/file-provider";
 import { ConfigurationService } from "../config/configuration-service";
+import { HostContextProvider } from "../auth/host-context-provider";
+import { AuthorizationService } from "../user/authorization-service";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { Config } from "../config";
+import { EntitlementService } from "../billing/entitlement-service";
+import { TeamDB } from "@gitpod/gitpod-db/lib";
 
 const POD_PATH_WORKSPACE_BASE = "/workspace";
 
 @injectable()
 export class ConfigProvider {
-    constructor(
-        @inject(GitpodFileParser) private readonly gitpodParser: GitpodFileParser,
-        @inject(HostContextProvider) private readonly hostContextProvider: HostContextProvider,
-        @inject(Config) private readonly config: Config,
-        @inject(ConfigurationService) private readonly configurationService: ConfigurationService,
-    ) {}
+    static readonly DEFINITELY_GP_REPO: Repository = {
+        host: "github.com",
+        owner: "gitpod-io",
+        name: "definitely-gp",
+        cloneUrl: "https://github.com/gitpod-io/definitely-gp",
+    };
+
+    @inject(GitpodFileParser) protected readonly gitpodParser: GitpodFileParser;
+    @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
+    @inject(AuthorizationService) protected readonly authService: AuthorizationService;
+    @inject(Config) protected readonly config: Config;
+    @inject(ConfigurationService) protected readonly configurationService: ConfigurationService;
+    @inject(EntitlementService) protected readonly entitlementService: EntitlementService;
+    @inject(TeamDB) protected readonly teamDB: TeamDB;
 
     public async fetchConfig(
         ctx: TraceContext,
@@ -83,10 +96,15 @@ export class ConfigProvider {
                 config.image = this.config.workspaceDefaults.workspaceImage;
             } else if (ImageConfigFile.is(config.image)) {
                 const dockerfilePath = [configBasePath, config.image.file].filter((s) => !!s).join("/");
-                const repo = commit.repository;
-                const rev = commit.revision;
+                let repo = commit.repository;
+                let rev = commit.revision;
                 const image = config.image!;
 
+                if (config._origin === "definitely-gp") {
+                    repo = ConfigProvider.DEFINITELY_GP_REPO;
+                    rev = "master";
+                    image.file = dockerfilePath;
+                }
                 if (!(AdditionalContentContext.is(commit) && commit.additionalFiles[dockerfilePath])) {
                     config.image = <ExternalImageConfigFile>{
                         ...image,
@@ -125,7 +143,7 @@ export class ConfigProvider {
         }
     }
 
-    private async fetchCustomConfig(
+    protected async fetchCustomConfig(
         ctx: TraceContext,
         user: User,
         commit: CommitContext,
@@ -136,7 +154,7 @@ export class ConfigProvider {
 
         try {
             let customConfig: WorkspaceConfig | undefined;
-            const configBasePath = "";
+            let configBasePath = "";
             if (AdditionalContentContext.is(commit) && commit.additionalFiles[".gitpod.yml"]) {
                 customConfigString = commit.additionalFiles[".gitpod.yml"];
                 const parseResult = this.gitpodParser.parse(customConfigString);
@@ -164,6 +182,21 @@ export class ConfigProvider {
                 const contextRepoConfig = services.fileProvider.getGitpodFileContent(commit, user);
                 customConfigString = await contextRepoConfig;
                 let origin: WorkspaceConfig["_origin"] = "repo";
+
+                if (!customConfigString) {
+                    /* We haven't found a Gitpod configuration file in the context repo - check definitely-gp.
+                     *
+                     * In case we had found a config file here, we'd still be checking the definitely GP repo, just to save some time.
+                     * While all those checks will be in vain, they should not leak memory either as they'll simply
+                     * be resolved and garbage collected.
+                     */
+                    const definitelyGpConfig = this.fetchExternalGitpodFileContent({ span }, commit.repository);
+                    const { content, basePath } = await definitelyGpConfig;
+                    customConfigString = content;
+                    // We do not only care about the config itself but also where we got it from
+                    configBasePath = basePath;
+                    origin = "definitely-gp";
+                }
 
                 if (!customConfigString) {
                     const inferredConfig = this.configurationService.guessRepositoryConfiguration(
@@ -215,7 +248,7 @@ export class ConfigProvider {
         };
     }
 
-    private async fetchWorkspaceImageSourceDocker(
+    protected async fetchWorkspaceImageSourceDocker(
         ctx: TraceContext,
         repository: Repository,
         revisionOrTagOrBranch: string,
@@ -254,7 +287,101 @@ export class ConfigProvider {
         }
     }
 
-    private async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
+    protected async fillInDefaultLocations(
+        cfg: WorkspaceConfig | undefined,
+        inferredConfig: Promise<WorkspaceConfig | undefined>,
+    ): Promise<void> {
+        if (!cfg) {
+            // there is no config - return
+            return;
+        }
+
+        if (!cfg.checkoutLocation) {
+            const inferredCfg = await inferredConfig;
+            if (inferredCfg) {
+                cfg.checkoutLocation = inferredCfg.checkoutLocation;
+            }
+        }
+        if (!cfg.workspaceLocation) {
+            const inferredCfg = await inferredConfig;
+            if (inferredCfg) {
+                cfg.workspaceLocation = inferredCfg.workspaceLocation;
+            }
+        }
+    }
+
+    protected async fetchExternalGitpodFileContent(
+        ctx: TraceContext,
+        repository: Repository,
+    ): Promise<{ content: MaybeContent; basePath: string }> {
+        const span = TraceContext.startSpan("fetchExternalGitpodFileContent", ctx);
+        span.setTag("repo", `${repository.owner}/${repository.name}`);
+
+        if (this.config.definitelyGpDisabled) {
+            span.finish();
+            return {
+                content: undefined,
+                basePath: `${repository.name}`,
+            };
+        }
+
+        try {
+            const ownerConfigBasePath = `${repository.name}/${repository.owner}`;
+            const baseConfigBasePath = `${repository.name}`;
+
+            const possibleConfigs = [
+                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod.yml`), ownerConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod`), ownerConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod.yml`), baseConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod`), baseConfigBasePath],
+            ];
+            for (const [configPromise, basePath] of possibleConfigs) {
+                const ownerConfig = await configPromise;
+                if (ownerConfig !== undefined) {
+                    return {
+                        content: ownerConfig,
+                        basePath: basePath as string,
+                    };
+                }
+            }
+            return {
+                content: undefined,
+                basePath: baseConfigBasePath,
+            };
+        } catch (e) {
+            TraceContext.setError({ span }, e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async fetchDefinitelyGpContent(ctx: TraceContext, filePath: string) {
+        const span = TraceContext.startSpan("fetchDefinitelyGpContent", ctx);
+        span.setTag("filePath", filePath);
+
+        try {
+            const url = `https://raw.githubusercontent.com/gitpod-io/definitely-gp/master/${filePath}`;
+            const response = await fetch(url, {
+                timeout: 10000,
+                method: "GET",
+            });
+            let content;
+            if (response.ok) {
+                try {
+                    content = await response.text();
+                } catch {}
+            }
+            return content;
+        } catch (e) {
+            TraceContext.setError({ span }, e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
         // Make sure the projectRoot does not leave POD_PATH_WORKSPACE_BASE as that's a common
         // assumption throughout the code (e.g. ws-daemon)
         const checkoutLocation = config.checkoutLocation;
@@ -280,7 +407,7 @@ export class ConfigProvider {
         }
     }
 
-    private leavesWorkspaceBase(normalizedPath: string) {
+    protected leavesWorkspaceBase(normalizedPath: string) {
         const pathSegments = normalizedPath.split(path.sep);
         return normalizedPath.includes("..") || pathSegments.slice(0, 2).join("/") != POD_PATH_WORKSPACE_BASE;
     }


### PR DESCRIPTION
This reverts changes to server from commit aeb688404b41ac9a4d2e8b0dbb96dbbd21c7a546.

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
