### PR TITLE
[ws-manager-mk2] test create w/o git config

### DIFF
--- a/components/ws-manager-mk2/controllers/create_test.go
+++ b/components/ws-manager-mk2/controllers/create_test.go
@@ -57,6 +57,34 @@ func TestCreateWorkspaceEnvironment(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "without Git config",
+			Context: &startWorkspaceContext{
+				Config: &config.Configuration{
+					WorkspaceClasses: map[string]*config.WorkspaceClass{
+						"default": {Name: "default"},
+					},
+				},
+				Workspace: &v1.Workspace{
+					Spec: v1.WorkspaceSpec{
+						Class: "default",
+					},
+				},
+			},
+			Expectation: Expectation{
+				Vars: []corev1.EnvVar{
+					{Name: "GITPOD_REPO_ROOT", Value: "/workspace"},
+					{Name: "GITPOD_REPO_ROOTS", Value: "/workspace"},
+					{Name: "GITPOD_THEIA_PORT", Value: "0"},
+					{Name: "THEIA_WORKSPACE_ROOT", Value: "/workspace"},
+					{Name: "GITPOD_WORKSPACE_CLASS", Value: "default"},
+					{Name: "THEIA_SUPERVISOR_ENDPOINT", Value: ":0"},
+					{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"},
+					{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"},
+					{Name: "GITPOD_INTERVAL", Value: "0"}, {Name: "GITPOD_MEMORY", Value: "0"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adding a test case for the scenario where no git spec is included. 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96504aa</samp>

Add a new test case for workspace environment variables without Git configuration. The test case verifies the expected values of `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, and `GITPOD_WORKSPACE_ID` in `components/ws-manager-mk2/controllers/create_test.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENG-629

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
