### PR TITLE
[gated-release] trigger staging/prod install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
                 "version": '${{ needs.configuration.outputs.version }}',
                 "repo": "https://github.com/gitpod-io/gitpod",
                 "commit": "${{github.sha}}",
-                "env": ${{ matrix.env }}
+                "env": "${{ matrix.env }}"
               }
             })
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,6 +289,10 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [ configuration, build-gitpod, create-runner ]
     if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [ staging, production ]
     steps:
       - uses: gitpod-io/gh-app-auth@v0.1
         id: auth
@@ -297,10 +301,6 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: trigger installation
-        strategy:
-          fail-fast: false
-          matrix:
-            env: [ staging, production ]
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   pull_request:
-    types: [opened, edited]
+    types: [ opened, edited ]
   push:
   workflow_dispatch:
     inputs:
@@ -24,7 +24,7 @@ jobs:
   configuration:
     name: Configure job parameters
     runs-on: ${{ needs.create-runner.outputs.label }}
-    needs: [create-runner]
+    needs: [ create-runner ]
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-configuration
       cancel-in-progress: true
@@ -91,7 +91,7 @@ jobs:
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
       (needs.configuration.outputs.preview_enable == 'true')
-    needs: [configuration, create-runner]
+    needs: [ configuration, create-runner ]
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-previewctl
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
@@ -114,7 +114,7 @@ jobs:
           echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}" -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
 
   infrastructure:
-    needs: [configuration, build-previewctl, create-runner]
+    needs: [ configuration, build-previewctl, create-runner ]
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
       (needs.configuration.outputs.preview_enable == 'true') &&
@@ -138,7 +138,7 @@ jobs:
 
   build-gitpod:
     name: Build Gitpod
-    needs: [configuration, create-runner]
+    needs: [ configuration, create-runner ]
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-gitpod
@@ -287,7 +287,7 @@ jobs:
 
   install-app:
     runs-on: ${{ needs.create-runner.outputs.label }}
-    needs: [configuration, build-gitpod, create-runner]
+    needs: [ configuration, build-gitpod, create-runner ]
     if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
     steps:
       - uses: gitpod-io/gh-app-auth@v0.1
@@ -297,6 +297,10 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: trigger installation
+        strategy:
+          fail-fast: false
+          matrix:
+            env: [ staging, production ]
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
@@ -307,7 +311,10 @@ jobs:
               workflow_id: 'install-app.yaml',
               ref: 'main',
               inputs: {
-                "version": '${{ needs.configuration.outputs.version }}'
+                "version": '${{ needs.configuration.outputs.version }}',
+                "installation_repo": "https://github.com/gitpod-io/gitpod",
+                "installation_commit": "${{github.sha}}",
+                "env": ${{ matrix.env }}
               }
             })
 
@@ -362,7 +369,7 @@ jobs:
 
   monitoring:
     name: "Install Monitoring Satellite"
-    needs: [infrastructure, build-previewctl, create-runner]
+    needs: [ infrastructure, build-previewctl, create-runner ]
     runs-on: ${{ needs.create-runner.outputs.label }}
     if: needs.configuration.outputs.with_monitoring == 'true'
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,8 +312,8 @@ jobs:
               ref: 'main',
               inputs: {
                 "version": '${{ needs.configuration.outputs.version }}',
-                "installation_repo": "https://github.com/gitpod-io/gitpod",
-                "installation_commit": "${{github.sha}}",
+                "repo": "https://github.com/gitpod-io/gitpod",
+                "commit": "${{github.sha}}",
                 "env": ${{ matrix.env }}
               }
             })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This depends on ENG-513 being done, before getting it merged



<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88d70f2</samp>

This pull request enhances the GitHub workflow for building and installing the Gitpod app. It refactors the `build.yml` file and adds support for multiple deployment environments.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-511

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
