### PR TITLE
[ws-daemon] error log clean-up

### DIFF
--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -60,7 +60,11 @@ func File(ctx context.Context, path string, onChange func()) error {
 
 	go func() {
 		defer func() {
-			log.WithError(err).Error("Stopping file watch")
+			if err != nil {
+				log.WithError(err).Error("Stopping file watch")
+			} else {
+				log.Info("Stopping file watch")
+			}
 
 			err = watcher.Close()
 			if err != nil {

--- a/components/ws-daemon/pkg/netlimit/netlimit.go
+++ b/components/ws-daemon/pkg/netlimit/netlimit.go
@@ -157,7 +157,7 @@ func (c *ConnLimiter) limitWorkspace(ctx context.Context, ws *dispatch.Workspace
 			case <-ticker.C:
 				counter, err := c.GetConnectionDropCounter(pid)
 				if err != nil {
-					log.WithFields(ws.OWI()).WithError(err).Errorf("could not get connection drop stats for %s", ws.WorkspaceID)
+					log.WithFields(ws.OWI()).WithError(err).Warnf("could not get connection drop stats")
 					continue
 				}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
While testing `gen103`, I observed `ws-daemon` error logs are noisy. There is still more noise, we'll have to keep chipping away over time.

[Context](https://cloudlogging.app.goo.gl/zpJYS18nzNRx3X9fA)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 054b007</samp>

Reduce log noise and duplication in ws-daemon. Change log levels and messages in `file.go`, and `netlimit.go` to reflect the severity and context of the events.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
After we ship this in gen104, our errors logs will be easier to parse for ws-daemon.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
