### PR TITLE
[server] run relationship updater on findUserById

### DIFF
--- a/components/server/src/authorization/authorizer.spec.db.ts
+++ b/components/server/src/authorization/authorizer.spec.db.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+import { v1 } from "@authzed/authzed-node";
+import { TypeORM } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { Authorizer } from "./authorizer";
+import { rel } from "./definitions";
+import { v4 } from "uuid";
+
+const expect = chai.expect;
+
+describe("Authorizer", async () => {
+    let container: Container;
+    let authorizer: Authorizer;
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+        authorizer = container.get<Authorizer>(Authorizer);
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    it("should removeUser", async () => {
+        const userId = v4();
+        await authorizer.addUser(userId);
+        await expected(rel.user(userId).installation.installation);
+        await expected(rel.user(userId).self.user(userId));
+        await expected(rel.installation.member.user(userId));
+
+        await authorizer.removeUser(userId);
+        await notExpected(rel.user(userId).installation.installation);
+        await notExpected(rel.user(userId).self.user(userId));
+        await notExpected(rel.installation.member.user(userId));
+    });
+
+    it("should addUser", async () => {
+        const userId = v4();
+        await notExpected(rel.user(userId).installation.installation);
+        await notExpected(rel.user(userId).self.user(userId));
+        await notExpected(rel.installation.member.user(userId));
+
+        await authorizer.addUser(userId);
+
+        await expected(rel.user(userId).installation.installation);
+        await expected(rel.user(userId).self.user(userId));
+        await expected(rel.installation.member.user(userId));
+
+        // add user to org
+        const org1Id = v4();
+        await authorizer.addUser(userId, org1Id);
+
+        await notExpected(rel.user(userId).installation.installation);
+        await notExpected(rel.installation.member.user(userId));
+        await expected(rel.user(userId).self.user(userId));
+        await expected(rel.user(userId).organization.organization(org1Id));
+
+        // add user to another org
+        const org2Id = v4();
+        await authorizer.addUser(userId, org2Id);
+
+        await notExpected(rel.user(userId).installation.installation);
+        await notExpected(rel.installation.member.user(userId));
+        await notExpected(rel.user(userId).organization.organization(org1Id));
+        await expected(rel.user(userId).self.user(userId));
+        await expected(rel.user(userId).organization.organization(org2Id));
+
+        // back to installation
+        await authorizer.addUser(userId);
+
+        await notExpected(rel.user(userId).organization.organization(org1Id));
+        await notExpected(rel.user(userId).organization.organization(org2Id));
+
+        await expected(rel.user(userId).installation.installation);
+        await expected(rel.user(userId).self.user(userId));
+        await expected(rel.installation.member.user(userId));
+    });
+
+    it("should addOrganization", async () => {
+        const orgId = v4();
+        await notExpected(rel.organization(orgId).installation.installation);
+
+        // add org with members and projects
+        const u1 = v4();
+        const u2 = v4();
+        const p1 = v4();
+        const p2 = v4();
+        await authorizer.addOrganization(
+            orgId,
+            [
+                { userId: u1, role: "member" },
+                { userId: u2, role: "owner" },
+            ],
+            [p1, p2],
+        );
+
+        await expected(rel.organization(orgId).installation.installation);
+        await expected(rel.organization(orgId).member.user(u1));
+        await expected(rel.organization(orgId).member.user(u2));
+        await expected(rel.organization(orgId).owner.user(u2));
+        await expected(rel.project(p1).org.organization(orgId));
+        await expected(rel.project(p2).org.organization(orgId));
+
+        // add org again with different members and projects
+        await authorizer.addOrganization(orgId, [{ userId: u2, role: "member" }], [p2]);
+        await expected(rel.organization(orgId).installation.installation);
+        await notExpected(rel.organization(orgId).member.user(u1));
+        await expected(rel.organization(orgId).member.user(u2));
+        await notExpected(rel.organization(orgId).owner.user(u2));
+        await notExpected(rel.project(p1).org.organization(orgId));
+        await expected(rel.project(p2).org.organization(orgId));
+    });
+
+    async function expected(relation: v1.Relationship): Promise<void> {
+        const rs = await authorizer.find(relation);
+        const message = async () => {
+            const expected = JSON.stringify(relation);
+            relation.subject = undefined;
+            const result = await authorizer.find(relation);
+            return `Expected ${expected} to be present, but it was not. Found ${JSON.stringify(result)}`;
+        };
+        expect(rs, await message()).to.not.be.undefined;
+    }
+
+    async function notExpected(relation: v1.Relationship): Promise<void> {
+        const rs = await authorizer.find(relation);
+        expect(rs).to.be.undefined;
+    }
+});

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -9,10 +9,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { inject, injectable } from "inversify";
-import {
-    observespicedbClientLatency as observeSpicedbClientLatency,
-    spicedbClientLatency,
-} from "../prometheus-metrics";
+import { observeSpicedbClientLatency, spicedbClientLatency } from "../prometheus-metrics";
 import { SpiceDBClient } from "./spicedb";
 
 @injectable()

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -66,7 +66,7 @@ export class OrganizationService {
             result = await this.teamDB.transaction(async (db) => {
                 result = await db.createTeam(userId, name);
                 const members = await db.findMembersByTeam(result.id);
-                await this.auth.addOrganization(result, members, []);
+                await this.auth.addOrganization(result.id, members, []);
                 return result;
             });
         } catch (err) {
@@ -120,8 +120,11 @@ export class OrganizationService {
                 },
             });
         } catch (err) {
-            const org = await this.teamDB.findTeamById(orgId);
-            await this.auth.addOrganization(org!, members, projects);
+            await this.auth.addOrganization(
+                orgId,
+                members,
+                projects.map((p) => p.id),
+            );
         }
     }
 

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -222,13 +222,18 @@ export function reportCentralizedPermsValidation(operation: string, matches: boo
     centralizedPermissionsValidationsTotal.inc({ operation, matches_expectation: String(matches) });
 }
 
+export const fgaRelationsUpdateClientLatency = new prometheusClient.Histogram({
+    name: "gitpod_fga_relationship_update_seconds",
+    help: "Histogram of completed relationship updates",
+});
+
 export const spicedbClientLatency = new prometheusClient.Histogram({
     name: "gitpod_spicedb_client_requests_completed_seconds",
     help: "Histogram of completed spicedb client requests",
     labelNames: ["operation", "outcome"],
 });
 
-export function observespicedbClientLatency(operation: string, outcome: Error | undefined, durationInSeconds: number) {
+export function observeSpicedbClientLatency(operation: string, outcome: Error | undefined, durationInSeconds: number) {
     spicedbClientLatency.observe(
         { operation, outcome: outcome === undefined ? "success" : "error" },
         durationInSeconds,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The relationship updater now also cleans up any relationships that should be removed selectively instead of wiping everything first and adding just those that are needed. This is so that relationships on shared resources don't appear broken when they are accessed concurrently.

Furthermore, we are running the relationship update (behind feature-flag) on `USerService#findById` which is the central access methods for `User` instances.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 669b8b0</samp>

Add feature flag and migration logic for centralized permissions. This pull request modifies `relationship-updater.ts` and `user-service.ts` to enable or disable the FGA relationship migration based on the feature flag.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-281
Fixes EXP-347

## How to test
<!-- Provide steps to test this PR -->

Here is what I did:
 - signed up, created a project, tested prebuilds, started and stopped a workspace.
 - verified in DB my user is set to `fgaRelationshipsVersion: 1`.
 - manually updated the DB entry to `fgaRelationshipsVersion: 123` and restarted redis (evict the cache)
 - reloaded the dashboard and verified that everything still works as expected (see above) and the DB entry is back to `fgaRelationshipsVersion: 1`,

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-migrate-on-load</li>
	<li><b>🔗 URL</b> - <a href="https://se-migrate-on-load.preview.gitpod-dev.com/workspaces" target="_blank">se-migrate-on-load.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-migrate-on-load-gha.14441</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
