### PR TITLE
Warn when IPFS is running out of storage

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/ipfs.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ipfs.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: ipfs-monitoring-rules
+spec:
+  groups:
+    - name: ipfs-alerts
+      rules:
+        - alert: IPFSAlmostOutOfStorage
+          labels:
+            severity: warning
+            team: workspace
+          for: 10m
+          annotations:
+            runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/IPFSAlmostOutOfStorage.md
+            summary: IPFS is running out of storage within a few days in a workspace cluster. Create and shift to a new workspace cluster with a fresh IPFS.
+            description: IPFS in cluster {{ $labels.cluster }} is running out of storage. This happens naturally for workspace clusters over time, and is prevented by recreating the clusters regularly. Once out of storage, IPFS will stop working, and we fall back to the GCP registry for workspace image pulls, resulting in slower workspace startup times.
+          expr: min(node_filesystem_avail_bytes{device="/dev/mapper/lvm--disk-ipfs", node=~"services-.*", cluster!~"ephemeral.*"}) by (cluster) < 600*1024*1024*1024

--- a/operations/observability/mixins/workspace/rules/central/ipfs.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ipfs.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
     - name: ipfs-alerts
       rules:
-        - alert: IPFSAlmostOutOfStorage
+        - alert: IPFSStorageLow
           labels:
             severity: warning
             team: workspace
@@ -23,3 +23,13 @@ spec:
             summary: IPFS is running out of storage within a few days in a workspace cluster. Create and shift to a new workspace cluster with a fresh IPFS.
             description: IPFS in cluster {{ $labels.cluster }} is running out of storage. This happens naturally for workspace clusters over time, and is prevented by recreating the clusters regularly. Once out of storage, IPFS will stop working, and we fall back to the GCP registry for workspace image pulls, resulting in slower workspace startup times.
           expr: min(node_filesystem_avail_bytes{device="/dev/mapper/lvm--disk-ipfs", node=~"services-.*", cluster!~"ephemeral.*"}) by (cluster) < 600*1024*1024*1024
+        - alert: IPFSStorageCritical
+          labels:
+            severity: critical
+            team: workspace
+          for: 10m
+          annotations:
+            runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/IPFSAlmostOutOfStorage.md
+            summary: IPFS is now very close to running out of storage in a workspace cluster. Create and shift to a new workspace cluster with a fresh IPFS.
+            description: IPFS in cluster {{ $labels.cluster }} has almost ran out of storage. This happens naturally for workspace clusters over time, and is prevented by recreating the clusters regularly. Once out of storage, IPFS will stop working, and we fall back to the GCP registry for workspace image pulls, resulting in slower workspace startup times.
+          expr: min(node_filesystem_avail_bytes{device="/dev/mapper/lvm--disk-ipfs", node=~"services-.*", cluster!~"ephemeral.*"}) by (cluster) < 200*1024*1024*1024


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add alert (warning) when IPFS is close to running out of storage (~few days before actually running out of storage).

Runbook: https://github.com/gitpod-io/runbooks/pull/419

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63fc751</samp>

Add a Prometheus alert rule for IPFS storage usage in workspace clusters. The rule warns when the IPFS device has less than 600 GB of free space and provides a runbook URL for troubleshooting.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-556

## How to test
<!-- Provide steps to test this PR -->

Alert query in explore: [link](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22C%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22min%28node_filesystem_avail_bytes%7Bdevice%3D%5C%22%2Fdev%2Fmapper%2Flvm--disk-ipfs%5C%22,%20node%3D~%5C%22services-.%2A%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%29%20by%20%28cluster%29%20%3C%20600%2A1024%2A1024%2A1024%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
