### PR TITLE
[obs] re-enable regular not active alerts

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -18,7 +18,7 @@ spec:
           severity: critical
           dedicated: included
         annotations:
-          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuildDurationAnomaly.md
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildDurationAnomaly.md
           summary: image-builder duration is unusually high in cluster {{ $labels.cluster }}
           description: Users are waiting too long for image builds
         expr: |

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -26,7 +26,7 @@ spec:
         # dedicated: included
       for: 10m
       annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceRegularNotActive.md
         summary: too many running but inactive workspaces
         description: too many running but inactive workspaces.
       expr: |
@@ -41,7 +41,7 @@ spec:
         # dedicated: included
       for: 10m
       annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceRegularNotActive.md
         summary: workspaces are not starting.
         description: inactive regular workspaces exists but workspaces are not being started.
       expr: |

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -22,6 +22,8 @@ spec:
     - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
       labels:
         severity: critical
+        # TODO: uncomment after recording rule import is working in Grafana Cloud
+        # dedicated: included
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
@@ -35,6 +37,8 @@ spec:
     - alert: GitpodWorkspacesNotStartingMk2
       labels:
         severity: critical
+        # TODO: uncomment after recording rule import is working in Grafana Cloud
+        # dedicated: included
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -28,7 +28,7 @@ spec:
         summary: too many running but inactive workspaces
         description: too many running but inactive workspaces.
       expr: |
-        gitpod_workspace_regular_not_active_percentage_mk2 > 0.08
+        sum(gitpod_workspace_regular_not_active_percentage_mk2) by(cluster) > 0.08
         AND
         sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 25
 
@@ -41,6 +41,6 @@ spec:
         summary: workspaces are not starting.
         description: inactive regular workspaces exists but workspaces are not being started.
       expr: |
-        avg_over_time(gitpod_workspace_regular_not_active_percentage_mk2[1m]) > 0
+        sum by(cluster) (avg_over_time(gitpod_workspace_regular_not_active_percentage_mk2[1m]) > 0)
         AND
-        rate(gitpod_ws_manager_mk2_workspace_startup_seconds_sum{type="Regular"}[1m]) == 0
+        sum by(cluster) (rate(gitpod_ws_manager_mk2_workspace_startup_seconds_sum{type="Regular"}[1m])) == 0

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -21,7 +21,7 @@ spec:
     rules:
     - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
       labels:
-        severity: warning
+        severity: critical
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md
@@ -34,7 +34,7 @@ spec:
 
     - alert: GitpodWorkspacesNotStartingMk2
       labels:
-        severity: warning
+        severity: critical
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that `gitpod_workspace_regular_not_active_percentage_mk2` is fixed, re-enable regular not active alerts.

Additionally, given yesterday's [incident](https://www.gitpodstatus.com/incidents/bsrqgmsxw1gr), we had data to test and fix the related alert expressions.

Depends on https://github.com/gitpod-io/runbooks/pull/418

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-20

## How to test
<!-- Provide steps to test this PR -->
Here you can see the recording rule is working again (it no longer has a value of 1), after I ran the enable alerts job on both workspace clusters.

![image](https://github.com/gitpod-io/gitpod/assets/1272076/2c5199aa-e15a-4e8f-9711-b6bc1b3c4ced)

Here you can see how the updated `GitpodWorkspaceTooManyRegularNotActiveMk2` alert (f608648715360a16e970a19a03ad73f1f2905378) would have caught the incident (this is me forwarding `us102`'s prometheus to confirm the expression):

![image](https://github.com/gitpod-io/gitpod/assets/1272076/153f7557-58b4-44da-a17c-442d9fb6317f)

Similar corrections to `GitpodWorkspacesNotStartingMk2` would have also helped catch the incident from July 26, too.

![image](https://github.com/gitpod-io/gitpod/assets/1272076/bd38b746-2bd3-4290-bcfc-cb801d7f5c72)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-f956c8d9687</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-f956c8d9687.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-f956c8d9687.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-fix-active-rule-gha.14015</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold

