### PR TITLE
Hide the latest editor warning for stopping or stopped workspaces

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -447,7 +447,8 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         const withPrebuild = WithPrebuild.is(this.state.workspace?.context);
         let phase: StartPhase | undefined = StartPhase.Preparing;
         let title = undefined;
-        let isTimedOut = false;
+        let isStoppingOrStoppedPhase = false;
+        let isError = error ? true : false;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
         const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
@@ -623,6 +624,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
+                isStoppingOrStoppedPhase = true;
                 if (isPrebuild) {
                     return (
                         <StartPage title="Prebuild in Progress">
@@ -660,6 +662,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
             // Stopped means the workspace ended regularly because it was shut down.
             case "stopped":
+                isStoppingOrStoppedPhase = true;
                 phase = StartPhase.Stopped;
                 if (this.state.hasImageBuildLogs) {
                     const restartWithDefaultImage = (event: React.MouseEvent) => {
@@ -677,7 +680,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 }
                 if (!isPrebuild && this.state.workspaceInstance.status.conditions.timeout) {
                     title = "Timed Out";
-                    isTimedOut = true;
                 }
                 statusMessage = (
                     <div>
@@ -711,7 +713,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 break;
         }
         return (
-            <StartPage phase={phase} error={error} title={title} showLatestIdeWarning={!isTimedOut && useLatest}>
+            <StartPage
+                phase={phase}
+                error={error}
+                title={title}
+                showLatestIdeWarning={useLatest && (isError || !isStoppingOrStoppedPhase)}
+            >
                 {statusMessage}
             </StartPage>
         );


### PR DESCRIPTION
## Description

Pick up changes from the community contribution in https://github.com/gitpod-io/gitpod/pull/16940. Cc @Devansu-Yadav 

For more context, see **[relevant section](https://www.notion.so/gitpod/How-we-develop-e8ce7e562478458a9223eb9b797415b2?pvs=4#ef8b432a56b6425db16039d603ac97f4)** in How we develop.

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11035

## How to test
1. Use Latest for the editor
2. Open a workspace
3. Stop a workspace
4. Notice the latest editor warning is not preset for stopping or stopped workspace

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-merge-16940</li>
	<li><b>🔗 URL</b> - <a href="https://gt-merge-16940.preview.gitpod-dev.com/workspaces" target="_blank">gt-merge-16940.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-merge-16940-gha.13958</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
