### PR TITLE
[server/FGA] added make_admin permission

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -268,7 +268,8 @@ export interface AdditionalUserData extends Partial<WorkspaceTimeoutSetting> {
     // additional user profile data
     profile?: ProfileDetails;
     shouldSeeMigrationMessage?: boolean;
-
+    // fgaRelationshipsVersion is the version of the spicedb relationships
+    fgaRelationshipsVersion?: number;
     // remembered workspace auto start options
     workspaceAutostartOptions?: WorkspaceAutostartOption[];
 }

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -40,6 +40,10 @@ export interface Project {
 }
 
 export namespace Project {
+    export function is(data?: any): data is Project {
+        return typeof data === "object" && ["id", "name", "cloneUrl", "teamId"].every((p) => p in data);
+    }
+
     export const create = (project: Omit<Project, "id" | "creationTime">): Project => {
         return {
             ...project,

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -25,7 +25,7 @@
     "start-testdb": "if netstat -tuln | grep ':23306 '; then echo 'Mysql is already running.'; else leeway run components/gitpod-db:init-testdb; fi",
     "start-spicedb": "leeway run components/spicedb:start-spicedb",
     "stop-spicedb": "leeway run components/spicedb:stop-spicedb",
-    "start-redis": "if netstat -tuln | grep ':6379 '; then echo 'Redis is already running.'; else docker run --rm --name test-redis -p 6379:6379 -d redis; fi",
+    "start-redis": "if netstat -tuln | grep ':6379 '; then echo 'Redis is already running.'; else docker run --rm --name test-redis -p 6379:6379 -d redis; while ! nc -z localhost 6379; do sleep 0.1; done; echo 'Redis is ready.'; fi",
     "stop-redis": "docker stop test-redis || true",
     "telepresence": "telepresence --swap-deployment server --method inject-tcp --run yarn start-inspect"
   },

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -337,7 +337,7 @@ export class Authorizer {
         );
     }
 
-    async removeAdminRole(userID: string) {
+    async removeInstallationAdminRole(userID: string) {
         await this.authorizer.writeRelationships(
             v1.WriteRelationshipsRequest.create({
                 updates: [

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -15,7 +15,7 @@ export type UserResourceType = "user";
 
 export type UserRelation = "self" | "container";
 
-export type UserPermission = "read_info" | "write_info" | "suspend";
+export type UserPermission = "read_info" | "write_info" | "suspend" | "make_admin";
 
 export type InstallationResourceType = "installation";
 

--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, ProjectDB, TeamDB, TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { AdditionalUserData, User } from "@gitpod/gitpod-protocol";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { Authorizer, Relationship, Resource, installation } from "./authorizer";
+import { Relation } from "./definitions";
+import { RelationshipUpdater } from "./relationship-updater";
+import { v4 } from "uuid";
+
+const expect = chai.expect;
+
+describe("RelationshipUpdater", async () => {
+    let container: Container;
+    let userDB: UserDB;
+    let orgDB: TeamDB;
+    let projectDB: ProjectDB;
+    let migrator: RelationshipUpdater;
+    let authorizer: Authorizer;
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+        BUILTIN_INSTLLATION_ADMIN_USER_ID;
+        userDB = container.get<UserDB>(UserDB);
+        orgDB = container.get<TeamDB>(TeamDB);
+        projectDB = container.get<ProjectDB>(ProjectDB);
+        migrator = container.get<RelationshipUpdater>(RelationshipUpdater);
+        authorizer = container.get<Authorizer>(Authorizer);
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    it("should update a simple user", async () => {
+        let user = await userDB.newUser();
+        user = await migrate(user);
+
+        await expected(user, "container", installation);
+        await expected(user, "self", user);
+        await notExpected(installation, "admin", user);
+        await expected(installation, "member", user);
+        await authorizer.removeAllRelationships("user", user.id);
+    });
+
+    it("should update an admin user", async () => {
+        let user = await userDB.newUser();
+        user.rolesOrPermissions = ["admin"];
+        user = await migrate(user);
+
+        await expected(user, "container", installation);
+        await expected(user, "self", user);
+        await expected(installation, "admin", user);
+        await expected(installation, "member", user);
+
+        // remove admin role
+        user.rolesOrPermissions = [];
+        // reset fgaRelationshipsVersion to force update
+        AdditionalUserData.set(user, { fgaRelationshipsVersion: undefined });
+        user = await userDB.storeUser(user);
+        user = await migrate(user);
+        await expected(user, "container", installation);
+        await expected(user, "self", user);
+        await notExpected(installation, "admin", user);
+        await expected(installation, "member", user);
+    });
+
+    it("should update a simple user organization owned", async () => {
+        let user = await userDB.newUser();
+        const org = await orgDB.createTeam(user.id, "MyOrg");
+        user.organizationId = org.id;
+        user = await userDB.storeUser(user);
+
+        user = await migrate(user);
+
+        await expected(user, "container", org);
+        await expected(user, "self", user);
+        await expected(org, "installation", installation);
+        await expected(org, "member", user);
+        await expected(org, "owner", user);
+    });
+
+    it("should update additional members on organization", async () => {
+        let user = await userDB.newUser();
+        const user2 = await userDB.newUser();
+        const org = await orgDB.createTeam(user.id, "MyOrg");
+        await orgDB.addMemberToTeam(user2.id, org.id);
+        user.organizationId = org.id;
+        user = await userDB.storeUser(user);
+
+        user = await migrate(user);
+
+        await expected(user, "container", org);
+        await expected(user, "self", user);
+
+        // we haven't called migrate on user2, so we don't expect any relationships
+        await notExpected(user2, "container", installation);
+        await notExpected(user2, "self", user2);
+
+        // but on the org user2 is a member
+        await expected(org, "installation", installation);
+        await expected(org, "member", user2);
+        await notExpected(org, "owner", user2);
+        await expected(org, "member", user);
+        await expected(org, "owner", user);
+    });
+
+    it("should update orgs with projects", async () => {
+        let user = await userDB.newUser();
+        const org = await orgDB.createTeam(user.id, "MyOrg");
+        const project = await projectDB.storeProject({
+            id: v4(),
+            name: "MyProject",
+            appInstallationId: "123",
+            cloneUrl: "https://github.com/gitpod-io/gitpod.git",
+            teamId: org.id,
+            creationTime: new Date().toISOString(),
+        });
+        user.organizationId = org.id;
+        user = await userDB.storeUser(user);
+
+        user = await migrate(user);
+
+        await expected(user, "container", org);
+        await expected(user, "self", user);
+
+        // but on the org user2 is a member
+        await expected(org, "installation", installation);
+        await expected(org, "member", user);
+        await expected(org, "owner", user);
+
+        await expected(project, "org", org);
+    });
+
+    async function expected(res: Resource, relation: Relation, target: Resource): Promise<void> {
+        const expected = new Relationship(
+            Resource.getType(res),
+            res.id,
+            relation,
+            Resource.getType(target),
+            target.id,
+        ).toString();
+        const rs = await authorizer.readRelationships(res, relation, target);
+        const all = await authorizer.readRelationships(res, relation);
+        expect(
+            rs.length,
+            `Expected ${expected} but got ${JSON.stringify(rs)} (all rs of this kind ${JSON.stringify(all)})`,
+        ).to.equal(1);
+        expect(rs[0].toString()).to.equal(expected);
+    }
+
+    async function notExpected(res: Resource, relation: Relation, target: Resource): Promise<void> {
+        const rs = await authorizer.readRelationships(res, relation, target);
+        const all = await authorizer.readRelationships(res, relation);
+        expect(
+            rs.length,
+            `Expected nothing but got ${JSON.stringify(rs)} (all rs of this kind ${JSON.stringify(all)})`,
+        ).to.equal(0);
+    }
+
+    async function migrate(user: User): Promise<User> {
+        user = await migrator.migrate(user);
+        expect(user.additionalData?.fgaRelationshipsVersion).to.equal(migrator.version);
+        return user;
+    }
+});

--- a/components/server/src/authorization/relationship-updater.ts
+++ b/components/server/src/authorization/relationship-updater.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { AdditionalUserData, Organization, User } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { RedisMutex } from "../redis/mutex";
+import { Authorizer } from "./authorizer";
+
+@injectable()
+export class RelationshipUpdater {
+    public readonly version = 1;
+
+    constructor(
+        @inject(RedisMutex) private readonly mutex: RedisMutex,
+        @inject(UserDB) private readonly userDB: UserDB,
+        @inject(TeamDB) private readonly orgDB: TeamDB,
+        @inject(ProjectDB) private readonly projectDB: ProjectDB,
+        @inject(Authorizer) private readonly authorizer: Authorizer,
+    ) {}
+
+    /**
+     * Updates all relationships for a user according to the current state of the database.
+     * @param user
+     * @returns
+     */
+    public async migrate(user: User): Promise<User> {
+        if (user?.additionalData?.fgaRelationshipsVersion === this.version) {
+            return user;
+        }
+        return this.mutex.using([`fga-migration-${user.id}`], 2000, async () => {
+            const before = new Date().getTime();
+            try {
+                log.info({ userId: user.id }, `Updating FGA relationships for user.`, {
+                    fromVersion: user?.additionalData?.fgaRelationshipsVersion,
+                    toVersion: this.version,
+                });
+                await this.updateUser(user);
+                const orgs = await this.orgDB.findTeamsByUser(user.id);
+                for (const org of orgs) {
+                    await this.updateOrganization(org);
+                }
+                return user;
+            } finally {
+                AdditionalUserData.set(user, {
+                    fgaRelationshipsVersion: this.version,
+                });
+                await this.userDB.updateUserPartial(user);
+                log.info({ userId: user.id }, `Finished updating relationships.`, {
+                    duration: new Date().getTime() - before,
+                });
+            }
+        });
+    }
+
+    private async updateUser(user: User): Promise<void> {
+        await this.authorizer.removeAllRelationships("user", user.id);
+        await this.authorizer.addUser(user.id, user.organizationId);
+        if (!user.organizationId) {
+            await this.authorizer.addInstallationMemberRole(user.id);
+            if ((user.rolesOrPermissions || []).includes("admin")) {
+                await this.authorizer.addInstallationAdminRole(user.id);
+            }
+        }
+    }
+
+    private async updateOrganization(org: Organization): Promise<void> {
+        await this.authorizer.removeAllRelationships("organization", org.id);
+        const members = await this.orgDB.findMembersByTeam(org.id);
+        const projects = await this.projectDB.findProjects(org.id);
+        await this.authorizer.addOrganization(org, members, projects);
+    }
+}

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -66,7 +66,7 @@ export class SpiceDBAuthorizer {
         let error: Error | undefined;
         try {
             const response = await this.client.writeRelationships(req);
-            log.info("[spicedb] Succesfully wrote relationships.", { response, request: req });
+            log.info("[spicedb] Successfully wrote relationships.", { response, request: req });
 
             return response;
         } catch (err) {
@@ -77,24 +77,43 @@ export class SpiceDBAuthorizer {
         }
     }
 
-    async deleteRelationships(req: v1.DeleteRelationshipsRequest): Promise<v1.DeleteRelationshipsResponse | undefined> {
+    async deleteRelationships(req: v1.DeleteRelationshipsRequest): Promise<v1.ReadRelationshipsResponse[]> {
         if (!this.client) {
-            return undefined;
+            return [];
         }
 
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {
-            const response = await this.client.deleteRelationships(req);
-            log.info("[spicedb] Succesfully deleted relationships.", { response, request: req });
-
-            return response;
+            const existing = await this.client.readRelationships(v1.ReadRelationshipsRequest.create(req));
+            if (existing.length > 0) {
+                const response = await this.client.deleteRelationships(req);
+                const after = await this.client.readRelationships(v1.ReadRelationshipsRequest.create(req));
+                if (after.length > 0) {
+                    log.error("[spicedb] Failed to delete relationships.", { existing, after, request: req });
+                }
+                log.info(`[spicedb] Successfully deleted ${existing.length} relationships.`, {
+                    response,
+                    request: req,
+                    existing,
+                });
+            }
+            return existing;
         } catch (err) {
             error = err;
             // While in we're running two authorization systems in parallel, we do not hard fail on writes.
+            //TODO throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "Failed to delete relationships.");
             log.error("[spicedb] Failed to delete relationships.", err, { req });
+            return [];
         } finally {
             observeSpicedbClientLatency("delete", error, timer());
         }
+    }
+
+    async readRelationships(req: v1.ReadRelationshipsRequest): Promise<v1.ReadRelationshipsResponse[]> {
+        if (!this.client) {
+            return [];
+        }
+        return this.client.readRelationships(req);
     }
 }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -128,6 +128,7 @@ import { RedisSubscriber } from "./messaging/redis-subscriber";
 import { Redis } from "ioredis";
 import { RedisPublisher, newRedisClient } from "@gitpod/gitpod-db/lib";
 import { UserService } from "./user/user-service";
+import { RelationshipUpdater as RelationshipUpdater } from "./authorization/relationship-updater";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -311,6 +312,7 @@ export const productionContainerModule = new ContainerModule(
                 return createInitializingAuthorizer(authorizer);
             })
             .inSingletonScope();
+        bind(RelationshipUpdater).toSelf().inSingletonScope();
 
         // grpc / Connect API
         bind(APIUserService).toSelf().inSingletonScope();

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -109,7 +109,7 @@ export class OrganizationService {
 
                 await db.deleteTeam(orgId);
 
-                await this.auth.deleteOrganization(orgId);
+                await this.auth.removeAllRelationships("organization", orgId);
             });
             return this.analytics.track({
                 userId: userId,

--- a/components/server/src/orgs/usage-service.spec.db.ts
+++ b/components/server/src/orgs/usage-service.spec.db.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TypeORM } from "@gitpod/gitpod-db/lib";
 import { Organization, User } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
@@ -47,21 +47,42 @@ describe("UsageService", async () => {
             centralizedPermissions: true,
         });
         os = container.get(OrganizationService);
-        const userDB = container.get<UserDB>(UserDB);
-        owner = await userDB.newUser();
+        const userService = container.get<UserService>(UserService);
+        owner = await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
         org = await os.createOrganization(owner.id, "myorg");
         const invite = await os.getOrCreateInvite(owner.id, org.id);
 
-        member = await userDB.newUser();
+        member = await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
         await os.joinOrganization(member.id, invite.id);
 
-        stranger = await userDB.newUser();
+        stranger = await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
 
-        const userService = container.get<UserService>(UserService);
-        admin = await userDB.newUser();
-        admin.rolesOrPermissions = ["admin"];
-        await userDB.storeUser(admin);
-        await userService.setAdminRole(admin.id, admin.id, true);
+        admin = await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
+        await userService.setAdminRole(BUILTIN_INSTLLATION_ADMIN_USER_ID, admin.id, true);
 
         us = container.get<UsageService>(UsageService);
         await us.getCostCenter(owner.id, org.id);

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -5,17 +5,17 @@
  */
 
 import { TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { Organization, User } from "@gitpod/gitpod-protocol";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
 import { OrganizationService } from "../orgs/organization-service";
+import { expectError } from "../test/expect-utils";
 import { createTestContainer } from "../test/service-testing-container-module";
 import { ProjectsService } from "./projects-service";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
-import { expectError } from "../test/expect-utils";
 
 const expect = chai.expect;
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -43,7 +43,7 @@ export class UserService {
         try {
             newUser = await this.userDb.transaction(async (userDb) => {
                 const result = await userDb.storeUser(newUser);
-                await this.authorizer.addUser(result.id);
+                await this.authorizer.addUser(result.id, organizationId);
                 if (organizationId) {
                     await this.authorizer.addOrganizationMemberRole(organizationId, result.id);
                 } else {
@@ -140,7 +140,7 @@ export class UserService {
                 target.rolesOrPermissions = newRoles;
                 const updatedUser = await userDb.storeUser(target);
                 if (admin) {
-                    await this.authorizer.addAdminRole(target.id);
+                    await this.authorizer.addInstallationAdminRole(target.id);
                 } else {
                     await this.authorizer.removeAdminRole(target.id);
                 }
@@ -150,7 +150,7 @@ export class UserService {
             if (admin) {
                 await this.authorizer.removeAdminRole(target.id);
             } else {
-                await this.authorizer.addAdminRole(target.id);
+                await this.authorizer.addInstallationAdminRole(target.id);
             }
             throw err;
         }

--- a/components/server/tsconfig.json
+++ b/components/server/tsconfig.json
@@ -3,8 +3,7 @@
         "outDir": "dist",
         "experimentalDecorators": true,
         "lib": [
-            "es6",
-            "esnext.asynciterable"
+            "ES2021"
         ],
         "strict": true,
         "noEmitOnError": false,

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -11,6 +11,7 @@ schema: |-
     permission read_info = self + container->member + container->owner + container->admin
     permission write_info = self + container->owner + container->admin
     permission suspend = self + container->owner + container->admin
+    permission make_admin = container->admin
   }
 
   // There's only one global installation


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adsda an explicit `make_admin` permission, so only admins can make other users admin.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29f38f9</samp>

This pull request implements a new authorization system based on spicedb, which supports installation admins, organization-owned users, and spicedb relationships. It refactors and updates the `authorizer.ts`, `user-service.ts`, and `organization-service.ts` modules, and adds new files and tests for the `SpiceDBAuthorizer` and `RelationshipUpdater` classes. It also modifies some interfaces, functions, and configurations in the `gitpod-protocol`, `projects-service`, and `tsconfig.json` files.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
