### PR TITLE
[jb-gw] enable reading of ssh config

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -338,7 +338,9 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             null,
             ProgressManager.getGlobalProgressIndicator(),
             false
-        ).withSshConnectionConfig {
+        )
+            .withParsingOpenSSHConfig(true)
+            .withSshConnectionConfig {
             val hostKeyVerifier = it.hostKeyVerifier
             if (hostKeyVerifier is OpenSshLikeHostKeyVerifier) {
                 val acceptHostKey = acceptHostKey(ideUrl, hostKeys)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

to allow user customizations of connectivity, i.e. proxy jumps

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ca9600</samp>

Enable OpenSSH config parsing for SSH connections to Gitpod workspaces. This enhances the compatibility and flexibility of the Gitpod gateway plugin for JetBrains IDEs.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
see EXP-279

## How to test
<!-- Provide steps to test this PR -->

You will need to check out this branch, build GW plugin and try to connect on gitpod.io following README.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
