### PR TITLE
[server/fga] centralize lookup of findUserById

### DIFF
--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -14,6 +14,7 @@ import { inject, injectable } from "inversify";
 import { Config } from "../config";
 import { AllAccessFunctionGuard, ExplicitFunctionAccessGuard, WithFunctionAccessGuard } from "./function-access";
 import { TokenResourceGuard, WithResourceAccessGuard } from "./resource-access";
+import { UserService } from "../user/user-service";
 
 export function getBearerToken(headers: IncomingHttpHeaders): string | undefined {
     const authorizationHeader = headers["authorization"];
@@ -40,9 +41,12 @@ function createBearerAuthError(message: string): BearerAuthError {
 
 @injectable()
 export class BearerAuth {
-    @inject(Config) protected readonly config: Config;
-    @inject(UserDB) protected readonly userDB: UserDB;
-    @inject(PersonalAccessTokenDB) protected readonly personalAccessTokenDB: PersonalAccessTokenDB;
+    constructor(
+        @inject(Config) private readonly config: Config,
+        @inject(UserDB) private readonly userDB: UserDB,
+        @inject(UserService) private readonly userService: UserService,
+        @inject(PersonalAccessTokenDB) private readonly personalAccessTokenDB: PersonalAccessTokenDB,
+    ) {}
 
     get restHandler(): express.RequestHandler {
         return async (req, res, next) => {
@@ -123,11 +127,7 @@ export class BearerAuth {
                     throw new Error("Failed to find PAT by hash");
                 }
 
-                const userByID = await this.userDB.findUserById(pat.userId);
-                if (!userByID) {
-                    throw new Error("Failed to find user referenced by PAT");
-                }
-
+                const userByID = await this.userService.findUserById(pat.userId, pat.userId);
                 return { user: userByID, scopes: pat.scopes };
             } catch (e) {
                 log.error("Failed to authenticate using PAT", e);
@@ -142,9 +142,8 @@ export class BearerAuth {
             throw createBearerAuthError("invalid Bearer token");
         }
 
-        // hack: load the user again to get ahold of all identities
-        // TODO(cw): instead of re-loading the user, we should properly join the identities in findUserByGitpodToken
-        const user = (await this.userDB.findUserById(userAndToken.user.id))!;
+        // load the user through user-service again to get ahold of all identities
+        const user = await this.userService.findUserById(userAndToken.user.id, userAndToken.user.id);
         return { user, scopes: userAndToken.token.scopes };
     }
 }

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -4,27 +4,24 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
-import { injectable, inject } from "inversify";
-import { UserDB } from "@gitpod/gitpod-db/lib";
-import { Strategy as DummyStrategy } from "passport-dummy";
-import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { Authenticator } from "../auth/authenticator";
-import { AuthProvider } from "../auth/auth-provider";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
+import * as express from "express";
+import { injectable } from "inversify";
+import { Strategy as DummyStrategy } from "passport-dummy";
+import { AuthProvider } from "../auth/auth-provider";
+import { Authenticator } from "../auth/authenticator";
+import { UserService } from "../user/user-service";
 import { DevData } from "./dev-data";
 
 @injectable()
 export class AuthenticatorDevImpl extends Authenticator {
-    @inject(UserDB) protected userDb: UserDB;
-
     protected async getAuthProviderForHost(_host: string): Promise<AuthProvider | undefined> {
-        return new DummyAuthProvider(this.userDb);
+        return new DummyAuthProvider(this.userService);
     }
 }
 
 class DummyAuthProvider implements AuthProvider {
-    constructor(protected userDb: UserDB) {}
+    constructor(protected userService: UserService) {}
     get info(): AuthProviderInfo {
         return {
             authProviderId: "Public-GitHub",
@@ -43,12 +40,10 @@ class DummyAuthProvider implements AuthProvider {
         throw new Error("Method not implemented.");
     };
     readonly strategy = new DummyStrategy(async (done) => {
-        const maybeUser = await this.userDb.findUserById(DevData.createTestUser().id);
-        if (!maybeUser) {
-            done(new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, "No dev user in DB."), undefined);
-        }
+        const testUser = DevData.createTestUser();
         try {
-            done(undefined, maybeUser);
+            const user = await this.userService.findUserById(testUser.id, testUser.id);
+            done(undefined, user);
         } catch (err) {
             done(err, undefined);
         }

--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -6,7 +6,7 @@
 
 import * as express from "express";
 import { postConstruct, injectable, inject } from "inversify";
-import { ProjectDB, TeamDB, UserDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
+import { ProjectDB, TeamDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { User, StartPrebuildResult, CommitContext, CommitInfo, Project, WebhookEvent } from "@gitpod/gitpod-protocol";
 import { PrebuildManager } from "./prebuild-manager";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -15,10 +15,12 @@ import { ContextParser } from "../workspace/context-parser-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { RepoURL } from "../repohost";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UserService } from "../user/user-service";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class BitbucketApp {
-    @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(UserService) protected readonly userService: UserService;
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
     @inject(TokenService) protected readonly tokenService: TokenService;
     @inject(ProjectDB) protected readonly projectDB: ProjectDB;
@@ -84,7 +86,7 @@ export class BitbucketApp {
         try {
             span.setTag("secret-token", secretToken);
             const [userid, tokenValue] = secretToken.split("|");
-            const user = await this.userDB.findUserById(userid);
+            const user = await this.userService.findUserById(userid, userid);
             if (!user) {
                 throw new Error("No user found for " + secretToken + " found.");
             } else if (!!user.blocked) {
@@ -94,7 +96,7 @@ export class BitbucketApp {
             if (!identity) {
                 throw new Error(`User ${user.id} has no identity for '${TokenService.GITPOD_AUTH_PROVIDER_ID}'.`);
             }
-            const tokens = await this.userDB.findTokensForIdentity(identity);
+            const tokens = await this.userService.findTokensForIdentity(userid, identity);
             const token = tokens.find((t) => t.token.value === tokenValue);
             if (!token) {
                 throw new Error(`User ${user.id} has no token with given value.`);
@@ -193,25 +195,25 @@ export class BitbucketApp {
         cloneURL: string,
         webhookInstaller: User,
     ): Promise<{ user: User; project?: Project }> {
-        const project = await this.projectDB.findProjectByCloneUrl(cloneURL);
-        if (project) {
-            if (project.userId) {
-                const user = await this.userDB.findUserById(project.userId);
-                if (user) {
-                    return { user, project };
+        try {
+            const project = await this.projectDB.findProjectByCloneUrl(cloneURL);
+            if (project) {
+                if (!project.teamId) {
+                    throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "Project has no teamId");
                 }
-            } else if (project.teamId) {
-                const teamMembers = await this.teamDB.findMembersByTeam(project.teamId || "");
+                const teamMembers = await this.teamDB.findMembersByTeam(project.teamId);
                 if (teamMembers.some((t) => t.userId === webhookInstaller.id)) {
                     return { user: webhookInstaller, project };
                 }
                 for (const teamMember of teamMembers) {
-                    const user = await this.userDB.findUserById(teamMember.userId);
+                    const user = await this.userService.findUserById(teamMember.userId, teamMember.userId);
                     if (user && user.identities.some((i) => i.authProviderId === "Public-Bitbucket")) {
                         return { user, project };
                     }
                 }
             }
+        } catch (err) {
+            log.info({ userId: webhookInstaller.id }, "Failed to find project and owner", err);
         }
         return { user: webhookInstaller };
     }

--- a/components/server/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/src/prebuilds/bitbucket-server-app.ts
@@ -6,7 +6,7 @@
 
 import * as express from "express";
 import { postConstruct, injectable, inject } from "inversify";
-import { ProjectDB, TeamDB, UserDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
+import { ProjectDB, TeamDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { PrebuildManager } from "./prebuild-manager";
 import { TokenService } from "../user/token-service";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -15,10 +15,12 @@ import { RepoURL } from "../repohost";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { ContextParser } from "../workspace/context-parser-service";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UserService } from "../user/user-service";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class BitbucketServerApp {
-    @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(UserService) protected readonly userService: UserService;
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
     @inject(TokenService) protected readonly tokenService: TokenService;
     @inject(ProjectDB) protected readonly projectDB: ProjectDB;
@@ -81,7 +83,7 @@ export class BitbucketServerApp {
         try {
             span.setTag("secret-token", secretToken);
             const [userid, tokenValue] = secretToken.split("|");
-            const user = await this.userDB.findUserById(userid);
+            const user = await this.userService.findUserById(userid, userid);
             if (!user) {
                 throw new Error("No user found for " + secretToken + " found.");
             } else if (!!user.blocked) {
@@ -91,7 +93,7 @@ export class BitbucketServerApp {
             if (!identity) {
                 throw new Error(`User ${user.id} has no identity for '${TokenService.GITPOD_AUTH_PROVIDER_ID}'.`);
             }
-            const tokens = await this.userDB.findTokensForIdentity(identity);
+            const tokens = await this.userService.findTokensForIdentity(userid, identity);
             const token = tokens.find((t) => t.token.value === tokenValue);
             if (!token) {
                 throw new Error(`User ${user.id} has no token with given value.`);
@@ -205,25 +207,25 @@ export class BitbucketServerApp {
         cloneURL: string,
         webhookInstaller: User,
     ): Promise<{ user: User; project?: Project }> {
-        const project = await this.projectDB.findProjectByCloneUrl(cloneURL);
-        if (project) {
-            if (project.userId) {
-                const user = await this.userDB.findUserById(project.userId);
-                if (user) {
-                    return { user, project };
+        try {
+            const project = await this.projectDB.findProjectByCloneUrl(cloneURL);
+            if (project) {
+                if (!project.teamId) {
+                    throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "Project has no teamId.");
                 }
-            } else if (project.teamId) {
-                const teamMembers = await this.teamDB.findMembersByTeam(project.teamId || "");
+                const teamMembers = await this.teamDB.findMembersByTeam(project.teamId);
                 if (teamMembers.some((t) => t.userId === webhookInstaller.id)) {
                     return { user: webhookInstaller, project };
                 }
                 for (const teamMember of teamMembers) {
-                    const user = await this.userDB.findUserById(teamMember.userId);
+                    const user = await this.userService.findUserById(webhookInstaller.id, teamMember.userId);
                     if (user && user.identities.some((i) => i.authProviderId === "Public-Bitbucket")) {
                         return { user, project };
                     }
                 }
             }
+        } catch (err) {
+            log.info({ userId: webhookInstaller.id }, "Failed to find project and owner", err);
         }
         return { user: webhookInstaller };
     }

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -39,6 +39,7 @@ import { ContextParser } from "../workspace/context-parser-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { RepoURL } from "../repohost";
 import { ApplicationError, ErrorCode } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { UserService } from "../user/user-service";
 
 /**
  * GitHub app urls:
@@ -54,8 +55,9 @@ import { ApplicationError, ErrorCode } from "@gitpod/gitpod-protocol/lib/messagi
 export class GithubApp {
     @inject(ProjectDB) protected readonly projectDB: ProjectDB;
     @inject(TeamDB) protected readonly teamDB: TeamDB;
-    @inject(AppInstallationDB) protected readonly appInstallationDB: AppInstallationDB;
     @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(AppInstallationDB) protected readonly appInstallationDB: AppInstallationDB;
+    @inject(UserService) protected readonly userService: UserService;
     @inject(TracedWorkspaceDB) protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
     @inject(GithubAppRules) protected readonly appRules: GithubAppRules;
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
@@ -646,7 +648,7 @@ export class GithubApp {
             return installationOwner;
         }
         for (const teamMember of teamMembers) {
-            const user = await this.userDB.findUserById(teamMember.userId);
+            const user = await this.userService.findUserById(teamMember.userId, teamMember.userId);
             if (user && user.identities.some((i) => i.authProviderId === "Public-GitHub")) {
                 return user;
             }
@@ -667,7 +669,7 @@ export class GithubApp {
         }
 
         const ownerID = installation.ownerUserID || "this-should-never-happen";
-        const user = await this.userDB.findUserById(ownerID);
+        const user = await this.userService.findUserById(ownerID, ownerID);
         if (!user) {
             return;
         }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -29,6 +29,7 @@ import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messag
 import { GitpodServerImpl } from "../workspace/gitpod-server-impl";
 import { WorkspaceStarter } from "../workspace/workspace-starter";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
+import { UserService } from "./user-service";
 
 export const ServerFactory = Symbol("ServerFactory");
 export type ServerFactory = () => GitpodServerImpl;
@@ -36,6 +37,7 @@ export type ServerFactory = () => GitpodServerImpl;
 @injectable()
 export class UserController {
     @inject(WorkspaceDB) protected readonly workspaceDB: WorkspaceDB;
+    @inject(UserService) protected readonly userService: UserService;
     @inject(UserDB) protected readonly userDb: UserDB;
     @inject(TeamDB) protected readonly teamDb: TeamDB;
     @inject(Authenticator) protected readonly authenticator: Authenticator;
@@ -97,7 +99,7 @@ export class UserController {
                         throw new ApplicationError(401, "Invalid OTS key");
                     }
 
-                    const user = await this.userDb.findUserById(userId);
+                    const user = await this.userService.findUserById(userId, userId);
                     if (!user) {
                         throw new ApplicationError(404, "User not found");
                     }
@@ -136,7 +138,10 @@ export class UserController {
 
                 // The user has supplied a valid token, we need to sign them in.
                 // Login this user (sets cookie as side-effect)
-                const user = await this.userDb.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+                const user = await this.userService.findUserById(
+                    BUILTIN_INSTLLATION_ADMIN_USER_ID,
+                    BUILTIN_INSTLLATION_ADMIN_USER_ID,
+                );
                 if (!user) {
                     // We respond with NOT_AUTHENTICATED to prevent gleaning whether the user, or token are invalid.
                     throw new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, "Admin user not found");

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -590,11 +590,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             throw new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, "User is not authenticated. Please login.");
         }
 
-        const user = await this.userDB.findUserById(this.userID);
-        if (!user) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "User does not exist.");
-        }
-
+        const user = await this.userService.findUserById(this.userID, this.userID);
         if (user.markedDeleted === true) {
             throw new ApplicationError(ErrorCodes.USER_DELETED, "User has been deleted.");
         }
@@ -1222,13 +1218,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const workspace = await this.internalGetWorkspace(user, workspaceId, this.workspaceDb.trace(ctx));
         await this.guardAccess({ kind: "workspace", subject: workspace }, "get");
 
-        const owner = await this.userDB.findUserById(workspace.ownerId);
-        if (!owner) {
-            return undefined;
+        try {
+            const owner = await this.userService.findUserById(user.id, workspace.ownerId);
+            await this.guardAccess({ kind: "user", subject: owner }, "get");
+            return { name: owner.name };
+        } catch (e) {
+            if (e.code === ErrorCodes.NOT_FOUND) {
+                return undefined;
+            }
+            throw e;
         }
-
-        await this.guardAccess({ kind: "user", subject: owner }, "get");
-        return { name: owner.name };
     }
 
     public async getWorkspaceUsers(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInstanceUser[]> {
@@ -1578,22 +1577,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         for (const repo of repositories) {
             const p = cloneUrlToProject.get(repo.cloneUrl);
-            const repoProvider = new URL(repo.cloneUrl).host.split(".")[0];
 
             if (p) {
-                if (p.userId) {
-                    const owner = await this.userDB.findUserById(p.userId);
-                    if (owner) {
-                        const ownerProviderMatchingRepoProvider = owner.identities.find((identity, index) =>
-                            identity.authProviderId.toLowerCase().includes(repoProvider),
-                        );
-                        if (ownerProviderMatchingRepoProvider) {
-                            repo.inUse = {
-                                userName: ownerProviderMatchingRepoProvider?.authName,
-                            };
-                        }
-                    }
-                } else if (p.teamOwners && p.teamOwners[0]) {
+                if (p.teamOwners && p.teamOwners[0]) {
                     repo.inUse = {
                         userName: p.teamOwners[0] || "somebody",
                     };
@@ -3151,19 +3137,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminGetUser(ctx: TraceContext, userId: string): Promise<User> {
         traceAPIParams(ctx, { userId });
 
-        await this.guardAdminAccess("adminGetUser", { id: userId }, Permission.ADMIN_USERS);
+        const admin = await this.guardAdminAccess("adminGetUser", { id: userId }, Permission.ADMIN_USERS);
 
-        let result: User | undefined;
-        try {
-            result = await this.userDB.findUserById(userId);
-        } catch (e) {
-            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
-        }
-
-        if (!result) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, "not found");
-        }
-        return result;
+        return await this.userService.findUserById(admin.id, userId);
     }
 
     async adminGetUsers(ctx: TraceContext, req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>> {
@@ -3262,30 +3238,20 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async adminVerifyUser(ctx: TraceContext, userId: string): Promise<User> {
-        await this.guardAdminAccess("adminVerifyUser", { id: userId }, Permission.ADMIN_USERS);
-        try {
-            const user = await this.userDB.findUserById(userId);
-            if (!user) {
-                throw new ApplicationError(ErrorCodes.NOT_FOUND, `No user with id ${userId} found.`);
-            }
-            this.verificationService.markVerified(user);
-            await this.userDB.updateUserPartial(user);
-            return user;
-        } catch (e) {
-            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
-        }
+        const admin = await this.guardAdminAccess("adminVerifyUser", { id: userId }, Permission.ADMIN_USERS);
+        const user = await this.userService.findUserById(admin.id, userId);
+
+        this.verificationService.markVerified(user);
+        await this.userDB.updateUserPartial(user);
+        return user;
     }
 
     async adminModifyRoleOrPermission(ctx: TraceContext, req: AdminModifyRoleOrPermissionRequest): Promise<User> {
         traceAPIParams(ctx, { req });
 
-        await this.guardAdminAccess("adminModifyRoleOrPermission", { req }, Permission.ADMIN_PERMISSIONS);
+        const admin = await this.guardAdminAccess("adminModifyRoleOrPermission", { req }, Permission.ADMIN_PERMISSIONS);
 
-        const target = await this.userDB.findUserById(req.id);
-        if (!target) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, "not found");
-        }
-
+        const target = await this.userService.findUserById(admin.id, req.id);
         const rolesOrPermissions = new Set((target.rolesOrPermissions || []) as string[]);
         req.rpp.forEach((e) => {
             if (e.add) {
@@ -3305,11 +3271,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<User> {
         traceAPIParams(ctx, { req });
 
-        await this.guardAdminAccess("adminModifyPermanentWorkspaceFeatureFlag", { req }, Permission.ADMIN_USERS);
-        const target = await this.userDB.findUserById(req.id);
-        if (!target) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, "not found");
-        }
+        const admin = await this.guardAdminAccess(
+            "adminModifyPermanentWorkspaceFeatureFlag",
+            { req },
+            Permission.ADMIN_USERS,
+        );
+        const target = await this.userService.findUserById(admin.id, req.id);
 
         const featureSettings: UserFeatureSettings = target.featureFlags || {};
         const featureFlags = new Set(featureSettings.permanentWSFeatureFlags || []);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We want to use `UserService#findUserById` as a central point for running the FGA migrations. In that light we need to make sure that our system is not bypassing the userServices (should do that anyway) and directly use the `userDb`.
This PR replaces the usages of `UserDB#findUserByID` with `UserService#findUserById`

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53b6a2e</samp>

This pull request refactors various classes that deal with user-related operations to use the `UserService` and `UserAuthentication` services instead of the `UserDB`, to improve the consistency and reliability of the user data and the authorization logic. It also reorders some imports and adds error handling and logging where needed. The affected classes include `Authenticator`, `BearerAuth`, `BitbucketApp`, `BitbucketServerApp`, `GithubApp`, `GitHubEnterpriseApp`, `GitLabApp`, `SessionHandler`, `UserController`, and `GitpodServerImpl`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-286

## How to test
<!-- Provide steps to test this PR -->

In addition the unit tests I spun up a preview environment to verify that these changes don't break any user flows.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-hook-up-migration</li>
	<li><b>🔗 URL</b> - <a href="https://se-hook-up-migration.preview.gitpod-dev.com/workspaces" target="_blank">se-hook-up-migration.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-hook-up-migration-gha.14367</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
