### PR TITLE
remove definetly-gp support

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1673,7 +1673,6 @@ type WorkspaceConfig struct {
 	// Where the config object originates from.
 	//
 	// repo - from the repository
-	// definitely-gp - from github.com/gitpod-io/definitely-gp
 	// derived - computed based on analyzing the repository
 	// default - our static catch-all default config
 	Origin            string        `json:"_origin,omitempty"`

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -971,12 +971,11 @@ export interface WorkspaceConfig {
      * Where the config object originates from.
      *
      * repo - from the repository
-     * definitly-gp - from github.com/gitpod-io/definitely-gp
      * derived - computed based on analyzing the repository
      * additional-content - config comes from additional content, usually provided through the project's configuration
      * default - our static catch-all default config
      */
-    _origin?: "repo" | "definitely-gp" | "derived" | "additional-content" | "default";
+    _origin?: "repo" | "derived" | "additional-content" | "default";
 
     /**
      * Set of automatically infered feature flags. That's not something the user can set, but

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -5,7 +5,6 @@
  */
 
 import { inject, injectable } from "inversify";
-import fetch from "node-fetch";
 import * as path from "path";
 import * as crypto from "crypto";
 
@@ -26,7 +25,6 @@ import {
 } from "@gitpod/gitpod-protocol";
 import { GitpodFileParser } from "@gitpod/gitpod-protocol/lib/gitpod-file-parser";
 
-import { MaybeContent } from "../repohost/file-provider";
 import { ConfigurationService } from "../config/configuration-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { AuthorizationService } from "../user/authorization-service";
@@ -39,13 +37,6 @@ const POD_PATH_WORKSPACE_BASE = "/workspace";
 
 @injectable()
 export class ConfigProvider {
-    static readonly DEFINITELY_GP_REPO: Repository = {
-        host: "github.com",
-        owner: "gitpod-io",
-        name: "definitely-gp",
-        cloneUrl: "https://github.com/gitpod-io/definitely-gp",
-    };
-
     @inject(GitpodFileParser) protected readonly gitpodParser: GitpodFileParser;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(AuthorizationService) protected readonly authService: AuthorizationService;
@@ -96,15 +87,10 @@ export class ConfigProvider {
                 config.image = this.config.workspaceDefaults.workspaceImage;
             } else if (ImageConfigFile.is(config.image)) {
                 const dockerfilePath = [configBasePath, config.image.file].filter((s) => !!s).join("/");
-                let repo = commit.repository;
-                let rev = commit.revision;
+                const repo = commit.repository;
+                const rev = commit.revision;
                 const image = config.image!;
 
-                if (config._origin === "definitely-gp") {
-                    repo = ConfigProvider.DEFINITELY_GP_REPO;
-                    rev = "master";
-                    image.file = dockerfilePath;
-                }
                 if (!(AdditionalContentContext.is(commit) && commit.additionalFiles[dockerfilePath])) {
                     config.image = <ExternalImageConfigFile>{
                         ...image,
@@ -143,7 +129,7 @@ export class ConfigProvider {
         }
     }
 
-    protected async fetchCustomConfig(
+    private async fetchCustomConfig(
         ctx: TraceContext,
         user: User,
         commit: CommitContext,
@@ -154,7 +140,7 @@ export class ConfigProvider {
 
         try {
             let customConfig: WorkspaceConfig | undefined;
-            let configBasePath = "";
+            const configBasePath = "";
             if (AdditionalContentContext.is(commit) && commit.additionalFiles[".gitpod.yml"]) {
                 customConfigString = commit.additionalFiles[".gitpod.yml"];
                 const parseResult = this.gitpodParser.parse(customConfigString);
@@ -182,21 +168,6 @@ export class ConfigProvider {
                 const contextRepoConfig = services.fileProvider.getGitpodFileContent(commit, user);
                 customConfigString = await contextRepoConfig;
                 let origin: WorkspaceConfig["_origin"] = "repo";
-
-                if (!customConfigString) {
-                    /* We haven't found a Gitpod configuration file in the context repo - check definitely-gp.
-                     *
-                     * In case we had found a config file here, we'd still be checking the definitely GP repo, just to save some time.
-                     * While all those checks will be in vain, they should not leak memory either as they'll simply
-                     * be resolved and garbage collected.
-                     */
-                    const definitelyGpConfig = this.fetchExternalGitpodFileContent({ span }, commit.repository);
-                    const { content, basePath } = await definitelyGpConfig;
-                    customConfigString = content;
-                    // We do not only care about the config itself but also where we got it from
-                    configBasePath = basePath;
-                    origin = "definitely-gp";
-                }
 
                 if (!customConfigString) {
                     const inferredConfig = this.configurationService.guessRepositoryConfiguration(
@@ -248,7 +219,7 @@ export class ConfigProvider {
         };
     }
 
-    protected async fetchWorkspaceImageSourceDocker(
+    private async fetchWorkspaceImageSourceDocker(
         ctx: TraceContext,
         repository: Repository,
         revisionOrTagOrBranch: string,
@@ -287,101 +258,7 @@ export class ConfigProvider {
         }
     }
 
-    protected async fillInDefaultLocations(
-        cfg: WorkspaceConfig | undefined,
-        inferredConfig: Promise<WorkspaceConfig | undefined>,
-    ): Promise<void> {
-        if (!cfg) {
-            // there is no config - return
-            return;
-        }
-
-        if (!cfg.checkoutLocation) {
-            const inferredCfg = await inferredConfig;
-            if (inferredCfg) {
-                cfg.checkoutLocation = inferredCfg.checkoutLocation;
-            }
-        }
-        if (!cfg.workspaceLocation) {
-            const inferredCfg = await inferredConfig;
-            if (inferredCfg) {
-                cfg.workspaceLocation = inferredCfg.workspaceLocation;
-            }
-        }
-    }
-
-    protected async fetchExternalGitpodFileContent(
-        ctx: TraceContext,
-        repository: Repository,
-    ): Promise<{ content: MaybeContent; basePath: string }> {
-        const span = TraceContext.startSpan("fetchExternalGitpodFileContent", ctx);
-        span.setTag("repo", `${repository.owner}/${repository.name}`);
-
-        if (this.config.definitelyGpDisabled) {
-            span.finish();
-            return {
-                content: undefined,
-                basePath: `${repository.name}`,
-            };
-        }
-
-        try {
-            const ownerConfigBasePath = `${repository.name}/${repository.owner}`;
-            const baseConfigBasePath = `${repository.name}`;
-
-            const possibleConfigs = [
-                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod.yml`), ownerConfigBasePath],
-                [this.fetchDefinitelyGpContent({ span }, `${ownerConfigBasePath}/.gitpod`), ownerConfigBasePath],
-                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod.yml`), baseConfigBasePath],
-                [this.fetchDefinitelyGpContent({ span }, `${baseConfigBasePath}/.gitpod`), baseConfigBasePath],
-            ];
-            for (const [configPromise, basePath] of possibleConfigs) {
-                const ownerConfig = await configPromise;
-                if (ownerConfig !== undefined) {
-                    return {
-                        content: ownerConfig,
-                        basePath: basePath as string,
-                    };
-                }
-            }
-            return {
-                content: undefined,
-                basePath: baseConfigBasePath,
-            };
-        } catch (e) {
-            TraceContext.setError({ span }, e);
-            throw e;
-        } finally {
-            span.finish();
-        }
-    }
-
-    protected async fetchDefinitelyGpContent(ctx: TraceContext, filePath: string) {
-        const span = TraceContext.startSpan("fetchDefinitelyGpContent", ctx);
-        span.setTag("filePath", filePath);
-
-        try {
-            const url = `https://raw.githubusercontent.com/gitpod-io/definitely-gp/master/${filePath}`;
-            const response = await fetch(url, {
-                timeout: 10000,
-                method: "GET",
-            });
-            let content;
-            if (response.ok) {
-                try {
-                    content = await response.text();
-                } catch {}
-            }
-            return content;
-        } catch (e) {
-            TraceContext.setError({ span }, e);
-            throw e;
-        } finally {
-            span.finish();
-        }
-    }
-
-    protected async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
+    private async validateConfig(config: WorkspaceConfig, user: User): Promise<void> {
         // Make sure the projectRoot does not leave POD_PATH_WORKSPACE_BASE as that's a common
         // assumption throughout the code (e.g. ws-daemon)
         const checkoutLocation = config.checkoutLocation;
@@ -407,7 +284,7 @@ export class ConfigProvider {
         }
     }
 
-    protected leavesWorkspaceBase(normalizedPath: string) {
+    private leavesWorkspaceBase(normalizedPath: string) {
         const pathSegments = normalizedPath.split(path.sep);
         return normalizedPath.includes("..") || pathSegments.slice(0, 2).join("/") != POD_PATH_WORKSPACE_BASE;
     }

--- a/components/server/src/workspace/image-source-provider.ts
+++ b/components/server/src/workspace/image-source-provider.ts
@@ -37,7 +37,7 @@ export class ImageSourceProvider {
 
             const imgcfg = config.image;
             if (ExternalImageConfigFile.is(imgcfg)) {
-                // we're asked to pull the Dockerfile from a repo possibly different than the one we're opening a workspace for (e.g. definitely-gp).
+                // we're asked to pull the Dockerfile from a repo possibly different than the one we're opening a workspace for.
                 const repository = imgcfg.externalSource.repository;
                 const hostContext = this.hostContextProvider.get(repository.host);
                 if (!hostContext || !hostContext.services) {

--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -11,7 +11,6 @@ containerRegistry:
   privateBaseImageAllowList: []
 database:
   inCluster: true
-disableDefinitelyGp: true
 domain: ""
 kind: Full
 metadata:

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -212,8 +212,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MaxAgeMs: 259200000,
 			Secret:   sessionSecret,
 		},
-		DefinitelyGpDisabled: ctx.Config.DisableDefinitelyGP,
-		GitHubApp:            githubApp,
+		GitHubApp: githubApp,
 		WorkspaceGarbageCollection: WorkspaceGarbageCollection{
 			Disabled:                   disableWsGarbageCollection,
 			IntervalSeconds:            1 * 60 * 60, // 1 hour

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -21,7 +21,6 @@ type ConfigSerialized struct {
 	DevBranch                         string      `json:"devBranch"`
 	InsecureNoDomain                  bool        `json:"insecureNoDomain"`
 	License                           string      `json:"license"`
-	DefinitelyGpDisabled              bool        `json:"definitelyGpDisabled"`
 	EnableLocalApp                    bool        `json:"enableLocalApp"`
 	DisableDynamicAuthProviderLogin   bool        `json:"disableDynamicAuthProviderLogin"`
 	MaxEnvvarPerUserCount             int32       `json:"maxEnvvarPerUserCount"`

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -75,7 +75,6 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = containerd.ContainerdLocationDefault.String()
 	cfg.Workspace.MaxLifetime = util.Duration(36 * time.Hour)
 	cfg.OpenVSX.URL = defaultOpenVSXURL
-	cfg.DisableDefinitelyGP = true
 
 	return nil
 }
@@ -142,8 +141,6 @@ type Config struct {
 	BlockNewUsers BlockNewUsers `json:"blockNewUsers"`
 
 	SSHGatewayHostKey *ObjectRef `json:"sshGatewayHostKey,omitempty"`
-
-	DisableDefinitelyGP bool `json:"disableDefinitelyGp"`
 
 	CustomCACert *ObjectRef `json:"customCACert,omitempty"`
 

--- a/install/installer/pkg/config/v1/config.md
+++ b/install/installer/pkg/config/v1/config.md
@@ -74,7 +74,6 @@ Config defines the v1 version structure of the gitpod config file
 |`blockNewUsers.passlist[ ]`|[]string|N|  |  Passlist []string `json:"passlist" validate:"min=1,unique,dive,fqdn"`|
 |`sshGatewayHostKey.kind`|string|N| `secret` ||
 |`sshGatewayHostKey.name`|string|Y|  ||
-|`disableDefinitelyGp`|bool|N|  ||
 |`dropImageRepo`|bool|N|  ||
 |`customization`||N|  ||
 |`components.proxy.service.serviceType`||N|  ||


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

compare to previous attempts it does not remove anything related to ExternalImageConfigFile

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Start workspaces with image builds from different contexts, branches, commits.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
