### PR TITLE
[lw-scans] Use oci-tool to download installer

### DIFF
--- a/scripts/lw-scan-images.sh
+++ b/scripts/lw-scan-images.sh
@@ -35,7 +35,7 @@ fi
 echo "=== Gathering list of _all_ images for $VERSION"
 # TODO(gpl) If we like this approach we should think about moving this into the installer as "list-images" or similar
 #           This would also remove the dependency to our dev image (yq4)
-INSTALLER="$BIN/installer"
+INSTALLER="$TMP/installer"
 "$OCI_TOOL" fetch file -o "$INSTALLER" --platform=linux-amd64 "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" app/installer
 echo ""
 chmod +x "$INSTALLER"

--- a/scripts/lw-scan-images.sh
+++ b/scripts/lw-scan-images.sh
@@ -26,30 +26,45 @@ if [ ! -f "$SCANNER" ]; then
   chmod +x "$SCANNER"
 fi
 
-echo "Gathering list of _all_ images for $VERSION"
+OCI_TOOL="$BIN/oci-tool"
+OCI_TOOL_VERSION="0.2.0"
+if [ ! -f "$OCI_TOOL" ]; then
+  curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v${OCI_TOOL_VERSION}/oci-tool_${OCI_TOOL_VERSION}_linux_amd64.tar.gz | tar xz -C "$(dirname "$OCI_TOOL")" && chmod +x "$OCI_TOOL"
+fi
+
+echo "=== Gathering list of _all_ images for $VERSION"
 # TODO(gpl) If we like this approach we should think about moving this into the installer as "list-images" or similar
 #           This would also remove the dependency to our dev image (yq4)
-docker run -v "$TMP":/workdir "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" config init -c "/workdir/config.yaml" --log-level=warn
-docker run -v "$TMP":/workdir "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" render -c "/workdir/config.yaml" --no-validation > "$TMP/rendered.yaml"
+INSTALLER="$BIN/installer"
+"$OCI_TOOL" fetch file -o "$INSTALLER" --platform=linux-amd64 "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" app/installer
+echo ""
+chmod +x "$INSTALLER"
+# Extract list of images from rendered YAMLs
+"$INSTALLER" config init -c "$TMP/config.yaml" --log-level=warn
+"$INSTALLER" render -c "$TMP/config.yaml" --no-validation > "$TMP/rendered.yaml"
 yq4 --no-doc '(.. | select(key == "image" and tag == "!!str"))' "$TMP/rendered.yaml" > "$TMP/images.txt"
+
 # shellcheck disable=SC2002
-echo "Found $(cat "$TMP/images.txt" | wc -l) images to scan"
+TOTAL_IMAGES=$(cat "$TMP/images.txt" | wc -l)
+echo "=== Found $TOTAL_IMAGES images to scan"
 
 # Scan all images, and push the result to Lacework
 # There, we can see the results in the "Vulnerabilities" tab, by searching for the Gitpod version
 # Note: Does not fail on CVEs!
+COUNTER=0
 while IFS= read -r IMAGE_REF; do
+  ((COUNTER=COUNTER+1))
   # TODO(gpl) Unclear why we can't access the docker.io images the GitHub workflow; it works from a workspace?
   if [[ "$EXCLUDE_DOCKER_IO" == "true" ]]; then
     if [[ "$IMAGE_REF" == "docker.io/"* ]]; then
-      echo "Skipping docker.io image: $IMAGE_REF"
+      echo "= Skipping docker.io image: $IMAGE_REF"
       continue
     fi
   fi
 
   NAME=$(echo "$IMAGE_REF" | cut -d ":" -f 1)
   TAG=$(echo "$IMAGE_REF" | cut -d ":" -f 2)
-  echo "Scanning $NAME : $TAG"
+  echo "= Scanning $NAME : $TAG [$COUNTER / $TOTAL_IMAGES]"
   "$SCANNER" image evaluate "$NAME" "$TAG" \
     --account-name gitpod \
     --access-token "$LW_ACCESS_TOKEN" \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5802429</samp>

Improve the image scanning script `lw-scan-images.sh` by using a custom downloader and enhancing the output.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-253

## How to test
 - Use the GHA https://github.com/gitpod-io/gitpod/actions/workflows/lacework-inline-scanner.yml to run a scan on this branch

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
