### PR TITLE
Run workspace integration tests on main, create action

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -11,6 +11,12 @@ inputs:
   preview_name:
     description: "Name of the preview environment to run the tests against"
     required: true
+  sa_key:
+    description: "The service account key to use when authenticating with GCP"
+    required: true
+  github_token:
+    description: "The GitHub token to use when authenticating with GitHub"
+    required: true
 
 runs:
   using: "composite"
@@ -19,7 +25,7 @@ runs:
       uses: google-github-actions/auth@v1
       with:
         token_format: access_token
-        credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+        credentials_json: "${{ inputs.sa_key }}"
     - name: Get Secrets from GCP
       id: "secrets"
       uses: "google-github-actions/get-secretmanager-secrets@v1"
@@ -48,10 +54,10 @@ runs:
       id: integration-test
       shell: bash
       env:
-        ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ROBOQUAT_TOKEN: ${{ inputs.github_token }}
         INTEGRATION_TEST_USERNAME: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USERNAME }}
         INTEGRATION_TEST_USER_TOKEN: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USER_TOKEN }}
-        PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+        PREVIEW_ENV_DEV_SA_KEY: ${{ inputs.sa_key }}
         PREVIEW_NAME: ${{ inputs.preview_name }}
       run: |
         set -euo pipefail

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -1,0 +1,95 @@
+name: Run integration tests
+description: Runs an integration test suite against an existing preview environment
+
+inputs:
+  test_suite:
+    description: "Test suite to run"
+    default: workspace
+  notify_slack_webhook:
+    description: "Optional Slack webhook to notify on test success/failure"
+    default: ""
+  preview_name:
+    description: "Name of the preview environment to run the tests against"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        token_format: access_token
+        credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+    - name: Get Secrets from GCP
+      id: "secrets"
+      uses: "google-github-actions/get-secretmanager-secrets@v1"
+      with:
+        secrets: |-
+          WORKSPACE_INTEGRATION_TEST_USERNAME:gitpod-core-dev/workspace-integration-test-username
+          WORKSPACE_INTEGRATION_TEST_USER_TOKEN:gitpod-core-dev/workspace-integration-test-user-token
+    - name: Setup
+      shell: bash
+      run: |
+        export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+        export HOME="/home/gitpod"
+        export PREVIEW_ENV_DEV_SA_KEY_PATH="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
+
+        echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+        gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+        leeway run dev/preview/previewctl:install
+
+        echo "Setting up access to core-dev and harvester"
+        previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+        previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+    - name: Integration Test
+      id: integration-test
+      shell: bash
+      env:
+        ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INTEGRATION_TEST_USERNAME: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USERNAME }}
+        INTEGRATION_TEST_USER_TOKEN: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USER_TOKEN }}
+        PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+        PREVIEW_NAME: ${{ inputs.preview_name }}
+      run: |
+        set -euo pipefail
+
+        printf -v start_time '%(%s)T'
+
+        pushd test
+        set +e
+        ./run.sh -s "${{ inputs.test_suite }}"
+        RC=${PIPESTATUS[0]}
+        set -e
+        popd
+
+        printf -v end_time '%(%s)T'
+        duration_sec=$((end_time - start_time))
+        duration_min=$((duration_sec / 60))
+        duration_sec=$((duration_sec % 60))
+        duration="${duration_min}m${duration_sec}s"
+        echo "duration=${duration}" >> $GITHUB_OUTPUT
+
+        exit $RC
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: "test/**/TEST-*.xml"
+      if: always()
+    - name: Test Summary
+      id: test_summary
+      uses: test-summary/action@v2
+      with:
+        paths: "test/**/TEST-*.xml"
+        show: "all"
+      if: always()
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      if: ${{ (success() || failure()) && inputs.notify_slack_webhook != '' }}
+      env:
+        SLACK_WEBHOOK: ${{ inputs.notify_slack_webhook }}
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped (took ${{ steps.integration-test.outputs.duration }})"
+        SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "The GitHub token to use when authenticating with GitHub"
     required: true
   latest_ide_version:
-    description: "The latest IDE version to use"
+    description: "Use the latest IDE version"
     required: false
     default: ""
   test_build_id:
@@ -116,6 +116,6 @@ runs:
       if: ${{ (success() || failure()) && inputs.notify_slack_webhook != '' }}
       env:
         SLACK_WEBHOOK: ${{ inputs.notify_slack_webhook }}
-        SLACK_COLOR: ${{ (success() && 'success') || (failure() && 'failure') || (cancelled() && 'cancelled') }}
+        SLACK_COLOR: ${{ steps.integration-test.outcome }}
         SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped (took ${{ steps.integration-test.outputs.duration }})"
         SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -17,6 +17,19 @@ inputs:
   github_token:
     description: "The GitHub token to use when authenticating with GitHub"
     required: true
+  latest_ide_version:
+    description: "The latest IDE version to use"
+    required: false
+    default: ""
+  test_build_id:
+    description: "The build ID of the test run. Used in the IDE integration tests."
+    required: false
+  test_build_url:
+    description: "The build URL of the test run. Used in the IDE integration tests."
+    required: false
+  test_build_ref:
+    description: "The build ref of the test run. Used in the IDE integration tests."
+    required: false
 
 runs:
   using: "composite"
@@ -38,6 +51,10 @@ runs:
       env:
         PREVIEW_ENV_DEV_SA_KEY: ${{ inputs.sa_key }}
         PREVIEW_NAME: ${{ inputs.preview_name }}
+        TEST_USE_LATEST_VERSION: ${{ inputs.latest_ide_version }}
+        TEST_BUILD_ID: ${{ inputs.test_build_id }}
+        TEST_BUILD_URL: ${{ inputs.test_build_url }}
+        TEST_BUILD_REF: ${{ inputs.test_build_ref }}
       run: |
         export LEEWAY_WORKSPACE_ROOT="$(pwd)"
         export HOME="/home/gitpod"

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -35,6 +35,9 @@ runs:
           WORKSPACE_INTEGRATION_TEST_USER_TOKEN:gitpod-core-dev/workspace-integration-test-user-token
     - name: Setup
       shell: bash
+      env:
+        PREVIEW_ENV_DEV_SA_KEY: ${{ inputs.sa_key }}
+        PREVIEW_NAME: ${{ inputs.preview_name }}
       run: |
         export LEEWAY_WORKSPACE_ROOT="$(pwd)"
         export HOME="/home/gitpod"

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -99,6 +99,6 @@ runs:
       if: ${{ (success() || failure()) && inputs.notify_slack_webhook != '' }}
       env:
         SLACK_WEBHOOK: ${{ inputs.notify_slack_webhook }}
-        SLACK_COLOR: ${{ job.status }}
+        SLACK_COLOR: ${{ (success() && 'success') || (failure() && 'failure') || (cancelled() && 'cancelled') }}
         SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped (took ${{ steps.integration-test.outputs.duration }})"
         SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,26 +115,24 @@ jobs:
   infrastructure:
     needs: [configuration, build-previewctl, create-runner]
     if: |
-      ((needs.configuration.outputs.pr_no_diff_skip != 'true') && (needs.configuration.outputs.preview_enable == 'true')) ||
-      (needs.configuration.outputs.is_main_branch == 'true')
+      (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
+      (needs.configuration.outputs.preview_enable == 'true') &&
+      (needs.configuration.outputs.is_main_branch != 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
-      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
-    outputs:
-      preview_name: ${{ (needs.configuration.outputs.is_main_branch == 'true' && github.run_id) || github.head_ref || github.ref_name }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
         id: create
         uses: ./.github/actions/preview-create
         with:
-          name: ${{ (needs.configuration.outputs.is_main_branch == 'true' && github.run_id) || github.head_ref || github.ref_name }}
+          name: ${{ github.head_ref || github.ref_name }}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          # Enable large vm on main to run the integration tests.
-          large_vm: ${{ needs.configuration.outputs.with_large_vm || github.ref == 'refs/heads/main' }}
+          large_vm: ${{ needs.configuration.outputs.with_large_vm }}
           recreate_vm: ${{ inputs.recreate_vm }}
 
   build-gitpod:
@@ -325,7 +323,7 @@ jobs:
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
-          name: ${{ needs.infrastructure.outputs.preview_name }}
+          name: ${{ github.head_ref || github.ref_name }}
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -401,7 +399,7 @@ jobs:
           ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
           INTEGRATION_TEST_USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
-          PREVIEW_NAME: ${{ needs.infrastructure.outputs.preview_name }}
+          PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
           TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
           TEST_USE_LATEST_VERSION: ${{ needs.configuration.outputs.latest_ide_version }}
           TEST_BUILD_ID: ${{ github.run_id }}
@@ -417,50 +415,6 @@ jobs:
           previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
           $GITHUB_WORKSPACE/test/run.sh -s ${TEST_SUITS}
-
-  workspace-integration-tests-gate:
-    name: "Run workspace integration tests"
-    needs:
-      - configuration
-      - build-previewctl
-      - build-gitpod
-      - infrastructure
-      - install
-      - create-runner
-    if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
-    runs-on: ${{ needs.create-runner.outputs.label }}
-    concurrency:
-      group: gate-workspace-integration-tests
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v3
-      - id: auth
-        uses: google-github-actions/auth@v1
-        with:
-          token_format: access_token
-          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-      - name: Get Secrets from GCP
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v1"
-        with:
-          secrets: |-
-            WORKSPACE_SLACK_WEBHOOK:gitpod-core-dev/workspace-slack-webhook
-      - name: Set release gate to evaluating
-        shell: bash
-        run: |
-          echo "todo"
-      - uses: ./.github/actions/integration-tests
-        with:
-          test_suite: workspace
-          notify_slack_webhook: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
-          preview_name: ${{ needs.infrastructure.outputs.preview_name }}
-          sa_key: ${{ secrets.GCP_CREDENTIALS }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update release gate
-        shell: bash
-        if: failure() || success() || cancelled()
-        run: |
-          echo "todo"
 
   delete-runner:
     if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,13 +445,20 @@ jobs:
         with:
           secrets: |-
             WORKSPACE_SLACK_WEBHOOK:gitpod-core-dev/workspace-slack-webhook
+      - name: Set release gate to evaluating
+        shell: bash
+        run: |
+          echo "todo"
       - uses: ./.github/actions/integration-tests
         with:
           test_suite: workspace
           notify_slack_webhook: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
           preview_name: ${{ needs.infrastructure.outputs.preview_name }}
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update release gate
         shell: bash
+        if: failure() || success() || cancelled()
         run: |
           echo "todo"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
       preview_enable: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-preview') || (steps.output.outputs.with_integration_tests != '') }}
+      preview_name: ${{ github.head_ref || github.ref_name }}
       preview_infra_provider: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-gce-vm') && 'gce' || 'harvester' }}
       build_no_cache: ${{ contains( steps.pr-details.outputs.pr_body, '[x] leeway-no-cache') }}
       build_no_test: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft no-test') }}
@@ -128,7 +129,7 @@ jobs:
         id: create
         uses: ./.github/actions/preview-create
         with:
-          name: ${{ github.head_ref || github.ref_name }}
+          name: ${{ needs.configuration.outputs.preview_name }}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -323,7 +324,7 @@ jobs:
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
-          name: ${{ github.head_ref || github.ref_name }}
+          name: ${{ needs.configuration.outputs.preview_name }}
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -398,7 +399,7 @@ jobs:
         id: integration-test
         uses: ./.github/actions/integration-tests
         with:
-          preview_name: ${{ github.head_ref || github.ref_name }}
+          preview_name: ${{ needs.configuration.outputs.preview_name }}
           test_suite: ${{ needs.configuration.outputs.with_integration_tests }}
           notify_slack_webhook: ''
           sa_key: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,24 +115,26 @@ jobs:
   infrastructure:
     needs: [configuration, build-previewctl, create-runner]
     if: |
-      (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
-      (needs.configuration.outputs.preview_enable == 'true') &&
-      (needs.configuration.outputs.is_main_branch != 'true')
+      ((needs.configuration.outputs.pr_no_diff_skip != 'true') && (needs.configuration.outputs.preview_enable == 'true')) ||
+      (needs.configuration.outputs.is_main_branch == 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
-      cancel-in-progress: true
+      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
+    outputs:
+      preview_name: ${{ (needs.configuration.outputs.is_main_branch == 'true' && github.run_id) || github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
         id: create
         uses: ./.github/actions/preview-create
         with:
-          name: ${{ github.head_ref || github.ref_name }}
+          name: ${{ (needs.configuration.outputs.is_main_branch == 'true' && github.run_id) || github.head_ref || github.ref_name }}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
-          large_vm: ${{ needs.configuration.outputs.with_large_vm }}
+          # Enable large vm on main to run the integration tests.
+          large_vm: ${{ needs.configuration.outputs.with_large_vm || github.ref == 'refs/heads/main' }}
           recreate_vm: ${{ inputs.recreate_vm }}
 
   build-gitpod:
@@ -323,7 +325,7 @@ jobs:
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
-          name: ${{ github.head_ref || github.ref_name }}
+          name: ${{ needs.infrastructure.outputs.preview_name }}
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
@@ -399,7 +401,7 @@ jobs:
           ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
           INTEGRATION_TEST_USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
-          PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
+          PREVIEW_NAME: ${{ needs.infrastructure.outputs.preview_name }}
           TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
           TEST_USE_LATEST_VERSION: ${{ needs.configuration.outputs.latest_ide_version }}
           TEST_BUILD_ID: ${{ github.run_id }}
@@ -415,6 +417,43 @@ jobs:
           previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
           $GITHUB_WORKSPACE/test/run.sh -s ${TEST_SUITS}
+
+  workspace-integration-tests-gate:
+    name: "Run workspace integration tests"
+    needs:
+      - configuration
+      - build-previewctl
+      - build-gitpod
+      - infrastructure
+      - install
+      - create-runner
+    if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
+    runs-on: ${{ needs.create-runner.outputs.label }}
+    concurrency:
+      group: gate-workspace-integration-tests
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v3
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Get Secrets from GCP
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v1"
+        with:
+          secrets: |-
+            WORKSPACE_SLACK_WEBHOOK:gitpod-core-dev/workspace-slack-webhook
+      - uses: ./.github/actions/integration-tests
+        with:
+          test_suite: workspace
+          notify_slack_webhook: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
+          preview_name: ${{ needs.infrastructure.outputs.preview_name }}
+      - name: Update release gate
+        shell: bash
+        run: |
+          echo "todo"
 
   delete-runner:
     if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,28 +393,20 @@ jobs:
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           leeway_segment_key: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+
       - name: Run integration test
-        shell: bash
-        env:
-          ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INTEGRATION_TEST_USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
-          INTEGRATION_TEST_USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
-          PREVIEW_NAME: ${{ github.head_ref || github.ref_name }}
-          TEST_SUITS: ${{ needs.configuration.outputs.with_integration_tests }}
-          TEST_USE_LATEST_VERSION: ${{ needs.configuration.outputs.latest_ide_version }}
-          TEST_BUILD_ID: ${{ github.run_id }}
-          TEST_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TEST_BUILD_REF: ${{ github.head_ref || github.ref }}
-        run: |
-          export HOME="/home/gitpod"
-          leeway run dev/preview/previewctl:install
-
-          echo "Setting up access to core-dev and harvester"
-          previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          $GITHUB_WORKSPACE/test/run.sh -s ${TEST_SUITS}
+        id: integration-test
+        uses: ./.github/actions/integration-tests
+        with:
+          preview_name: ${{ github.head_ref || github.ref_name }}
+          test_suite: ${{ needs.configuration.outputs.with_integration_tests }}
+          notify_slack_webhook: ''
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          latest_ide_version: ${{ needs.configuration.outputs.latest_ide_version }}
+          test_build_id: ${{ github.run_id }}
+          test_build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          test_build_ref: ${{ github.head_ref || github.ref }}
 
   delete-runner:
     if: always()

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -127,104 +127,20 @@ jobs:
         with:
           token_format: access_token
           credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-      # do this step as early as possible, so that Slack Notify failure has the secret
-      # any earlier, and it conflicts with create previ
       - name: Get Secrets from GCP
         id: "secrets"
         uses: "google-github-actions/get-secretmanager-secrets@v1"
         with:
           secrets: |-
             WORKSPACE_SLACK_WEBHOOK:gitpod-core-dev/workspace-slack-webhook
-            WORKSPACE_INTEGRATION_TEST_USERNAME:gitpod-core-dev/workspace-integration-test-username
-            WORKSPACE_INTEGRATION_TEST_USER_TOKEN:gitpod-core-dev/workspace-integration-test-user-token
+
       - name: Integration Test
         id: integration-test
-        shell: bash
-        env:
-          ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          USERNAME: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USERNAME }}
-          USER_TOKEN: ${{ steps.secrets.outputs.WORKSPACE_INTEGRATION_TEST_USER_TOKEN }}
-          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-          PREVIEW_NAME: ${{ needs.configuration.outputs.name }}
-        run: |
-          set -euo pipefail
-
-          printf -v start_time '%(%s)T'
-
-          export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-          export HOME="/home/gitpod"
-          export PREVIEW_ENV_DEV_SA_KEY_PATH="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
-
-          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          leeway run dev/preview/previewctl:install
-
-          echo "Setting up access to core-dev and harvester"
-          previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          # start integration test
-          args=()
-          args+=( "-kubeconfig=/home/gitpod/.kube/config" )
-          args+=( "-namespace=default" )
-          [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
-          args+=( "-timeout=180m" )
-
-          BASE_TESTS_DIR="$GITHUB_WORKSPACE/test/tests"
-          CONTENT_SERVICE_TESTS="$BASE_TESTS_DIR/components/content-service"
-          IMAGE_BUILDER_TESTS="$BASE_TESTS_DIR/components/image-builder"
-          WS_DAEMON_TESTS="$BASE_TESTS_DIR/components/ws-daemon"
-          WS_MANAGER_TESTS="$BASE_TESTS_DIR/components/ws-manager"
-          WORKSPACE_TESTS="$BASE_TESTS_DIR/workspace"
-
-          go install github.com/jstemmer/go-junit-report/v2@latest
-
-          FAILURE_COUNT=0
-
-          WORKSPACE_TEST_LIST="$CONTENT_SERVICE_TESTS $IMAGE_BUILDER_TESTS $WS_DAEMON_TESTS $WS_MANAGER_TESTS $WORKSPACE_TESTS"
-          TEST_NAME="workspace"
-          echo "running integration for ${TEST_NAME}-parallel"
-
-          cd "${GITHUB_WORKSPACE}/test"
-          set +e
-          go test -p 10 -v $WORKSPACE_TEST_LIST "${args[@]}" -parallel-features=true 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST-${TEST_NAME}.xml" -iocopy
-          RC=${PIPESTATUS[0]}
-          set -e
-
-          if [ "${RC}" -ne "0" ]; then
-            FAILURE_COUNT=$((FAILURE_COUNT+1))
-          fi
-
-          printf -v end_time '%(%s)T'
-          duration_sec=$((end_time - start_time))
-          duration_min=$((duration_sec / 60))
-          duration_sec=$((duration_sec % 60))
-          duration="${duration_min}m${duration_sec}s"
-          echo "duration=${duration}" >> $GITHUB_OUTPUT
-
-          exit $FAILURE_COUNT
-      - uses: actions/upload-artifact@v3
+        uses: ./.github/actions/integration-tests
         with:
-          name: test-results
-          path: "test/**/TEST-*.xml"
-        if: always()
-      - name: Test Summary
-        id: test_summary
-        uses: test-summary/action@v2
-        with:
-          paths: "test/**/TEST-*.xml"
-          show: "all"
-        if: always()
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: success() || failure()
-        env:
-          SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped (took ${{ steps.integration-test.outputs.duration }})"
-          SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
+          preview_name: ${{ needs.configuration.outputs.name }}
+          test_suite: workspace
+          notify_slack_webhook: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
 
   delete:
     name: Delete preview environment

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -141,6 +141,8 @@ jobs:
           preview_name: ${{ needs.configuration.outputs.name }}
           test_suite: workspace
           notify_slack_webhook: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   delete:
     name: Delete preview environment

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -1,5 +1,8 @@
 name: "Workspace integration tests"
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Run the workspace integration tests on push to main
  * Prepares for setting the e2e test release gate in dedicated, which will be done at a later point. In the meantime, we can use these test runs to monitor the stability of the tests in preparation for making it a gate.
* Create a new `integration-tests` action, to reduce duplication in how we run the e2e tests (there's 4 places that all do it slightly differently, `build.yml`, `workspace-integration-tests.yml`, calling `test/run.sh` directly, and `ide-integration-tests.yml`).
  * The action consolidates this by calling `test/run.sh`, which then contains the logic for running the integration tests.
  * Update the `build` and `workspace-integration-tests` workflows to use this action
  * Will propose an update to the IDE integration tests workflow in a different PR to also use this action

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d301fd2</samp>

This pull request introduces a new GitHub action to run integration tests against preview environments, and updates the workspace integration tests and build workflows to use the new action. The goal is to streamline the integration testing process and improve the test coverage.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to ENG-34

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - wv-run-e2e8fb3700516</li>
	<li><b>🔗 URL</b> - <a href="https://wv-run-e2e8fb3700516.preview.gitpod-dev.com/workspaces" target="_blank">wv-run-e2e8fb3700516.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - wv-run-e2e-tests-on-main-gha.14306</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
