### PR TITLE
[server] added metric for db pool queueing (#18477)

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -47,6 +47,11 @@ export const dbConnectionsFree = new prometheusClient.Gauge({
     help: "Number of free connections in TypeORM pool",
 });
 
+export const dbConnectionsEnqueued = new prometheusClient.Counter({
+    name: "gitpod_typeorm_enqueued_connections",
+    help: "Number of times requests put on the queue, because the pool was maxed out.",
+});
+
 const loginCompletedTotal = new prometheusClient.Counter({
     name: "gitpod_login_completed_total",
     help: "Total number of logins completed into gitpod, by status",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a metric that counts the number of times a connection request could not immediately fulfilled but was put on the queue because the connection pool was exhausted.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ff970e</samp>

Added a new metric `dbConnectionsEnqueued` to measure database connection pool saturation in the server component. This metric is exposed by the `./prometheus-metrics.ts` module and updated by an event listener in `./init.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
