### PR TITLE
[proxy] Add services.DOMAIN handlers for IDP and Apps ENG-524

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -172,6 +172,8 @@ http:// {
 	redir https://{host}{uri} permanent
 }
 
+# The services directly correlate to Public Services exposed by Dedicated
+# When adding new endpoints, please notify Team Engine
 https://services.{$GITPOD_DOMAIN} {
 	import enable_log
 	import remove_server_header
@@ -187,7 +189,7 @@ https://services.{$GITPOD_DOMAIN} {
 	handle /apps/* {
 		uri strip_prefix /apps/
 
-		service http://server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
+		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 	}
 }
 

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -184,7 +184,7 @@ https://services.{$GITPOD_DOMAIN} {
 		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 	}
 
-	handle_path /apps/* {
+	handle /apps/* {
 		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 	}
 }

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -172,6 +172,25 @@ http:// {
 	redir https://{host}{uri} permanent
 }
 
+https://services.{$GITPOD_DOMAIN} {
+	import enable_log
+	import remove_server_header
+	import ssl_configuration
+	import security_headers
+
+	handle /idp/* {
+		uri strip_prefix /idp/
+
+		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
+	}
+
+	handle /apps/* {
+		uri strip_prefix /apps/
+
+		service http://server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
+	}
+}
+
 https://{$GITPOD_DOMAIN} {
 	import enable_log
 	import remove_server_header

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -185,8 +185,6 @@ https://services.{$GITPOD_DOMAIN} {
 	}
 
 	handle_path /apps/* {
-		rewrite * /api/apps{path}	# results in /api/apps/gitlab for example
-
 		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 	}
 }

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -180,14 +180,12 @@ https://services.{$GITPOD_DOMAIN} {
 	import ssl_configuration
 	import security_headers
 
-	handle /idp/* {
-		uri strip_prefix /idp/
-
+	handle /idp {
 		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 	}
 
-	handle /apps/* {
-		uri strip_prefix /apps/
+	handle_path /apps/* {
+		rewrite * /api/apps/{path}
 
 		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 	}

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -180,12 +180,12 @@ https://services.{$GITPOD_DOMAIN} {
 	import ssl_configuration
 	import security_headers
 
-	handle /idp {
+	handle /idp/* {
 		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 	}
 
 	handle_path /apps/* {
-		rewrite * /api/apps/{path}
+		rewrite * /api/apps{path}	# results in /api/apps/gitlab for example
 
 		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9aea4b2</samp>

Add proxy configuration for services subdomain in `Caddyfile`. This enables the identity provider and app store features of Gitpod.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mp-proxy-services</li>
	<li><b>🔗 URL</b> - <a href="https://mp-proxy-services.preview.gitpod-dev.com/workspaces" target="_blank">mp-proxy-services.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - mp-proxy-services-gha.14149</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
