### PR TITLE
[JB GW]: Support ssh over websocket tunnel 

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     compileOnly("org.eclipse.jetty.websocket:websocket-api:9.4.44.v20210927")
     testImplementation(kotlin("test"))
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+    implementation("org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.44.v20210927")
 }
 
 // Configure gradle-intellij-plugin plugin.

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -13,7 +13,9 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.ui.Messages
+import com.intellij.remote.AuthType
 import com.intellij.remote.RemoteCredentialsHolder
+import com.intellij.remoteDev.util.onTerminationOrNow
 import com.intellij.ssh.AskAboutHostKey
 import com.intellij.ssh.OpenSshLikeHostKeyVerifier
 import com.intellij.ssh.connectionBuilder
@@ -24,6 +26,10 @@ import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.application
 import com.intellij.util.io.DigestUtil
+import com.intellij.util.io.await
+import com.intellij.util.io.delete
+import com.intellij.util.net.ssl.CertificateManager
+import com.intellij.util.proxy.CommonProxy
 import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
@@ -39,7 +45,6 @@ import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
 import io.gitpod.jetbrains.icons.GitpodIcons
 import kotlinx.coroutines.*
-import kotlinx.coroutines.future.await
 import java.net.URL
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -48,12 +53,16 @@ import java.time.Duration
 import java.util.*
 import javax.swing.JLabel
 import kotlin.coroutines.coroutineContext
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.writeText
+
 
 @Suppress("UnstableApiUsage", "OPT_IN_USAGE")
 class GitpodConnectionProvider : GatewayConnectionProvider {
     private val activeConnections = ConcurrentHashMap<String, LifetimeDefinition>()
     private val gitpod = service<GitpodConnectionService>()
     private val connectionHandleFactory = service<GitpodConnectionHandleFactory>()
+    private val settings = service<GitpodSettingsState>()
 
     private val httpClient = HttpClient.newBuilder()
         .followRedirects(HttpClient.Redirect.ALWAYS)
@@ -79,7 +88,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             parameters["debugWorkspace"] == "true"
         )
 
-        var connectionKeyId = "${connectParams.gitpodHost}-${connectParams.resolvedWorkspaceId}-${connectParams.backendPort}"
+        var connectionKeyId =
+            "${connectParams.gitpodHost}-${connectParams.resolvedWorkspaceId}-${connectParams.backendPort}"
 
         var found = true
         val connectionLifetime = activeConnections.computeIfAbsent(connectionKeyId) {
@@ -185,7 +195,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                         if (WorkspaceInstance.isUpToDate(lastUpdate, update)) {
                             continue
                         }
-                        resolvedIdeUrl = update.ideUrl.replace(connectParams.actualWorkspaceId, connectParams.resolvedWorkspaceId)
+                        resolvedIdeUrl =
+                            update.ideUrl.replace(connectParams.actualWorkspaceId, connectParams.resolvedWorkspaceId)
                         lastUpdate = update
                         if (!update.status.conditions.failed.isNullOrBlank()) {
                             setErrorMessage(update.status.conditions.failed)
@@ -195,34 +206,42 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                 phaseMessage.text = "Preparing"
                                 statusMessage.text = "Preparing workspace..."
                             }
+
                             "building" -> {
                                 phaseMessage.text = "Building"
                                 statusMessage.text = "Building workspace image..."
                             }
+
                             "pending" -> {
                                 phaseMessage.text = "Preparing"
                                 statusMessage.text = "Allocating resources …"
                             }
+
                             "creating" -> {
                                 phaseMessage.text = "Creating"
                                 statusMessage.text = "Pulling workspace image …"
                             }
+
                             "initializing" -> {
                                 phaseMessage.text = "Starting"
                                 statusMessage.text = "Initializing workspace content …"
                             }
+
                             "running" -> {
                                 phaseMessage.text = "Running"
                                 statusMessage.text = "Connecting..."
                             }
+
                             "interrupted" -> {
                                 phaseMessage.text = "Starting"
                                 statusMessage.text = "Checking workspace …"
                             }
+
                             "stopping" -> {
                                 phaseMessage.text = "Stopping"
                                 statusMessage.text = ""
                             }
+
                             "stopped" -> {
                                 if (update.status.conditions.timeout.isNullOrBlank()) {
                                     phaseMessage.text = "Stopped"
@@ -231,6 +250,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                 }
                                 statusMessage.text = ""
                             }
+
                             else -> {
                                 phaseMessage.text = ""
                                 statusMessage.text = ""
@@ -245,17 +265,28 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                         if (thinClientJob == null && update.status.phase == "running") {
                             thinClientJob = launch {
                                 try {
-                                    val hostKeys = resolveHostKeys(URL(update.ideUrl), connectParams)
-                                    if (hostKeys.isNullOrEmpty()) {
-                                        setErrorMessage("${connectParams.gitpodHost} installation does not allow SSH access, public keys cannot be found")
+                                    val ideUrl = URL(resolvedIdeUrl)
+                                    val ownerToken = client.server.getOwnerToken(update.workspaceId).await()
+
+                                    var credentials = resolveCredentialsWithDirectSSH(
+                                        ideUrl,
+                                        ownerToken,
+                                        connectParams,
+                                    )
+                                    if (credentials == null) {
+                                        credentials = resolveCredentialsWithWebSocketTunnel(
+                                            ideUrl,
+                                            ownerToken,
+                                            connectParams,
+                                            connectionLifetime
+                                        )
+                                    }
+                                    if (credentials == null) {
+                                        setErrorMessage("${connectParams.gitpodHost} installation does not allow SSH access")
                                         return@launch
                                     }
-                                    val ownerToken = client.server.getOwnerToken(update.workspaceId).await()
-                                    val sshHostUrl =
-                                        URL(resolvedIdeUrl.replace(connectParams.resolvedWorkspaceId, "${connectParams.resolvedWorkspaceId}.ssh"))
-                                    val credentials =
-                                        resolveCredentials(sshHostUrl, connectParams.resolvedWorkspaceId, ownerToken, hostKeys)
-                                    val joinLink = resolveJoinLink(URL(resolvedIdeUrl), ownerToken, connectParams)
+
+                                    val joinLink = resolveJoinLink(ideUrl, ownerToken, connectParams)
                                     if (joinLink.isNullOrEmpty()) {
                                         setErrorMessage("failed to fetch JetBrains Gateway Join Link.")
                                         return@launch
@@ -310,6 +341,95 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
         return connectionHandleFactory.createGitpodConnectionHandle(connectionLifetime, connectionPanel, connectParams)
     }
 
+    private suspend fun resolveCredentialsWithWebSocketTunnel(
+        ideUrl: URL,
+        ownerToken: String,
+        connectParams: ConnectParams,
+        connectionLifetime: Lifetime,
+    ): RemoteCredentialsHolder? {
+        val keyPair = createSSHKeyPair(ideUrl, connectParams, ownerToken)
+        if (keyPair == null || keyPair.privateKey.isNullOrEmpty()) {
+            return null
+        }
+
+        try {
+            val privateKeyFile = kotlin.io.path.createTempFile()
+            privateKeyFile.writeText(keyPair.privateKey)
+            connectionLifetime.onTerminationOrNow {
+                privateKeyFile.delete()
+            }
+
+            val proxies = CommonProxy.getInstance().select(ideUrl)
+            val sslContext = CertificateManager.getInstance().sslContext
+            val sshWebSocketServer = GitpodWebSocketTunnelServer(
+                "wss://${ideUrl.host}/_supervisor/tunnel/ssh",
+                ownerToken,
+                proxies,
+                sslContext
+            )
+            sshWebSocketServer.start(connectionLifetime)
+
+            var hostKeys = emptyList<SSHHostKey>()
+            if (keyPair.hostKey != null) {
+                hostKeys = listOf(SSHHostKey(keyPair.hostKey.type, keyPair.hostKey.value))
+            }
+
+            return resolveCredentials(
+                "localhost",
+                sshWebSocketServer.port,
+                "gitpod",
+                null,
+                privateKeyFile.absolutePathString(),
+                hostKeys
+            )
+        } catch (t: Throwable) {
+            thisLogger().error(
+                "${connectParams.gitpodHost}: web socket tunnel: failed to connect:",
+                t
+            )
+            return null
+        }
+    }
+
+    private suspend fun resolveCredentialsWithDirectSSH(
+        ideUrl: URL,
+        ownerToken: String,
+        connectParams: ConnectParams
+    ): RemoteCredentialsHolder? {
+        if (settings.forceHttpTunnel) {
+            return null
+        }
+        val hostKeys = resolveHostKeys(ideUrl, connectParams)
+        if (hostKeys.isNullOrEmpty()) {
+            thisLogger().error("${connectParams.gitpodHost}: direct SSH: failed to resolve host keys for")
+            return null
+        }
+
+        try {
+            val sshHostUrl =
+                URL(
+                    ideUrl.toString().replace(
+                        connectParams.resolvedWorkspaceId,
+                        "${connectParams.resolvedWorkspaceId}.ssh"
+                    )
+                )
+            return resolveCredentials(
+                sshHostUrl.host,
+                22,
+                connectParams.resolvedWorkspaceId,
+                ownerToken,
+                null,
+                hostKeys
+            )
+        } catch (t: Throwable) {
+            thisLogger().error(
+                "${connectParams.gitpodHost}: direct SSH: failed to resolve credentials",
+                t
+            )
+            return null
+        }
+    }
+
     private suspend fun resolveJoinLink(
         ideUrl: URL,
         ownerToken: String,
@@ -323,37 +443,64 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private fun resolveCredentials(
-        ideUrl: URL,
-        userName: String,
-        password: String,
+        host: String,
+        port: Int,
+        userName: String?,
+        password: String?,
+        privateKeyFile: String?,
         hostKeys: List<SSHHostKey>
     ): RemoteCredentialsHolder {
         val credentials = RemoteCredentialsHolder()
-        credentials.setHost(ideUrl.host)
-        credentials.port = 22
-        credentials.userName = userName
-        credentials.password = password
-        credentials.connectionBuilder(
+        credentials.setHost(host)
+        credentials.port = port
+        if (userName != null) {
+            credentials.userName = userName
+        }
+        if (password != null) {
+            credentials.password = password
+        } else if (privateKeyFile != null) {
+            credentials.setPrivateKeyFile(privateKeyFile)
+            credentials.authType = AuthType.KEY_PAIR
+        }
+        var builder = credentials.connectionBuilder(
             null,
             ProgressManager.getGlobalProgressIndicator(),
             false
-        )
-            .withParsingOpenSSHConfig(true)
-            .withSshConnectionConfig {
-            val hostKeyVerifier = it.hostKeyVerifier
-            if (hostKeyVerifier is OpenSshLikeHostKeyVerifier) {
-                val acceptHostKey = acceptHostKey(ideUrl, hostKeys)
-                it.copy(
-                    hostKeyVerifier = hostKeyVerifier.copy(
-                        acceptChangedHostKey = acceptHostKey,
-                        acceptUnknownHostKey = acceptHostKey
+        ).withParsingOpenSSHConfig(true)
+        if (hostKeys.isNotEmpty()) {
+            builder = builder.withSshConnectionConfig {
+                val hostKeyVerifier = it.hostKeyVerifier
+                if (hostKeyVerifier is OpenSshLikeHostKeyVerifier) {
+                    val acceptHostKey = acceptHostKey(host, hostKeys)
+                    it.copy(
+                        hostKeyVerifier = hostKeyVerifier.copy(
+                            acceptChangedHostKey = acceptHostKey,
+                            acceptUnknownHostKey = acceptHostKey
+                        )
                     )
-                )
-            } else {
-                it
+                } else {
+                    it
+                }
             }
-        }.connect()
+        }
+        builder.connect()
         return credentials
+    }
+
+    private suspend fun createSSHKeyPair(
+        ideUrl: URL,
+        connectParams: ConnectParams,
+        ownerToken: String
+    ): CreateSSHKeyPairResponse? {
+        val value =
+            fetchWS("https://${ideUrl.host}/_supervisor/v1/ssh_keys/create", connectParams, ownerToken)
+        if (value.isNullOrBlank()) {
+            return null
+        }
+        return with(jacksonMapper) {
+            propertyNamingStrategy = PropertyNamingStrategies.LowerCamelCaseStrategy()
+            readValue(value, object : TypeReference<CreateSSHKeyPairResponse>() {})
+        }
     }
 
     private suspend fun resolveHostKeys(
@@ -395,12 +542,12 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private fun acceptHostKey(
-        ideUrl: URL,
+        host: String,
         hostKeys: List<SSHHostKey>
     ): AskAboutHostKey {
         val hostKeysByType = hostKeys.groupBy({ it.type.lowercase() }) { it.hostKey }
         val acceptHostKey: AskAboutHostKey = { hostName, keyType, fingerprint, _ ->
-            if (hostName != ideUrl.host) {
+            if (hostName != host) {
                 false
             }
             val matchedHostKeys = hostKeysByType[keyType.lowercase()]
@@ -487,4 +634,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private data class SSHHostKey(val type: String, val hostKey: String)
+
+    private data class SSHPublicKey(val type: String, val value: String)
+
+    private data class CreateSSHKeyPairResponse(val privateKey: String, val hostKey: SSHPublicKey?)
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsConfigurable.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsConfigurable.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.dsl.builder.LabelPosition
-import com.intellij.ui.dsl.builder.bindText
-import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.layout.ValidationInfoBuilder
 
 class GitpodSettingsConfigurable : BoundConfigurable("Gitpod") {
@@ -23,11 +20,18 @@ class GitpodSettingsConfigurable : BoundConfigurable("Gitpod") {
             row {
                 textField()
                     .label("Gitpod Host:", LabelPosition.LEFT)
-                    .horizontalAlign(HorizontalAlign.FILL)
+                    .align(Align.FILL)
                     .bindText(state::gitpodHost)
                     .validationOnApply(::validateGitpodHost)
                     .validationOnInput(::validateGitpodHost)
             }
+            row {
+                checkBox("Force SSH over HTTP tunnel")
+                    .bindSelected(state::forceHttpTunnel)
+                    .comment("Helpful if you are behind a firewall/proxy that blocks SSH or " +
+                            "have complicated SSH setup (bastions, proxy jumps, etc.)")
+            }
+
         }
     }
 

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsState.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsState.kt
@@ -36,6 +36,15 @@ class GitpodSettingsState : PersistentStateComponent<GitpodSettingsState> {
             dispatcher.multicaster.didChange()
         }
 
+    var forceHttpTunnel: Boolean = false
+        set(value) {
+            if (value == field) {
+                return
+            }
+            field = value
+            dispatcher.multicaster.didChange()
+        }
+
     private interface Listener : EventListener {
         fun didChange()
     }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWebSocketTunnelServer.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWebSocketTunnelServer.kt
@@ -1,0 +1,215 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.jetbrains.rd.util.lifetime.Lifetime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.eclipse.jetty.client.HttpClient
+import org.eclipse.jetty.client.HttpProxy
+import org.eclipse.jetty.client.Socks4Proxy
+import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.websocket.jsr356.ClientContainer
+import java.net.*
+import java.nio.ByteBuffer
+import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.net.ssl.SSLContext
+import javax.websocket.*
+import javax.websocket.ClientEndpointConfig.Configurator
+import javax.websocket.MessageHandler.Partial
+
+class GitpodWebSocketTunnelServer(
+    private val url: String,
+    private val ownerToken: String,
+    private val proxies: List<Proxy>,
+    private val sslContext: SSLContext
+) {
+    private val serverSocket = ServerSocket(0) // pass 0 to have the system choose a free port
+
+    val port: Int
+        get() = serverSocket.localPort
+
+    private val clients = CopyOnWriteArrayList<GitpodWebSocketTunnelClient>()
+
+    fun start(lifetime: Lifetime) {
+        val job = GlobalScope.launch(Dispatchers.IO) {
+            thisLogger().info("gitpod: tunnel[$url]: listening on port $port")
+            try {
+                while (isActive) {
+                    try {
+                        val clientSocket = serverSocket.accept()
+                        launch(Dispatchers.IO) {
+                            handleClientConnection(clientSocket)
+                        }
+                    } catch (t: Throwable) {
+                        if (isActive) {
+                            thisLogger().error("gitpod: tunnel[$url]: failed to accept", t)
+                        }
+                    }
+                }
+            } catch (t: Throwable) {
+                if (isActive) {
+                    thisLogger().error("gitpod: tunnel[$url]: failed to listen", t)
+                }
+            } finally {
+                thisLogger().info("gitpod: tunnel[$url]: stopped")
+            }
+        }
+        lifetime.onTerminationOrNow {
+            job.cancel()
+            serverSocket.close()
+            clients.forEach { it.close() }
+            clients.clear()
+        }
+    }
+
+    private fun handleClientConnection(clientSocket: Socket) {
+        val socketClient = GitpodWebSocketTunnelClient(url, clientSocket)
+        try {
+            val inputStream = clientSocket.getInputStream()
+            val outputStream = clientSocket.getOutputStream()
+
+            // Forward data from WebSocket to TCP client
+            socketClient.onMessageCallback = { data ->
+                outputStream.write(data)
+                thisLogger().trace("gitpod: tunnel[$url]: received ${data.size} bytes")
+            }
+
+            connectToWebSocket(socketClient)
+
+            clients.add(socketClient)
+
+            val buffer = ByteArray(1024)
+            var read: Int
+            while (inputStream.read(buffer).also { read = it } != -1) {
+                // Forward data from TCP to WebSocket
+                socketClient.sendData(buffer.copyOfRange(0, read))
+                thisLogger().trace("gitpod: tunnel[$url]: sent $read bytes")
+            }
+        } catch (t: Throwable) {
+            if (t is SocketException && t.message?.contains("Socket closed") == true) {
+                return
+            }
+            thisLogger().error("gitpod: tunnel[$url]: failed to pipe", t)
+        } finally {
+            clients.remove(socketClient)
+            socketClient.close()
+        }
+    }
+
+    private fun connectToWebSocket(socketClient: GitpodWebSocketTunnelClient) {
+        val ssl: SslContextFactory = SslContextFactory.Client()
+        ssl.sslContext = sslContext
+        val httpClient = HttpClient(ssl)
+        for (proxy in proxies) {
+            if (proxy.type() == Proxy.Type.DIRECT) {
+                continue
+            }
+            val proxyAddress = proxy.address()
+            if (proxyAddress !is InetSocketAddress) {
+                thisLogger().warn("gitpod: tunnel[$url]: unexpected proxy: $proxy")
+                continue
+            }
+            val hostName = proxyAddress.hostString
+            val port = proxyAddress.port
+            if (proxy.type() == Proxy.Type.HTTP) {
+                httpClient.proxyConfiguration.proxies.add(HttpProxy(hostName, port))
+            } else if (proxy.type() == Proxy.Type.SOCKS) {
+                httpClient.proxyConfiguration.proxies.add(Socks4Proxy(hostName, port))
+            }
+        }
+        val container = ClientContainer(httpClient)
+
+        // stop container immediately since we close only when a session is already gone
+        container.setStopTimeout(0)
+
+        // allow clientContainer to own httpClient (for start/stop lifecycle)
+        container.client.addManaged(httpClient)
+        container.start()
+
+        // Create config to add custom headers
+        val config = ClientEndpointConfig.Builder.create()
+            .configurator(object : Configurator() {
+                override fun beforeRequest(headers: MutableMap<String, List<String>>) {
+                    headers["x-gitpod-owner-token"] = Collections.singletonList(ownerToken)
+                }
+            })
+            .build()
+
+        try {
+            socketClient.container = container;
+            container.connectToServer(socketClient, config, URI(url))
+        } catch (t: Throwable) {
+            container.stop()
+            throw t
+        }
+    }
+
+}
+
+class GitpodWebSocketTunnelClient(
+    private val url: String,
+    private val tcpSocket: Socket
+) : Endpoint(), Partial<ByteBuffer> {
+    private lateinit var webSocketSession: Session
+    var onMessageCallback: ((ByteArray) -> Unit)? = null
+    var container: ClientContainer? = null
+
+    override fun onOpen(session: Session, config: EndpointConfig) {
+        session.addMessageHandler(this)
+        this.webSocketSession = session
+    }
+
+    override fun onClose(session: Session, closeReason: CloseReason) {
+        thisLogger().info("gitpod: tunnel[$url]: closed ($closeReason)")
+        this.doClose()
+    }
+
+    override fun onError(session: Session?, thr: Throwable?) {
+        thisLogger().error("gitpod: tunnel[$url]: failed", thr)
+        this.doClose()
+    }
+
+    private fun doClose() {
+        try {
+            tcpSocket.close()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to close socket", t)
+        }
+        try {
+            container?.stop()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to stop container", t)
+        }
+    }
+
+    fun sendData(data: ByteArray) {
+        webSocketSession.asyncRemote.sendBinary(ByteBuffer.wrap(data))
+    }
+
+    fun close() {
+        try {
+            webSocketSession?.close()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to close", t)
+        }
+        try {
+            container?.stop()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to stop container", t)
+        }
+    }
+
+    override fun onMessage(partialMessage: ByteBuffer, last: Boolean) {
+        val data = ByteArray(partialMessage.remaining())
+        partialMessage.get(data)
+        onMessageCallback?.invoke(data)
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In some networks SSH either blocked or accessible via complicated setup (bastions, proxy jumps). This PR introduces an alternative mode of connectivity via HTTP tunnel directly into Gitpod workspace, i.e. work around SSH Gateway. This mode is either picked is a fallback or a user can force it in settings.

✅ depends on https://github.com/gitpod-io/gitpod/pull/18411

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 936f0a9</samp>

This pull request adds support for different SSH connection methods to the JetBrains IDE plugin, and includes the generated Java code for the supervisor API. It modifies the `GitpodConnectionProvider.kt` file to implement the new features, and adds the `GitpodWebSocketTunnelServer.kt` file to enable web socket tunneling. It also removes the `api` folder from the `.gitignore` file and adds the `InfoServiceGrpc.java` file to the repository.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-279

## How to test
<!-- Provide steps to test this PR -->

- Download a plugin from the dev channel corresponding to this branch: https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev (version should start from **0.0.1-ak-jb_gw_web_socket_tunnel**)
- Install it from the disk in your JetBrains Gateway, apply and restart.
- Check that you have in preferences now `Force SSH over HTTP tunnel` setting, leave it disabled for now.
- Start a workspace on Dogfood (or gitpod.io if you are trying after IDE deployment later today) using some JB IDE.
- Verify that you can connect over HTTP tunnel and features like port forwarding and `gp preview` still working. You can check that in GW idea.log you don't have yet logs with prefixes like `gitpod: tunnel`
- Now close the client, enable HTTP tunnel in settings, and try everything again. Everything should work still, in logs you will see now `gitpod: tunnel`. When a client is clsoed, you should see a log that the tunnel is stopped.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
