### PR TITLE
Disable create release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,24 +276,6 @@ jobs:
           GITHUB_USER: roboquat
           GITHUB_EMAIL: roboquat@gitpod.io
           VERSION: ${{ needs.configuration.outputs.version }}
-      - name: Trigger release workflow in dedicated
-        if: github.ref == 'refs/heads/main'
-        run: |
-          curl -f -X POST \
-            -H "Authorization: token ${TOKEN}" \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            "https://api.github.com/repos/gitpod-io/gitpod-dedicated/dispatches" \
-            -d '{
-              "event_type": "create_release",
-              "client_payload": {
-                "env": "staging",
-                "release": "${{needs.configuration.outputs.version}}",
-                "installation_repo": "https://github.com/gitpod-io/gitpod",
-                "installation_commit": "${{github.sha}}"
-              }
-            }'
-        env:
-          TOKEN: ${{ secrets.GH_WORKFLOW_TRIGGER_PAT }}
 
   install-app:
     runs-on: ${{ needs.create-runner.outputs.label }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is currently broken, I'll work on fixing it. But in the meantime, there's no need to run it

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
