### PR TITLE
fix watch mode

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.5",
   "license": "UNLICENSED",
   "scripts": {
-    "build": "mkdir -p lib; tsc && cp -f src/*.js src/*d.ts lib"
+    "build": "mkdir -p lib && cp -f src/*.js src/*d.ts lib && tsc "
   },
   "files": [
     "src",

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.5",
   "license": "UNLICENSED",
   "scripts": {
-    "build": "tsc && cp -f src/*.js src/*d.ts lib"
+    "build": "mkdir -p lib && cp -f src/*.js src/*d.ts lib && tsc"
   },
   "files": [
     "src",

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsc && cp -f src/*.js src/*d.ts lib",
+    "build": "mkdir -p lib && cp -f src/*.js src/*d.ts lib && tsc",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "test:brk": "yarn test --inspect-brk"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allow watch components using `yarn build -w`

When running yarn watch in `server` the three components handled here fail currently. The `-w` argument is appended to the last command which needs to be `tsc`.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8dcf710</samp>

The `build` scripts in three TypeScript packages were modified to copy the source files before or after running the TypeScript compiler. This improves the consistency and reliability of the generated lib directories.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Run `yarn watch` in `components/server` and verify there are no errors.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
