### PR TITLE
[workspace-cluster] bump docker and docker compose deps

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -20,8 +20,8 @@ defaultArgs:
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.4.tar.gz"
   clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2023.1.5.tar.gz"
   jbBackendVersion: "latest"
-  dockerVersion: 20.10.23
-  dockerComposeVersion: "2.18.1-gitpod.2"
+  dockerVersion: "20.10.24"
+  dockerComposeVersion: "2.20.2-gitpod.1"
 provenance:
   enabled: true
   slsa: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Depends on https://github.com/gitpod-io/compose/releases/tag/v2.20.2-gitpod.1, refer to https://github.com/gitpod-io/compose/pull/1 for background.

Also, [updated](https://www.notion.so/gitpod/Generation-eb8b655c6aa94373a73896c8055f5c9a?pvs=4#e9a879085b3a42f8a5abc42f637462da) related release instructions.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de650a7</samp>

Update `dockerVersion` and `dockerComposeVersion` in `WORKSPACE.yaml` to use the latest versions. This is part of a pull request to improve Gitpod's workspace containers.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
From a preview environment:
1. start a workspace from https://github.com/gitpod-samples/template-docker-compose in this PR's preview environment
2. Check the docker compose version (you can also try from https://github.com/kylos101/gitpod-custom-image)
```
gitpod /workspace/template-docker-compose (main) $ docker compose version
Docker Compose version v2.20.2-gitpod.1
gitpod /workspace/template-docker-compose (main) $ docker-compose version
Docker Compose version v2.20.2-gitpod.1
```
3. Check the docker version (docker -v)
   * It won't match what we set in WORKSPACE.yaml.
   * It the workspace is lacking docker (https://github.com/kylos101/gitpod-custom-image), it won't be added (this seems like a separate `docker-up` bug), the behavior is the same in `dogfood`. Created https://linear.app/gitpod/issue/ENG-617 for posterity.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-cc8cc467fbb</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-cc8cc467fbb.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-cc8cc467fbb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-compose-update-gha.14934</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
