### PR TITLE
[server] remove Project.userId

### DIFF
--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -34,27 +34,15 @@ export default function ProjectDetail(props: { project: Project; owner: string |
                             {props.project.name}
                         </a>
                     </Property>
-                    {props.project.userId ? (
-                        <Property name="Owner">
-                            <Link
-                                className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                                to={"/admin/users/" + props.project.userId}
-                            >
-                                {props.owner}
-                            </Link>
-                            <span className="text-gray-400 dark:text-gray-500"> (User)</span>
-                        </Property>
-                    ) : (
-                        <Property name="Owner">
-                            <Link
-                                className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                                to={"/admin/orgs/" + props.project.teamId}
-                            >
-                                {props.owner}
-                            </Link>
-                            <span className="text-gray-400 dark:text-gray-500"> (Organization)</span>
-                        </Property>
-                    )}
+                    <Property name="Owner">
+                        <Link
+                            className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
+                            to={"/admin/orgs/" + props.project.teamId}
+                        >
+                            {props.owner}
+                        </Link>
+                        <span className="text-gray-400 dark:text-gray-500"> (Organization)</span>
+                    </Property>
                 </div>
                 <div className="flex w-full mt-6">
                     <Property name="Incremental Prebuilds">

--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -57,15 +57,9 @@ export function ProjectsSearch() {
     useEffect(() => {
         (async () => {
             if (currentProject) {
-                if (currentProject.userId) {
-                    const owner = await getGitpodService().server.adminGetUser(currentProject.userId);
+                const owner = await getGitpodService().server.adminGetTeamById(currentProject.teamId);
+                if (owner) {
                     setCurrentProjectOwner(owner.name);
-                }
-                if (currentProject.teamId) {
-                    const owner = await getGitpodService().server.adminGetTeamById(currentProject.teamId);
-                    if (owner) {
-                        setCurrentProjectOwner(owner.name);
-                    }
                 }
             }
         })();

--- a/components/dashboard/src/data/projects/list-projects-query.ts
+++ b/components/dashboard/src/data/projects/list-projects-query.ts
@@ -10,33 +10,26 @@ import { useCallback } from "react";
 import { listAllProjects } from "../../service/public-api";
 import { useCurrentOrg } from "../organizations/orgs-query";
 
-type TeamOrUserID = {
-    teamId?: string;
-    userId?: string;
-};
-
 export type ListProjectsQueryResults = {
     projects: Project[];
 };
 
 export const useListProjectsQuery = () => {
-    const team = useCurrentOrg().data;
-
-    const teamId = team?.id;
-
+    const org = useCurrentOrg().data;
+    const orgId = org?.id;
     return useQuery<ListProjectsQueryResults>({
         // Projects are either tied to current team, otherwise current user
-        queryKey: getListProjectsQueryKey({ teamId }),
+        queryKey: getListProjectsQueryKey(orgId || ""),
         cacheTime: 1000 * 60 * 60 * 1, // 1 hour
         queryFn: async () => {
-            if (!teamId) {
+            if (!orgId) {
                 return {
                     projects: [],
                     latestPrebuilds: new Map(),
                 };
             }
 
-            const projects = await listAllProjects({ teamId });
+            const projects = await listAllProjects({ orgId });
             return {
                 projects,
             };
@@ -49,24 +42,24 @@ export const useRefreshProjects = () => {
     const queryClient = useQueryClient();
 
     return useCallback(
-        ({ teamId, userId }: TeamOrUserID) => {
-            // Don't refetch if no team/user is provided
-            if (!teamId && !userId) {
+        (orgId: string) => {
+            // Don't refetch if no org is provided
+            if (!orgId) {
                 return;
             }
 
             queryClient.refetchQueries({
-                queryKey: getListProjectsQueryKey({ teamId, userId }),
+                queryKey: getListProjectsQueryKey(orgId),
             });
         },
         [queryClient],
     );
 };
 
-export const getListProjectsQueryKey = ({ teamId, userId }: TeamOrUserID) => {
-    if (!teamId && !userId) {
-        throw new Error("Must provide either a teamId or userId for projects query key");
+export const getListProjectsQueryKey = (orgId: string) => {
+    if (!orgId) {
+        throw new Error("Must provide either an orgId for projects query key");
     }
 
-    return ["projects", "list", teamId ? { teamId } : { userId }];
+    return ["projects", "list", { orgId }];
 };

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -204,7 +204,7 @@ export default function NewProject() {
                 });
 
                 // TODO: After converting this to a mutation, we can handle invalidating/updating the query in a side effect
-                refreshProjects(project.teamId ? { teamId: project.teamId } : { userId: project.userId || "" });
+                refreshProjects(project.teamId);
 
                 setProject(project);
             } catch (error) {

--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -71,12 +71,10 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
             return;
         }
         (async () => {
-            let projects: Project[];
-            if (!!org.data) {
-                projects = await listAllProjects({ teamId: org.data?.id });
-            } else {
-                projects = await listAllProjects({ userId: user?.id });
+            if (!org.data) {
+                return;
             }
+            let projects = await listAllProjects({ orgId: org.data.id });
 
             // Find project matching with slug, otherwise with name
             const project = projects.find((p) => Project.slug(p) === slugs.projectSlug);
@@ -86,20 +84,12 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
                     if (t.id === org.data?.id) {
                         continue;
                     }
-                    const projects = await listAllProjects({ teamId: t.id });
+                    const projects = await listAllProjects({ orgId: t.id });
                     const project = projects.find((p) => Project.slug(p) === slugs.projectSlug);
                     if (project) {
                         // redirect to the other org
                         history.push(location.pathname + "?org=" + t.id);
                     }
-                }
-
-                // check personal projects
-                const projects = await listAllProjects({ userId: user.id });
-                const project = projects.find((p) => Project.slug(p) === slugs.projectSlug);
-                if (project) {
-                    // redirect to the other org
-                    history.push(location.pathname + "?org=0");
                 }
             }
             setProject(project);

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -66,14 +66,14 @@ export function publicApiTeamRoleToProtocol(role: TeamRole): TeamMemberRole {
     }
 }
 
-export async function listAllProjects(opts: { userId?: string; teamId?: string }): Promise<ProtocolProject[]> {
+export async function listAllProjects(opts: { orgId: string }): Promise<ProtocolProject[]> {
     let pagination = {
         page: 1,
         pageSize: 100,
     };
 
     const response = await projectsService.listProjects({
-        teamId: opts.teamId,
+        teamId: opts.orgId,
         pagination,
     });
     const results = response.projects;
@@ -84,7 +84,7 @@ export async function listAllProjects(opts: { userId?: string; teamId?: string }
             page: 1 + pagination.page,
         };
         const response = await projectsService.listProjects({
-            teamId: opts.teamId,
+            teamId: opts.orgId,
             pagination,
         });
         results.push(...response.projects);

--- a/components/gitpod-db/src/project-db.spec.db.ts
+++ b/components/gitpod-db/src/project-db.spec.db.ts
@@ -47,7 +47,6 @@ class ProjectDBSpec {
             name: "some-project",
             slug: "some-project",
             cloneUrl: "some-random-clone-url",
-            userId: user.id,
             teamId: "team-1",
             appInstallationId: "app-1",
         });

--- a/components/gitpod-db/src/redis/publisher.ts
+++ b/components/gitpod-db/src/redis/publisher.ts
@@ -3,6 +3,7 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
+import "reflect-metadata";
 
 import { inject, injectable } from "inversify";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/gitpod-db/src/typeorm/entity/db-project.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project.ts
@@ -32,13 +32,6 @@ export class DBProject {
     @Index("ind_teamId")
     teamId: string;
 
-    @Column({
-        default: "",
-        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
-    })
-    @Index("ind_userId")
-    userId?: string;
-
     @Column()
     appInstallationId: string;
 

--- a/components/gitpod-protocol/src/encryption/encryption-engine.ts
+++ b/components/gitpod-protocol/src/encryption/encryption-engine.ts
@@ -3,6 +3,7 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
+import "reflect-metadata";
 
 import * as crypto from "crypto";
 import { injectable } from "inversify";

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -30,7 +30,6 @@ export interface Project {
     slug?: string;
     cloneUrl: string;
     teamId: string;
-    userId?: string;
     appInstallationId: string;
     settings?: ProjectSettings;
     creationTime: string;

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -398,14 +398,14 @@ export class PrebuildManager {
         commit: CommitInfo,
     ) {
         const span = TraceContext.startSpan("storePrebuildInfo", ctx);
-        const { userId, teamId, name: projectName, id: projectId } = project;
+        const { teamId, name: projectName, id: projectId } = project;
         try {
             await this.workspaceDB.trace({ span }).storePrebuildInfo({
                 id: pws.id,
                 buildWorkspaceId: pws.buildWorkspaceId,
                 basedOnPrebuildId: ws.basedOnPrebuildId,
                 teamId,
-                userId,
+                userId: user.id,
                 projectName,
                 projectId,
                 startedAt: pws.creationTime,

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -269,7 +269,7 @@ export class ProjectsService {
         });
 
         // Install the prebuilds webhook if possible
-        const { userId, teamId, cloneUrl } = project;
+        const { teamId, cloneUrl } = project;
         const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         const hostContext = parsedUrl?.host ? this.hostContextProvider.get(parsedUrl?.host) : undefined;
         const authProvider = hostContext && hostContext.authProvider.info;
@@ -286,11 +286,10 @@ export class ProjectsService {
                 // in the project creation flow, we only propose repositories where the user is actually allowed to
                 // install a webhook.
                 if (await repositoryService.canInstallAutomatedPrebuilds(installer, cloneUrl)) {
-                    log.info("Update prebuild installation for project.", {
-                        teamId,
-                        userId,
-                        installerId: installer.id,
-                    });
+                    log.info(
+                        { organizationId: teamId, userId: installer.id },
+                        "Update prebuild installation for project.",
+                    );
                     await repositoryService.installAutomatedPrebuilds(installer, cloneUrl);
                 }
             }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2843,16 +2843,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!project) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "Project not found");
         }
-        // TODO(janx): This if/else block should probably become a GuardedProject.
-        if (project.userId) {
-            if (user.id !== project.userId) {
-                // Projects owned by a single user can only be accessed by that user
-                throw new ApplicationError(ErrorCodes.PERMISSION_DENIED, "Not allowed to access this project");
-            }
-        } else {
-            // Anyone who can read a team's information (i.e. any team member) can manage team projects
-            await this.guardTeamOperation(project.teamId || "", "get", "not_implemented");
-        }
+        // Anyone who can read a team's information (i.e. any team member) can manage team projects
+        await this.guardTeamOperation(project.teamId, "get", "not_implemented");
     }
 
     public async deleteProject(ctx: TraceContext, projectId: string): Promise<void> {

--- a/components/server/src/workspace/workspace-factory.ts
+++ b/components/server/src/workspace/workspace-factory.ts
@@ -240,14 +240,10 @@ export class WorkspaceFactory {
             };
 
             let projectId: string | undefined;
-            // associate with a project, if it's the personal project of the current user
-            if (project?.userId && project?.userId === user.id) {
-                projectId = project.id;
-            }
             // associate with a project, if the current user is a team member
-            if (project?.teamId) {
+            if (project) {
                 const teams = await this.teamDB.findTeamsByUser(user.id);
-                if (teams.some((t) => t.id === project?.teamId)) {
+                if (teams.some((t) => t.id === project.teamId)) {
                     projectId = project.id;
                 }
             }
@@ -380,14 +376,10 @@ export class WorkspaceFactory {
             }
 
             let projectId: string | undefined;
-            // associate with a project, if it's the personal project of the current user
-            if (project?.userId && project?.userId === user.id) {
-                projectId = project.id;
-            }
             // associate with a project, if the current user is a team member
-            if (project?.teamId) {
+            if (project) {
                 const teams = await this.teamDB.findTeamsByUser(user.id);
-                if (teams.some((t) => t.id === project?.teamId)) {
+                if (teams.some((t) => t.id === project.teamId)) {
                     projectId = project.id;
                 }
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Since we no longer support user-owned projects, we should remove any leftover code paths and the property on the type.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3579171</samp>

No summary available (Limit exceeded: required to process 147298 tokens, but only 50000 are allowed per call)

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-remove-df0429cfde</li>
	<li><b>🔗 URL</b> - <a href="https://se-remove-df0429cfde.preview.gitpod-dev.com/workspaces" target="_blank">se-remove-df0429cfde.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-remove-userproject-gha.14414</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
