### PR TITLE
[obs] Fix gitpod_workspace_regular_not_active_percentage_mk2, and temporarily disable related alerts

### DIFF
--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -15,13 +15,13 @@ spec:
     rules:
     - record: gitpod_workspace_regular_not_active_percentage_mk2
       expr: |
-        gitpod_ws_manager_mk2_workspace_activity_total{active="false"} / gitpod_ws_manager_mk2_workspace_activity_total
+        sum(gitpod_ws_manager_mk2_workspace_activity_total{active="false"}) by (cluster) / sum(gitpod_ws_manager_mk2_workspace_activity_total) by (cluster)
 
   - name: workspace-alerts
     rules:
     - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
       labels:
-        severity: critical
+        severity: warning
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
@@ -34,7 +34,7 @@ spec:
 
     - alert: GitpodWorkspacesNotStartingMk2
       labels:
-        severity: critical
+        severity: warning
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The metric is always 1, related alerts will never fire.

We'll likely replace the existing alerts too, using one that detects anomalies given zscore. This would be similar to `GitpodImageBuildDurationAnomaly` from https://github.com/gitpod-io/gitpod/pull/18331.

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENG-20

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
