### PR TITLE
[fga] Introduce sshkeyservice

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -32,7 +32,7 @@ export type UserResourceType = "user";
 
 export type UserRelation = "self" | "organization" | "installation";
 
-export type UserPermission = "read_info" | "write_info" | "make_admin";
+export type UserPermission = "read_info" | "write_info" | "make_admin" | "read_ssh" | "write_ssh";
 
 export type InstallationResourceType = "installation";
 

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -129,6 +129,7 @@ import { RedisPublisher, newRedisClient } from "@gitpod/gitpod-db/lib";
 import { UserService } from "./user/user-service";
 import { RelationshipUpdater } from "./authorization/relationship-updater";
 import { WorkspaceService } from "./workspace/workspace-service";
+import { SSHKeyService } from "./user/sshkey-service";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -142,6 +143,8 @@ export const productionContainerModule = new ContainerModule(
         bind(UserService).toSelf().inSingletonScope();
         bind(UserDeletionService).toSelf().inSingletonScope();
         bind(AuthorizationService).to(AuthorizationServiceImpl).inSingletonScope();
+
+        bind(SSHKeyService).toSelf().inSingletonScope();
 
         bind(TokenService).toSelf().inSingletonScope();
         bind(TokenProvider).toService(TokenService);

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { Organization, SSHPublicKeyValue, User } from "@gitpod/gitpod-protocol";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { SSHKeyService } from "./sshkey-service";
+import { OrganizationService } from "../orgs/organization-service";
+
+const expect = chai.expect;
+
+describe("SSHKeyService", async () => {
+    let container: Container;
+    let ss: SSHKeyService;
+
+    let owner: User;
+    let member: User;
+    let org: Organization;
+
+    const testSSHkeys: SSHPublicKeyValue[] = [
+        {
+            name: "foo",
+            key: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBN+Mh3U/3We4VYtV1QmWUFIzFLTUeegl1Ao5/QGtCRGAZn8bxX9KlCrrWISIjSYAwCajIEGSPEZwPNMBoK8XD8Q= test@gitpod",
+        },
+        {
+            name: "bar",
+            key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK0wmN/Cr3JXqmLW7u+g9pTh+wyqDHpSQEIQczXkVx9q bar@gitpod",
+        },
+    ];
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+
+        const userDB = container.get<UserDB>(UserDB);
+        owner = await userDB.newUser();
+
+        const os = container.get(OrganizationService);
+        org = await os.createOrganization(owner.id, "myorg");
+
+        member = await userDB.newUser();
+        const invite = await os.getOrCreateInvite(owner.id, org.id);
+        await os.joinOrganization(member.id, invite.id);
+
+        const adminUser = await userDB.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID)!;
+        if (!adminUser) {
+            throw new Error("admin user not found");
+        }
+
+        ss = container.get(SSHKeyService);
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    it("should add ssh key", async () => {
+        const resp1 = await ss.hasSSHPublicKey(member.id);
+        expect(resp1).to.be.false;
+
+        await ss.addSSHPublicKey(member.id, testSSHkeys[0]);
+
+        const resp2 = await ss.hasSSHPublicKey(member.id);
+        expect(resp2).to.be.true;
+    });
+
+    it("should list ssh keys", async () => {
+        await ss.addSSHPublicKey(member.id, testSSHkeys[0]);
+        await ss.addSSHPublicKey(member.id, testSSHkeys[1]);
+
+        const keys = await ss.getSSHPublicKeys(member.id);
+        expect(keys.length).to.equal(2);
+        expect(testSSHkeys.some((k) => k.name === keys[0].name && k.key === keys[0].key)).to.be.true;
+        expect(testSSHkeys.some((k) => k.name === keys[1].name && k.key === keys[1].key)).to.be.true;
+    });
+
+    it("should delete ssh keys", async () => {
+        await ss.addSSHPublicKey(member.id, testSSHkeys[0]);
+        await ss.addSSHPublicKey(member.id, testSSHkeys[1]);
+
+        const keys = await ss.getSSHPublicKeys(member.id);
+        expect(keys.length).to.equal(2);
+
+        await ss.deleteSSHPublicKey(member.id, keys[0].id);
+
+        const keys2 = await ss.getSSHPublicKeys(member.id);
+        expect(keys2.length).to.equal(1);
+    });
+});

--- a/components/server/src/user/sshkey-service.ts
+++ b/components/server/src/user/sshkey-service.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { DBWithTracing, TracedWorkspaceDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { SSHPublicKeyValue, UserSSHPublicKeyValue, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { UpdateSSHKeyRequest } from "@gitpod/ws-manager/lib";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+
+@injectable()
+export class SSHKeyService {
+    constructor(
+        @inject(TracedWorkspaceDB) private readonly workspaceDb: DBWithTracing<WorkspaceDB>,
+        @inject(UserDB) private readonly userDB: UserDB,
+        @inject(WorkspaceManagerClientProvider)
+        private readonly workspaceManagerClientProvider: WorkspaceManagerClientProvider,
+    ) {}
+
+    async hasSSHPublicKey(userId: string): Promise<boolean> {
+        return this.userDB.hasSSHPublicKey(userId);
+    }
+
+    async getSSHPublicKeys(userId: string): Promise<UserSSHPublicKeyValue[]> {
+        const list = await this.userDB.getSSHPublicKeys(userId);
+        return list.map((e) => ({
+            id: e.id,
+            name: e.name,
+            key: e.key,
+            fingerprint: e.fingerprint,
+            creationTime: e.creationTime,
+            lastUsedTime: e.lastUsedTime,
+        }));
+    }
+
+    async addSSHPublicKey(userId: string, value: SSHPublicKeyValue): Promise<UserSSHPublicKeyValue> {
+        const data = await this.userDB.addSSHPublicKey(userId, value);
+        this.updateSSHKeysForRegularRunningInstances(userId).catch(() => {
+            /* noop */
+        });
+        return {
+            id: data.id,
+            name: data.name,
+            key: data.key,
+            fingerprint: data.fingerprint,
+            creationTime: data.creationTime,
+            lastUsedTime: data.lastUsedTime,
+        };
+    }
+
+    async deleteSSHPublicKey(userId: string, id: string): Promise<void> {
+        await this.userDB.deleteSSHPublicKey(userId, id);
+        this.updateSSHKeysForRegularRunningInstances(userId).catch(() => {
+            /* noop */
+        });
+    }
+
+    private async updateSSHKeysForRegularRunningInstances(userId: string) {
+        const updateSSHKeysOfInstance = async (instance: WorkspaceInstance, sshKeys: string[]) => {
+            try {
+                const req = new UpdateSSHKeyRequest();
+                req.setId(instance.id);
+                req.setKeysList(sshKeys);
+                const cli = await this.workspaceManagerClientProvider.get(instance.region);
+                await cli.updateSSHPublicKey({}, req);
+            } catch (err) {
+                const logCtx = { userId, instanceId: instance.id };
+                log.error(logCtx, "Could not update ssh public key for instance", err);
+            }
+        };
+        try {
+            const sshKeys = (await this.userDB.getSSHPublicKeys(userId)).map((e) => e.key);
+            const instances = await this.workspaceDb.trace({}).findRegularRunningInstances(userId);
+            return Promise.allSettled(instances.map((instance) => updateSSHKeysOfInstance(instance, sshKeys)));
+        } catch (err) {
+            log.error("Failed to update ssh keys on running instances.", err);
+        }
+    }
+}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2446,22 +2446,22 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     async hasSSHPublicKey(ctx: TraceContext): Promise<boolean> {
         const user = await this.checkUser("hasSSHPublicKey");
-        return this.sshKeyservice.hasSSHPublicKey(user.id);
+        return this.sshKeyservice.hasSSHPublicKey(user.id, user.id);
     }
 
     async getSSHPublicKeys(ctx: TraceContext): Promise<UserSSHPublicKeyValue[]> {
         const user = await this.checkUser("getSSHPublicKeys");
-        return this.sshKeyservice.getSSHPublicKeys(user.id);
+        return this.sshKeyservice.getSSHPublicKeys(user.id, user.id);
     }
 
     async addSSHPublicKey(ctx: TraceContext, value: SSHPublicKeyValue): Promise<UserSSHPublicKeyValue> {
         const user = await this.checkUser("addSSHPublicKey");
-        return this.sshKeyservice.addSSHPublicKey(user.id, value);
+        return this.sshKeyservice.addSSHPublicKey(user.id, user.id, value);
     }
 
     async deleteSSHPublicKey(ctx: TraceContext, id: string): Promise<void> {
         const user = await this.checkUser("deleteSSHPublicKey");
-        return this.sshKeyservice.deleteSSHPublicKey(user.id, id);
+        return this.sshKeyservice.deleteSSHPublicKey(user.id, user.id, id);
     }
 
     async setProjectEnvironmentVariable(

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -14,6 +14,9 @@ schema: |-
     permission read_info = self + organization->member + organization->owner + installation->admin
     permission write_info = self
     permission make_admin = installation->admin + organization->installation_admin
+
+    permission read_ssh = self
+    permission write_ssh = self
   }
 
   // There's only one global installation


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b816b9d</samp>

This pull request introduces SSH key management functionality to the server component, by adding a new SSHKeyService class that handles the logic of creating, updating, and deleting SSH keys for users and workspaces. It also adds unit tests for the service class and refactors the GitpodServerImpl class to use the service methods.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/EXP-394/

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
