### PR TITLE
[spicedb] Small schema adjustments

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -161,8 +161,8 @@ export class Authorizer {
             set(rel.user(userId).self.user(userId)), //
             set(
                 owningOrgId
-                    ? rel.user(userId).container.organization(owningOrgId)
-                    : rel.user(userId).container.installation,
+                    ? rel.user(userId).organization.organization(owningOrgId)
+                    : rel.user(userId).installation.installation,
             ),
         );
     }

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -18,9 +18,9 @@ export type Permission = UserPermission | InstallationPermission | OrganizationP
 
 export type UserResourceType = "user";
 
-export type UserRelation = "self" | "container";
+export type UserRelation = "self" | "organization" | "installation";
 
-export type UserPermission = "read_info" | "write_info" | "suspend" | "make_admin";
+export type UserPermission = "read_info" | "write_info" | "make_admin";
 
 export type InstallationResourceType = "installation";
 
@@ -85,10 +85,10 @@ export const rel = {
                 };
             },
 
-            get container() {
+            get organization() {
                 const result2 = {
                     ...result,
-                    relation: "container",
+                    relation: "organization",
                 };
                 return {
                     organization(objectId: string) {
@@ -102,6 +102,15 @@ export const rel = {
                             },
                         } as v1.Relationship;
                     },
+                };
+            },
+
+            get installation() {
+                const result2 = {
+                    ...result,
+                    relation: "installation",
+                };
+                return {
                     get installation() {
                         return {
                             ...result2,

--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -47,13 +47,13 @@ describe("RelationshipUpdater", async () => {
 
     it("should update a simple user", async () => {
         let user = await userDB.newUser();
-        await notExpected(rel.user(user.id).container.installation);
+        await notExpected(rel.user(user.id).installation.installation);
         await notExpected(rel.user(user.id).self.user(user.id));
         await notExpected(rel.installation.member.user(user.id));
 
         user = await migrate(user);
 
-        await expected(rel.user(user.id).container.installation);
+        await expected(rel.user(user.id).installation.installation);
         await expected(rel.user(user.id).self.user(user.id));
         await notExpected(rel.installation.admin.user(user.id));
         await expected(rel.installation.member.user(user.id));
@@ -65,7 +65,7 @@ describe("RelationshipUpdater", async () => {
         user = await userDB.storeUser(user);
         user = await migrate(user);
 
-        await expected(rel.user(user.id).container.installation);
+        await expected(rel.user(user.id).installation.installation);
         await expected(rel.user(user.id).self.user(user.id));
         await expected(rel.installation.admin.user(user.id));
         await expected(rel.installation.member.user(user.id));
@@ -77,7 +77,7 @@ describe("RelationshipUpdater", async () => {
         user = await userDB.storeUser(user);
         user = await migrate(user);
 
-        await expected(rel.user(user.id).container.installation);
+        await expected(rel.user(user.id).installation.installation);
         await expected(rel.user(user.id).self.user(user.id));
         await notExpected(rel.installation.admin.user(user.id));
         await expected(rel.installation.member.user(user.id));
@@ -92,7 +92,7 @@ describe("RelationshipUpdater", async () => {
         user = await migrate(user);
 
         await expected(rel.user(user.id).self.user(user.id));
-        await expected(rel.user(user.id).container.organization(org.id));
+        await expected(rel.user(user.id).organization.organization(org.id));
         await expected(rel.organization(org.id).installation.installation);
         await expected(rel.organization(org.id).member.user(user.id));
         await expected(rel.organization(org.id).owner.user(user.id));
@@ -109,10 +109,10 @@ describe("RelationshipUpdater", async () => {
         user = await migrate(user);
 
         await expected(rel.user(user.id).self.user(user.id));
-        await expected(rel.user(user.id).container.organization(org.id));
+        await expected(rel.user(user.id).organization.organization(org.id));
 
         // we haven't called migrate on user2, so we don't expect any relationships
-        await notExpected(rel.user(user2.id).container.installation);
+        await notExpected(rel.user(user2.id).installation.installation);
         await notExpected(rel.user(user2.id).self.user(user2.id));
 
         // but on the org user2 is a member
@@ -124,7 +124,7 @@ describe("RelationshipUpdater", async () => {
 
         user2 = await migrate(user2);
 
-        await expected(rel.user(user2.id).container.installation);
+        await expected(rel.user(user2.id).installation.installation);
         await expected(rel.user(user2.id).self.user(user2.id));
 
         // rest should be the same

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -79,19 +79,15 @@ describe("UserService", async () => {
     it("createUser", async () => {
         expect(await auth.hasPermissionOnUser(user.id, "read_info", user.id)).to.be.true;
         expect(await auth.hasPermissionOnUser(user.id, "write_info", user.id)).to.be.true;
-        expect(await auth.hasPermissionOnUser(user.id, "suspend", user.id)).to.be.true;
 
         expect(await auth.hasPermissionOnUser(user2.id, "read_info", user.id)).to.be.true;
         expect(await auth.hasPermissionOnUser(user2.id, "write_info", user.id)).to.be.false;
-        expect(await auth.hasPermissionOnUser(user2.id, "suspend", user.id)).to.be.false;
 
         expect(await auth.hasPermissionOnUser(nonOrgUser.id, "read_info", user.id)).to.be.false;
         expect(await auth.hasPermissionOnUser(nonOrgUser.id, "write_info", user.id)).to.be.false;
-        expect(await auth.hasPermissionOnUser(nonOrgUser.id, "suspend", user.id)).to.be.false;
 
         expect(await auth.hasPermissionOnUser(admin.id, "read_info", user.id)).to.be.true;
-        expect(await auth.hasPermissionOnUser(admin.id, "write_info", user.id)).to.be.true;
-        expect(await auth.hasPermissionOnUser(admin.id, "suspend", user.id)).to.be.true;
+        expect(await auth.hasPermissionOnUser(admin.id, "write_info", user.id)).to.be.false;
     });
 
     it("updateLoggedInUser_avatarUrlNotUpdatable", async () => {

--- a/components/spicedb/BUILD.yaml
+++ b/components/spicedb/BUILD.yaml
@@ -3,6 +3,9 @@ packages:
     type: generic
     srcs:
       - "schema/*.yaml"
+    config:
+      test:
+      - ["zed", "validate", "./schema/schema.yaml"]
 
   - name: lib
     type: go

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -5,13 +5,15 @@
 schema: |-
   definition user {
     relation self: user
-    relation container: organization | installation
+
+    // Only ONE of the following relations is ever present for a given user (XOR)
+    relation organization: organization
+    relation installation: installation
 
     // permissions
-    permission read_info = self + container->member + container->owner + container->admin
-    permission write_info = self + container->owner + container->admin
-    permission suspend = self + container->owner + container->admin
-    permission make_admin = container->admin
+    permission read_info = self + organization->member + organization->owner + installation->admin
+    permission write_info = self
+    permission make_admin = installation->admin
   }
 
   // There's only one global installation
@@ -81,7 +83,7 @@ schema: |-
 relationships: |-
   // we have one installation
   installation:installation_0#member@user:user_0
-  user:user_0#container@installation:installation_0
+  user:user_0#installation@installation:installation_0
 
   installation:installation_0#admin@user:user_admin
 


### PR DESCRIPTION
## Description

Small changes based on this discussion: https://gitpod.slack.com/archives/C05JERNDYLE/p1690532118878689

~Let's wait with this until https://github.com/gitpod-io/gitpod/pull/18369 got merged.~ :heavy_check_mark: 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cb2f65</samp>

Updated the user model and permissions in the `SpiceDB` schema and added a validation step for the schema file.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
