### PR TITLE
Update help links in SSH settings

### DIFF
--- a/components/dashboard/src/user-settings/SSHKeys.tsx
+++ b/components/dashboard/src/user-settings/SSHKeys.tsx
@@ -69,15 +69,12 @@ export function AddSSHKeyModal(props: AddModalProps) {
                     </Alert>
                 )}
                 <div className="text-gray-500 dark:text-gray-400 text-md">
-                    Add an SSH key for secure access workspaces via SSH.{" "}
-                    <a href="/docs/configure/ssh" target="gitpod-ssh-doc" className="gp-link">
-                        Learn more
-                    </a>
+                    Add an SSH key for secure access to workspaces via SSH.
                 </div>
                 <Alert type="info" className="mt-2">
                     SSH key are used to connect securely to workspaces.{" "}
                     <a
-                        href="https://www.gitpod.io/docs/configure/ssh#create-an-ssh-key"
+                        href="https://www.gitpod.io/docs/configure/user-settings/ssh#create-an-ssh-key"
                         target="gitpod-create-ssh-key-doc"
                         className="gp-link"
                     >


### PR DESCRIPTION
## Description

Minor updates in helps links in SSH settings.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPNBD0/p1690672241986189) (internal). Cc @mbrevoort 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b66dab5</samp>

Update and simplify SSH documentation links in user settings.

</details>

## How to test
1. Go to SSH settings inside user settings
2. Try to create a new SSH key
3. Notice there's no duplicate help link (Learn more) inside the modal—it's already linked on the SSH settings page

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-c4d35232b6</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-c4d35232b6.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-c4d35232b6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-update-help-links-in-ssh-settings-gha.14402</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
