### PR TITLE
[server] fix Suggested Context URLs for BBS – EXP-354

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -279,10 +279,16 @@ export class BitbucketServerApi {
         );
     }
 
+    /**
+     * https://developer.atlassian.com/server/bitbucket/rest/v811/api-group-repository/#api-api-latest-repos-get
+     */
     async getRepos(
         user: User,
         query: {
             permission?: "REPO_READ" | "REPO_WRITE" | "REPO_ADMIN";
+            /**
+             * defaults to 25
+             */
             limit: number;
         },
     ) {

--- a/components/server/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.ts
@@ -25,7 +25,7 @@ export class BitbucketServerService extends RepositoryService {
     @inject(BitbucketServerContextParser) protected contextParser: BitbucketServerContextParser;
 
     async getRepositoriesForAutomatedPrebuilds(user: User): Promise<ProviderRepository[]> {
-        const repos = await this.api.getRepos(user, { limit: 100, permission: "REPO_ADMIN" });
+        const repos = await this.api.getRepos(user, { limit: 1000, permission: "REPO_ADMIN" });
         return (repos.values || []).map((r) => {
             const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href!;
             // const webUrl = r.links?.self[0]?.href?.replace("/browse", "");


### PR DESCRIPTION
* add repositories of all accessible projects
* remove user repositories from Apps (wrong permission query)
* implement `getUserRepos` for BBS

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afc61e4</samp>

This pull request adds support for Bitbucket Server integration with Gitpod, enabling users to access their repositories, projects, and prebuilds from the Gitpod dashboard. It also improves the logging, readability, and performance of the Bitbucket Server API client and service classes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-354



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-bbs-suggestions</li>
	<li><b>🔗 URL</b> - <a href="https://at-bbs-suggestions.preview.gitpod-dev.com/workspaces" target="_blank">at-bbs-suggestions.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-bbs-suggestions-gha.14832</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
