### PR TITLE
Enable leader election in ws-manager-mk2

### DIFF
--- a/components/ws-manager-mk2/cmd/sample-workspace/main.go
+++ b/components/ws-manager-mk2/cmd/sample-workspace/main.go
@@ -10,10 +10,11 @@ import (
 	"log"
 	"time"
 
-	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
+
+	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 )
 
 func main() {

--- a/components/ws-manager-mk2/config/manager/manager.yaml
+++ b/components/ws-manager-mk2/config/manager/manager.yaml
@@ -33,8 +33,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -68,13 +68,9 @@ func init() {
 }
 
 func main() {
-	var enableLeaderElection bool
 	var configFN string
 	var jsonLog bool
 	var verbose bool
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&configFN, "config", "", "Path to the config file")
 	flag.BoolVar(&jsonLog, "json-log", true, "produce JSON log output on verbose level")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
@@ -125,7 +121,7 @@ func main() {
 		MetricsBindAddress:     cfg.Prometheus.Addr,
 		Port:                   9443,
 		HealthProbeBindAddress: cfg.Health.Addr,
-		LeaderElection:         enableLeaderElection,
+		LeaderElection:         true,
 		LeaderElectionID:       "ws-manager-mk2-leader.gitpod.io",
 		NewCache:               cache.MultiNamespacedCacheBuilder([]string{cfg.Manager.Namespace, cfg.Manager.SecretsNamespace}),
 	})

--- a/install/installer/pkg/components/ws-manager-mk2/deployment.go
+++ b/install/installer/pkg/components/ws-manager-mk2/deployment.go
@@ -5,10 +5,6 @@
 package wsmanagermk2
 
 import (
-	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -16,6 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -176,7 +177,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: common.Replicas(ctx, Component),
+				Replicas: pointer.Int32(2),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/ws-manager-mk2/deployment.go
+++ b/install/installer/pkg/components/ws-manager-mk2/deployment.go
@@ -59,7 +59,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Name: Component,
 			Args: []string{
 				"--config", "/config/config.json",
-				"--leader-elect",
 			},
 			Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManagerMk2.Version),
 			ImagePullPolicy: corev1.PullIfNotPresent,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4df6f5</samp>

This pull request enhances the ws-manager-mk2 component, which is responsible for managing workspaces in Gitpod. It fixes an import error, removes an unnecessary flag, and enables leader election for the controller.

</details>

## Related Issue(s)
Fixes ENG-53

## How to test
- Open the Preview environment and check workspaces work as expected
- Kill one of the ws-manager-mk2 pods and check the logs of the remaining one, checking for the leader election

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-ha-mk2</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-ha-mk2.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-ha-mk2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-ha-mk2-gha.14639</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
