### PR TITLE
[server] try to fix org membership on login

### DIFF
--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -12,7 +12,6 @@ import { UserAuthentication } from "../user/user-authentication";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Identity, User } from "@gitpod/gitpod-protocol";
-import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib";
 import { reportJWTCookieIssued } from "../prometheus-metrics";
 import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { OrganizationService } from "../orgs/organization-service";
@@ -117,7 +116,7 @@ export class IamSessionApp {
                 // Also, if that step repeatedly fails, it would fail the login process earlier but
                 // in a more consistent state.
                 await this.orgService.addOrUpdateMember(
-                    existingUser.id,
+                    undefined,
                     existingUser.organizationId,
                     existingUser.id,
                     "member",
@@ -158,7 +157,7 @@ export class IamSessionApp {
             },
         });
 
-        await this.orgService.addOrUpdateMember(BUILTIN_INSTLLATION_ADMIN_USER_ID, organizationId, user.id, "member");
+        await this.orgService.addOrUpdateMember(undefined, organizationId, user.id, "member");
         return user;
     }
 }

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -179,12 +179,14 @@ export class OrganizationService {
     }
 
     public async addOrUpdateMember(
-        userId: string,
+        userId: string | undefined, // undefined means it is a system call, not a user call
         orgId: string,
         memberId: string,
         role: OrgMemberRole,
     ): Promise<void> {
-        await this.auth.checkPermissionOnOrganization(userId, "write_members", orgId);
+        if (userId) {
+            await this.auth.checkPermissionOnOrganization(userId, "write_members", orgId);
+        }
         if (role !== "owner") {
             const members = await this.teamDB.findMembersByTeam(orgId);
             if (!members.some((m) => m.userId !== memberId && m.role === "owner")) {


### PR DESCRIPTION
in case it didn't succeed on first attempt this might help during the following ones.

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69f54c6</samp>

Refactor `iam-session-app.ts` to optimize login with OIDC and organization membership. Reduce database queries and check organization validity.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
