### PR TITLE
[server] fix tsc complaining about complex type

### DIFF
--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -111,7 +111,7 @@ export class GithubApp {
                     res.redirect(301, this.getBadgeImageURL());
                 });
 
-        app.on("installation.created", (ctx) => {
+        app.on("installation.created", (ctx: Context<"installation.created">) => {
             catchError(
                 (async () => {
                     const targetAccountName = `${ctx.payload.installation.account.login}`;
@@ -136,7 +136,7 @@ export class GithubApp {
                 })(),
             );
         });
-        app.on("installation.deleted", (ctx) => {
+        app.on("installation.deleted", (ctx: Context<"installation.deleted">) => {
             catchError(
                 (async () => {
                     const installationId = `${ctx.payload.installation.id}`;
@@ -145,7 +145,7 @@ export class GithubApp {
             );
         });
 
-        app.on("repository.renamed", (ctx) => {
+        app.on("repository.renamed", (ctx: Context<"repository.renamed">) => {
             catchError(
                 (async () => {
                     const { action, repository, installation } = ctx.payload;
@@ -172,7 +172,7 @@ export class GithubApp {
             // TODO(at): handle deleted as well
         });
 
-        app.on("push", (ctx) => {
+        app.on("push", (ctx: Context<"push">) => {
             catchError(this.handlePushEvent(ctx));
         });
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a few explicit types, so that tsc is not complaining when opening this file in the editor.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bc366d</samp>

Improved type annotations for GitHub webhook event handlers in `github-app.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
