### PR TITLE
[fga] extract WorkspaceService.start

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -22,10 +22,10 @@
     "test:db": "cleanup() { echo 'Cleanup started'; yarn stop-services; }; trap cleanup EXIT; . $(leeway run components/gitpod-db:db-test-env) && yarn start-services && mocha --opts mocha.opts './**/*.spec.db.js'  --exclude './node_modules/**'",
     "start-services": "yarn start-testdb && yarn start-redis && yarn start-spicedb",
     "stop-services": "yarn stop-redis && yarn stop-spicedb",
-    "start-testdb": "if netstat -tuln | grep ':23306 '; then echo 'Mysql is already running.'; else leeway run components/gitpod-db:init-testdb; fi",
+    "start-testdb": "leeway run components/gitpod-db:init-testdb",
     "start-spicedb": "leeway run components/spicedb:start-spicedb",
     "stop-spicedb": "leeway run components/spicedb:stop-spicedb",
-    "start-redis": "if netstat -tuln | grep ':6379 '; then echo 'Redis is already running.'; else docker run --rm --name test-redis -p 6379:6379 -d redis; fi",
+    "start-redis": "if redis-cli -h ${REDIS_HOST:-0.0.0.0} -e ping; then echo 'Redis is already running.'; else docker run --rm --name test-redis -p 6379:6379 -d redis; fi",
     "stop-redis": "docker stop test-redis || true",
     "telepresence": "telepresence --swap-deployment server --method inject-tcp --run yarn start-inspect"
   },

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -19,7 +19,7 @@
     "test:leeway": "yarn build && yarn test",
     "test": "yarn test:unit && yarn test:db",
     "test:unit": "mocha --opts mocha.opts './**/*.spec.js' --exclude './node_modules/**'",
-    "test:db": "cleanup() { echo 'Cleanup started'; yarn stop-spicedb; }; trap cleanup EXIT; . $(leeway run components/gitpod-db:db-test-env) && yarn start-spicedb && mocha --opts mocha.opts './**/*.spec.db.js'  --exclude './node_modules/**'",
+    "test:db": "cleanup() { echo 'Cleanup started'; yarn stop-services; }; trap cleanup EXIT; . $(leeway run components/gitpod-db:db-test-env) && yarn start-services && mocha --opts mocha.opts './**/*.spec.db.js'  --exclude './node_modules/**'",
     "start-services": "yarn start-testdb && yarn start-redis && yarn start-spicedb",
     "stop-services": "yarn stop-redis && yarn stop-spicedb",
     "start-testdb": "if netstat -tuln | grep ':23306 '; then echo 'Mysql is already running.'; else leeway run components/gitpod-db:init-testdb; fi",

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -13,7 +13,6 @@ import { createConnectTransport } from "@bufbuild/connect-node";
 import { Code, ConnectError, PromiseClient, createPromiseClient } from "@bufbuild/connect";
 import { AddressInfo } from "net";
 import { TeamsService as TeamsServiceDefinition } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
-import { WorkspaceStarter } from "../workspace/workspace-starter";
 import { UserAuthentication } from "../user/user-authentication";
 import { APITeamsService } from "./teams";
 import { v4 as uuidv4 } from "uuid";
@@ -24,6 +23,7 @@ import { Connection } from "typeorm";
 import { Timestamp } from "@bufbuild/protobuf";
 import { APIWorkspacesService } from "./workspaces";
 import { APIStatsService } from "./stats";
+import { WorkspaceService } from "../workspace/workspace-service";
 
 const expect = chai.expect;
 
@@ -43,7 +43,7 @@ export class APITeamsServiceSpec {
         this.container.bind(APIWorkspacesService).toSelf().inSingletonScope();
         this.container.bind(APIStatsService).toSelf().inSingletonScope();
 
-        this.container.bind(WorkspaceStarter).toConstantValue({} as WorkspaceStarter);
+        this.container.bind(WorkspaceService).toConstantValue({} as WorkspaceService);
         this.container.bind(UserAuthentication).toConstantValue({} as UserAuthentication);
 
         // Clean-up database

--- a/components/server/src/api/user.ts
+++ b/components/server/src/api/user.ts
@@ -23,15 +23,16 @@ import {
     GetGitTokenResponse,
     BlockUserResponse,
 } from "@gitpod/public-api/lib/gitpod/experimental/v1/user_pb";
-import { WorkspaceStarter } from "../workspace/workspace-starter";
 import { UserAuthentication } from "../user/user-authentication";
+import { WorkspaceService } from "../workspace/workspace-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 import { validate } from "uuid";
-import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 
 @injectable()
 export class APIUserService implements ServiceImpl<typeof UserServiceInterface> {
-    @inject(WorkspaceStarter) protected readonly workspaceStarter: WorkspaceStarter;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(UserAuthentication) protected readonly userService: UserAuthentication;
 
     public async getAuthenticatedUser(req: GetAuthenticatedUserRequest): Promise<GetAuthenticatedUserResponse> {
@@ -73,14 +74,17 @@ export class APIUserService implements ServiceImpl<typeof UserServiceInterface> 
 
         // TODO: Once connect-node supports middlewares, lift the tracing into the middleware.
         const trace = {};
-        await this.userService.blockUser(userId, true);
+        // TODO for now we use SYSTEM_USER, since it is only called by internal componenets like usage
+        // and not exposed publically, but there should be better way to get an authenticated user
+        await this.userService.blockUser(SYSTEM_USER, userId, true);
         log.info(`Blocked user ${userId}.`, {
             userId,
             reason,
         });
 
-        const stoppedWorkspaces = await this.workspaceStarter.stopRunningWorkspacesForUser(
+        const stoppedWorkspaces = await this.workspaceService.stopRunningWorkspacesForUser(
             trace,
+            SYSTEM_USER,
             userId,
             reason,
             StopWorkspacePolicy.IMMEDIATELY,

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -59,7 +59,7 @@ export class Authorizer {
         permission: OrganizationPermission,
         orgId: string,
     ): Promise<boolean> {
-        if (userId === "SYSTEM_USER") {
+        if (userId === SYSTEM_USER) {
             return true;
         }
 
@@ -89,7 +89,7 @@ export class Authorizer {
     }
 
     async hasPermissionOnProject(userId: string, permission: ProjectPermission, projectId: string): Promise<boolean> {
-        if (userId === "SYSTEM_USER") {
+        if (userId === SYSTEM_USER) {
             return true;
         }
 
@@ -119,7 +119,7 @@ export class Authorizer {
     }
 
     async hasPermissionOnUser(userId: string, permission: UserPermission, resourceUserId: string): Promise<boolean> {
-        if (userId === "SYSTEM_USER") {
+        if (userId === SYSTEM_USER) {
             return true;
         }
 
@@ -152,7 +152,7 @@ export class Authorizer {
         permission: WorkspacePermission,
         workspaceId: string,
     ): Promise<boolean> {
-        if (userId === "SYSTEM_USER") {
+        if (userId === SYSTEM_USER) {
             return true;
         }
 

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -73,7 +73,7 @@ export type WorkspaceResourceType = "workspace";
 
 export type WorkspaceRelation = "org" | "owner";
 
-export type WorkspacePermission = "access" | "stop" | "delete" | "read_info";
+export type WorkspacePermission = "access" | "start" | "stop" | "delete" | "read_info";
 
 export const rel = {
     user(id: string) {

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -4,15 +4,15 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import * as grpc from "@grpc/grpc-js";
 import { v1 } from "@authzed/authzed-node";
 import { IAnalyticsWriter, NullAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
-import { IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
+import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
 import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
-import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import { ContainerModule } from "inversify";
 import { v4 } from "uuid";
 import { AuthProviderParams } from "../auth/auth-provider";
-import { HostContextProviderFactory } from "../auth/host-context-provider";
+import { HostContextProvider, HostContextProviderFactory } from "../auth/host-context-provider";
 import { HostContextProviderImpl } from "../auth/host-context-provider-impl";
 import { SpiceDBClient } from "../authorization/spicedb";
 import { Config } from "../config";
@@ -21,7 +21,22 @@ import { testContainer } from "@gitpod/gitpod-db/lib";
 import { productionContainerModule } from "../container-module";
 import { createMock } from "./mocks/mock";
 import { UsageServiceClientMock } from "./mocks/usage-service-client-mock";
-import { env } from "process";
+import { env, nextTick } from "process";
+import { WorkspaceManagerClientProviderSource } from "@gitpod/ws-manager/lib/client-provider-source";
+import { WorkspaceClusterWoTLS } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import {
+    BuildInfo,
+    BuildResponse,
+    BuildStatus,
+    IImageBuilderClient,
+    LogInfo,
+    ResolveWorkspaceImageResponse,
+} from "@gitpod/image-builder/lib";
+import { IWorkspaceManagerClient, StartWorkspaceResponse } from "@gitpod/ws-manager/lib";
+import { TokenProvider } from "../user/token-provider";
+import { GitHubScope } from "../github/scopes";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 /**
  * Expects a fully configured production container and
@@ -30,12 +45,117 @@ import { env } from "process";
  *  - replaces the analytics writer with a null analytics writer
  */
 const mockApplyingContainerModule = new ContainerModule((bind, unbound, isbound, rebind) => {
+    rebind(HostContextProvider).toConstantValue({
+        get: () => {
+            const authProviderId = "Public-GitHub";
+            return {
+                authProvider: {
+                    authProviderId,
+                },
+            };
+        },
+    });
+    rebind(TokenProvider).toConstantValue(<TokenProvider>{
+        getTokenForHost: async () => {
+            return {
+                value: "test",
+                scopes: [GitHubScope.EMAIL, GitHubScope.PUBLIC, GitHubScope.PRIVATE],
+            };
+        },
+    });
     rebind(UsageServiceDefinition.name).toConstantValue(createMock(new UsageServiceClientMock()));
     rebind(StorageClient).toConstantValue(createMock());
-    rebind(WorkspaceManagerClientProvider).toConstantValue(createMock());
-    rebind(IDEServiceDefinition.name).toConstantValue(createMock());
+    rebind(WorkspaceManagerClientProviderSource).toDynamicValue((): WorkspaceManagerClientProviderSource => {
+        const clusters: WorkspaceClusterWoTLS[] = [
+            {
+                name: "eu-central-1",
+                region: "europe",
+                url: "https://ws.gitpod.io",
+                state: "available",
+                maxScore: 100,
+                score: 100,
+                govern: true,
+            },
+        ];
+        return <WorkspaceManagerClientProviderSource>{
+            getAllWorkspaceClusters: async () => {
+                return clusters;
+            },
+            getWorkspaceCluster: async (name: string) => {
+                return clusters.find((c) => c.name === name);
+            },
+        };
+    });
+    rebind(WorkspaceManagerClientProvider)
+        .toSelf()
+        .onActivation((_, provider) => {
+            provider["createConnection"] = () => {
+                const channel = <Partial<grpc.Channel>>{
+                    getConnectivityState() {
+                        return grpc.connectivityState.READY;
+                    },
+                };
+                return Object.assign(
+                    <Partial<grpc.Client>>{
+                        getChannel() {
+                            return channel;
+                        },
+                    },
+                    <IImageBuilderClient & IWorkspaceManagerClient>{
+                        resolveWorkspaceImage(request, metadata, options, callback) {
+                            const response = new ResolveWorkspaceImageResponse();
+                            response.setStatus(BuildStatus.DONE_SUCCESS);
+                            callback(null, response);
+                        },
+                        build(request, metadata, options) {
+                            const listeners = new Map<string | symbol, Function>();
+                            nextTick(() => {
+                                const response = new BuildResponse();
+                                response.setStatus(BuildStatus.DONE_SUCCESS);
+                                response.setRef("my-test-build-ref");
+                                const buildInfo = new BuildInfo();
+                                const logInfo = new LogInfo();
+                                logInfo.setUrl("https://ws.gitpod.io/my-test-image-build/logs");
+                                buildInfo.setLogInfo(logInfo);
+                                response.setInfo(buildInfo);
+                                listeners.get("data")!(response);
+                                listeners.get("end")!();
+                            });
+                            return {
+                                on(event, callback) {
+                                    listeners.set(event, callback);
+                                },
+                            };
+                        },
+                        startWorkspace(request, metadata, options, callback) {
+                            const workspaceId = request.getServicePrefix();
+                            const response = new StartWorkspaceResponse();
+                            response.setUrl(`https://${workspaceId}.ws.gitpod.io`);
+                            callback(null, response);
+                        },
+                    },
+                ) as any;
+            };
+            return provider;
+        });
+    rebind(IDEServiceDefinition.name).toConstantValue(
+        createMock(<Partial<IDEServiceClient>>{
+            async resolveWorkspaceConfig() {
+                return {
+                    envvars: [],
+                    supervisorImage: "gitpod/supervisor:latest",
+                    webImage: "gitpod/code:latest",
+                    ideImageLayers: [],
+                    refererIde: "code",
+                    ideSettings: "",
+                    tasks: "",
+                };
+            },
+        }),
+    );
 
     rebind<Partial<Config>>(Config).toConstantValue({
+        hostUrl: new GitpodHostUrl("https://gitpod.io"),
         blockNewUsers: {
             enabled: false,
             passlist: [],
@@ -43,6 +163,23 @@ const mockApplyingContainerModule = new ContainerModule((bind, unbound, isbound,
         redis: {
             address: (env.REDIS_HOST || "127.0.0.1") + ":" + (env.REDIS_PORT || "6379"),
         },
+        workspaceDefaults: {
+            workspaceImage: "gitpod/workspace-full",
+            defaultFeatureFlags: [],
+            previewFeatureFlags: [],
+        },
+        workspaceClasses: [
+            {
+                category: "general",
+                description: "The default workspace class",
+                displayName: "Default",
+                id: "default",
+                isDefault: true,
+                powerups: 0,
+            },
+        ],
+        authProviderConfigs: [],
+        installationShortname: "gitpod",
     });
     rebind(IAnalyticsWriter).toConstantValue(NullAnalyticsWriter);
     rebind(HostContextProviderFactory)

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -74,6 +74,7 @@ describe("SSHKeyService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        container.unbindAll();
     });
 
     it("should add ssh key", async () => {

--- a/components/server/src/user/user-authentication.ts
+++ b/components/server/src/user/user-authentication.ts
@@ -39,8 +39,8 @@ export class UserAuthentication {
         @inject(HostContextProvider) private readonly hostContextProvider: HostContextProvider,
     ) {}
 
-    async blockUser(targetUserId: string, block: boolean): Promise<User> {
-        const target = await this.userService.findUserById(targetUserId, targetUserId);
+    async blockUser(userId: string, targetUserId: string, block: boolean): Promise<User> {
+        const target = await this.userService.findUserById(userId, targetUserId);
         if (!target) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "not found");
         }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -27,9 +27,9 @@ import { ClientMetadata } from "../websocket/websocket-connection-manager";
 import * as fs from "fs/promises";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { GitpodServerImpl } from "../workspace/gitpod-server-impl";
-import { WorkspaceStarter } from "../workspace/workspace-starter";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { UserService } from "./user-service";
+import { WorkspaceService } from "../workspace/workspace-service";
 
 export const ServerFactory = Symbol("ServerFactory");
 export type ServerFactory = () => GitpodServerImpl;
@@ -47,7 +47,7 @@ export class UserController {
     @inject(SessionHandler) protected readonly sessionHandler: SessionHandler;
     @inject(OneTimeSecretServer) protected readonly otsServer: OneTimeSecretServer;
     @inject(OneTimeSecretDB) protected readonly otsDb: OneTimeSecretDB;
-    @inject(WorkspaceStarter) protected readonly workspaceStarter: WorkspaceStarter;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(ServerFactory) private readonly serverFactory: ServerFactory;
 
     get apiRouter(): express.Router {
@@ -241,8 +241,8 @@ export class UserController {
             // stop all running workspaces
             const user = req.user as User;
             if (user) {
-                this.workspaceStarter
-                    .stopRunningWorkspacesForUser({}, user.id, "logout", StopWorkspacePolicy.NORMALLY)
+                this.workspaceService
+                    .stopRunningWorkspacesForUser({}, user.id, user.id, "logout", StopWorkspacePolicy.NORMALLY)
                     .catch((error) =>
                         log.error(logContext, "cannot stop workspaces on logout", { error, ...logPayload }),
                     );

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -928,9 +928,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             };
         }
 
-        if (!!workspace.softDeleted) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Workspace not found!");
-        }
         // (gpl) We keep this check here for backwards compatibility, it should be superfluous in the future
         // no matter if the workspace is shared or not, you cannot create a new instance
         await this.guardAccess({ kind: "workspaceInstance", subject: undefined, workspace }, "create");

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -130,7 +130,7 @@ import { UserDeletionService } from "../user/user-deletion-service";
 import { UserAuthentication } from "../user/user-authentication";
 import { ContextParser } from "./context-parser-service";
 import { GitTokenScopeGuesser } from "./git-token-scope-guesser";
-import { WorkspaceStarter, isClusterMaintenanceError } from "./workspace-starter";
+import { isClusterMaintenanceError } from "./workspace-starter";
 import { HeadlessLogUrls } from "@gitpod/gitpod-protocol/lib/headless-workspace-log";
 import { HeadlessLogService, HeadlessLogEndpoint } from "./headless-log-service";
 import { ConfigProvider, InvalidGitpodYMLError } from "./config-provider";
@@ -155,7 +155,7 @@ import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { ListUsageRequest, ListUsageResponse } from "@gitpod/gitpod-protocol/lib/usage";
 import { VerificationService } from "../auth/verification-service";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { EntitlementService, MayStartWorkspaceResult } from "../billing/entitlement-service";
+import { EntitlementService } from "../billing/entitlement-service";
 import { formatPhoneNumber } from "../user/phone-numbers";
 import { IDEService } from "../ide-service";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
@@ -167,8 +167,6 @@ import {
     getExperimentsClientForBackend,
 } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { increaseDashboardErrorBoundaryCounter, reportCentralizedPermsValidation } from "../prometheus-metrics";
-import { RegionService } from "./region-service";
-import { isWorkspaceRegion, WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { EnvVarService } from "./env-var-service";
 import { LinkedInService } from "../linkedin-service";
 import { SnapshotService, WaitForSnapshotOptions } from "./snapshot-service";
@@ -223,7 +221,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         @inject(IncrementalPrebuildsService) private readonly incrementalPrebuildsService: IncrementalPrebuildsService,
         @inject(ConfigProvider) private readonly configProvider: ConfigProvider,
         @inject(WorkspaceService) private readonly workspaceService: WorkspaceService,
-        @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
         @inject(SnapshotService) private readonly snapshotService: SnapshotService,
         @inject(WorkspaceManagerClientProvider)
         private readonly workspaceManagerClientProvider: WorkspaceManagerClientProvider,
@@ -839,7 +836,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkAndBlockUser("deleteAccount");
         await this.guardAccess({ kind: "user", subject: user! }, "delete");
 
-        await this.userDeletionService.deleteUser(user.id);
+        await this.userDeletionService.deleteUser(user.id, user.id);
     }
 
     public async getWorkspace(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInfo> {
@@ -911,15 +908,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const user = await this.checkAndBlockUser("startWorkspace", undefined, { workspaceId });
 
+        // (gpl) We keep this check here for backwards compatibility, it should be superfluous in the future
         const workspace = await this.workspaceService.getWorkspace(user.id, workspaceId);
-        const mayStartPromise = this.mayStartWorkspace(
-            ctx,
-            user,
-            workspace.organizationId,
-            this.workspaceDb.trace(ctx).findRegularRunningInstances(user.id),
-        );
         await this.guardAccess({ kind: "workspace", subject: workspace }, "get");
 
+        // (gpl) We keep this check here for backwards compatibility, it should be superfluous in the future
         const runningInstance = await this.workspaceDb.trace(ctx).findRunningInstance(workspace.id);
         if (runningInstance) {
             traceWI(ctx, { instanceId: runningInstance.id });
@@ -938,35 +931,17 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!!workspace.softDeleted) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "Workspace not found!");
         }
-
+        // (gpl) We keep this check here for backwards compatibility, it should be superfluous in the future
         // no matter if the workspace is shared or not, you cannot create a new instance
         await this.guardAccess({ kind: "workspaceInstance", subject: undefined, workspace }, "create");
 
-        if (workspace.type !== "regular") {
-            throw new ApplicationError(ErrorCodes.PERMISSION_DENIED, "Cannot (re-)start irregular workspace.");
-        }
-
-        if (workspace.deleted) {
-            throw new ApplicationError(ErrorCodes.PERMISSION_DENIED, "Cannot (re-)start a deleted workspace.");
-        }
-        const envVarsPromise = this.envVarService.resolve(workspace);
-        const projectPromise = workspace.projectId
-            ? ApplicationError.notFoundToUndefined(this.projectsService.getProject(user.id, workspace.projectId))
-            : Promise.resolve(undefined);
-
-        await mayStartPromise;
-
-        options.region = await this.determineWorkspaceRegion(workspace, options.region || "");
-
-        // at this point we're about to actually start a new workspace
-        const result = await this.workspaceStarter.startWorkspace(
-            ctx,
-            workspace,
-            user,
-            await projectPromise,
-            await envVarsPromise,
-            options,
+        options.region = await this.workspaceService.determineWorkspaceRegion(
+            user.id,
+            workspaceId,
+            options.region || "",
+            this.clientHeaderFields.clientRegion,
         );
+        const result = await this.workspaceService.startWorkspace(ctx, user, workspaceId, options);
         traceWI(ctx, { instanceId: result.instanceID });
         return result;
     }
@@ -1396,7 +1371,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 ? (await this.projectsService.findProjectsByCloneUrl(user.id, context.repository.cloneUrl))[0]
                 : undefined;
 
-            const mayStartWorkspacePromise = this.mayStartWorkspace(
+            const mayStartWorkspacePromise = this.workspaceService.mayStartWorkspace(
                 ctx,
                 user,
                 options.organizationId,
@@ -1439,19 +1414,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 throw err;
             }
 
-            const envVarsPromise = this.envVarService.resolve(workspace);
-            options.region = await this.determineWorkspaceRegion(workspace, options.region || "");
-
             logContext.workspaceId = workspace.id;
             traceWI(ctx, { workspaceId: workspace.id });
-            const startWorkspaceResult = await this.workspaceStarter.startWorkspace(
-                ctx,
-                workspace,
-                user,
-                project,
-                await envVarsPromise,
-                options,
+
+            options.region = await this.workspaceService.determineWorkspaceRegion(
+                user.id,
+                workspace.id,
+                options.region || "",
+                this.clientHeaderFields.clientRegion,
             );
+            const startWorkspaceResult = await this.workspaceService.startWorkspace(ctx, user, workspace.id, options);
             ctx.span?.log({ event: "startWorkspaceComplete", ...startWorkspaceResult });
 
             return {
@@ -1653,41 +1625,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         pollPrebuildAvailable.cancel();
 
         return result;
-    }
-
-    private async mayStartWorkspace(
-        ctx: TraceContext,
-        user: User,
-        organizationId: string,
-        runningInstances: Promise<WorkspaceInstance[]>,
-    ): Promise<void> {
-        let result: MayStartWorkspaceResult = {};
-        try {
-            result = await this.entitlementService.mayStartWorkspace(user, organizationId, runningInstances);
-            TraceContext.addNestedTags(ctx, { mayStartWorkspace: { result } });
-        } catch (err) {
-            log.error({ userId: user.id }, "EntitlementSerivce.mayStartWorkspace error", err);
-            TraceContext.setError(ctx, err);
-            return; // we don't want to block workspace starts because of internal errors
-        }
-        if (!!result.needsVerification) {
-            throw new ApplicationError(ErrorCodes.NEEDS_VERIFICATION, `Please verify your account.`);
-        }
-        if (!!result.usageLimitReachedOnCostCenter) {
-            throw new ApplicationError(
-                ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED,
-                "Increase usage limit and try again.",
-                {
-                    attributionId: result.usageLimitReachedOnCostCenter,
-                },
-            );
-        }
-        if (!!result.hitParallelWorkspaceLimit) {
-            throw new ApplicationError(
-                ErrorCodes.TOO_MANY_RUNNING_WORKSPACES,
-                `You cannot run more than ${result.hitParallelWorkspaceLimit.max} workspaces at the same time. Please stop a workspace before starting another one.`,
-            );
-        }
     }
 
     public async getFeaturedRepositories(ctx: TraceContext): Promise<WhitelistedRepository[]> {
@@ -3097,12 +3034,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminBlockUser(ctx: TraceContext, req: AdminBlockUserRequest): Promise<User> {
         traceAPIParams(ctx, { req });
 
-        await this.guardAdminAccess("adminBlockUser", { req }, Permission.ADMIN_USERS);
+        const admin = await this.guardAdminAccess("adminBlockUser", { req }, Permission.ADMIN_USERS);
 
-        const targetUser = await this.userAuthentication.blockUser(req.id, req.blocked);
+        const targetUser = await this.userAuthentication.blockUser(admin.id, req.id, req.blocked);
 
-        const stoppedWorkspaces = await this.workspaceStarter.stopRunningWorkspacesForUser(
+        const stoppedWorkspaces = await this.workspaceService.stopRunningWorkspacesForUser(
             ctx,
+            admin.id,
             req.id,
             "user blocked by admin",
             StopWorkspacePolicy.IMMEDIATELY,
@@ -3119,10 +3057,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminDeleteUser(ctx: TraceContext, userId: string): Promise<void> {
         traceAPIParams(ctx, { userId });
 
-        await this.guardAdminAccess("adminDeleteUser", { id: userId }, Permission.ADMIN_PERMISSIONS);
+        const admin = await this.guardAdminAccess("adminDeleteUser", { id: userId }, Permission.ADMIN_PERMISSIONS);
 
         try {
-            await this.userDeletionService.deleteUser(userId);
+            await this.userDeletionService.deleteUser(admin.id, userId);
         } catch (e) {
             throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
         }
@@ -3735,50 +3673,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             default:
                 return new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, err.details);
         }
-    }
-
-    private async determineWorkspaceRegion(ws: Workspace, preference: WorkspaceRegion): Promise<WorkspaceRegion> {
-        const guessWorkspaceRegionEnabled = await getExperimentsClientForBackend().getValueAsync(
-            "guessWorkspaceRegion",
-            false,
-            {
-                user: { id: this.userID || "" },
-            },
-        );
-
-        const regionLogContext = {
-            requested_region: preference,
-            client_region_from_header: this.clientHeaderFields.clientRegion,
-            experiment_enabled: false,
-            guessed_region: "",
-        };
-
-        let targetRegion = preference;
-        if (!isWorkspaceRegion(preference)) {
-            targetRegion = "";
-        } else {
-            targetRegion = preference;
-        }
-
-        if (guessWorkspaceRegionEnabled) {
-            regionLogContext.experiment_enabled = true;
-
-            if (!preference) {
-                // Attempt to identify the region based on LoadBalancer headers, if there was no explicit choice on the request.
-                // The Client region contains the two letter country code.
-                if (this.clientHeaderFields.clientRegion) {
-                    const countryCode = this.clientHeaderFields.clientRegion;
-
-                    targetRegion = RegionService.countryCodeToNearestWorkspaceRegion(countryCode);
-                    regionLogContext.guessed_region = targetRegion;
-                }
-            }
-        }
-
-        const logCtx = { userId: this.userID, workspaceId: ws.id };
-        log.info(logCtx, "[guessWorkspaceRegion] Workspace with region selection", regionLogContext);
-
-        return targetRegion;
     }
 
     async getIDToken(): Promise<void> {}

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -259,6 +259,10 @@ export class WorkspaceService {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Cannot (re-)start irregular workspace.");
         }
 
+        if (!!workspace.softDeleted) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Workspace not found!");
+        }
+
         const envVarsPromise = this.envVarService.resolve(workspace);
         const projectPromise = workspace.projectId
             ? ApplicationError.notFoundToUndefined(this.projectsService.getProject(user.id, workspace.projectId))

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -6,7 +6,16 @@
 
 import { inject, injectable } from "inversify";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
-import { Project, User, Workspace, WorkspaceContext, WorkspaceSoftDeletion } from "@gitpod/gitpod-protocol";
+import {
+    GitpodServer,
+    Project,
+    StartWorkspaceResult,
+    User,
+    Workspace,
+    WorkspaceContext,
+    WorkspaceInstance,
+    WorkspaceSoftDeletion,
+} from "@gitpod/gitpod-protocol";
 import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Authorizer } from "../authorization/authorizer";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -14,7 +23,13 @@ import { WorkspaceFactory } from "./workspace-factory";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { WorkspaceStarter } from "./workspace-starter";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { EntitlementService, MayStartWorkspaceResult } from "../billing/entitlement-service";
 import * as crypto from "crypto";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { WorkspaceRegion, isWorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { RegionService } from "./region-service";
+import { ProjectsService } from "../projects/projects-service";
+import { EnvVarService } from "./env-var-service";
 
 @injectable()
 export class WorkspaceService {
@@ -22,6 +37,9 @@ export class WorkspaceService {
         @inject(WorkspaceFactory) private readonly factory: WorkspaceFactory,
         @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
         @inject(WorkspaceDB) private readonly db: WorkspaceDB,
+        @inject(EntitlementService) private readonly entitlementService: EntitlementService,
+        @inject(EnvVarService) private readonly envVarService: EnvVarService,
+        @inject(ProjectsService) private readonly projectsService: ProjectsService,
         @inject(Authorizer) private readonly auth: Authorizer,
     ) {}
 
@@ -109,6 +127,7 @@ export class WorkspaceService {
         });
     }
 
+    // stopWorkspace and related methods below
     async stopWorkspace(
         userId: string,
         workspaceId: string,
@@ -124,6 +143,29 @@ export class WorkspaceService {
             return;
         }
         await this.workspaceStarter.stopWorkspaceInstance({}, instance.id, instance.region, reason, policy);
+    }
+
+    public async stopRunningWorkspacesForUser(
+        ctx: TraceContext,
+        userId: string,
+        targetUserId: string,
+        reason: string,
+        policy?: StopWorkspacePolicy,
+    ): Promise<Workspace[]> {
+        const infos = await this.db.findRunningInstancesWithWorkspaces(undefined, targetUserId);
+        await Promise.all(
+            infos.map(async (info) => {
+                await this.auth.checkPermissionOnWorkspace(userId, "stop", info.workspace.id);
+                await this.workspaceStarter.stopWorkspaceInstance(
+                    ctx,
+                    info.latestInstance.id,
+                    info.latestInstance.region,
+                    reason,
+                    policy,
+                );
+            }),
+        );
+        return infos.map((instance) => instance.workspace);
     }
 
     /**
@@ -179,5 +221,143 @@ export class WorkspaceService {
             throw err;
         }
         log.info(`Purged Workspace ${workspaceId} and all WorkspaceInstances for this workspace`, { workspaceId });
+    }
+
+    // startWorkspace and related methods below
+    async startWorkspace(
+        ctx: TraceContext,
+        user: User,
+        workspaceId: string,
+        options?: GitpodServer.StartWorkspaceOptions,
+    ): Promise<StartWorkspaceResult> {
+        await this.auth.checkPermissionOnWorkspace(user.id, "start", workspaceId);
+
+        const workspace = await this.doGetWorkspace(user.id, workspaceId);
+        const mayStartPromise = this.mayStartWorkspace(
+            ctx,
+            user,
+            workspace.organizationId,
+            this.db.findRegularRunningInstances(user.id),
+        );
+
+        const runningInstance = await this.db.findRunningInstance(workspace.id);
+        if (runningInstance) {
+            return {
+                instanceID: runningInstance.id,
+                workspaceURL: runningInstance.ideUrl,
+            };
+        }
+
+        if (workspace.type !== "regular") {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Cannot (re-)start irregular workspace.");
+        }
+
+        const envVarsPromise = this.envVarService.resolve(workspace);
+        const projectPromise = workspace.projectId
+            ? ApplicationError.notFoundToUndefined(this.projectsService.getProject(user.id, workspace.projectId))
+            : Promise.resolve(undefined);
+
+        await mayStartPromise;
+
+        // at this point we're about to actually start a new workspace
+        const result = await this.workspaceStarter.startWorkspace(
+            ctx,
+            workspace,
+            user,
+            await projectPromise,
+            await envVarsPromise,
+            options,
+        );
+        return result;
+    }
+
+    /**
+     * @deprecated TODO (gpl) This should be private, but in favor of smaller PRs, will be public for now.
+     * @param ctx
+     * @param user
+     * @param organizationId
+     * @param runningInstances
+     * @returns
+     */
+    public async mayStartWorkspace(
+        ctx: TraceContext,
+        user: User,
+        organizationId: string,
+        runningInstances: Promise<WorkspaceInstance[]>,
+    ): Promise<void> {
+        let result: MayStartWorkspaceResult = {};
+        try {
+            result = await this.entitlementService.mayStartWorkspace(user, organizationId, runningInstances);
+            TraceContext.addNestedTags(ctx, { mayStartWorkspace: { result } });
+        } catch (err) {
+            log.error({ userId: user.id }, "EntitlementSerivce.mayStartWorkspace error", err);
+            TraceContext.setError(ctx, err);
+            return; // we don't want to block workspace starts because of internal errors
+        }
+        if (!!result.needsVerification) {
+            throw new ApplicationError(ErrorCodes.NEEDS_VERIFICATION, `Please verify your account.`);
+        }
+        if (!!result.usageLimitReachedOnCostCenter) {
+            throw new ApplicationError(
+                ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED,
+                "Increase usage limit and try again.",
+                {
+                    attributionId: result.usageLimitReachedOnCostCenter,
+                },
+            );
+        }
+        if (!!result.hitParallelWorkspaceLimit) {
+            throw new ApplicationError(
+                ErrorCodes.TOO_MANY_RUNNING_WORKSPACES,
+                `You cannot run more than ${result.hitParallelWorkspaceLimit.max} workspaces at the same time. Please stop a workspace before starting another one.`,
+            );
+        }
+    }
+
+    async determineWorkspaceRegion(
+        userId: string,
+        workspaceId: string,
+        preference: WorkspaceRegion,
+        clientCountryCode: string | undefined,
+    ): Promise<WorkspaceRegion> {
+        const guessWorkspaceRegionEnabled = await getExperimentsClientForBackend().getValueAsync(
+            "guessWorkspaceRegion",
+            false,
+            {
+                user: { id: userId || "" },
+            },
+        );
+
+        const regionLogContext = {
+            requested_region: preference,
+            client_region_from_header: clientCountryCode,
+            experiment_enabled: false,
+            guessed_region: "",
+        };
+
+        let targetRegion = preference;
+        if (!isWorkspaceRegion(preference)) {
+            targetRegion = "";
+        } else {
+            targetRegion = preference;
+        }
+
+        if (guessWorkspaceRegionEnabled) {
+            regionLogContext.experiment_enabled = true;
+
+            if (!preference) {
+                // Attempt to identify the region based on LoadBalancer headers, if there was no explicit choice on the request.
+                // The Client region contains the two letter country code.
+                if (clientCountryCode) {
+                    targetRegion = RegionService.countryCodeToNearestWorkspaceRegion(clientCountryCode);
+                    regionLogContext.guessed_region = targetRegion;
+                }
+            }
+        }
+
+        const logCtx = { userId, workspaceId };
+        log.info(logCtx, "[guessWorkspaceRegion] Workspace with region selection", regionLogContext);
+
+        return targetRegion;
     }
 }

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -97,6 +97,7 @@ schema: |-
 
     // Note: All of this is modelled after current behavior.
     // There are a lot of improvements we can make here in the light of Organizations, but we explicitly do that as a separate step
+    permission start = owner
     permission stop = owner + org->installation_admin
     permission delete = owner
 


### PR DESCRIPTION
## Description
Extracts api.startWorkspace into WorkspaceService.startWorkspace, and adds some basic tests.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a1394b</samp>

This pull request refactors the server-side code for starting and stopping workspaces, by using a new `WorkspaceService` interface that consolidates the logic and checks the permissions, entitlements, limits, and other parameters. It also updates the tests and other components that depend on the old `WorkspaceStarter` interface, and improves the region guessing logic.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-321

## How to test
 - start a regular workspace :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-fga-wor2ec2aa2e5d</li>
	<li><b>🔗 URL</b> - <a href="https://ak-fga-wor2ec2aa2e5d.preview.gitpod-dev.com/workspaces" target="_blank">ak-fga-wor2ec2aa2e5d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-fga_workspace_start-gha.15283</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
