### PR TITLE
Improve GithubRepositoryProvider.getUserRepos – EXP-407

### DIFF
--- a/components/server/src/github/github-repository-provider.spec.ts
+++ b/components/server/src/github/github-repository-provider.spec.ts
@@ -78,5 +78,10 @@ class TestGithubContextRepositoryProvider {
             "f5b041513bfab914b5fbf7ae55788d9835004d76",
         ]);
     }
+
+    @test public async testGetUserRepos() {
+        const result = await this.provider.getUserRepos(this.user);
+        expect(result).to.include("https://github.com/gitpod-io/gitpod");
+    }
 }
 module.exports = new TestGithubContextRepositoryProvider(); // Only to circumvent no usage warning :-/

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -217,7 +217,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         for (const type of ["contributedTo", "original", "forked"]) {
             const nodes = result.data.viewer[type]?.nodes;
             if (nodes) {
-                urls.push(nodes.map((n: any) => n?.url).filter((u: any) => typeof u === "string"));
+                urls.push(...nodes.map((n: any) => n?.url).filter((u: any) => typeof u === "string"));
             }
         }
         return urls;

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -194,7 +194,6 @@ export class GithubRepositoryProvider implements RepositoryProvider {
                   original: repositories(
                     first: 100
                     ownerAffiliations: OWNER
-                    privacy: PUBLIC
                     isFork: false
                     isLocked: false
                     orderBy: {field: UPDATED_AT, direction: DESC}
@@ -204,7 +203,6 @@ export class GithubRepositoryProvider implements RepositoryProvider {
                   forked: repositories(
                     first: 100
                     ownerAffiliations: OWNER
-                    privacy: PUBLIC
                     isFork: true
                     isLocked: false
                     orderBy: {field: UPDATED_AT, direction: DESC}


### PR DESCRIPTION
The graphql query is extend to mimic what you would see in Top Repositories box visiting github.com.

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca89a5a</samp>

Rewrite `getUserRepos` method in `github-repository-provider.ts` to use a more complex GraphQL query that fetchs and categorizes the user's repositories. This improves performance, accuracy, and supports a new UI feature.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-407

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-gh-getuserrepos</li>
	<li><b>🔗 URL</b> - <a href="https://at-gh-getuserrepos.preview.gitpod-dev.com/workspaces" target="_blank">at-gh-getuserrepos.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-gh-getuserrepos-gha.14977</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
