### PR TITLE
Ak/jb gw tunnel old (do not merge)

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     compileOnly("org.eclipse.jetty.websocket:websocket-api:9.4.44.v20210927")
     testImplementation(kotlin("test"))
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+    implementation("org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.44.v20210927")
 }
 
 // Configure gradle-intellij-plugin plugin.

--- a/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=232.8660
-pluginUntilBuild=232.*
+pluginSinceBuild=231.9161
+pluginUntilBuild=231.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2023.2
+pluginVerifierIdeVersions=2023.1
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=232.8660-EAP-CANDIDATE-SNAPSHOT
+platformVersion=231.9161-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -1,5 +1,5 @@
 # Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
-environmentName=latest
+environmentName=stable
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=io.gitpod.jetbrains

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -43,6 +43,7 @@ import com.jetbrains.rd.util.URI
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
+import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
 import io.gitpod.jetbrains.icons.GitpodIcons
 import kotlinx.coroutines.*
 import java.net.URL

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -26,7 +26,6 @@ import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.application
 import com.intellij.util.io.DigestUtil
-import com.intellij.util.io.await
 import com.intellij.util.io.delete
 import com.intellij.util.net.ssl.CertificateManager
 import com.intellij.util.proxy.CommonProxy
@@ -46,6 +45,7 @@ import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
 import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
 import io.gitpod.jetbrains.icons.GitpodIcons
 import kotlinx.coroutines.*
+import kotlinx.coroutines.future.await
 import java.net.URL
 import java.net.http.HttpClient
 import java.net.http.HttpRequest

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsConfigurable.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsConfigurable.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.dsl.builder.LabelPosition
-import com.intellij.ui.dsl.builder.bindText
-import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.layout.ValidationInfoBuilder
 
 class GitpodSettingsConfigurable : BoundConfigurable("Gitpod") {
@@ -23,11 +20,18 @@ class GitpodSettingsConfigurable : BoundConfigurable("Gitpod") {
             row {
                 textField()
                     .label("Gitpod Host:", LabelPosition.LEFT)
-                    .horizontalAlign(HorizontalAlign.FILL)
+                    .align(Align.FILL)
                     .bindText(state::gitpodHost)
                     .validationOnApply(::validateGitpodHost)
                     .validationOnInput(::validateGitpodHost)
             }
+            row {
+                checkBox("Force SSH over HTTP tunnel")
+                    .bindSelected(state::forceHttpTunnel)
+                    .comment("Helpful if you are behind a firewall/proxy that blocks SSH or " +
+                            "have complicated SSH setup (bastions, proxy jumps, etc.)")
+            }
+
         }
     }
 

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsState.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodSettingsState.kt
@@ -36,6 +36,15 @@ class GitpodSettingsState : PersistentStateComponent<GitpodSettingsState> {
             dispatcher.multicaster.didChange()
         }
 
+    var forceHttpTunnel: Boolean = false
+        set(value) {
+            if (value == field) {
+                return
+            }
+            field = value
+            dispatcher.multicaster.didChange()
+        }
+
     private interface Listener : EventListener {
         fun didChange()
     }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWebSocketTunnelServer.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWebSocketTunnelServer.kt
@@ -1,0 +1,212 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.jetbrains.rd.util.lifetime.Lifetime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.eclipse.jetty.client.HttpClient
+import org.eclipse.jetty.client.HttpProxy
+import org.eclipse.jetty.client.Socks4Proxy
+import org.eclipse.jetty.util.ssl.SslContextFactory
+import org.eclipse.jetty.websocket.jsr356.ClientContainer
+import java.net.*
+import java.nio.ByteBuffer
+import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.net.ssl.SSLContext
+import javax.websocket.*
+import javax.websocket.ClientEndpointConfig.Configurator
+import javax.websocket.MessageHandler.Partial
+
+class GitpodWebSocketTunnelServer(
+    private val url: String,
+    private val ownerToken: String,
+    private val proxies: List<Proxy>,
+    private val sslContext: SSLContext
+) {
+    private val serverSocket = ServerSocket(0) // pass 0 to have the system choose a free port
+
+    val port: Int
+        get() = serverSocket.localPort
+
+    private val clients = CopyOnWriteArrayList<GitpodWebSocketTunnelClient>()
+
+    fun start(lifetime: Lifetime) {
+        val job = GlobalScope.launch(Dispatchers.IO) {
+            thisLogger().info("gitpod: tunnel[$url]: listening on port $port")
+            try {
+                while (isActive) {
+                    try {
+                        val clientSocket = serverSocket.accept()
+                        launch(Dispatchers.IO) {
+                            handleClientConnection(clientSocket)
+                        }
+                    } catch (t: Throwable) {
+                        if (isActive) {
+                            thisLogger().error("gitpod: tunnel[$url]: failed to accept", t)
+                        }
+                    }
+                }
+            } catch (t: Throwable) {
+                if (isActive) {
+                    thisLogger().error("gitpod: tunnel[$url]: failed to listen", t)
+                }
+            } finally {
+                thisLogger().info("gitpod: tunnel[$url]: stopped")
+            }
+        }
+        lifetime.onTerminationOrNow {
+            job.cancel()
+            serverSocket.close()
+            clients.forEach { it.close() }
+            clients.clear()
+        }
+    }
+
+    private fun handleClientConnection(clientSocket: Socket) {
+        val socketClient = GitpodWebSocketTunnelClient(url, clientSocket)
+        try {
+            val inputStream = clientSocket.getInputStream()
+            val outputStream = clientSocket.getOutputStream()
+
+            // Forward data from WebSocket to TCP client
+            socketClient.onMessageCallback = { data ->
+                outputStream.write(data)
+                thisLogger().trace("gitpod: tunnel[$url]: received ${data.size} bytes")
+            }
+
+            connectToWebSocket(socketClient)
+
+            clients.add(socketClient)
+
+            val buffer = ByteArray(1024)
+            var read: Int
+            while (inputStream.read(buffer).also { read = it } != -1) {
+                // Forward data from TCP to WebSocket
+                socketClient.sendData(buffer.copyOfRange(0, read))
+                thisLogger().trace("gitpod: tunnel[$url]: sent $read bytes")
+            }
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to pipe", t)
+        } finally {
+            clients.remove(socketClient)
+            socketClient.close()
+        }
+    }
+
+    private fun connectToWebSocket(socketClient: GitpodWebSocketTunnelClient) {
+        val ssl: SslContextFactory = SslContextFactory.Client()
+        ssl.sslContext = sslContext
+        val httpClient = HttpClient(ssl)
+        for (proxy in proxies) {
+            if (proxy.type() == Proxy.Type.DIRECT) {
+                continue
+            }
+            val proxyAddress = proxy.address()
+            if (proxyAddress !is InetSocketAddress) {
+                thisLogger().warn("gitpod: tunnel[$url]: unexpected proxy: $proxy")
+                continue
+            }
+            val hostName = proxyAddress.hostString
+            val port = proxyAddress.port
+            if (proxy.type() == Proxy.Type.HTTP) {
+                httpClient.proxyConfiguration.proxies.add(HttpProxy(hostName, port))
+            } else if (proxy.type() == Proxy.Type.SOCKS) {
+                httpClient.proxyConfiguration.proxies.add(Socks4Proxy(hostName, port))
+            }
+        }
+        val container = ClientContainer(httpClient)
+
+        // stop container immediately since we close only when a session is already gone
+        container.setStopTimeout(0)
+
+        // allow clientContainer to own httpClient (for start/stop lifecycle)
+        container.client.addManaged(httpClient)
+        container.start()
+
+        // Create config to add custom headers
+        val config = ClientEndpointConfig.Builder.create()
+            .configurator(object : Configurator() {
+                override fun beforeRequest(headers: MutableMap<String, List<String>>) {
+                    headers["x-gitpod-owner-token"] = Collections.singletonList(ownerToken)
+                }
+            })
+            .build()
+
+        try {
+            socketClient.container = container;
+            container.connectToServer(socketClient, config, URI(url))
+        } catch (t: Throwable) {
+            container.stop()
+            throw t
+        }
+    }
+
+}
+
+class GitpodWebSocketTunnelClient(
+    private val url: String,
+    private val tcpSocket: Socket
+) : Endpoint(), Partial<ByteBuffer> {
+    private lateinit var webSocketSession: Session
+    var onMessageCallback: ((ByteArray) -> Unit)? = null
+    var container: ClientContainer? = null
+
+    override fun onOpen(session: Session, config: EndpointConfig) {
+        session.addMessageHandler(this)
+        this.webSocketSession = session
+    }
+
+    override fun onClose(session: Session, closeReason: CloseReason) {
+        thisLogger().info("gitpod: tunnel[$url]: closed ($closeReason)")
+        this.doClose()
+    }
+
+    override fun onError(session: Session?, thr: Throwable?) {
+        thisLogger().error("gitpod: tunnel[$url]: failed", thr)
+        this.doClose()
+    }
+
+    private fun doClose() {
+        try {
+            tcpSocket.close()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to close socket", t)
+        }
+        try {
+            container?.stop()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to stop container", t)
+        }
+    }
+
+    fun sendData(data: ByteArray) {
+        webSocketSession.asyncRemote.sendBinary(ByteBuffer.wrap(data))
+    }
+
+    fun close() {
+        try {
+            webSocketSession?.close()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to close", t)
+        }
+        try {
+            container?.stop()
+        } catch (t: Throwable) {
+            thisLogger().error("gitpod: tunnel[$url]: failed to stop container", t)
+        }
+    }
+
+    override fun onMessage(partialMessage: ByteBuffer, last: Boolean) {
+        val data = ByteArray(partialMessage.remaining())
+        partialMessage.get(data)
+        onMessageCallback?.invoke(data)
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/common/GitpodConnectionHandleFactory.kt
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.common
+
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodConnectionProvider
+import javax.swing.JComponent
+
+@Suppress("UnstableApiUsage")
+interface GitpodConnectionHandleFactory {
+    fun createGitpodConnectionHandle(
+            lifetime: Lifetime,
+            component: JComponent,
+            params: GitpodConnectionProvider.ConnectParams
+    ): GatewayConnectionHandle
+
+    suspend fun connect(
+        lifetime: Lifetime,
+        connector: com.jetbrains.gateway.ssh.HostTunnelConnector,
+        tcpJoinLink: java.net.URI
+    ): com.jetbrains.gateway.thinClientLink.ThinClientHandle
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectionHandle.kt
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.latest
+
+import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
+import com.jetbrains.gateway.api.CustomConnectionFrameContext
+import com.jetbrains.gateway.api.GatewayConnectionHandle
+import com.jetbrains.gateway.ssh.ClientOverSshTunnelConnector
+import com.jetbrains.gateway.ssh.HostTunnelConnector
+import com.jetbrains.gateway.thinClientLink.ThinClientHandle
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
+import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
+import java.net.URI
+import javax.swing.JComponent
+
+class GitpodConnectionHandle(
+        lifetime: Lifetime,
+        private val component: JComponent,
+        private val params: ConnectParams
+) : GatewayConnectionHandle(lifetime) {
+    override fun customComponentProvider(lifetime: Lifetime) = object : CustomConnectionFrameComponentProvider {
+        override val closeConfirmationText = "Disconnect from ${getTitle()}?"
+        override fun createComponent(context: CustomConnectionFrameContext) = component
+    }
+
+    override fun getTitle(): String {
+        return params.title
+    }
+
+    override fun hideToTrayOnStart(): Boolean {
+        return false
+    }
+}
+@Suppress("UnstableApiUsage")
+class LatestGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
+    override fun createGitpodConnectionHandle(
+            lifetime: Lifetime,
+            component: JComponent,
+            params: ConnectParams
+    ): GatewayConnectionHandle {
+        return GitpodConnectionHandle(lifetime, component, params)
+    }
+
+    override suspend fun connect(lifetime: Lifetime, connector: HostTunnelConnector, tcpJoinLink: URI): ThinClientHandle {
+        return ClientOverSshTunnelConnector(
+            lifetime,
+            connector
+        ).connect(tcpJoinLink)
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectionHandle.kt
@@ -2,9 +2,8 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.gateway
+package io.gitpod.jetbrains.gateway.stable
 
-import com.intellij.openapi.components.Service
 import com.jetbrains.gateway.api.CustomConnectionFrameComponentProvider
 import com.jetbrains.gateway.api.CustomConnectionFrameContext
 import com.jetbrains.gateway.api.GatewayConnectionHandle
@@ -13,6 +12,7 @@ import com.jetbrains.gateway.ssh.HostTunnelConnector
 import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.gateway.GitpodConnectionProvider.ConnectParams
+import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
 import java.net.URI
 import javax.swing.JComponent
 
@@ -21,7 +21,7 @@ class GitpodConnectionHandle(
         private val component: JComponent,
         private val params: ConnectParams
 ) : GatewayConnectionHandle(lifetime) {
-    override fun customComponentProvider(lifetime: Lifetime) = object : CustomConnectionFrameComponentProvider {
+    override fun customComponentProvider() = object : CustomConnectionFrameComponentProvider {
         override val closeConfirmationText = "Disconnect from ${getTitle()}?"
         override fun createComponent(context: CustomConnectionFrameContext) = component
     }
@@ -34,10 +34,10 @@ class GitpodConnectionHandle(
         return false
     }
 }
+
 @Suppress("UnstableApiUsage")
-@Service
-class GitpodConnectionHandleFactory {
-    fun createGitpodConnectionHandle(
+class StableGitpodConnectionHandleFactory : GitpodConnectionHandleFactory {
+    override fun createGitpodConnectionHandle(
             lifetime: Lifetime,
             component: JComponent,
             params: ConnectParams
@@ -45,10 +45,11 @@ class GitpodConnectionHandleFactory {
         return GitpodConnectionHandle(lifetime, component, params)
     }
 
-    suspend fun connect(lifetime: Lifetime, connector: HostTunnelConnector, tcpJoinLink: URI): ThinClientHandle {
+    override suspend fun connect(lifetime: Lifetime, connector: HostTunnelConnector, tcpJoinLink: URI): ThinClientHandle {
         return ClientOverSshTunnelConnector(
             lifetime,
-            connector
-        ).connect(tcpJoinLink)
+            connector,
+            tcpJoinLink
+        ).connect()
     }
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -5,6 +5,8 @@
 -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory"
+                            serviceImplementation="io.gitpod.jetbrains.gateway.latest.LatestGitpodConnectionHandleFactory"/>
     </extensions>
     <extensions defaultExtensionNs="com.jetbrains">
     </extensions>

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -5,6 +5,8 @@
 -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory"
+                            serviceImplementation="io.gitpod.jetbrains.gateway.stable.StableGitpodConnectionHandleFactory"/>
     </extensions>
     <extensions defaultExtensionNs="com.jetbrains">
     </extensions>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44ed59e</samp>

This pull request adds support for WebSocket tunneling for SSH connections to the Gitpod JetBrains Gateway plugin. It also updates the plugin to work with multiple versions of the IntelliJ Platform and the JetBrains Gateway plugin, and adds a new setting to force the use of HTTP tunneling. It modifies several Kotlin files and Gradle properties files, and adds some new files and classes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
