### PR TITLE
Update inactive workspaces caret direction

### DIFF
--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -112,7 +112,7 @@ const WorkspacesPage: FunctionComponent = () => {
                                         className="flex cursor-pointer py-6 px-6 flex-row text-gray-400 bg-gray-50  hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 rounded-xl mb-2"
                                     >
                                         <div className="pr-2">
-                                            <Arrow direction={showInactive ? "up" : "down"} />
+                                            <Arrow direction={showInactive ? "down" : "right"} />
                                         </div>
                                         <div className="flex flex-grow flex-col ">
                                             <div className="font-medium text-gray-500 dark:text-gray-200 truncate">


### PR DESCRIPTION
## Description

This will update the **caret direction** on the **inactive workspaces** element.

⚠️ Haven't tested on the preview environment yet, but should work as described in the screenshots below.

Thanks @mbrevoort for bringing this up again, see [relevant discussion](https://gitpod.slack.com/archives/C05CX6U4UBU/p1690385350741639?thread_ts=1690307601.504289&cid=C05CX6U4UBU) (internal). 🏓 

| Collapsed (BEFORE) | Collapsed (AFTER) |
|--------|--------|
| <img width="1268" alt="Frame 1720" src="https://github.com/gitpod-io/gitpod/assets/120486/f36fcf39-0736-4cf2-aa5b-a53f9d5fa447"> | <img width="1268" alt="Frame 1721" src="https://github.com/gitpod-io/gitpod/assets/120486/cab4e6b9-9e77-47b5-a037-25ed437e4278"> | 

| Expanded (BEFORE) | Expanded (AFTER) |
|--------|--------|
| <img width="1268" alt="Frame 1722" src="https://github.com/gitpod-io/gitpod/assets/120486/5e20621a-3521-489e-a5e4-5c64f3763620"> | <img width="1268" alt="Frame 1723" src="https://github.com/gitpod-io/gitpod/assets/120486/eb888ec2-c4de-40bf-9530-415a01af0874"> |

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6aea037</samp>

Improved the arrow icon in the inactive workspaces list. This change makes the icon reflect the actual state of the list and enhances the dashboard UI.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-acfc5626e7</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-acfc5626e7.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-acfc5626e7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-update-inactive-workspaces-caret-direction-gha.14255</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
