### PR TITLE
[server] don't error on project not_found

### DIFF
--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -25,6 +25,17 @@ export namespace ApplicationError {
     export function hasErrorCode(e: any): e is Error & { code: ErrorCode; data?: any } {
         return e && e.code !== undefined;
     }
+
+    export async function notFoundToUndefined<T>(p: Promise<T>): Promise<T | undefined> {
+        try {
+            return await p;
+        } catch (e) {
+            if (hasErrorCode(e) && e.code === ErrorCodes.NOT_FOUND) {
+                return undefined;
+            }
+            throw e;
+        }
+    }
 }
 
 export namespace ErrorCode {

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -34,6 +34,7 @@ import { BearerAuth } from "../auth/bearer-authenticator";
 import { ProjectsService } from "../projects/projects-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export const HEADLESS_LOGS_PATH_PREFIX = "/headless-logs";
 export const HEADLESS_LOG_DOWNLOAD_PATH_PREFIX = "/headless-log-download";
@@ -214,7 +215,9 @@ export class HeadlessLogController {
 
         let teamMembers: TeamMemberInfo[] = [];
         if (workspace?.projectId) {
-            const p = await this.projectService.getProject(user.id, workspace.projectId);
+            const p = await ApplicationError.notFoundToUndefined(
+                this.projectService.getProject(user.id, workspace.projectId),
+            );
             if (p?.teamId) {
                 teamMembers = await this.teamDb.findMembersByTeam(p.teamId);
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -696,10 +696,7 @@ export class WorkspaceStarter {
         metadata.setMetaId(workspace.id);
         if (workspace.projectId) {
             metadata.setProject(workspace.projectId);
-            const project = await this.projectDB.findProjectById(workspace.projectId);
-            if (project && project.teamId) {
-                metadata.setTeam(project.teamId);
-            }
+            metadata.setTeam(workspace.organizationId);
         }
 
         return metadata;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need to handle the not_found error during when projects are actually optional, i.e. during workspace start.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-628

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-start-wa387281c97</li>
	<li><b>🔗 URL</b> - <a href="https://se-start-wa387281c97.preview.gitpod-dev.com/workspaces" target="_blank">se-start-wa387281c97.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-start-ws-wo-project-gha.14480</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
