### PR TITLE
[dev] Blowtorch: minor fix for current kubernetes version

### DIFF
--- a/dev/blowtorch/pkg/dart/injector.go
+++ b/dev/blowtorch/pkg/dart/injector.go
@@ -133,6 +133,7 @@ func Inject(cfg *rest.Config, namespace, targetService string, options ...Inject
 
 	renamedSpec := oldService.Spec.DeepCopy()
 	renamedSpec.ClusterIP = ""
+	renamedSpec.ClusterIPs = []string{}
 	renamedMeta := oldService.ObjectMeta.DeepCopy()
 	renamedMeta.Name = fmt.Sprintf(fmtOriginalService, oldService.Name)
 	renamedMeta.ResourceVersion = ""
@@ -162,6 +163,7 @@ func Inject(cfg *rest.Config, namespace, targetService string, options ...Inject
 
 	newSpec := oldService.Spec.DeepCopy()
 	newSpec.ClusterIP = ""
+	newSpec.ClusterIPs = []string{}
 	newSpec.Selector = labels
 	newMeta := oldService.ObjectMeta.DeepCopy()
 	if newMeta.Labels == nil {
@@ -333,6 +335,8 @@ func Remove(cfg *rest.Config, namespace, targetService string) error {
 		GracePeriodSeconds: &gracePeriod,
 	})
 	if err != nil {
+
+		log.Info("tried to: proxy deployment deleted")
 		return err
 	}
 	log.WithField("name", pdp).Info("proxy deployment deleted")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5bf5fa</samp>

Remove an unnecessary word from `test/README.md` that was likely added by mistake.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-reproduce-grpc</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-reproduce-grpc.preview.gitpod-dev.com/workspaces" target="_blank">gpl-reproduce-grpc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-reproduce-grpc-gha.14737</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
