### PR TITLE
Add a new trust bundle for custom SSL certificates

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -133,6 +133,8 @@ type Configuration struct {
 	TimeoutMaxConcurrentReconciles int `json:"timeoutMaxConcurrentReconciles,omitempty"`
 	// ExperimentalMode controls if experimental features are enabled
 	ExperimentalMode bool `json:"experimentalMode"`
+	// EnableCustomSSLCertificate controls if we need to support custom SSL certificates for git operations
+	EnableCustomSSLCertificate bool `json:"enableCustomSSLCertificate"`
 }
 
 type WorkspaceClass struct {

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -562,7 +562,7 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 	result = append(result, corev1.EnvVar{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"})
 
 	const (
-		customCAMountPath = "/etc/ssl/certs/custom-ca.crt"
+		customCAMountPath = "/etc/ssl/certs/gitpod-ca.crt"
 		certsMountPath    = "/etc/ssl/certs/"
 	)
 

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -316,7 +316,7 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 			},
 		},
 		{
-			Name: "custom-ca-crt",
+			Name: "gitpod-ca-crt",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "gitpod-customer-certificate-bundle"},
@@ -496,8 +496,8 @@ func createWorkspaceContainer(sctx *startWorkspaceContext) (*corev1.Container, e
 				MountPropagation: &mountPropagation,
 			},
 			{
-				Name:      "custom-ca-crt",
-				MountPath: "/etc/ssl/certs/custom-ca.crt",
+				Name:      "gitpod-ca-crt",
+				MountPath: "/etc/ssl/certs/gitpod-ca.crt",
 				SubPath:   "ca-certificates.crt",
 				ReadOnly:  true,
 			},

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -315,6 +315,14 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 				},
 			},
 		},
+		{
+			Name: "ca-certificates",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "gitpod-customer-certificate-bundle"},
+				},
+			},
+		},
 	}
 
 	workloadType := "regular"
@@ -486,6 +494,12 @@ func createWorkspaceContainer(sctx *startWorkspaceContext) (*corev1.Container, e
 				MountPath:        "/.workspace",
 				Name:             "daemon-mount",
 				MountPropagation: &mountPropagation,
+			},
+			{
+				Name:      "ca-certificates",
+				MountPath: "/etc/ssl/certs/ca-certificates.crt",
+				SubPath:   "ca-certificates.crt",
+				ReadOnly:  true,
 			},
 		},
 		ReadinessProbe:           readinessProbe,

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -37,7 +37,7 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	gitpodCustomCertificateBundleSource := []trust.BundleSource{
 		{
-			UseDefaultCAs: pointer.Bool(false),
+			UseDefaultCAs: pointer.Bool(true),
 		},
 	}
 
@@ -49,7 +49,7 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		})
 
-		gitpodCustomCertificateBundleSource = append(gitpodCaBundleSources, trust.BundleSource{
+		gitpodCustomCertificateBundleSource = append(gitpodCustomCertificateBundleSource, trust.BundleSource{
 			Secret: &trust.SourceObjectKeySelector{
 				Name:        ctx.Config.CustomCACert.Name,
 				KeySelector: trust.KeySelector{Key: "ca.crt"},

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -48,6 +48,13 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	if ctx.Config.CustomCACert != nil {
+		gitpodCaBundleSources = append(gitpodCaBundleSources, trust.BundleSource{
+			Secret: &trust.SourceObjectKeySelector{
+				Name:        ctx.Config.CustomCACert.Name,
+				KeySelector: trust.KeySelector{Key: "ca.crt"},
+			},
+		})
+
 		gitpodCustomCertificateBundleSource = append(gitpodCaBundleSources, trust.BundleSource{
 			Secret: &trust.SourceObjectKeySelector{
 				Name:        ctx.Config.CustomCACert.Name,

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -37,7 +37,7 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	gitpodCustomCertificateBundleSource := []trust.BundleSource{
 		{
-			UseDefaultCAs: pointer.Bool(true),
+			UseDefaultCAs: pointer.Bool(false),
 		},
 	}
 

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -39,12 +39,6 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 		{
 			UseDefaultCAs: pointer.Bool(true),
 		},
-		{
-			Secret: &trust.SourceObjectKeySelector{
-				Name:        secretCAName,
-				KeySelector: trust.KeySelector{Key: "ca.crt"},
-			},
-		},
 	}
 
 	if ctx.Config.CustomCACert != nil {

--- a/install/installer/pkg/components/cluster/certmanager.go
+++ b/install/installer/pkg/components/cluster/certmanager.go
@@ -35,8 +35,20 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 	}
 
+	gitpodCustomCertificateBundleSource := []trust.BundleSource{
+		{
+			UseDefaultCAs: pointer.Bool(true),
+		},
+		{
+			Secret: &trust.SourceObjectKeySelector{
+				Name:        secretCAName,
+				KeySelector: trust.KeySelector{Key: "ca.crt"},
+			},
+		},
+	}
+
 	if ctx.Config.CustomCACert != nil {
-		gitpodCaBundleSources = append(gitpodCaBundleSources, trust.BundleSource{
+		gitpodCustomCertificateBundleSource = append(gitpodCaBundleSources, trust.BundleSource{
 			Secret: &trust.SourceObjectKeySelector{
 				Name:        ctx.Config.CustomCACert.Name,
 				KeySelector: trust.KeySelector{Key: "ca.crt"},
@@ -176,6 +188,21 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Target: trust.BundleTarget{
 					ConfigMap: &trust.KeySelector{
 						Key: "gitpod-ca.crt",
+					},
+				},
+			},
+		},
+		// trust Bundle for custom SSL certificates
+		&trust.Bundle{
+			TypeMeta: common.TypeMetaBundle,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gitpod-customer-certificate-bundle",
+			},
+			Spec: trust.BundleSpec{
+				Sources: gitpodCustomCertificateBundleSource,
+				Target: trust.BundleTarget{
+					ConfigMap: &trust.KeySelector{
+						Key: "ca-certificates.crt",
 					},
 				},
 			},

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -262,6 +262,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		}{Addr: fmt.Sprintf(":%d", HealthPort)},
 	}
 
+	if ctx.Config.CustomCACert != nil {
+		wsmcfg.Manager.EnableCustomSSLCertificate = true
+	}
+
 	fc, err := common.ToJSONString(wsmcfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal ws-manager config: %w", err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b41472</samp>

Add support for custom SSL certificates in cert-manager. Use a new variable and a config map to provide custom CA certificates to cert-manager pods.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Check the configmap `gitpod-customer-certificate-bundle` exists
- Check the file `/etc/ssl/certs/ca-certificates.crt` in a workspace is mounted volume from the `ca-certificates` configmap
- Configure the installer with a custom CA certificate and check the `/etc/ssl/certs/ca-certificates.crt` contains the certificate


#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-cus2745037e55</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-cus2745037e55.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-cus2745037e55.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-custom-cert-trust-gha.14838</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
