### PR TITLE
[server] FIx missing User.fullName attribute for SSO users – EXP-365

### DIFF
--- a/components/server/src/iam/iam-oidc-create-session-payload.ts
+++ b/components/server/src/iam/iam-oidc-create-session-payload.ts
@@ -71,6 +71,9 @@ export interface OIDCCreateSessionPayload {
         Expiry: string; // "2023-01-10T12:00:00Z",
         IssuedAt: string; // "2023-01-01T12:00:00Z",
     };
+    /**
+     * https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+     */
     claims: {
         aud: string;
         email: string;
@@ -80,10 +83,16 @@ export interface OIDCCreateSessionPayload {
         hd?: string; // accepted domain, e.g. "gitpod.io"
         iss: string; // "https://accounts.google.com"
         locale: string; // e.g. "de"
+        /**
+         * End-User's full name in displayable form including all name parts, possibly including titles and suffixes, ordered according to the End-User's locale and preferences.
+         */
         name: string;
         picture: string; // URL of avatar
+        /**
+         * Subject - Identifier for the End-User at the Issuer.
+         */
         sub: string; // "1234567890"
     };
-    organizationId: string; // TODO(gpl) Remove once we implemented either SKIM, or a proper UserService
+    organizationId: string;
     oidcClientConfigId: string;
 }

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -42,6 +42,9 @@ class TestIamSessionApp {
         createUser: (params) => {
             return { id: "id-new-user" } as any;
         },
+        updateUser: (userId, update) => {
+            return {} as any;
+        },
     };
     protected userAuthenticationMock: Partial<UserAuthentication> = {
         findUserForLogin: async (params) => {

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -128,6 +128,10 @@ export class IamSessionApp {
                 primaryEmail: recent.primaryEmail,
                 lastSigninTime: new Date().toISOString(),
             });
+            await this.userService.updateUser(user.id, {
+                id: user.id,
+                fullName: payload.claims.name,
+            });
         }
     }
 
@@ -141,6 +145,7 @@ export class IamSessionApp {
                     organizationId,
                     identity: { ...this.mapOIDCProfileToIdentity(payload), lastSigninTime: new Date().toISOString() },
                     userUpdate: (user) => {
+                        user.fullName = claims.name;
                         user.name = claims.name;
                         user.avatarUrl = claims.picture;
                     },


### PR DESCRIPTION
Git config prefers `User.fullName` for `git config user.name`, see https://github.com/gitpod-io/gitpod/blob/24f7b609bf79b247d72d1841282639726bcd5891/components/server/src/workspace/workspace-starter.ts#L550

This PR should re-add this values.

Users would have to re-login to get this updated.

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e2b967</samp>

This pull request enhances the integration of OpenID Connect identity providers by improving the documentation of the `OIDCCreateSessionPayload` interface and updating the user's full name from the claims.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-365

## How to test
* login into you SSO account with Google using https://at-sso-fullname.preview.gitpod-dev.com/login/acme
* start a workspace and see your `git config user.name` is set properly

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-sso-fullname</li>
	<li><b>🔗 URL</b> - <a href="https://at-sso-fullname.preview.gitpod-dev.com/workspaces" target="_blank">at-sso-fullname.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-sso-fullName-gha.14797</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
