### PR TITLE
Add routing for workspace port by using a subname

### DIFF
--- a/components/proxy/conf/workspace-handler.full
+++ b/components/proxy/conf/workspace-handler.full
@@ -12,7 +12,10 @@ handle @foreign_content2 {
 	}
 }
 
-@workspace_port header_regexp host Host ^(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+# Map url for ports listening inside workspace
+# https://<workspacePort>-<workspaceID>.ws<location>.gitpod.io
+# or https://<subname>-<workspacePort>-<workspaceID>.ws<location>.gitpod.io
+@workspace_port header_regexp host Host ^(?:[a-z0-9][a-z0-9\-]*-)?(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 handle @workspace_port {
 	reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 		import workspace_transport


### PR DESCRIPTION
Related to https://github.com/gitpod-io/gitpod/issues/8784

## Description
Ports are mapped from url with form of https://{workspacePort}-{workspaceID}.ws{location}.gitpod.io

However, when you have to expose multiple services from the same port (wordpress multi-site based on domains for us) you need to have multiple domain names mapping to the same port.

This PR changes the regex to allow the url like https://{subname}-{workspacePort}-{workspaceID}.ws{location}.gitpod.io to map to the service

It does not break any previous mapping.

<details>
<summary>Changes summary and walkthrough generated by Copilot</summary>

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

https://github.com/gitpod-io/website/issues/3884

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
