### PR TITLE
[server/fga] improved api and code-gen

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -6,27 +6,26 @@
 
 import { v1 } from "@authzed/authzed-node";
 
-import { Organization, Project, TeamMemberInfo, TeamMemberRole, User } from "@gitpod/gitpod-protocol";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib";
+import { Organization, Project, TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import {
-    InstallationID,
-    InstallationRelation,
     OrganizationPermission,
-    OrganizationRelation,
     Permission,
     ProjectPermission,
-    ProjectRelation,
     Relation,
     ResourceType,
     UserPermission,
-    UserRelation,
+    rel,
 } from "./definitions";
 import { SpiceDBAuthorizer } from "./spicedb-authorizer";
-import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib";
 
 export function createInitializingAuthorizer(spiceDbAuthorizer: SpiceDBAuthorizer): Authorizer {
     const target = new Authorizer(spiceDbAuthorizer);
-    const initialized = target.addInstallationAdminRole(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+    const initialized = (async () => {
+        await target.addInstallationAdminRole(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+        await target.addUser(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+    })();
     return new Proxy(target, {
         get(target, propKey, receiver) {
             const originalMethod = target[propKey as keyof typeof target];
@@ -43,24 +42,6 @@ export function createInitializingAuthorizer(spiceDbAuthorizer: SpiceDBAuthorize
     });
 }
 
-export const installation = {
-    type: "installation",
-    id: InstallationID,
-};
-
-export type Resource = typeof installation | User | Organization | Project;
-export namespace Resource {
-    export function getType(res: Resource): ResourceType {
-        return (res as any).type === "installation"
-            ? "installation"
-            : User.is(res)
-            ? "user"
-            : Project.is(res)
-            ? "project"
-            : "organization";
-    }
-}
-
 export class Authorizer {
     constructor(private authorizer: SpiceDBAuthorizer) {}
 
@@ -72,14 +53,14 @@ export class Authorizer {
         const req = v1.CheckPermissionRequest.create({
             subject: subject("user", userId),
             permission,
-            resource: objectRef("organization", orgId),
+            resource: object("organization", orgId),
             consistency,
         });
 
         return this.authorizer.check(req, { userId });
     }
 
-    async checkOrgPermissionAndThrow(userId: string, permission: OrganizationPermission, orgId: string) {
+    async checkPermissionOnOrganization(userId: string, permission: OrganizationPermission, orgId: string) {
         if (await this.hasPermissionOnOrganization(userId, permission, orgId)) {
             return;
         }
@@ -98,14 +79,14 @@ export class Authorizer {
         const req = v1.CheckPermissionRequest.create({
             subject: subject("user", userId),
             permission,
-            resource: objectRef("project", projectId),
+            resource: object("project", projectId),
             consistency,
         });
 
         return this.authorizer.check(req, { userId });
     }
 
-    async checkProjectPermissionAndThrow(userId: string, permission: ProjectPermission, projectId: string) {
+    async checkPermissionOnProject(userId: string, permission: ProjectPermission, projectId: string) {
         if (await this.hasPermissionOnProject(userId, permission, projectId)) {
             return;
         }
@@ -124,14 +105,14 @@ export class Authorizer {
         const req = v1.CheckPermissionRequest.create({
             subject: subject("user", userId),
             permission,
-            resource: objectRef("user", userResourceId),
+            resource: object("user", userResourceId),
             consistency,
         });
 
         return this.authorizer.check(req, { userId });
     }
 
-    async checkUserPermissionAndThrow(userId: string, permission: UserPermission, resourceUserId: string) {
+    async checkPermissionOnUser(userId: string, permission: UserPermission, resourceUserId: string) {
         if (await this.hasPermissionOnUser(userId, permission, resourceUserId)) {
             return;
         }
@@ -176,272 +157,85 @@ export class Authorizer {
     }
 
     async addUser(userId: string, owningOrgId?: string) {
-        const updates = [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("user", userId), "self", subject("user", userId)),
-            }),
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(
-                    objectRef("user", userId),
-                    "container",
-                    owningOrgId ? subject("organization", owningOrgId) : subject("installation", InstallationID),
-                ),
-            }),
-        ];
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates,
-            }),
+            set(rel.user(userId).self.user(userId)), //
+            set(
+                owningOrgId
+                    ? rel.user(userId).container.organization(owningOrgId)
+                    : rel.user(userId).container.installation,
+            ),
         );
     }
 
     async addOrganizationRole(orgID: string, userID: string, role: TeamMemberRole): Promise<void> {
+        const updates = [set(rel.organization(orgID).member.user(userID))];
         if (role === "owner") {
-            await this.addOrganizationOwnerRole(orgID, userID);
+            updates.push(set(rel.organization(orgID).owner.user(userID)));
         } else {
-            await this.addOrganizationMemberRole(orgID, userID);
+            updates.push(remove(rel.organization(orgID).owner.user(userID)));
         }
+        await this.authorizer.writeRelationships(...updates);
     }
 
-    async addOrganizationOwnerRole(orgID: string, userID: string): Promise<void> {
-        await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: this.addOrganizationOwnerRoleUpdates(orgID, userID),
-            }),
-        );
-    }
-
-    async addOrganizationMemberRole(orgID: string, userID: string): Promise<void> {
-        await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: this.addOrganizationMemberRoleUpdates(orgID, userID),
-            }),
-        );
-    }
-
-    async removeOrganizationOwnerRole(orgID: string, userID: string): Promise<void> {
-        await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: this.removeOrganizationOwnerRoleUpdates(orgID, userID),
-            }),
-        );
-    }
-
-    async removeUserFromOrg(orgID: string, userID: string): Promise<void> {
-        await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: [
-                    ...this.removeOrganizationMemberRoleUpdates(orgID, userID),
-                    ...this.removeOrganizationOwnerRoleUpdates(orgID, userID),
-                ],
-            }),
-        );
+    async removeOrganizationRole(orgID: string, userID: string, role: TeamMemberRole): Promise<void> {
+        const updates = [remove(rel.organization(orgID).owner.user(userID))];
+        if (role === "member") {
+            updates.push(remove(rel.organization(orgID).member.user(userID)));
+        }
+        await this.authorizer.writeRelationships(...updates);
     }
 
     async addProjectToOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: this.addProjectToOrgUpdates(orgID, projectID),
-            }),
+            set(rel.project(projectID).org.organization(orgID)), //
         );
     }
 
     async removeProjectFromOrg(orgID: string, projectID: string): Promise<void> {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: this.removeProjectFromOrgUpdates(orgID, projectID),
-            }),
+            remove(rel.project(projectID).org.organization(orgID)), //
         );
     }
 
     async addOrganization(org: Organization, members: TeamMemberInfo[], projects: Project[]): Promise<void> {
-        const updates: v1.RelationshipUpdate[] = [];
-
-        // every org belongs to the installation
-        updates.push(
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(
-                    objectRef("organization", org.id),
-                    "installation",
-                    subject("installation", InstallationID),
-                ),
-            }),
-        );
-
         for (const member of members) {
-            updates.push(...this.addOrganizationRoleUpdates(org.id, member.userId, member.role));
+            await this.addOrganizationRole(org.id, member.userId, member.role);
         }
 
         for (const project of projects) {
-            updates.push(...this.addProjectToOrgUpdates(org.id, project.id));
+            await this.addProjectToOrg(org.id, project.id);
         }
 
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: updates,
-            }),
+            set(rel.organization(org.id).installation.installation), //
         );
     }
 
     async addInstallationMemberRole(userID: string) {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(
-                            objectRef("installation", InstallationID),
-                            "member",
-                            subject("user", userID),
-                        ),
-                    }),
-                ],
-            }),
+            set(rel.installation.member.user(userID)), //
         );
     }
 
     async removeInstallationMemberRole(userID: string) {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(
-                            objectRef("installation", InstallationID),
-                            "member",
-                            subject("user", userID),
-                        ),
-                    }),
-                ],
-            }),
+            remove(rel.installation.member.user(userID)), //
         );
     }
 
     async addInstallationAdminRole(userID: string) {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.TOUCH,
-                        relationship: relationship(
-                            objectRef("installation", InstallationID),
-                            "admin",
-                            subject("user", userID),
-                        ),
-                    }),
-                ],
-            }),
+            set(rel.installation.admin.user(userID)), //
         );
     }
 
     async removeInstallationAdminRole(userID: string) {
         await this.authorizer.writeRelationships(
-            v1.WriteRelationshipsRequest.create({
-                updates: [
-                    v1.RelationshipUpdate.create({
-                        operation: v1.RelationshipUpdate_Operation.DELETE,
-                        relationship: relationship(
-                            objectRef("installation", InstallationID),
-                            "admin",
-                            subject("user", userID),
-                        ),
-                    }),
-                ],
-            }),
+            remove(rel.installation.admin.user(userID)), //
         );
     }
 
-    private addOrganizationRoleUpdates(orgID: string, userID: string, role: TeamMemberRole): v1.RelationshipUpdate[] {
-        if (role === "owner") {
-            return this.addOrganizationOwnerRoleUpdates(orgID, userID);
-        }
-        return this.addOrganizationMemberRoleUpdates(orgID, userID);
-    }
-
-    private addOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-            }),
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("user", userID), "container", subject("organization", orgID)),
-            }),
-        ];
-    }
-
-    private addOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            ...this.addOrganizationMemberRoleUpdates(orgID, userID),
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-            }),
-        ];
-    }
-
-    private removeOrganizationOwnerRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("organization", orgID), "owner", subject("user", userID)),
-            }),
-        ];
-    }
-
-    private removeOrganizationMemberRoleUpdates(orgID: string, userID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("organization", orgID), "member", subject("user", userID)),
-            }),
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("user", userID), "container", subject("organization", orgID)),
-            }),
-        ];
-    }
-
-    private removeProjectFromOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.DELETE,
-                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
-            }),
-        ];
-    }
-
-    private addProjectToOrgUpdates(orgID: string, projectID: string): v1.RelationshipUpdate[] {
-        return [
-            v1.RelationshipUpdate.create({
-                operation: v1.RelationshipUpdate_Operation.TOUCH,
-                relationship: relationship(objectRef("project", projectID), "org", subject("organization", orgID)),
-            }),
-        ];
-    }
-
-    public async readRelationships(
-        inst: typeof installation,
-        relation: InstallationRelation,
-        target: Resource,
-    ): Promise<Relationship[]>;
-    public async readRelationships(user: User, relation: UserRelation, target: Resource): Promise<Relationship[]>;
-    public async readRelationships(
-        org: Organization,
-        relation: OrganizationRelation,
-        target: Resource,
-    ): Promise<Relationship[]>;
-    public async readRelationships(
-        project: Project,
-        relation: ProjectRelation,
-        target: Resource,
-    ): Promise<Relationship[]>;
-    public async readRelationships(subject: Resource, relation?: Relation, object?: Resource): Promise<Relationship[]>;
-    public async readRelationships(subject: Resource, relation?: Relation, object?: Resource): Promise<Relationship[]> {
+    public async find(relation: v1.Relationship): Promise<v1.Relationship | undefined> {
         const relationShips = await this.authorizer.readRelationships({
             consistency: v1.Consistency.create({
                 requirement: {
@@ -450,69 +244,46 @@ export class Authorizer {
                 },
             }),
             relationshipFilter: {
-                resourceType: Resource.getType(subject),
-                optionalResourceId: subject.id,
-                optionalRelation: relation || "",
-                optionalSubjectFilter: object && {
-                    subjectType: Resource.getType(object),
-                    optionalSubjectId: object?.id,
+                resourceType: relation.resource?.objectType || "",
+                optionalResourceId: relation.resource?.objectId || "",
+                optionalRelation: relation.relation,
+                optionalSubjectFilter: relation.subject?.object && {
+                    subjectType: relation.subject.object.objectType,
+                    optionalSubjectId: relation.subject.object.objectId,
                 },
             },
         });
-        return relationShips
-            .map((rel) => {
-                const subject = rel.relationship?.subject?.object;
-                const object = rel.relationship?.resource;
-                const relation = rel.relationship?.relation;
-                if (!subject || !object || !relation) {
-                    throw new Error("Invalid relationship");
-                }
-                return new Relationship(
-                    object.objectType as ResourceType,
-                    object.objectId!,
-                    relation as Relation,
-                    subject.objectType as ResourceType,
-                    subject.objectId!,
-                );
-            })
-            .sort((a, b) => {
-                return a.toString().localeCompare(b.toString());
-            });
+        if (relationShips.length === 0) {
+            return undefined;
+        }
+        return relationShips[0].relationship;
     }
 }
 
-export class Relationship {
-    constructor(
-        public readonly subjectType: ResourceType,
-        public readonly subjectID: string,
-        public readonly relation: Relation,
-        public readonly objectType: ResourceType,
-        public readonly objectID: string,
-    ) {}
-
-    public toString(): string {
-        return `${this.subjectType}:${this.subjectID}#${this.relation}@${this.objectType}:${this.objectID}`;
-    }
+function set(rs: v1.Relationship): v1.RelationshipUpdate {
+    return v1.RelationshipUpdate.create({
+        operation: v1.RelationshipUpdate_Operation.TOUCH,
+        relationship: rs,
+    });
 }
 
-function objectRef(type: ResourceType, id: string): v1.ObjectReference {
+function remove(rs: v1.Relationship): v1.RelationshipUpdate {
+    return v1.RelationshipUpdate.create({
+        operation: v1.RelationshipUpdate_Operation.DELETE,
+        relationship: rs,
+    });
+}
+
+function object(type: ResourceType, id: string): v1.ObjectReference {
     return v1.ObjectReference.create({
         objectId: id,
         objectType: type,
     });
 }
 
-function relationship(res: v1.ObjectReference, relation: Relation, subject: v1.SubjectReference): v1.Relationship {
-    return v1.Relationship.create({
-        relation: relation,
-        resource: res,
-        subject: subject,
-    });
-}
-
 function subject(type: ResourceType, id: string, relation?: Relation | Permission): v1.SubjectReference {
     return v1.SubjectReference.create({
-        object: objectRef(type, id),
+        object: object(type, id),
         optionalRelation: relation,
     });
 }

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -4,7 +4,10 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { v1 } from "@authzed/authzed-node";
+
 export const InstallationID = "1";
+
 export type ResourceType = UserResourceType | InstallationResourceType | OrganizationResourceType | ProjectResourceType;
 
 export type Relation = UserRelation | InstallationRelation | OrganizationRelation | ProjectRelation;
@@ -50,3 +53,267 @@ export type ProjectResourceType = "project";
 export type ProjectRelation = "org" | "editor" | "viewer";
 
 export type ProjectPermission = "read_info" | "write_info" | "delete";
+
+export const rel = {
+    user(id: string) {
+        const result: Partial<v1.Relationship> = {
+            resource: {
+                objectType: "user",
+                objectId: id,
+            },
+        };
+        return {
+            get self() {
+                const result2 = {
+                    ...result,
+                    relation: "self",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get container() {
+                const result2 = {
+                    ...result,
+                    relation: "container",
+                };
+                return {
+                    organization(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "organization",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                    get installation() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "installation",
+                                    objectId: "1",
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+        };
+    },
+
+    get installation() {
+        const result: Partial<v1.Relationship> = {
+            resource: {
+                objectType: "installation",
+                objectId: "1",
+            },
+        };
+        return {
+            get member() {
+                const result2 = {
+                    ...result,
+                    relation: "member",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get admin() {
+                const result2 = {
+                    ...result,
+                    relation: "admin",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+        };
+    },
+
+    organization(id: string) {
+        const result: Partial<v1.Relationship> = {
+            resource: {
+                objectType: "organization",
+                objectId: id,
+            },
+        };
+        return {
+            get installation() {
+                const result2 = {
+                    ...result,
+                    relation: "installation",
+                };
+                return {
+                    get installation() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "installation",
+                                    objectId: "1",
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get member() {
+                const result2 = {
+                    ...result,
+                    relation: "member",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get owner() {
+                const result2 = {
+                    ...result,
+                    relation: "owner",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+        };
+    },
+
+    project(id: string) {
+        const result: Partial<v1.Relationship> = {
+            resource: {
+                objectType: "project",
+                objectId: id,
+            },
+        };
+        return {
+            get org() {
+                const result2 = {
+                    ...result,
+                    relation: "org",
+                };
+                return {
+                    organization(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "organization",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get editor() {
+                const result2 = {
+                    ...result,
+                    relation: "editor",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get viewer() {
+                const result2 = {
+                    ...result,
+                    relation: "viewer",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                    organization(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "organization",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+        };
+    },
+};

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -57,7 +57,7 @@ export class SpiceDBAuthorizer {
         }
     }
 
-    async writeRelationships(req: v1.WriteRelationshipsRequest): Promise<v1.WriteRelationshipsResponse | undefined> {
+    async writeRelationships(...updates: v1.RelationshipUpdate[]): Promise<v1.WriteRelationshipsResponse | undefined> {
         if (!this.client) {
             return undefined;
         }
@@ -65,13 +65,17 @@ export class SpiceDBAuthorizer {
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {
-            const response = await this.client.writeRelationships(req);
-            log.info("[spicedb] Successfully wrote relationships.", { response, request: req });
+            const response = await this.client.writeRelationships(
+                v1.WriteRelationshipsRequest.create({
+                    updates,
+                }),
+            );
+            log.info("[spicedb] Successfully wrote relationships.", { response, updates });
 
             return response;
         } catch (err) {
             error = err;
-            log.error("[spicedb] Failed to write relationships.", err, { req });
+            log.error("[spicedb] Failed to write relationships.", err, { updates });
         } finally {
             observeSpicedbClientLatency("write", error, timer());
         }

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -42,7 +42,7 @@ export class OrganizationService {
     }
 
     async getOrganization(userId: string, orgId: string): Promise<Organization> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "read_info", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "read_info", orgId);
         const result = await this.teamDB.findTeamById(orgId);
         if (!result) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Organization ${orgId} not found`);
@@ -55,7 +55,7 @@ export class OrganizationService {
         orgId: string,
         changes: Pick<Organization, "name">,
     ): Promise<Organization> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "write_info", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "write_info", orgId);
         return this.teamDB.updateTeam(orgId, changes);
     }
 
@@ -70,7 +70,7 @@ export class OrganizationService {
             });
         } catch (err) {
             if (result! && result.id) {
-                await this.auth.removeUserFromOrg(result.id, userId);
+                await this.auth.removeOrganizationRole(result.id, userId, "member");
             }
 
             throw err;
@@ -94,7 +94,7 @@ export class OrganizationService {
     }
 
     public async deleteOrganization(userId: string, orgId: string): Promise<void> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "delete", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "delete", orgId);
         const projects = await this.projectsService.getProjects(userId, orgId);
 
         const members = await this.teamDB.findMembersByTeam(orgId);
@@ -125,12 +125,12 @@ export class OrganizationService {
     }
 
     public async listMembers(userId: string, orgId: string): Promise<OrgMemberInfo[]> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "read_members", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "read_members", orgId);
         return this.teamDB.findMembersByTeam(orgId);
     }
 
     public async getOrCreateInvite(userId: string, orgId: string): Promise<TeamMembershipInvite> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "invite_members", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "invite_members", orgId);
         const invite = await this.teamDB.findGenericInviteByTeamId(orgId);
         if (invite) {
             if (await this.teamDB.hasActiveSSO(orgId)) {
@@ -142,7 +142,7 @@ export class OrganizationService {
     }
 
     public async resetInvite(userId: string, orgId: string): Promise<TeamMembershipInvite> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "invite_members", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "invite_members", orgId);
         if (await this.teamDB.hasActiveSSO(orgId)) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "Invites are disabled for SSO-enabled organizations.");
         }
@@ -173,7 +173,7 @@ export class OrganizationService {
                 return invite.teamId;
             });
         } catch (err) {
-            await this.auth.removeUserFromOrg(invite.teamId, userId);
+            await this.auth.removeOrganizationRole(invite.teamId, userId, "member");
             throw err;
         }
     }
@@ -184,7 +184,7 @@ export class OrganizationService {
         memberId: string,
         role: OrgMemberRole,
     ): Promise<void> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "write_members", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "write_members", orgId);
         if (role !== "owner") {
             const members = await this.teamDB.findMembersByTeam(orgId);
             if (!members.some((m) => m.userId !== memberId && m.role === "owner")) {
@@ -204,13 +204,10 @@ export class OrganizationService {
                 await db.addMemberToTeam(memberId, orgId);
                 await db.setTeamMemberRole(memberId, orgId, role);
                 await this.auth.addOrganizationRole(orgId, memberId, role);
-                if (role === "member") {
-                    await this.auth.removeOrganizationOwnerRole(orgId, memberId);
-                }
             });
         } catch (err) {
             //TODO simply removing the user is not necessarily the right thing to do here, as the user might have been a member before
-            await this.auth.removeUserFromOrg(orgId, memberId);
+            await this.auth.removeOrganizationRole(orgId, memberId, "member");
             throw err;
         }
         // we can remove the built-in installation admin now
@@ -226,9 +223,9 @@ export class OrganizationService {
     public async removeOrganizationMember(userId: string, orgId: string, memberId: string): Promise<void> {
         // The user is leaving a team, if they are removing themselves from the team.
         if (userId === memberId) {
-            await this.auth.checkOrgPermissionAndThrow(userId, "read_info", orgId);
+            await this.auth.checkPermissionOnOrganization(userId, "read_info", orgId);
         } else {
-            await this.auth.checkOrgPermissionAndThrow(userId, "write_members", orgId);
+            await this.auth.checkPermissionOnOrganization(userId, "write_members", orgId);
         }
 
         // Check for existing membership.
@@ -262,7 +259,7 @@ export class OrganizationService {
         try {
             await this.teamDB.transaction(async (db) => {
                 await db.removeMemberFromTeam(userToBeRemoved.id, orgId);
-                await this.auth.removeUserFromOrg(orgId, memberId);
+                await this.auth.removeOrganizationRole(orgId, memberId, "member");
             });
         } catch (err) {
             // Rollback to the original role the user had
@@ -280,12 +277,12 @@ export class OrganizationService {
     }
 
     async getSettings(userId: string, orgId: string): Promise<OrganizationSettings> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "read_settings", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "read_settings", orgId);
         return (await this.teamDB.findOrgSettings(orgId)) || {};
     }
 
     async updateSettings(userId: string, orgId: string, settings: OrganizationSettings): Promise<OrganizationSettings> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "write_settings", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "write_settings", orgId);
         await this.teamDB.setOrgSettings(orgId, settings);
         return settings;
     }

--- a/components/server/src/orgs/usage-service.ts
+++ b/components/server/src/orgs/usage-service.ts
@@ -26,7 +26,7 @@ export class UsageService {
     ) {}
 
     async getCostCenter(userId: string, organizationId: string): Promise<CostCenterJSON> {
-        await this.authorizer.checkOrgPermissionAndThrow(userId, "read_info", organizationId);
+        await this.authorizer.checkPermissionOnOrganization(userId, "read_info", organizationId);
 
         const { costCenter } = await this.usageService.getCostCenter({
             attributionId: AttributionId.render(AttributionId.createFromOrganizationId(organizationId)),
@@ -46,11 +46,11 @@ export class UsageService {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Unexpected usageLimit value: ${usageLimit}`);
         }
 
-        await this.authorizer.checkOrgPermissionAndThrow(userId, "write_billing", organizationId);
+        await this.authorizer.checkPermissionOnOrganization(userId, "write_billing", organizationId);
 
         const costCenter = await this.getCostCenter(userId, organizationId);
         if (costCenter?.billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE) {
-            await this.authorizer.checkOrgPermissionAndThrow(userId, "write_billing_admin", organizationId);
+            await this.authorizer.checkPermissionOnOrganization(userId, "write_billing_admin", organizationId);
         }
         await this.usageService.setCostCenter({
             costCenter: {
@@ -70,7 +70,7 @@ export class UsageService {
             });
         }
         const orgId = attributionId.teamId;
-        await this.authorizer.checkOrgPermissionAndThrow(userId, "read_billing", orgId);
+        await this.authorizer.checkPermissionOnOrganization(userId, "read_billing", orgId);
 
         const response = await this.usageService.listUsage({
             attributionId: AttributionId.render(attributionId),
@@ -112,7 +112,7 @@ export class UsageService {
         userId: string,
         organizationId: string,
     ): Promise<{ usedCredits: number; usageLimit: number }> {
-        await this.authorizer.checkOrgPermissionAndThrow(userId, "read_billing", organizationId);
+        await this.authorizer.checkPermissionOnOrganization(userId, "read_billing", organizationId);
 
         const attributionId = AttributionId.createFromOrganizationId(organizationId);
         const costCenter = this.getCostCenter(userId, organizationId);
@@ -162,7 +162,7 @@ export class UsageService {
     }
 
     async addCreditNote(userId: string, organizationId: string, credits: number, description: string): Promise<void> {
-        await this.authorizer.checkOrgPermissionAndThrow(userId, "write_billing_admin", organizationId);
+        await this.authorizer.checkPermissionOnOrganization(userId, "write_billing_admin", organizationId);
         await this.usageService.addUsageCreditNote({
             attributionId: AttributionId.render(AttributionId.createFromOrganizationId(organizationId)),
             credits,

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -40,7 +40,7 @@ export class ProjectsService {
     ) {}
 
     async getProject(userId: string, projectId: string): Promise<Project> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "read_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "read_info", projectId);
         const project = await this.projectDB.findProjectById(projectId);
         if (!project) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Project ${projectId} not found.`);
@@ -49,7 +49,7 @@ export class ProjectsService {
     }
 
     async getProjects(userId: string, orgId: string): Promise<Project[]> {
-        await this.auth.checkOrgPermissionAndThrow(userId, "read_info", orgId);
+        await this.auth.checkPermissionOnOrganization(userId, "read_info", orgId);
         const projects = await this.projectDB.findProjects(orgId);
         return await this.filterByReadAccess(userId, projects);
     }
@@ -107,7 +107,7 @@ export class ProjectsService {
     }
 
     async markActive(userId: string, projectId: string): Promise<void> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "read_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "read_info", projectId);
         await this.projectDB.updateProjectUsage(projectId, {
             lastWorkspaceStart: new Date().toISOString(),
         });
@@ -127,7 +127,7 @@ export class ProjectsService {
 
     async getProjectOverview(user: User, projectId: string): Promise<Project.Overview> {
         const project = await this.getProject(user.id, projectId);
-        await this.auth.checkProjectPermissionAndThrow(user.id, "read_info", project.id);
+        await this.auth.checkPermissionOnProject(user.id, "read_info", project.id);
         // Check for a cached project overview (fast!)
         const cachedPromise = this.projectDB.findCachedProjectOverview(project.id);
 
@@ -156,7 +156,7 @@ export class ProjectsService {
     }
 
     async getBranchDetails(user: User, project: Project, branchName?: string): Promise<Project.BranchDetails[]> {
-        await this.auth.checkProjectPermissionAndThrow(user.id, "read_info", project.id);
+        await this.auth.checkPermissionOnProject(user.id, "read_info", project.id);
 
         const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         if (!parsedUrl) {
@@ -198,7 +198,7 @@ export class ProjectsService {
         { name, slug, cloneUrl, teamId, appInstallationId }: CreateProjectParams,
         installer: User,
     ): Promise<Project> {
-        await this.auth.checkOrgPermissionAndThrow(installer.id, "create_project", teamId);
+        await this.auth.checkPermissionOnOrganization(installer.id, "create_project", teamId);
 
         if (cloneUrl.length >= 1000) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Clone URL must be less than 1k characters.");
@@ -298,7 +298,7 @@ export class ProjectsService {
     }
 
     async deleteProject(userId: string, projectId: string, transactionCtx?: TransactionalContext): Promise<void> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "delete", projectId);
+        await this.auth.checkPermissionOnProject(userId, "delete", projectId);
 
         let orgId: string | undefined = undefined;
         try {
@@ -329,7 +329,7 @@ export class ProjectsService {
 
     async findPrebuilds(userId: string, params: FindPrebuildsParams): Promise<PrebuildWithStatus[]> {
         const { projectId, prebuildId } = params;
-        await this.auth.checkProjectPermissionAndThrow(userId, "read_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "read_info", projectId);
         const project = await this.projectDB.findProjectById(projectId);
         if (!project) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Project ${projectId} not found.`);
@@ -375,7 +375,7 @@ export class ProjectsService {
     }
 
     async updateProject(userId: string, partialProject: PartialProject): Promise<void> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "write_info", partialProject.id);
+        await this.auth.checkPermissionOnProject(userId, "write_info", partialProject.id);
 
         const partial: PartialProject = { id: partialProject.id };
         const allowedFields: (keyof Project)[] = ["settings"];
@@ -394,12 +394,12 @@ export class ProjectsService {
         value: string,
         censored: boolean,
     ): Promise<void> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "write_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "write_info", projectId);
         return this.projectDB.setProjectEnvironmentVariable(projectId, name, value, censored);
     }
 
     async getProjectEnvironmentVariables(userId: string, projectId: string): Promise<ProjectEnvVar[]> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "read_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "read_info", projectId);
         return this.projectDB.getProjectEnvironmentVariables(projectId);
     }
 
@@ -409,7 +409,7 @@ export class ProjectsService {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Environment Variable ${variableId} not found.`);
         }
         try {
-            await this.auth.checkProjectPermissionAndThrow(userId, "read_info", result.projectId);
+            await this.auth.checkPermissionOnProject(userId, "read_info", result.projectId);
         } catch (err) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Environment Variable ${variableId} not found.`);
         }
@@ -418,12 +418,12 @@ export class ProjectsService {
 
     async deleteProjectEnvironmentVariable(userId: string, variableId: string): Promise<void> {
         const variable = await this.getProjectEnvironmentVariableById(userId, variableId);
-        await this.auth.checkProjectPermissionAndThrow(userId, "write_info", variable.projectId);
+        await this.auth.checkPermissionOnProject(userId, "write_info", variable.projectId);
         return this.projectDB.deleteProjectEnvironmentVariable(variableId);
     }
 
     async isProjectConsideredInactive(userId: string, projectId: string): Promise<boolean> {
-        await this.auth.checkProjectPermissionAndThrow(userId, "read_info", projectId);
+        await this.auth.checkPermissionOnProject(userId, "read_info", projectId);
         const usage = await this.projectDB.getProjectUsage(projectId);
         if (!usage?.lastWorkspaceStart) {
             return false;
@@ -440,7 +440,7 @@ export class ProjectsService {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Project with ${cloneUrl} not found.`);
         }
         try {
-            await this.auth.checkProjectPermissionAndThrow(userId, "read_info", project.id);
+            await this.auth.checkPermissionOnProject(userId, "read_info", project.id);
         } catch (err) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Project with ${cloneUrl} not found.`);
         }

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -6,6 +6,7 @@
 
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import * as chai from "chai";
+import "mocha";
 import { Container } from "inversify";
 import { createTestContainer } from "../test/service-testing-container-module";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TypeORM } from "@gitpod/gitpod-db/lib";

--- a/components/spicedb/codegen/codegen.go
+++ b/components/spicedb/codegen/codegen.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/authzed/spicedb/pkg/development"
 	"github.com/authzed/spicedb/pkg/namespace"
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
 	dev_v1 "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	implv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
@@ -60,6 +61,7 @@ func GenerateDefinition(schema *compiler.CompiledSchema) string {
 	relation := "export type Relation ="
 	permission := "export type Permission ="
 	other := ""
+	fluentApi := ""
 
 	// list definitions
 	for _, def := range schema.ObjectDefinitions {
@@ -68,6 +70,7 @@ func GenerateDefinition(schema *compiler.CompiledSchema) string {
 		resourceTypeName := simpleName + "ResourceType"
 		resource += "\n  | " + resourceTypeName + ""
 		other += "\nexport type " + resourceTypeName + " = \"" + def.Name + "\";\n"
+		fluentApi += "\n" + generateFluentAPI(def)
 		// check if relations exists
 		hasRelations := false
 		for _, rel := range def.Relation {
@@ -107,13 +110,90 @@ func GenerateDefinition(schema *compiler.CompiledSchema) string {
 		}
 	}
 
-	return `/**
- * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
- * Licensed under the GNU Affero General Public License (AGPL).
- * See License.AGPL.txt in the project root for license information.
- */
+	return `
+		/**
+		* Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+		* Licensed under the GNU Affero General Public License (AGPL).
+		* See License.AGPL.txt in the project root for license information.
+		*/
 
-export const InstallationID = "1";
-` +
-		resource + ";\n\n" + relation + ";\n\n" + permission + ";\n\n" + other
+		import { v1 } from "@authzed/authzed-node";
+
+		export const InstallationID = "1";
+
+		` + resource + `;
+
+		` + relation + `;
+
+		` + permission + `;
+
+		` + other + `
+
+		export const rel = {
+			` + fluentApi + `
+		};
+		`
+}
+
+func generateFluentAPI(def *corev1.NamespaceDefinition) string {
+	ifElse := func(cond bool, ifTrue string, ifFalse string) string {
+		if cond {
+			return ifTrue
+		}
+		return ifFalse
+	}
+
+	relations := ""
+	for _, rel := range def.Relation {
+		if namespace.GetRelationKind(rel) != implv1.RelationMetadata_RELATION {
+			continue
+		}
+
+		objects := ``
+		for _, t := range rel.TypeInformation.AllowedDirectRelations {
+			objects += `
+				` + ifElse(t.Namespace == "installation",
+				"get "+t.Namespace+"()",
+				t.Namespace+"(objectId: string)") + ` {
+				return {
+					...result2,
+					subject: {
+						object: {
+							objectType: "` + t.Namespace + `",
+							objectId: ` + ifElse(t.Namespace == "installation", `"1"`, "objectId") + `,
+						},
+					},
+				} as v1.Relationship;
+			},`
+		}
+
+		relations += `
+			get ` + rel.Name + `() {
+				const result2 = {
+                    ...result,
+                    relation: "` + rel.Name + `",
+                };
+				return {
+					` + objects + `
+				};
+			},
+
+		`
+	}
+
+	return `
+	` + ifElse(def.Name == "installation",
+		`get `+def.Name+`() {`,
+		``+def.Name+`(id: string) {`) + `
+		const result: Partial<v1.Relationship> = {
+			resource: {
+				objectType: "` + def.Name + `",
+				objectId: ` + ifElse(def.Name == "installation", `"1"`, "id") + `
+			},
+		};
+		return {
+			` + relations + `
+		};
+	},
+`
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Enhancements to code generator and fga API

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43e6509</samp>

This pull request updates the server authorization module to use the new Authzed client library and its helper functions, and refactors some of the existing code to improve clarity and correctness. It affects the files `authorizer.ts`, `definitions.ts`, `relationship-updater.ts`, and `relationship-updater.spec.db.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] with-monitoring
</details>

/hold
