### PR TITLE
[preview] update VM image to gitpod-k3s-202308101245

### DIFF
--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -60,7 +60,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 
 	go func() {
 		defer func() {
-			log.WithError(err).Error("Stopping file watch")
+			log.WithError(err).Info("Stopping file watch")
 
 			err = watcher.Close()
 			if err != nil {

--- a/components/ws-daemon/pkg/daemon/markunmount.go
+++ b/components/ws-daemon/pkg/daemon/markunmount.go
@@ -112,7 +112,7 @@ func (c *MarkUnmountFallback) WorkspaceUpdated(ctx context.Context, ws *dispatch
 
 		err := unmountMark(ws.InstanceID)
 		if err != nil {
-			log.WithFields(ws.OWI()).WithError(err).Error("cannot unmount mark mount from within ws-daemon")
+			log.WithFields(ws.OWI()).WithError(err).Warn("cannot unmount mark mount from within ws-daemon")
 			c.activityCounter.WithLabelValues("false").Inc()
 		} else {
 			c.activityCounter.WithLabelValues("true").Inc()

--- a/components/ws-daemon/pkg/netlimit/netlimit.go
+++ b/components/ws-daemon/pkg/netlimit/netlimit.go
@@ -157,7 +157,7 @@ func (c *ConnLimiter) limitWorkspace(ctx context.Context, ws *dispatch.Workspace
 			case <-ticker.C:
 				counter, err := c.GetConnectionDropCounter(pid)
 				if err != nil {
-					log.WithFields(ws.OWI()).WithError(err).Errorf("could not get connection drop stats for %s", ws.WorkspaceID)
+					log.WithFields(ws.OWI()).WithError(err).Warnf("could not get connection drop stats")
 					continue
 				}
 

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308091714"
+  default     = "gitpod-k3s-202308101245"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308091714"
+  default     = "gitpod-k3s-202308101245"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308091714"
+  default     = "gitpod-k3s-202308101245"
 }
 
 variable "cert_issuer" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4d5b81</samp>

This pull request changes the log levels and messages of some components to improve clarity and reduce noise. It also updates the default VM image for the preview environment to a newer version.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
