### PR TITLE
Update workspaces list

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -93,7 +93,7 @@ function ContextMenu(props: ContextMenuProps) {
     );
 
     return (
-        <div className="relative">
+        <div className="relative inline-block">
             <div
                 className="cursor-pointer"
                 onClick={(e) => {

--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -6,7 +6,6 @@
 
 import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
 import ContextMenu, { ContextMenuEntry } from "./ContextMenu";
-import CaretDown from "../icons/CaretDown.svg";
 import { useFeatureFlag } from "../data/featureflag-query";
 
 export default function PendingChangesDropdown(props: { workspaceInstance?: WorkspaceInstance }) {
@@ -45,16 +44,15 @@ export default function PendingChangesDropdown(props: { workspaceInstance?: Work
         }
     }
     if (totalChanges <= 0) {
-        return <div className="text-sm text-gray-400 dark:text-gray-500">No Changes</div>;
+        return <></>;
     }
     return (
         <ContextMenu menuEntries={menuEntries} customClasses="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0">
-            <p className="flex justify-center text-gitpod-red">
-                <span>
-                    {totalChanges} Change{totalChanges === 1 ? "" : "s"}
+            <span className="inline" title="Pending Changes">
+                <span className="bg-gitpod-red text-gray-50 rounded-xl px-1.5 py-0.5 text-xs ml-2 font-medium">
+                    {totalChanges}
                 </span>
-                <img className="m-2" src={CaretDown} alt="caret icon pointing down" />
-            </p>
+            </span>
         </ContextMenu>
     );
 }

--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -99,7 +99,7 @@ export default function Menu() {
                             </ul>
                         </nav>
                         {/* Hide normal user menu on small screens */}
-                        <UserMenu user={user} className="hidden md:block" />
+                        <UserMenu user={user} className="hidden md:block h-10" />
                         {/* Show a user menu w/ admin & feedback links on small screens */}
                         <UserMenu
                             user={user}

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -4,18 +4,11 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import {
-    CommitContext,
-    Workspace,
-    WorkspaceInfo,
-    ContextURL,
-    WorkspaceInstanceRepoStatus,
-} from "@gitpod/gitpod-protocol";
+import { CommitContext, Workspace, WorkspaceInfo, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { FunctionComponent, useMemo, useState } from "react";
 import { Item, ItemField, ItemFieldIcon } from "../components/ItemsList";
 import PendingChangesDropdown from "../components/PendingChangesDropdown";
-import Tooltip from "../components/Tooltip";
 import dayjs from "dayjs";
 import { WorkspaceEntryOverflowMenu } from "./WorkspaceOverflowMenu";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
@@ -40,8 +33,6 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
     const workspace = info.workspace;
     const currentBranch = repo?.branch || Workspace.getBranchName(info.workspace) || "<unknown>";
     const project = getProjectPath(workspace);
-    const normalizedContextUrl = ContextURL.getNormalizedURL(workspace)?.toString();
-    const normalizedContextUrlDescription = normalizedContextUrl || workspace.contextURL; // Instead of showing nothing, we prefer to show the raw content instead
 
     const changeMenuState = (state: boolean) => {
         setMenuActive(state);
@@ -64,50 +55,25 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
             <ItemFieldIcon>
                 <WorkspaceStatusIndicator instance={info?.latestInstance} />
             </ItemFieldIcon>
-            <ItemField className="w-3/12 flex flex-col my-auto">
+            <ItemField className="w-3/12 my-auto">
                 <a href={startUrl}>
-                    <div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
-                        {workspace.id}
+                    <span className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400 max-w-xs overflow-hidden whitespace-nowrap truncate">
+                        {true ? currentBranch : "Custom description (branch)"}
+                    </span>
+                </a>
+                <span className="text-gray-300 font-normal inline-block px-1">&middot;</span>
+                <span className="text-sm w-full text-gray-400 overflow-ellipsis font-normal truncate">
+                    {dayjs(WorkspaceInfo.lastActiveISODate(info)).fromNow()}
+                </span>
+                <PendingChangesDropdown workspaceInstance={info.latestInstance} />
+
+                <a href={project ? "https://" + project : undefined}>
+                    <div className="text-sm overflow-ellipsis truncate text-gray-500 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 max-w-32">
+                        {project || "Unknown"}
                     </div>
                 </a>
-                <Tooltip content={project ? "https://" + project : ""} allowWrap={true}>
-                    <a href={project ? "https://" + project : undefined}>
-                        <div className="text-sm overflow-ellipsis truncate text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400">
-                            {project || "Unknown"}
-                        </div>
-                    </a>
-                </Tooltip>
             </ItemField>
-            {!shortVersion && (
-                <>
-                    <ItemField className="w-4/12 flex flex-col my-auto">
-                        <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
-                            {workspace.description}
-                        </div>
-                        <a href={normalizedContextUrl}>
-                            <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">
-                                {normalizedContextUrlDescription}
-                            </div>
-                        </a>
-                    </ItemField>
-                    <ItemField className="w-2/12 flex flex-col my-auto">
-                        <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
-                            <Tooltip content={currentBranch}>{currentBranch}</Tooltip>
-                        </div>
-                        <div className="mr-auto">
-                            <PendingChangesDropdown workspaceInstance={info.latestInstance} />
-                        </div>
-                    </ItemField>
-                    <ItemField className="w-2/12 flex my-auto">
-                        <Tooltip content={`Created ${dayjs(info.workspace.creationTime).fromNow()}`}>
-                            <div className="text-sm w-full text-gray-400 overflow-ellipsis truncate">
-                                {dayjs(WorkspaceInfo.lastActiveISODate(info)).fromNow()}
-                            </div>
-                        </Tooltip>
-                    </ItemField>
-                    <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
-                </>
-            )}
+            <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
         </Item>
     );
 };

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
                 rose: colors.rose,
                 "gitpod-black": "#161616",
                 "gitpod-gray": "#8E8787",
-                "gitpod-red": "#CE4A3E",
+                "gitpod-red": "#E05634",
                 "gitpod-kumquat-light": "#FFE4BC",
                 "gitpod-kumquat": "#FFB45B",
                 "gitpod-kumquat-dark": "#FF8A00",


### PR DESCRIPTION
## Description

An attempt to improve the workspaces list UX, based on the [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1690561717746299) (internal).

| BEFORE | AFTER |
|--------|--------|
| <img width="1512" alt="Frame 1729" src="https://github.com/gitpod-io/gitpod/assets/120486/536014ee-41c0-457e-83a2-2db57f805edf"> | <img width="1512" alt="Frame 1730" src="https://github.com/gitpod-io/gitpod/assets/120486/af141db9-825f-4d0e-89eb-c10e3eb3adbb"> | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06427ee</samp>

Improved the UI of the dashboard by simplifying the `PendingChangesDropdown` and `WorkspaceEntry` components, fixing the alignment and contrast of the `ContextMenu` and `UserMenu` components, and adjusting the `gitpod-red` color.

</details>

## How to test

Start a few workspaces, and see if the information on the workspaces list helps you find what you want. 🧪 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
