### PR TITLE
Call e2e test workflow from main build with installer version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,6 +409,17 @@ jobs:
           test_build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           test_build_ref: ${{ github.head_ref || github.ref }}
 
+  workspace-integration-tests-main:
+    name: "Run workspace integration tests on main branch"
+    needs:
+      - configuration
+      - build-gitpod
+      - create-runner
+    # if: needs.configuration.outputs.is_main_branch == 'true'
+    uses: ./.github/workflows/workspace-integration-tests.yml
+    with:
+      version: ${{ needs.configuration.outputs.version }}
+
   delete-runner:
     if: always()
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,7 +415,7 @@ jobs:
       - configuration
       - build-gitpod
       - create-runner
-    # if: needs.configuration.outputs.is_main_branch == 'true'
+    if: needs.configuration.outputs.is_main_branch == 'true'
     uses: ./.github/workflows/workspace-integration-tests.yml
     with:
       version: ${{ needs.configuration.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,6 +419,7 @@ jobs:
     uses: ./.github/workflows/workspace-integration-tests.yml
     with:
       version: ${{ needs.configuration.outputs.version }}
+    secrets: inherit
 
   delete-runner:
     if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,7 +415,7 @@ jobs:
       - configuration
       - build-gitpod
       - create-runner
-    if: needs.configuration.outputs.is_main_branch == 'true'
+    # if: needs.configuration.outputs.is_main_branch == 'true'
     uses: ./.github/workflows/workspace-integration-tests.yml
     with:
       version: ${{ needs.configuration.outputs.version }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -67,9 +67,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+          if [[ '${{ inputs.name }}' != '' ]]; then
               {
-                  echo "name=${{ github.event.inputs.name }}"
+                  echo "name=${{ inputs.name }}"
               } >> $GITHUB_OUTPUT
           else
               {
@@ -77,9 +77,9 @@ jobs:
               } >> $GITHUB_OUTPUT
           fi
 
-          if [[ '${{ github.event.inputs.version }}' != '' ]]; then
+          if [[ '${{ inputs.version }}' != '' ]]; then
               {
-                  echo "version=${{ github.event.inputs.version }}"
+                  echo "version=${{ inputs.version }}"
               } >> $GITHUB_OUTPUT
           else
               # Find the most recent successful build on main. Look back up to 10 builds.
@@ -118,7 +118,7 @@ jobs:
           infrastructure_provider: gce
           large_vm: true
       - name: Deploy Gitpod to the preview environment
-        if: github.event.inputs.skip_deploy != 'true'
+        if: inputs.skip_deploy != 'true'
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
@@ -159,7 +159,7 @@ jobs:
   delete:
     name: Delete preview environment
     needs: [configuration, infrastructure, check, create-runner]
-    if: github.event.inputs.skip_delete != 'true' && always()
+    if: inputs.skip_delete != 'true' && always()
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-oci-tool-gha.14121

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -1,15 +1,14 @@
 name: "Workspace integration tests"
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       name:
         required: false
+        type: string
         description: "The name of the preview environment, or leave empty to use a default name"
       version:
         required: false
+        type: string
         description: "The version of Gitpod to install (leave empty to target the latest successful build on main)"
       skip_deploy:
         required: false
@@ -19,6 +18,16 @@ on:
         required: false
         type: boolean
         description: "Skip delete preview environment (debug only)"
+  workflow_call:
+    inputs:
+      name:
+        required: false
+        type: string
+        description: "The name of the preview environment, or leave empty to use a default name"
+      version:
+        required: false
+        type: string
+        description: "The version of Gitpod to install (leave empty to target the latest successful build on main)"
   schedule:
     - cron: "0 3,12 * * *"
 


### PR DESCRIPTION
## Description

Fix: in the previous PR I had configured the e2e tests to run on push events to main, but it was not using the installer version of that pushed commit (it chooses the last successful green build).

Now, instead of triggering on pushes to main, have the `Build` workflow trigger the e2e test workflow on main, and explicitly pass the installer version of that commit.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c56e91</samp>

This pull request adds the ability to run workspace integration tests on the main branch using a reusable workflow. It modifies the `.github/workflows/workspace-integration-tests.yml` and `.github/workflows/build.yml` files to enable this functionality.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
