### PR TITLE
[db] Run tests against mysql 8.0.33

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,10 +145,12 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
-        image: mysql:5.7
+        image: bitnami/mysql:8.0.33-debian-11-r24
         env:
           MYSQL_ROOT_PASSWORD: test
-          MYSQL_TCP_PORT: 23306
+          #MYSQL_TCP_PORT: 23306 bitnami/mysql does not honor this, but has it's own:
+          MYSQL_PORT_NUMBER: 23306
+          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         ports:
           - 23306:23306
       redis:
@@ -161,6 +163,8 @@ jobs:
         DB_HOST: "mysql"
         DB_PORT: "23306"
         REDIS_HOST: "redis"
+        # GitHub action + MySQL 8.0 need longer to initialize
+        DB_RETRIES: 5
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-environment
@@ -222,8 +226,6 @@ jobs:
         id: leeway
         shell: bash
         env:
-          DB_HOST: "mysql"
-          DB_PORT: "23306"
           NODE_OPTIONS: "--max_old_space_size=4096"
           JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
           VERSION: ${{needs.configuration.outputs.version}}

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -76,7 +76,8 @@ packages:
         # Check if a DB is present. If not: start one and wait until it's up
         # Note: In CI there is a DB running as sidecar; in workspaces we're starting it once.
         #       Re-use of the instance because of the init scripts (cmp. next step).
-        - ["sh", "-c", "mysqladmin ping -h $DB_HOST --port $DB_PORT -p$DB_PASSWORD -u$DB_USER --silent || (docker run --name test-mysql -d -e MYSQL_ROOT_PASSWORD=$DB_PASSWORD -e MYSQL_TCP_PORT=$DB_PORT -p $DB_PORT:$DB_PORT mysql:5.7; while ! mysqladmin ping -h \"$DB_HOST\" -P \"$DB_PORT\" -p$DB_PASSWORD -u$DB_USER --silent; do echo \"waiting for DB...\"; sleep 2; done)"]
+        # (gpl): It would be nice to use bitnami/mysql here as we do in previews. However the container does not start in Gitpod workspaces due to some docker/kernel/namespace issue.
+        - ["sh", "-c", "mysqladmin ping --wait=${DB_RETRIES:-1} -h $DB_HOST --port $DB_PORT -p$DB_PASSWORD -u$DB_USER --default-auth=mysql_native_password --silent || (docker run --name test-mysql -d -e MYSQL_ROOT_PASSWORD=$DB_PASSWORD -e MYSQL_TCP_PORT=$DB_PORT -p $DB_PORT:$DB_PORT mysql:8.0.33 --default-authentication-plugin=mysql_native_password; while ! mysqladmin ping -h \"$DB_HOST\" -P \"$DB_PORT\" -p$DB_PASSWORD -u$DB_USER --default-auth=mysql_native_password --silent; do echo \"waiting for DB...\"; sleep 2; done)"]
         # Apply the DB initialization scripts (re-creates the "gitpod" DB if already there)
         - ["mkdir", "-p", "init-scripts"]
         - ["sh", "-c", "find . -name \"*.sql\" | sort | xargs -I file cp file init-scripts"]

--- a/install/installer/pkg/helm/common.go
+++ b/install/installer/pkg/helm/common.go
@@ -6,13 +6,21 @@ package helm
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"os"
+	"strings"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
 )
 
 // KeyValue ensure that a key/value pair is correctly formatted for Values
 func KeyValue(key string, value string) string {
 	return fmt.Sprintf("%s=%s", key, value)
+}
+
+// KeyValueArray ensure that a key/value pair is correctly formatted for Arrays
+func KeyValueArray(key string, arr []string) string {
+	// Helm array nomenclature
+	return KeyValue(key, fmt.Sprintf("{%s}", strings.Join(arr, ",")))
 }
 
 // KeyFileValue ensure that a key/value pair is correctly formatted for FileValues

--- a/install/installer/pkg/helm/helm.go
+++ b/install/installer/pkg/helm/helm.go
@@ -154,8 +154,7 @@ func ImagePullSecrets(key string, ctx *common.RenderContext) string {
 			pullSecrets = append(pullSecrets, i.Name)
 		}
 
-		// Helm array nomenclature
-		return KeyValue(key, fmt.Sprintf("{%s}", strings.Join(pullSecrets, ",")))
+		return KeyValueArray(key, pullSecrets)
 	}
 
 	// Nothing to be set


### PR DESCRIPTION
## Description

While we are already using mysql 8.0.33 in preview envs, tests in workspace and CI have been running with mysql 5.7 this PR changes that.


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7de01c6</samp>

Updated the MySQL version and authentication plugin for the in-cluster database component and the MySQL service used in the build and test workflows. This improves compatibility and consistency with the MySQL 8.0 client library used in the `components/gitpod-db` package.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-374

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-test-db-80</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-test-db-80.preview.gitpod-dev.com/workspaces" target="_blank">gpl-test-db-80.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-test-db-80-gha.16508</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-test-db-80%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
