### PR TITLE
Make Git env vars independent of custom certs

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -569,6 +569,12 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 	result = append(result, corev1.EnvVar{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"})
 	result = append(result, corev1.EnvVar{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"})
 
+	// We don't require that Git be configured for workspaces
+	if sctx.Workspace.Spec.Git != nil {
+		result = append(result, corev1.EnvVar{Name: "GITPOD_GIT_USER_NAME", Value: sctx.Workspace.Spec.Git.Username})
+		result = append(result, corev1.EnvVar{Name: "GITPOD_GIT_USER_EMAIL", Value: sctx.Workspace.Spec.Git.Email})
+	}
+
 	if sctx.Config.EnableCustomSSLCertificate {
 		const (
 			customCAMountPath = "/etc/ssl/certs/gitpod-ca.crt"
@@ -578,12 +584,6 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 		result = append(result, corev1.EnvVar{Name: "NODE_EXTRA_CA_CERTS", Value: customCAMountPath})
 		result = append(result, corev1.EnvVar{Name: "GIT_SSL_CAPATH", Value: certsMountPath})
 		result = append(result, corev1.EnvVar{Name: "GIT_SSL_CAINFO", Value: customCAMountPath})
-
-		// We don't require that Git be configured for workspaces
-		if sctx.Workspace.Spec.Git != nil {
-			result = append(result, corev1.EnvVar{Name: "GITPOD_GIT_USER_NAME", Value: sctx.Workspace.Spec.Git.Username})
-			result = append(result, corev1.EnvVar{Name: "GITPOD_GIT_USER_EMAIL", Value: sctx.Workspace.Spec.Git.Email})
-		}
 	}
 
 	// System level env vars

--- a/components/ws-manager-mk2/controllers/create_test.go
+++ b/components/ws-manager-mk2/controllers/create_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/ws-manager/api/config"
+	v1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCreateWorkspaceEnvironment(t *testing.T) {
+	type Expectation struct {
+		Error string
+		Vars  []corev1.EnvVar
+	}
+	tests := []struct {
+		Name        string
+		Expectation Expectation
+		Context     *startWorkspaceContext
+	}{
+		{
+			Name: "with Git config",
+			Context: &startWorkspaceContext{
+				Config: &config.Configuration{
+					WorkspaceClasses: map[string]*config.WorkspaceClass{
+						"default": {Name: "default"},
+					},
+				},
+				Workspace: &v1.Workspace{
+					Spec: v1.WorkspaceSpec{
+						Class: "default",
+						Git: &v1.GitSpec{
+							Username: "foobar",
+							Email:    "foo@bar.com",
+						},
+					},
+				},
+			},
+			Expectation: Expectation{
+				Vars: []corev1.EnvVar{
+					{Name: "GITPOD_REPO_ROOT", Value: "/workspace"},
+					{Name: "GITPOD_REPO_ROOTS", Value: "/workspace"},
+					{Name: "GITPOD_THEIA_PORT", Value: "0"},
+					{Name: "THEIA_WORKSPACE_ROOT", Value: "/workspace"},
+					{Name: "GITPOD_WORKSPACE_CLASS", Value: "default"},
+					{Name: "THEIA_SUPERVISOR_ENDPOINT", Value: ":0"},
+					{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"},
+					{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"},
+					{Name: "GITPOD_GIT_USER_NAME", Value: "foobar"},
+					{Name: "GITPOD_GIT_USER_EMAIL", Value: "foo@bar.com"},
+					{Name: "GITPOD_INTERVAL", Value: "0"}, {Name: "GITPOD_MEMORY", Value: "0"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var act Expectation
+
+			res, err := createWorkspaceEnvironment(test.Context)
+			if err != nil {
+				act.Error = err.Error()
+			}
+			act.Vars = res
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("createWorkspaceEnvironment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR makes the `GITPOD_GIT` env vars available independently of the custom certs. This fixes a bug introduced [in this prior change](https://github.com/gitpod-io/gitpod/compare/main-gha.14775...main-gha.14990#diff-d09717ec68b9f2e7ccaadfca4d83a88aa5829550acc58befab3e70123ec676c0R583-R586).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14eb921</samp>

Refactor and test the Git configuration handling in the ws-manager-mk2 component. This change improves the consistency and reliability of setting the Git author information in the workspace pods based on the workspace spec. The change affects the files `create.go` and `create_test.go` in the `controllers` package.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-629

## How to test
See unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
