### PR TITLE
[server] fix flaky tests

### DIFF
--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -22,14 +22,6 @@ export class SpiceDBAuthorizer {
         private client: SpiceDBClient,
     ) {}
 
-    /**
-     * @deprecated only for testing
-     */
-    async logRelationships() {
-        //        const resources = await this.client?.readRelationships({});
-        //log.info(JSON.stringify(resources, undefined, 2));
-    }
-
     async check(
         req: v1.CheckPermissionRequest,
         experimentsFields: {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -49,7 +49,7 @@ import { HostContextProviderImpl } from "./auth/host-context-provider-impl";
 import { AuthJWT, SignInJWT } from "./auth/jwt";
 import { LoginCompletionHandler } from "./auth/login-completion-handler";
 import { VerificationService } from "./auth/verification-service";
-import { Authorizer } from "./authorization/authorizer";
+import { Authorizer, createInitializingAuthorizer } from "./authorization/authorizer";
 import { SpiceDBClient, spicedbClientFromEnv } from "./authorization/spicedb";
 import { BillingModes } from "./billing/billing-mode";
 import { EntitlementService, EntitlementServiceImpl } from "./billing/entitlement-service";
@@ -305,7 +305,12 @@ export const productionContainerModule = new ContainerModule(
             .toDynamicValue(() => spicedbClientFromEnv())
             .inSingletonScope();
         bind(SpiceDBAuthorizer).toSelf().inSingletonScope();
-        bind(Authorizer).toSelf().inSingletonScope();
+        bind(Authorizer)
+            .toDynamicValue((ctx) => {
+                const authorizer = ctx.container.get<SpiceDBAuthorizer>(SpiceDBAuthorizer);
+                return createInitializingAuthorizer(authorizer);
+            })
+            .inSingletonScope();
 
         // grpc / Connect API
         bind(APIUserService).toSelf().inSingletonScope();

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -14,7 +14,6 @@ import { OrganizationService } from "../orgs/organization-service";
 import { createTestContainer } from "../test/service-testing-container-module";
 import { ProjectsService } from "./projects-service";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { SpiceDBAuthorizer } from "../authorization/spicedb-authorizer";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { expectError } from "../test/expect-utils";
 
@@ -41,8 +40,6 @@ describe("ProjectsService", async () => {
         const orgService = container.get(OrganizationService);
         org = await orgService.createOrganization(owner.id, "my-org");
 
-        const a = container.get(SpiceDBAuthorizer);
-        await a.logRelationships();
         // create and add a member
         member = await userDB.newUser();
         const invite = await orgService.getOrCreateInvite(owner.id, org.id);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes a race condition where we would need to await initialization of the Authorizer before using it.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f747a3</samp>

Refactored the `Authorizer` class to use a proxy pattern and removed unused code from tests and `SpiceDBAuthorizer`. This improves the code structure and reduces complexity.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
