### PR TITLE
[ws-daemon] Fix workspace location for log backup

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -293,10 +293,9 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 			WorkspaceID: ws.Spec.Ownership.WorkspaceID,
 			InstanceID:  ws.Name,
 		},
-		WorkspaceLocation: ws.Spec.WorkspaceLocation,
-		SnapshotName:      snapshotName,
-		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
-		UpdateGitStatus:   ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
+		SnapshotName:    snapshotName,
+		BackupLogs:      ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
+		UpdateGitStatus: ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
 	})
 
 	err = retry.RetryOnConflict(retryParams, func() error {

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -97,11 +97,10 @@ type InitOptions struct {
 }
 
 type BackupOptions struct {
-	Meta              WorkspaceMeta
-	WorkspaceLocation string
-	BackupLogs        bool
-	UpdateGitStatus   bool
-	SnapshotName      string
+	Meta            WorkspaceMeta
+	BackupLogs      bool
+	UpdateGitStatus bool
+	SnapshotName    string
 }
 
 func NewWorkspaceOperations(config content.Config, provider *WorkspaceProvider, reg prometheus.Registerer) (WorkspaceOperations, error) {
@@ -231,7 +230,7 @@ func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts
 	}
 
 	if opts.BackupLogs {
-		err := wso.uploadWorkspaceLogs(ctx, opts)
+		err := wso.uploadWorkspaceLogs(ctx, opts, ws.Location)
 		if err != nil {
 			// we do not fail the workspace yet because we still might succeed with its content!
 			glog.WithError(err).WithFields(ws.OWI()).Error("log backup failed")
@@ -345,9 +344,9 @@ func ensureCleanSlate(location string) error {
 	return nil
 }
 
-func (wso *DefaultWorkspaceOperations) uploadWorkspaceLogs(ctx context.Context, opts BackupOptions) (err error) {
+func (wso *DefaultWorkspaceOperations) uploadWorkspaceLogs(ctx context.Context, opts BackupOptions, location string) (err error) {
 	// currently we're only uploading prebuild log files
-	logFiles, err := logs.ListPrebuildLogFiles(ctx, opts.WorkspaceLocation)
+	logFiles, err := logs.ListPrebuildLogFiles(ctx, location)
 	if err != nil {
 		return err
 	}

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -1106,6 +1106,7 @@ func (c *ComponentAPI) ClearImageBuilderClientCache() {
 type ContentService interface {
 	csapi.ContentServiceClient
 	csapi.WorkspaceServiceClient
+	csapi.HeadlessLogServiceClient
 }
 
 func (c *ComponentAPI) ContentService() (ContentService, error) {
@@ -1141,11 +1142,13 @@ func (c *ComponentAPI) ContentService() (ContentService, error) {
 	type cs struct {
 		csapi.ContentServiceClient
 		csapi.WorkspaceServiceClient
+		csapi.HeadlessLogServiceClient
 	}
 
 	c.contentServiceStatus.ContentService = cs{
-		ContentServiceClient:   csapi.NewContentServiceClient(conn),
-		WorkspaceServiceClient: csapi.NewWorkspaceServiceClient(conn),
+		ContentServiceClient:     csapi.NewContentServiceClient(conn),
+		WorkspaceServiceClient:   csapi.NewWorkspaceServiceClient(conn),
+		HeadlessLogServiceClient: csapi.NewHeadlessLogServiceClient(conn),
 	}
 
 	return c.contentServiceStatus.ContentService, nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix workspace location for logs backup. Use the session's location (path on daemon host) instead of the WorkspaceLocation of the CRD (comes from .gitpod.yml's workspaceLocation)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c9fa34</samp>

Refactor `uploadWorkspaceLogs` and `BackupOptions` to use workspace location from `Workspace` object. This reduces code complexity and redundancy.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-50

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env, by creating a prebuild without this change (no logs in dashboard when viewing the completed prebuild), and then a prebuild after this change, which does show logs even after reloading the page.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
