### PR TITLE
[supervisor-api] don't generate java typings separately

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -52,7 +52,6 @@ tasks:
           (cd install/installer && make deps)
           exit 0
     - name: Java
-      init: leeway run components/supervisor-api:generate-java
       command: |
           if [ -z "$RUN_GRADLE_TASK" ]; then
             read -r -p "Press enter to continue Java gradle task"

--- a/components/supervisor-api/BUILD.yaml
+++ b/components/supervisor-api/BUILD.yaml
@@ -7,16 +7,3 @@ packages:
     config:
       commands:
         - ["echo"]
-  - name: java
-    type: generic
-    srcs:
-      - "*.proto"
-      - "third_party/**/*.proto"
-      - "generate-java.sh"
-    config:
-      commands:
-        - ["./generate-java.sh"]
-scripts:
-  - name: generate-java
-    description: Generate Java files from Surpervisor API proto files
-    script: ./generate-java.sh

--- a/components/supervisor-api/generate.sh
+++ b/components/supervisor-api/generate.sh
@@ -47,3 +47,6 @@ local_go_protoc "$COMPONENTS_DIR"
 go_protoc_gateway "$COMPONENTS_DIR"
 ./generate-java.sh
 update_license
+
+# remove trailing whitespace
+find "$COMPONENTS_DIR/supervisor-api/java" -name "*.java" -type f -print0 | xargs -0 pre-commit run trailing-whitespace --files

--- a/components/supervisor-api/java/BUILD.yaml
+++ b/components/supervisor-api/java/BUILD.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: lib
     type: generic
-    deps:
-      - components/supervisor-api:java
     srcs:
       - "**/*.java"
       - "build.gradle"
@@ -12,5 +10,4 @@ packages:
       - "settings.gradle"
     config:
       commands:
-        - ["cp", "-r", "components-supervisor-api--java/java/src/main/java", "src/main"]
         - ["./gradlew", "build"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

to avoid ditry changes


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34591b2</samp>

Simplify the generation of Java files for the supervisor-api component by using a script instead of a separate leeway target and manual copy. Remove unnecessary commands and files related to the old generation process.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- build should pass
- you can also open this PR on gitpod.io and see that there are not dirty change when leeway finish init


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
