### PR TITLE
[fga] WorkspaceService.getOwnerToken + getIDECredentials

### DIFF
--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -5,7 +5,6 @@
  */
 
 import { createServiceMock, Event, Project, Team, User } from "@gitpod/gitpod-protocol";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 const u1: User = {
     id: "1234",
@@ -253,9 +252,6 @@ const gitpodServiceMock = createServiceMock({
                 },
             },
         };
-    },
-    getBillingModeForUser: async () => {
-        return BillingMode.NONE;
     },
 });
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -236,7 +236,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     listUsage(req: ListUsageRequest): Promise<ListUsageResponse>;
 
-    getBillingModeForUser(): Promise<BillingMode>;
     getBillingModeForTeam(teamId: string): Promise<BillingMode>;
 
     getLinkedInClientId(): Promise<string>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -177,7 +177,6 @@ const defaultFunctions: FunctionsConfig = {
     getPriceInformation: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },
     getBillingModeForTeam: { group: "default", points: 1 },
-    getBillingModeForUser: { group: "default", points: 1 },
     getLinkedInClientId: { group: "default", points: 1 },
     connectWithLinkedIn: { group: "default", points: 1 },
 

--- a/components/server/src/billing/billing-mode.ts
+++ b/components/server/src/billing/billing-mode.ts
@@ -6,7 +6,6 @@
 
 import { inject, injectable } from "inversify";
 
-import { User } from "@gitpod/gitpod-protocol";
 import { Config } from "../config";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { CostCenter_BillingStrategy } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
@@ -22,7 +21,7 @@ export class BillingModes {
         @inject(UsageService) private readonly usageService: UsageService,
     ) {}
 
-    public async getBillingMode(userId: string, organizationId: string, now: Date): Promise<BillingMode> {
+    public async getBillingMode(userId: string, organizationId: string): Promise<BillingMode> {
         if (!this.config.enablePayment) {
             // Payment is not enabled. E.g. Dedicated
             return { mode: "none" };
@@ -33,7 +32,11 @@ export class BillingModes {
         return { mode: "usage-based", paid };
     }
 
-    async getBillingModeForUser(user: User, now: Date): Promise<BillingMode> {
+    /**
+     * @deprecated use getBillingMode(userId, organizationId) instead
+     * @returns
+     */
+    async getBillingModeForUser(): Promise<BillingMode> {
         if (!this.config.enablePayment) {
             // Payment is not enabled. E.g. Self-Hosted.
             return { mode: "none" };

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -47,49 +47,44 @@ export interface EntitlementService {
     mayStartWorkspace(
         user: User,
         organizationId: string,
-        date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult>;
 
     /**
      * A user may set the workspace timeout if they have a professional subscription
-     * @param user
-     * @param date The date for which we want to know whether the user is allowed to set a timeout (depends on active subscription)
+     * @param userId
+     * @param organizationId
      */
-    maySetTimeout(user: User, date: Date): Promise<boolean>;
+    maySetTimeout(userId: string, organizationId?: string): Promise<boolean>;
 
     /**
      * Returns the default workspace timeout for the given user at a given point in time
-     * @param user
-     * @param date The date for which we want to know the default workspace timeout (depends on active subscription)
+     * @param userId
+     * @param organizationId
      */
-    getDefaultWorkspaceTimeout(user: User, date: Date): Promise<WorkspaceTimeoutDuration>;
+    getDefaultWorkspaceTimeout(userId: string, organizationId: string): Promise<WorkspaceTimeoutDuration>;
 
     /**
      * Returns the default workspace lifetime for the given user at a given point in time
-     * @param user
-     * @param date The date for which we want to know the default workspace timeout (depends on active subscription)
+     * @param userId
+     * @param organizationId
      */
-    getDefaultWorkspaceLifetime(user: User, date: Date): Promise<WorkspaceTimeoutDuration>;
-
-    /**
-     * Returns true if the user ought to land on a workspace cluster that provides more resources
-     * compared to the default case.
-     */
-    userGetsMoreResources(user: User): Promise<boolean>;
+    getDefaultWorkspaceLifetime(userId: string, organizationId: string): Promise<WorkspaceTimeoutDuration>;
 
     /**
      * Returns true if network connections should be limited
-     * @param user
+     * @param userId
+     * @param organizationId
      */
-    limitNetworkConnections(user: User, date: Date): Promise<boolean>;
+    limitNetworkConnections(userId: string, organizationId: string): Promise<boolean>;
 
     /**
-     * Returns BillingTier of this particular user
+     * Returns BillingTier of this organization
      *
-     * @param user
+     * @param userId
+     * @param organizationId
      */
-    getBillingTier(user: User): Promise<BillingTier>;
+    getBillingTier(userId: string, organizationId: string): Promise<BillingTier>;
 }
 
 /**
@@ -107,7 +102,6 @@ export class EntitlementServiceImpl implements EntitlementService {
     async mayStartWorkspace(
         user: User,
         organizationId: string,
-        date: Date = new Date(),
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
         try {
@@ -117,13 +111,13 @@ export class EntitlementServiceImpl implements EntitlementService {
                     needsVerification: true,
                 };
             }
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            const billingMode = await this.billingModes.getBillingMode(user.id, organizationId);
             switch (billingMode.mode) {
                 case "none":
                     // if payment is not enabled users can start as many parallel workspaces as they want
                     return {};
                 case "usage-based":
-                    return this.ubp.mayStartWorkspace(user, organizationId, date, runningInstances);
+                    return this.ubp.mayStartWorkspace(user, organizationId, runningInstances);
                 default:
                     throw new Error("Unsupported billing mode: " + (billingMode as any).mode); // safety net
             }
@@ -133,65 +127,50 @@ export class EntitlementServiceImpl implements EntitlementService {
         }
     }
 
-    async maySetTimeout(user: User, date: Date = new Date()): Promise<boolean> {
+    async maySetTimeout(userId: string, organizationId?: string): Promise<boolean> {
         try {
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            // TODO(gpl): We need to replace this with ".getBillingMode(user.id, organizationId);" once all callers forward organizationId
+            const billingMode = await this.billingModes.getBillingModeForUser();
             switch (billingMode.mode) {
                 case "none":
                     // when payment is disabled users can do everything
                     return true;
                 case "usage-based":
-                    return this.ubp.maySetTimeout(user, date);
+                    return this.ubp.maySetTimeout(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: maySetTimeout", err);
+            log.error({ userId }, "EntitlementService error: maySetTimeout", err);
             return true;
         }
     }
 
-    async getDefaultWorkspaceTimeout(user: User, date: Date = new Date()): Promise<WorkspaceTimeoutDuration> {
+    async getDefaultWorkspaceTimeout(userId: string, organizationId: string): Promise<WorkspaceTimeoutDuration> {
         try {
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
                     return WORKSPACE_TIMEOUT_DEFAULT_LONG;
                 case "usage-based":
-                    return this.ubp.getDefaultWorkspaceTimeout(user, date);
+                    return this.ubp.getDefaultWorkspaceTimeout(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: getDefaultWorkspaceTimeout", err);
+            log.error({ userId }, "EntitlementService error: getDefaultWorkspaceTimeout", err);
             return WORKSPACE_TIMEOUT_DEFAULT_LONG;
         }
     }
 
-    async getDefaultWorkspaceLifetime(user: User, date: Date = new Date()): Promise<WorkspaceTimeoutDuration> {
+    async getDefaultWorkspaceLifetime(userId: string, organizationId: string): Promise<WorkspaceTimeoutDuration> {
         try {
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
                     return WORKSPACE_LIFETIME_LONG;
                 case "usage-based":
-                    return this.ubp.getDefaultWorkspaceLifetime(user, date);
+                    return this.ubp.getDefaultWorkspaceLifetime(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: getDefaultWorkspaceLifetime", err);
+            log.error({ userId }, "EntitlementService error: getDefaultWorkspaceLifetime", err);
             return WORKSPACE_LIFETIME_LONG;
-        }
-    }
-
-    async userGetsMoreResources(user: User, date: Date = new Date()): Promise<boolean> {
-        try {
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
-            switch (billingMode.mode) {
-                case "none":
-                    // TODO(gpl) Not sure this makes sense, but it's the way it was before
-                    return false;
-                case "usage-based":
-                    return this.ubp.userGetsMoreResources(user);
-            }
-        } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: userGetsMoreResources", err);
-            return true;
         }
     }
 
@@ -199,38 +178,37 @@ export class EntitlementServiceImpl implements EntitlementService {
      * Returns true if network connections should be limited
      * @param user
      */
-    async limitNetworkConnections(user: User, date: Date): Promise<boolean> {
+    async limitNetworkConnections(userId: string, organizationId: string): Promise<boolean> {
         try {
-            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
                     return false;
                 case "usage-based":
-                    return this.ubp.limitNetworkConnections(user, date);
+                    return this.ubp.limitNetworkConnections(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: limitNetworkConnections", err);
+            log.error({ userId }, "EntitlementService error: limitNetworkConnections", err);
             return false;
         }
     }
 
     /**
      * Returns true if network connections should be limited
-     * @param user
+     * @param userId
+     * @param organizationId
      */
-    async getBillingTier(user: User): Promise<BillingTier> {
+    async getBillingTier(userId: string, organizationId: string): Promise<BillingTier> {
         try {
-            const now = new Date();
-            const billingMode = await this.billingModes.getBillingModeForUser(user, now);
+            const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    // TODO(gpl) Is this true? Cross-check this whole interface with Self-Hosted before next release!
                     return "paid";
                 case "usage-based":
-                    return this.ubp.getBillingTier(user);
+                    return billingMode.paid ? "paid" : "free";
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: getBillingTier", err);
+            log.error({ userId }, "EntitlementService error: getBillingTier", err);
             return "paid";
         }
     }

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -293,12 +293,7 @@ export class PrebuildManager {
     protected async checkUsageLimitReached(user: User, organizationId: string): Promise<void> {
         let result: MayStartWorkspaceResult = {};
         try {
-            result = await this.entitlementService.mayStartWorkspace(
-                user,
-                organizationId,
-                new Date(),
-                Promise.resolve([]),
-            );
+            result = await this.entitlementService.mayStartWorkspace(user, organizationId, Promise.resolve([]));
         } catch (err) {
             log.error({ userId: user.id }, "EntitlementService.mayStartWorkspace error", err);
             return; // we don't want to block workspace starts because of internal errors

--- a/components/server/src/test/expect-utils.ts
+++ b/components/server/src/test/expect-utils.ts
@@ -11,11 +11,12 @@ export async function expectError(errorCode: ErrorCode, code: Promise<any> | (()
     const msg = "expected error: " + errorCode + (message ? " - " + message : "");
     try {
         await (code instanceof Function ? code() : code);
-        expect.fail(msg);
+        expect.fail(msg + " - succeeded");
     } catch (err) {
         if (!ApplicationError.hasErrorCode(err)) {
             throw err;
         }
-        expect(err && ApplicationError.hasErrorCode(err) && err.code, msg).to.equal(errorCode);
+        const actual = err && ApplicationError.hasErrorCode(err) && err.code;
+        expect(actual, msg + " - got: " + actual).to.equal(errorCode);
     }
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -653,7 +653,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkUser("maySetTimeout");
         await this.guardAccess({ kind: "user", subject: user }, "get");
 
-        return await this.entitlementService.maySetTimeout(user, new Date());
+        return await this.entitlementService.maySetTimeout(user.id);
     }
 
     public async updateWorkspaceTimeoutSetting(
@@ -668,7 +668,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkAndBlockUser("updateWorkspaceTimeoutSetting");
         await this.guardAccess({ kind: "user", subject: user }, "update");
 
-        if (!(await this.entitlementService.maySetTimeout(user, new Date()))) {
+        if (!(await this.entitlementService.maySetTimeout(user.id))) {
             throw new Error("configure workspace timeout only available for paid user.");
         }
 
@@ -1672,12 +1672,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<void> {
         let result: MayStartWorkspaceResult = {};
         try {
-            result = await this.entitlementService.mayStartWorkspace(
-                user,
-                organizationId,
-                new Date(),
-                runningInstances,
-            );
+            result = await this.entitlementService.mayStartWorkspace(user, organizationId, runningInstances);
             TraceContext.addNestedTags(ctx, { mayStartWorkspace: { result } });
         } catch (err) {
             log.error({ userId: user.id }, "EntitlementSerivce.mayStartWorkspace error", err);
@@ -1867,10 +1862,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const user = await this.checkUser("setWorkspaceTimeout");
 
-        if (!(await this.entitlementService.maySetTimeout(user, new Date()))) {
-            throw new ApplicationError(ErrorCodes.PLAN_PROFESSIONAL_REQUIRED, "Plan upgrade is required");
-        }
-
         let validatedDuration;
         try {
             validatedDuration = WorkspaceTimeoutDuration.validate(duration);
@@ -1879,6 +1870,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
 
         const workspace = await this.workspaceService.getWorkspace(user.id, workspaceId);
+        if (!(await this.entitlementService.maySetTimeout(user.id, workspace.organizationId))) {
+            throw new ApplicationError(ErrorCodes.PLAN_PROFESSIONAL_REQUIRED, "Plan upgrade is required");
+        }
+
         const runningInstances = await this.workspaceDb.trace(ctx).findRegularRunningInstances(user.id);
         const runningInstance = runningInstances.find((i) => i.workspaceId === workspaceId);
         if (!runningInstance) {
@@ -1905,9 +1900,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const user = await this.checkUser("getWorkspaceTimeout");
 
-        const canChange = await this.entitlementService.maySetTimeout(user, new Date());
-
         const workspace = await this.workspaceService.getWorkspace(user.id, workspaceId);
+        const canChange = await this.entitlementService.maySetTimeout(user.id, workspace.organizationId);
+
         const runningInstance = await this.workspaceDb.trace(ctx).findRunningInstance(workspaceId);
         if (!runningInstance) {
             log.warn({ userId: user.id, workspaceId }, "Can only get keep-alive for running workspaces");
@@ -4159,20 +4154,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return await this.guardTeamOperation(attributionId.teamId, operation, fineGrainedOp);
     }
 
-    async getBillingModeForUser(ctx: TraceContextWithSpan): Promise<BillingMode> {
-        traceAPIParams(ctx, {});
-
-        const user = await this.checkUser("getBillingModeForUser");
-        return this.billingModes.getBillingModeForUser(user, new Date());
-    }
-
     async getBillingModeForTeam(ctx: TraceContextWithSpan, teamId: string): Promise<BillingMode> {
         traceAPIParams(ctx, { teamId });
 
         const user = await this.checkAndBlockUser("getBillingModeForTeam");
         await this.guardTeamOperation(teamId, "get", "not_implemented");
 
-        return this.billingModes.getBillingMode(user.id, teamId, new Date());
+        return this.billingModes.getBillingMode(user.id, teamId);
     }
 
     // (SaaS) – admin
@@ -4188,7 +4176,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!parsedAttributionId) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unable to parse attributionId");
         }
-        return this.billingModes.getBillingMode(user.id, parsedAttributionId.teamId, new Date());
+        return this.billingModes.getBillingMode(user.id, parsedAttributionId.teamId);
     }
 
     async adminGetCostCenter(ctx: TraceContext, attributionId: string): Promise<CostCenterJSON | undefined> {

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -98,6 +98,37 @@ describe("WorkspaceService", async () => {
         await expectError(ErrorCodes.NOT_FOUND, () => svc.getWorkspace(stranger.id, ws.id));
     });
 
+    it("should getOwnerToken", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            () => svc.getOwnerToken(owner.id, ws.id),
+            "NOT_FOUND for non-running workspace",
+        );
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            () => svc.getOwnerToken(stranger.id, ws.id),
+            "NOT_FOUND if stranger asks for the owner token",
+        );
+    });
+
+    it("should getIDECredentials", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        const ideCredentials = await svc.getIDECredentials(owner.id, ws.id);
+        expect(ideCredentials, "IDE credentials should be present").to.not.be.undefined;
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            () => svc.getIDECredentials(stranger.id, ws.id),
+            "NOT_FOUND if stranger asks for the IDE credentials",
+        );
+    });
+
     it("should stopWorkspace", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -85,7 +85,7 @@ describe("WorkspaceService", async () => {
         await createTestWorkspace(svc, org, owner, project);
 
         // Stranger can't create a workspace in our org
-        await expectError(ErrorCodes.NOT_FOUND, () => createTestWorkspace(svc, org, stranger, project));
+        await expectError(ErrorCodes.NOT_FOUND, createTestWorkspace(svc, org, stranger, project));
     });
 
     it("should getWorkspace", async () => {
@@ -95,7 +95,7 @@ describe("WorkspaceService", async () => {
         const foundWorkspace = await svc.getWorkspace(owner.id, ws.id);
         expect(foundWorkspace?.id).to.equal(ws.id);
 
-        await expectError(ErrorCodes.NOT_FOUND, () => svc.getWorkspace(stranger.id, ws.id));
+        await expectError(ErrorCodes.NOT_FOUND, svc.getWorkspace(stranger.id, ws.id));
     });
 
     it("should getOwnerToken", async () => {
@@ -104,13 +104,13 @@ describe("WorkspaceService", async () => {
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.getOwnerToken(owner.id, ws.id),
+            svc.getOwnerToken(owner.id, ws.id),
             "NOT_FOUND for non-running workspace",
         );
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.getOwnerToken(stranger.id, ws.id),
+            svc.getOwnerToken(stranger.id, ws.id),
             "NOT_FOUND if stranger asks for the owner token",
         );
     });
@@ -124,7 +124,7 @@ describe("WorkspaceService", async () => {
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.getIDECredentials(stranger.id, ws.id),
+            svc.getIDECredentials(stranger.id, ws.id),
             "NOT_FOUND if stranger asks for the IDE credentials",
         );
     });
@@ -134,7 +134,8 @@ describe("WorkspaceService", async () => {
         const ws = await createTestWorkspace(svc, org, owner, project);
 
         await svc.stopWorkspace(owner.id, ws.id, "test stopping stopped workspace");
-        await expectError(ErrorCodes.NOT_FOUND, () =>
+        await expectError(
+            ErrorCodes.NOT_FOUND,
             svc.stopWorkspace(stranger.id, ws.id, "test stranger stopping stopped workspace"),
         );
     });
@@ -145,7 +146,7 @@ describe("WorkspaceService", async () => {
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.deleteWorkspace(stranger.id, ws.id),
+            svc.deleteWorkspace(stranger.id, ws.id),
             "stranger can't delete workspace",
         );
 
@@ -153,7 +154,7 @@ describe("WorkspaceService", async () => {
         // TODO(gpl) For now, we keep the old behavior which will return a workspace, even if it's marked as "softDeleted"
         // await expectError(
         //     ErrorCodes.NOT_FOUND,
-        //     () => svc.getWorkspace(owner.id, ws.id),
+        //     svc.getWorkspace(owner.id, ws.id),
         //     "getWorkspace should return NOT_FOUND after deletion",
         // );
         const ws2 = await svc.getWorkspace(owner.id, ws.id);
@@ -166,14 +167,14 @@ describe("WorkspaceService", async () => {
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.hardDeleteWorkspace(stranger.id, ws.id),
+            svc.hardDeleteWorkspace(stranger.id, ws.id),
             "stranger can't hard-delete workspace",
         );
 
         await svc.hardDeleteWorkspace(owner.id, ws.id);
         await expectError(
             ErrorCodes.NOT_FOUND,
-            () => svc.getWorkspace(owner.id, ws.id),
+            svc.getWorkspace(owner.id, ws.id),
             "getWorkspace should return NOT_FOUND after hard-deletion",
         );
     });

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -14,6 +14,7 @@ import { WorkspaceFactory } from "./workspace-factory";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { WorkspaceStarter } from "./workspace-starter";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import * as crypto from "crypto";
 
 @injectable()
 export class WorkspaceService {
@@ -59,15 +60,53 @@ export class WorkspaceService {
     }
 
     async getWorkspace(userId: string, workspaceId: string): Promise<Workspace> {
+        return this.doGetWorkspace(userId, workspaceId);
+    }
+
+    // Internal method for allowing for additional DBs to be passed in
+    private async doGetWorkspace(userId: string, workspaceId: string, db: WorkspaceDB = this.db): Promise<Workspace> {
         await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
 
-        const workspace = await this.db.findById(workspaceId);
+        const workspace = await db.findById(workspaceId);
         // TODO(gpl) We might want to add || !!workspace.softDeleted here in the future, but we were unsure how that would affect existing clients
         // In order to reduce risk, we leave it for a future changeset.
         if (!workspace || workspace.deleted) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "Workspace not found.");
         }
         return workspace;
+    }
+
+    async getOwnerToken(userId: string, workspaceId: string): Promise<string> {
+        await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
+
+        // Check: is deleted?
+        await this.getWorkspace(userId, workspaceId);
+
+        const latestInstance = await this.db.findCurrentInstance(workspaceId);
+        const ownerToken = latestInstance?.status.ownerToken;
+        if (!ownerToken) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "owner token not found");
+        }
+        return ownerToken;
+    }
+
+    async getIDECredentials(userId: string, workspaceId: string): Promise<string> {
+        await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
+
+        const ws = await this.getWorkspace(userId, workspaceId);
+        if (ws.config.ideCredentials) {
+            return ws.config.ideCredentials;
+        }
+
+        return this.db.transaction(async (db) => {
+            const ws = await this.doGetWorkspace(userId, workspaceId, db);
+            if (ws.config.ideCredentials) {
+                return ws.config.ideCredentials;
+            }
+            ws.config.ideCredentials = crypto.randomBytes(32).toString("base64");
+            await db.store(ws);
+            return ws.config.ideCredentials;
+        });
     }
 
     async stopWorkspace(

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -164,9 +164,6 @@ export async function getWorkspaceClassForInstance(
                     break;
             }
         }
-        if (!workspaceClass && (await entitlementService.userGetsMoreResources(user))) {
-            workspaceClass = config.find((c) => !!c.marker?.moreResources)?.id;
-        }
         if (!workspaceClass) {
             workspaceClass = config.find((c) => !!c.isDefault)?.id;
         }
@@ -893,7 +890,7 @@ export class WorkspaceStarter {
                 }
             }
 
-            const billingTier = await this.entitlementService.getBillingTier(user);
+            const billingTier = await this.entitlementService.getBillingTier(user.id, workspace.organizationId);
 
             let featureFlags: NamedWorkspaceFeatureFlag[] = workspace.config._featureFlags || [];
             featureFlags = featureFlags.concat(this.config.workspaceDefaults.defaultFeatureFlags);
@@ -916,7 +913,7 @@ export class WorkspaceStarter {
 
             featureFlags = featureFlags.filter((f) => !excludeFeatureFlags.includes(f));
 
-            if (await this.shouldEnableConnectionLimiting(user)) {
+            if (await this.shouldEnableConnectionLimiting(user.id, workspace.organizationId)) {
                 featureFlags.push("workspace_connection_limiting");
             }
 
@@ -980,8 +977,8 @@ export class WorkspaceStarter {
         }
     }
 
-    private async shouldEnableConnectionLimiting(user: User): Promise<boolean> {
-        return this.entitlementService.limitNetworkConnections(user, new Date());
+    private async shouldEnableConnectionLimiting(userId: string, organizationId: string): Promise<boolean> {
+        return this.entitlementService.limitNetworkConnections(userId, organizationId);
     }
 
     private shouldEnablePSI(billingTier: BillingTier): boolean {
@@ -1519,9 +1516,15 @@ export class WorkspaceStarter {
             user,
             lastValidWorkspaceInstanceId,
         );
-        const userTimeoutPromise = this.entitlementService.getDefaultWorkspaceTimeout(user, new Date());
-        const allowSetTimeoutPromise = this.entitlementService.maySetTimeout(user, new Date());
-        const workspaceLifetimePromise = this.entitlementService.getDefaultWorkspaceLifetime(user, new Date());
+        const userTimeoutPromise = this.entitlementService.getDefaultWorkspaceTimeout(
+            user.id,
+            workspace.organizationId,
+        );
+        const allowSetTimeoutPromise = this.entitlementService.maySetTimeout(user.id, workspace.organizationId);
+        const workspaceLifetimePromise = this.entitlementService.getDefaultWorkspaceLifetime(
+            user.id,
+            workspace.organizationId,
+        );
 
         const featureFlags = instance.configuration!.featureFlags || [];
 


### PR DESCRIPTION
## Description

Blocked by: https://github.com/gitpod-io/gitpod/pull/18410

Adds WorkspaceService.getOwnerToken + getIDECredentials, incl. basic tests

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34b9acc</samp>

This pull request enhances the `WorkspaceService` class with new methods for owner token and IDE credentials logic, and refactors the `GitpodServerImpl` class and the `workspace-service.spec.db.ts` file to use the improved service layer. These changes aim to reduce code duplication, improve modularity, and increase test coverage and quality for the workspace component.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-318, EXP-319

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
