### PR TITLE
Use the correct GCP servce account to remove the VM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,7 +430,7 @@ jobs:
       - integration-test
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -61,7 +61,7 @@ jobs:
       - build
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -206,7 +206,7 @@ jobs:
       - delete
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -84,7 +84,7 @@ jobs:
       - scan-images
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -189,7 +189,7 @@ jobs:
       - delete
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -33,7 +33,7 @@ jobs:
       - delete
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -72,7 +72,7 @@ jobs:
       - delete
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -251,7 +251,7 @@ jobs:
       - delete
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@secrets
     secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}


### PR DESCRIPTION
## Description

We are using the old secret tied to a different GCP project

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4246d1</samp>

This pull request renames the GCP credentials secret used by the delete-vm action in various GitHub workflows to `SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS`. This improves the readability and consistency of the secret name across the workflows that use it.

</details>


#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
