### PR TITLE
Improve organization members filter

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -88,7 +88,7 @@ export default function MembersPage() {
 
     return (
         <>
-            <Header title="Members" subtitle="Manage organization members." />
+            <Header title="Members" subtitle="Manage organization members and their permissions." />
             <div className="app-container">
                 <div className="flex mb-3 mt-3">
                     <div className="flex relative h-10 my-auto">
@@ -105,28 +105,29 @@ export default function MembersPage() {
                             onChange={(e) => setSearchText(e.target.value)}
                         />
                     </div>
-                    <div className="flex-1" />
-                    <div className="py-2 pl-3">
+                    <div className="py-2 pl-3 pr-1 border border-gray-100 ml-2 rounded-md">
                         <DropDown
-                            prefix="Role: "
                             customClasses="w-32"
-                            activeEntry={roleFilter === "owner" ? "Owner" : roleFilter === "member" ? "Member" : "All"}
+                            activeEntry={
+                                roleFilter === "owner" ? "Owners" : roleFilter === "member" ? "Members" : "All"
+                            }
                             entries={[
                                 {
                                     title: "All",
                                     onClick: () => setRoleFilter(undefined),
                                 },
                                 {
-                                    title: "Owner",
+                                    title: "Owners",
                                     onClick: () => setRoleFilter("owner"),
                                 },
                                 {
-                                    title: "Member",
+                                    title: "Members",
                                     onClick: () => setRoleFilter("member"),
                                 },
                             ]}
                         />
                     </div>
+                    <div className="flex-1" />
                     {isOwner && (
                         <button
                             onClick={() => {


### PR DESCRIPTION
## Description

UX updates for the organization members page, improving the role filter.

Extracting some first ideas from the [relevant frame](https://www.figma.com/file/r480CWajzC4JJlZmdDiJen/Projects-V2-(Sandbox)?type=design&node-id=1163%3A1302&mode=design&t=K57SriYQSPOBODJy-1) (internal). Cc @loujaybee 

Next steps could include:
1. Dropping the table header
2. Removing the joined date information and move that to an audit log
3. Move the role switch to the context menu to avoid accidental changes and arrow element repetition

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23ef648</samp>

Improved the organization dashboard UI and added a role filter feature. The changes in `Members.tsx` enhance the user experience and clarity of managing team members and their permissions.

</details>

| BEFORE | AFTER |
|--------|--------|
| <img width="1366" alt="Screenshot 2023-08-10 at 11 45 47 (2)" src="https://github.com/gitpod-io/gitpod/assets/120486/6c4a6a2f-d310-4635-8338-96c3a90330a5"> | <img width="1366" alt="Screenshot 2023-08-10 at 12 01 34 (2)" src="https://github.com/gitpod-io/gitpod/assets/120486/475e8518-fada-4e5f-b10c-9ea18e722d3d"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-improvec57208e64c</li>
	<li><b>🔗 URL</b> - <a href="https://gt-improvec57208e64c.preview.gitpod-dev.com/workspaces" target="_blank">gt-improvec57208e64c.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-improve-org-members-filter-gha.15049</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
