### PR TITLE
[obs] introduce workspace alerts for Dedicated

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -31,8 +31,8 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
-          summary: image-builder is crash looping in cluster {{ $labels.cluster }}
-          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 2 minutes.
+          summary: image-builder-mk3 is crash looping in cluster {{ $labels.cluster }}
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
         expr: |
           increase(kube_pod_container_status_restarts_total{container="image-builder-mk3", cluster!~"ephemeral.*"}[1m]) > 3
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -22,9 +22,9 @@ spec:
           summary: image-builder duration is unusually high in cluster {{ $labels.cluster }}
           description: This means customers are waiting for image builds, potentially
         expr: |
-          (avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1h])-avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1d]))
+          (avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild", cluster!~"ephemeral.*"}[1h])-avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild", cluster!~"ephemeral.*"}[1d]))
           /
-          stddev_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[14d]) >=2.0
+          stddev_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild", cluster!~"ephemeral.*"}[14d]) >=2.0
       - alert: GitpodImageBuilderCrashlooping
         labels:
           severity: critical

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -18,7 +18,7 @@ spec:
           severity: critical
           dedicated: included
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuildDurationAnomaly.md
           summary: image-builder duration is unusually high in cluster {{ $labels.cluster }}
           description: This means customers are waiting for image builds, potentially
         expr: |
@@ -30,9 +30,20 @@ spec:
           severity: critical
           dedicated: included
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuilderCrashlooping.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: image-builder is crash looping in cluster {{ $labels.cluster }}
-          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 2 minutes.
         expr: |
           increase(kube_pod_container_status_restarts_total{container="image-builder-mk3", cluster!~"ephemeral.*"}[1m]) > 3
-        for: 2m
+        for: 3m
+      - alert: GitpodImageBuilderReplicasMismatch
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicasMismatch.md
+          summary: The desired number of replicas for image-builder-mk3 are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }} .
+        expr: |
+          kube_deployment_spec_replicas{container="image-builder-mk3", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="image-builder-mk3", cluster!~"ephemeral.*"}
+        for: 3m

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: image-builder-monitoring-rules
+spec:
+  groups:
+    - name: image-builder
+      rules:
+      - alert: GitpodImageBuildDurationAnomaly
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
+          summary: image-builder duration is unusually high in cluster {{ $labels.cluster }}
+          description: This means customers are waiting for image builds, potentially
+        expr: |
+          (avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1h])-avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1d]))
+          /
+          stddev_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[14d]) >=2.0

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -41,7 +41,7 @@ spec:
           severity: critical
           dedicated: included
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicasMismatch.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
           summary: The desired number of replicas for image-builder-mk3 are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }} .
         expr: |

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -20,7 +20,7 @@ spec:
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuildDurationAnomaly.md
           summary: image-builder duration is unusually high in cluster {{ $labels.cluster }}
-          description: This means customers are waiting for image builds, potentially
+          description: Users are waiting too long for image builds
         expr: |
           (avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild", cluster!~"ephemeral.*"}[1h])-avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild", cluster!~"ephemeral.*"}[1d]))
           /
@@ -42,8 +42,8 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
-          summary: The desired number of replicas for image-builder-mk3 are not available in cluster {{ $labels.cluster }}
-          description: The mismatch is {{ printf "%.2f" $value }} .
+          summary: Desired number of replicas for image-builder-mk3 are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
           kube_deployment_spec_replicas{container="image-builder-mk3", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="image-builder-mk3", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -8,10 +8,10 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: image-builder-monitoring-rules
+  name: image-builder-central-monitoring-rules
 spec:
   groups:
-    - name: image-builder
+    - name: image-builder-central
       rules:
       - alert: GitpodImageBuildDurationAnomaly
         labels:
@@ -25,3 +25,14 @@ spec:
           (avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1h])-avg_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[1d]))
           /
           stddev_over_time(gitpod_ws_manager_mk2_workspace_phase_total{phase="Running", type="ImageBuild"}[14d]) >=2.0
+      - alert: GitpodImageBuilderCrashlooping
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuilderCrashlooping.md
+          summary: image-builder is crash looping in cluster {{ $labels.cluster }}
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+        expr: |
+          increase(kube_pod_container_status_restarts_total{container="image-builder-mk3", cluster!~"ephemeral.*"}[1m]) > 3
+        for: 2m

--- a/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
+++ b/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
@@ -15,7 +15,8 @@ spec:
       rules:
       - alert: GitpodNodeLabelerCrashLooping
         labels:
-          severity: warning
+          severity: critical
+          dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: node-labeler is crashlooping in cluster {{ $labels.cluster }}.

--- a/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
+++ b/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: node-labeler-central-monitoring-rules
+spec:
+  groups:
+    - name: node-labeler
+      rules:
+      - alert: GitpodNodeLabelerCrashLooping
+        labels:
+          severity: warning
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
+          summary: node-labeler is crashlooping in cluster {{ $labels.cluster }}.
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
+        expr: |
+          increase(kube_pod_container_status_restarts_total{container="node-labeler", cluster!~"ephemeral.*"}[1m]) > 3
+        for: 3m
+      - alert: GitpodNodeLabelerReplicasMismatch
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
+          summary: The desired number of replicas for node-labeler are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }} .
+        expr: |
+          kube_deployment_spec_replicas{container="node-labeler", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="node-labeler", cluster!~"ephemeral.*"}
+        for: 3m

--- a/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
+++ b/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
@@ -30,8 +30,8 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
-          summary: The desired number of replicas for node-labeler are not available in cluster {{ $labels.cluster }}
-          description: The mismatch is {{ printf "%.2f" $value }} .
+          summary: Desired number of replicas for node-labeler are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
           kube_deployment_spec_replicas{container="node-labeler", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="node-labeler", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -30,8 +30,8 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
-          summary: The desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
-          description: The mismatch is {{ printf "%.2f" $value }} .
+          summary: Desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
           kube_deployment_spec_replicas{container="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-manager-mk2", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -19,6 +19,7 @@ spec:
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
-          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
         expr: |
-          increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[10m]) > 0
+          increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[1m]) > 3
+        for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -15,7 +15,8 @@ spec:
       rules:
       - alert: GitpodWsManagerMk2CrashLooping
         labels:
-          severity: warning
+          severity: critical
+          dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -17,7 +17,7 @@ spec:
         labels:
           severity: warning
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
           description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
         expr: |

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
     - name: ws-manager
       rules:
-      - alert: GitpodWsManagerCrashLoopingMk2
+      - alert: GitpodWsManagerMk2CrashLooping
         labels:
           severity: warning
         annotations:
@@ -22,4 +22,15 @@ spec:
           description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
         expr: |
           increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[1m]) > 3
+        for: 3m
+      - alert: GitpodWsManagerMk2ReplicasMismatch
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicasMismatch.md
+          summary: The desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }} .
+        expr: |
+          kube_deployment_spec_replicas{container="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-manager-mk2", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -28,7 +28,7 @@ spec:
           severity: critical
           dedicated: included
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicasMismatch.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
           summary: The desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }} .
         expr: |

--- a/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
@@ -19,19 +19,19 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
-          summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
+          summary: ws-proxy is crashlooping in cluster {{ $labels.cluster }}.
           description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
         expr: |
-          increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[1m]) > 3
+          increase(kube_pod_container_status_restarts_total{container="ws-proxy", cluster!~"ephemeral.*"}[1m]) > 3
         for: 3m
-      - alert: GitpodWsManagerMk2ReplicasMismatch
+      - alert: GitpodWsProxyReplicasMismatch
         labels:
           severity: critical
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
-          summary: The desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
+          summary: The desired number of replicas for ws-proxy are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }} .
         expr: |
-          kube_deployment_spec_replicas{container="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-manager-mk2", cluster!~"ephemeral.*"}
+          kube_deployment_spec_replicas{container="ws-proxy", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-proxy", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
@@ -15,7 +15,8 @@ spec:
       rules:
       - alert: GitpodWsProxyCrashLooping
         labels:
-          severity: warning
+          severity: critical
+          dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
           summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.

--- a/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: ws-proxy-central-monitoring-rules
+spec:
+  groups:
+    - name: ws-proxy
+      rules:
+      - alert: GitpodWsProxyCrashLooping
+        labels:
+          severity: warning
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentCrashlooping.md
+          summary: ws-manager-mk2 is crashlooping in cluster {{ $labels.cluster }}.
+          description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 3 minutes.
+        expr: |
+          increase(kube_pod_container_status_restarts_total{container="ws-manager-mk2", cluster!~"ephemeral.*"}[1m]) > 3
+        for: 3m
+      - alert: GitpodWsManagerMk2ReplicasMismatch
+        labels:
+          severity: critical
+          dedicated: included
+        annotations:
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
+          summary: The desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }} .
+        expr: |
+          kube_deployment_spec_replicas{container="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-manager-mk2", cluster!~"ephemeral.*"}
+        for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
@@ -30,8 +30,8 @@ spec:
           dedicated: included
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceDeploymentReplicaMismatch.md
-          summary: The desired number of replicas for ws-proxy are not available in cluster {{ $labels.cluster }}
-          description: The mismatch is {{ printf "%.2f" $value }} .
+          summary: Desired number of replicas for ws-proxy are not available in cluster {{ $labels.cluster }}
+          description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
           kube_deployment_spec_replicas{container="ws-proxy", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-proxy", cluster!~"ephemeral.*"}
         for: 3m


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
New alerts
* GitpodImageBuildDurationAnomaly
* GitpodImageBuilderCrashlooping
* GitpodImageBuilderReplicasMismatch
* GitpodNodeLabelerCrashLooping
* GitpodNodeLabelerReplicasMismatch
* GitpodWsManagerMk2ReplicasMismatch
* GitpodWsProxyCrashLooping
* GitpodWsProxyReplicasMismatch

Changed alerts
* GitpodWsManagerMk2CrashLooping (renamed and tweaked existing alert)

Depends on https://github.com/gitpod-io/runbooks/pull/417

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-15
Fixes ENG-474

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
