### PR TITLE
Revert "Change gh runners concurrency rules"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,7 +74,6 @@ gitpod:summary
       If enabled this will create the environment on GCE infra
 - [ ] with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
-- [ ] with-monitoring
 </details>
 
 /hold

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,15 @@ jobs:
   create-runner:
     uses: ./.github/workflows/create_runner.yml
     secrets: inherit
-    concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-create-runner
-      cancel-in-progress: false
 
   configuration:
     name: Configure job parameters
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-configuration
-      cancel-in-progress: true
+      # github.head_ref is set by a pull_request event - contains the name of the source branch of the PR
+      # github.ref_name is set if the event is NOT a pull_request - it contains only the branch name.
+      group: ${{ github.head_ref || github.ref_name }}-configuration
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
@@ -42,7 +40,6 @@ jobs:
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
       with_werft: ${{ steps.output.outputs.with-werft }}
       with_integration_tests: ${{ steps.output.outputs.with_integration_tests }}
-      with_monitoring: ${{ contains( steps.pr-details.outputs.pr_body, '[x] with-monitoring') }}
       latest_ide_version: ${{ contains( steps.pr-details.outputs.pr_body, '[x] latest-ide-version=true') }}
       leeway_cache_bucket: ${{ steps.output.outputs.leeway_cache_bucket }}
       pr_number: ${{ steps.pr-details.outputs.number }}
@@ -90,7 +87,7 @@ jobs:
       (needs.configuration.outputs.preview_enable == 'true')
     needs: [configuration, create-runner]
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-previewctl
+      group: ${{ github.workflow }}-${{ github.ref }}-build-previewctl
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
@@ -118,7 +115,7 @@ jobs:
       (needs.configuration.outputs.is_main_branch != 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
+      group: ${{ github.head_ref || github.ref_name }}-infrastructure
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -138,7 +135,9 @@ jobs:
     needs: [configuration, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-gitpod
+      group: ${{ github.head_ref || github.ref_name }}-build-gitpod
+      # For the main branch we always want the build job to run to completion
+      # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
@@ -330,8 +329,8 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
-      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
+      group: ${{ github.workflow }}-${{ github.ref }}-install
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Deploy Gitpod to the preview environment
@@ -373,9 +372,8 @@ jobs:
     name: "Install Monitoring Satellite"
     needs: [infrastructure, build-previewctl, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
-    if: needs.configuration.outputs.with_monitoring == 'true'
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
+      group: ${{ github.workflow }}-${{ github.ref }}-monitoring
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -400,7 +398,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-new-dev-image-gha.13182
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-integration-test
+      group: ${{ github.workflow }}-${{ github.ref }}-integration-test
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -446,6 +444,3 @@ jobs:
     secrets: inherit
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
-    concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-delete-runner
-      cancel-in-progress: false

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1702,6 +1702,7 @@ type WorkspaceConfig struct {
 	// Where the config object originates from.
 	//
 	// repo - from the repository
+	// definitely-gp - from github.com/gitpod-io/definitely-gp
 	// derived - computed based on analyzing the repository
 	// default - our static catch-all default config
 	Origin            string        `json:"_origin,omitempty"`

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -970,11 +970,12 @@ export interface WorkspaceConfig {
      * Where the config object originates from.
      *
      * repo - from the repository
+     * definitly-gp - from github.com/gitpod-io/definitely-gp
      * derived - computed based on analyzing the repository
      * additional-content - config comes from additional content, usually provided through the project's configuration
      * default - our static catch-all default config
      */
-    _origin?: "repo" | "derived" | "additional-content" | "default";
+    _origin?: "repo" | "definitely-gp" | "derived" | "additional-content" | "default";
 
     /**
      * Set of automatically infered feature flags. That's not something the user can set, but

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -4,42 +4,55 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
+import fetch from "node-fetch";
 import * as path from "path";
+import * as crypto from "crypto";
 
+import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import {
-    AdditionalContentContext,
-    Commit,
+    User,
+    WorkspaceConfig,
     CommitContext,
+    Repository,
+    ImageConfigString,
     ExternalImageConfigFile,
     ImageConfigFile,
-    ImageConfigString,
+    Commit,
     NamedWorkspaceFeatureFlag,
-    ProjectConfig,
-    Repository,
-    User,
+    AdditionalContentContext,
     WithDefaultConfig,
-    WorkspaceConfig,
+    ProjectConfig,
 } from "@gitpod/gitpod-protocol";
 import { GitpodFileParser } from "@gitpod/gitpod-protocol/lib/gitpod-file-parser";
-import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 
-import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { HostContextProvider } from "../auth/host-context-provider";
-import { Config } from "../config";
+import { MaybeContent } from "../repohost/file-provider";
 import { ConfigurationService } from "../config/configuration-service";
+import { HostContextProvider } from "../auth/host-context-provider";
+import { AuthorizationService } from "../user/authorization-service";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { Config } from "../config";
+import { EntitlementService } from "../billing/entitlement-service";
+import { TeamDB } from "@gitpod/gitpod-db/lib";
 
 const POD_PATH_WORKSPACE_BASE = "/workspace";
 
 @injectable()
 export class ConfigProvider {
-    constructor(
-        @inject(GitpodFileParser) private readonly gitpodParser: GitpodFileParser,
-        @inject(HostContextProvider) private readonly hostContextProvider: HostContextProvider,
-        @inject(Config) private readonly config: Config,
-        @inject(ConfigurationService) private readonly configurationService: ConfigurationService,
-    ) {}
+    static readonly DEFINITELY_GP_REPO: Repository = {
+        host: "github.com",
+        owner: "gitpod-io",
+        name: "definitely-gp",
+        cloneUrl: "https://github.com/gitpod-io/definitely-gp",
+    };
+
+    @inject(GitpodFileParser) protected readonly gitpodParser: GitpodFileParser;
+    @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
+    @inject(AuthorizationService) protected readonly authService: AuthorizationService;
+    @inject(Config) protected readonly config: Config;
+    @inject(ConfigurationService) protected readonly configurationService: ConfigurationService;
+    @inject(EntitlementService) protected readonly entitlementService: EntitlementService;
+    @inject(TeamDB) protected readonly teamDB: TeamDB;
 
     public async fetchConfig(
         ctx: TraceContext,
@@ -83,10 +96,15 @@ export class ConfigProvider {
                 config.image = this.config.workspaceDefaults.workspaceImage;
             } else if (ImageConfigFile.is(config.image)) {
                 const dockerfilePath = [configBasePath, config.image.file].filter((s) => !!s).join("/");
-                const repo = commit.repository;
-                const rev = commit.revision;
+                let repo = commit.repository;
+                let rev = commit.revision;
                 const image = config.image!;
 
+                if (config._origin === "definitely-gp") {
+                    repo = ConfigProvider.DEFINITELY_GP_REPO;
+                    rev = "master";
+                    image.file = dockerfilePath;
+                }
                 if (!(AdditionalContentContext.is(commit) && commit.additionalFiles[dockerfilePath])) {
                     config.image = <ExternalImageConfigFile>{
                         ...image,
@@ -125,7 +143,7 @@ export class ConfigProvider {
         }
     }
 
-    private async fetchCustomConfig(
+    protected async fetchCustomConfig(
         ctx: TraceContext,
         user: User,
         commit: CommitContext,
@@ -136,7 +154,7 @@ export class ConfigProvider {
 
         try {
             let customConfig: WorkspaceConfig | undefined;
-            const configBasePath = "";
+            let configBasePath = "";
             if (AdditionalContentContext.is(commit) && commit.additionalFiles[".gitpod.yml"]) {
                 customConfigString = commit.additionalFiles[".gitpod.yml"];
                 const parseResult = this.gitpodParser.parse(customConfigString);
@@ -164,6 +182,21 @@ export class ConfigProvider {
                 const contextRepoConfig = services.fileProvider.getGitpodFileContent(commit, user);
                 customConfigString = await contextRepoConfig;
                 let origin: WorkspaceConfig["_origin"] = "repo";
+
+                if (!customConfigString) {
+                    /* We haven't found a Gitpod configuration file in the context repo - check definitely-gp.
+                     *
+                     * In case we had found a config file here, we'd still be checking the definitely GP repo, just to save some time.
+                     * While all those checks will be in vain, they should not leak memory either as they'll simply
+                     * be resolved and garbage collected.
+                     */
+                    const definitelyGpConfig = this.fetchExternalGitpodFileContent({ span }, commit.repository);
+                    const { content, basePath } = await definitelyGpConfig;
+                    customConfigString = content;
+                    // We do not only care about the config itself but also where we got it from
+                    configBasePath = basePath;
+                    origin = "definitely-gp";
+                }
 
                 if (!customConfigString) {
                     const inferredConfig = this.configurationService.guessRepositoryConfiguration(
@@ -215,7 +248,7 @@ export class ConfigProvider {
         };
     }
 
-    private async fetchWorkspaceImageSourceDocker(
+    protected async fetchWorkspaceImageSourceDocker(
         ctx: TraceContext,
         repository: Repository,
         revisionOrTagOrBranch: string,
@@ -254,7 +287,101 @@ export class ConfigProvider {
         }
     }
 
-    private async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
+    protected async fillInDefaultLocations(
+        cfg: WorkspaceConfig | undefined,
+        inferredConfig: Promise<WorkspaceConfig | undefined>,
+    ): Promise<void> {
+        if (!cfg) {
+            // there is no config - return
+            return;
+        }
+
+        if (!cfg.checkoutLocation) {
+            const inferredCfg = await inferredConfig;
+            if (inferredCfg) {
+                cfg.checkoutLocation = inferredCfg.checkoutLocation;
+            }
+        }
+        if (!cfg.workspaceLocation) {
+            const inferredCfg = await inferredConfig;
+            if (inferredCfg) {
+                cfg.workspaceLocation = inferredCfg.workspaceLocation;
+            }
+        }
+    }
+
+    protected async fetchExternalGitpodFileContent(
+        ctx: TraceContext,
+        repository: Repository,
+    ): Promise<{ content: MaybeContent; basePath: string }> {
+        const span = TraceContext.startSpan("fetchExternalGitpodFileContent", ctx);
+        span.setTag("repo", `${repository.owner}/${repository.name}`);
+
+        if (this.config.definitelyGpDisabled) {
+            span.finish();
+            return {
+                content: undefined,
+                basePath: `${repository.name}`,
+            };
+        }
+
+        try {
+            const ownerConfigBasePath = `${repository.name}/${repository.owner}`;
+            const baseConfigBasePath = `${repository.name}`;
+
+            const possibleConfigs = [
+                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod.yml`), ownerConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod`), ownerConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod.yml`), baseConfigBasePath],
+                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod`), baseConfigBasePath],
+            ];
+            for (const [configPromise, basePath] of possibleConfigs) {
+                const ownerConfig = await configPromise;
+                if (ownerConfig !== undefined) {
+                    return {
+                        content: ownerConfig,
+                        basePath: basePath as string,
+                    };
+                }
+            }
+            return {
+                content: undefined,
+                basePath: baseConfigBasePath,
+            };
+        } catch (e) {
+            TraceContext.setError({ span }, e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async fetchDefinitelyGpContent(ctx: TraceContext, filePath: string) {
+        const span = TraceContext.startSpan("fetchDefinitelyGpContent", ctx);
+        span.setTag("filePath", filePath);
+
+        try {
+            const url = `https://raw.githubusercontent.com/gitpod-io/definitely-gp/master/${filePath}`;
+            const response = await fetch(url, {
+                timeout: 10000,
+                method: "GET",
+            });
+            let content;
+            if (response.ok) {
+                try {
+                    content = await response.text();
+                } catch {}
+            }
+            return content;
+        } catch (e) {
+            TraceContext.setError({ span }, e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
         // Make sure the projectRoot does not leave POD_PATH_WORKSPACE_BASE as that's a common
         // assumption throughout the code (e.g. ws-daemon)
         const checkoutLocation = config.checkoutLocation;
@@ -280,7 +407,7 @@ export class ConfigProvider {
         }
     }
 
-    private leavesWorkspaceBase(normalizedPath: string) {
+    protected leavesWorkspaceBase(normalizedPath: string) {
         const pathSegments = normalizedPath.split(path.sep);
         return normalizedPath.includes("..") || pathSegments.slice(0, 2).join("/") != POD_PATH_WORKSPACE_BASE;
     }


### PR DESCRIPTION
Reverts gitpod-io/gitpod#18281

The original PR didn't run any tests, e.g. 
> 🌎  cached remotely (ignored)     components/public-api-server:app  

Trying to find the needle in the haystack, as something is wrong with tests relying on test-db.