### PR TITLE
[test] Improve e2e test slack message

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -116,6 +116,8 @@ runs:
       if: ${{ (success() || failure()) && inputs.notify_slack_webhook != '' }}
       env:
         SLACK_WEBHOOK: ${{ inputs.notify_slack_webhook }}
+        SLACK_ICON_EMOJI: ":test_tube:"
+        SLACK_USERNAME: "Integration Tests: ${{ inputs.test_suite }}"
         SLACK_COLOR: ${{ steps.integration-test.outcome }}
         SLACK_MESSAGE: "${{ steps.test_summary.outputs.passed }} tests passed, ${{ steps.test_summary.outputs.failed }} tests failed, ${{ steps.test_summary.outputs.skipped }} tests skipped (took ${{ steps.integration-test.outputs.duration }})"
         SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -98,8 +98,10 @@ jobs:
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ steps.secrets.outputs.WORKSPACE_SLACK_WEBHOOK }}
+          SLACK_ICON_EMOJI: ":test_tube:"
+          SLACK_USERNAME: "Integration Tests: workspace"
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Workspace Integration Tests failed"
+          SLACK_MESSAGE: "Workspace Integration Tests failed during configuration, is main build green?"
           SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
 
   infrastructure:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Quick PR to improve the e2e test slack message 🧪

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfa6681</samp>

This pull request refactors the Slack notification steps of the integration-tests and workspace-integration-tests workflows to use the integration-tests action. This improves the consistency and clarity of the notifications and reduces code duplication.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
