### PR TITLE
fail workspace start gracefully on shutdown

### DIFF
--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -110,6 +110,7 @@ export class WsExpressHandler {
 
     dispose(): Promise<void> {
         return new Promise((resolve, reject) => {
+            // stop accepting new connections and emit when all connections are closed
             this.wss.close((err) => {
                 if (err) {
                     reject(err);
@@ -117,6 +118,10 @@ export class WsExpressHandler {
                     resolve();
                 }
             });
+            // terminate all existing connections
+            for (const client of this.wss.clients) {
+                client.terminate();
+            }
         });
     }
 }

--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -107,4 +107,16 @@ export class WsExpressHandler {
         }
         return pathname === matcher;
     }
+
+    dispose(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.wss.close((err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
 }

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -74,7 +74,7 @@ export class PrebuildManager implements Disposable {
     private readonly disposables = new DisposableCollection();
 
     constructor() {
-        this.disposables.push(this.shutdownTokenSource);
+        this.disposables.push(Disposable.create(() => this.shutdownTokenSource.cancel()));
     }
 
     async abortPrebuildsForBranch(ctx: TraceContext, project: Project, user: User, branch: string): Promise<void> {

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -186,6 +186,7 @@ export type FailedInstanceStartReason =
     | "imageBuildFailed"
     | "resourceExhausted"
     | "workspaceClusterMaintenance"
+    | "serverShuttingDown"
     | "other";
 export function increaseFailedInstanceStartCounter(reason: FailedInstanceStartReason) {
     instanceStartsFailedTotal.inc({ reason });

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -214,6 +214,7 @@ export class Server {
 
             const wsPingPongHandler = new WsConnectionHandler();
             const wsHandler = new WsExpressHandler(httpServer, verifyClient);
+            this.disposables.push(wsHandler);
             wsHandler.ws(
                 websocketConnectionHandler.path,
                 (ws, request) => {

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -51,6 +51,7 @@ import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
 import { JobRunner } from "./jobs/runner";
 import { RedisSubscriber } from "./messaging/redis-subscriber";
+import { PrebuildManager } from "./prebuilds/prebuild-manager";
 
 @injectable()
 export class Server {
@@ -96,7 +97,10 @@ export class Server {
         @inject(IamSessionApp) private readonly iamSessionAppCreator: IamSessionApp,
         @inject(API) private readonly api: API,
         @inject(RedisSubscriber) private readonly redisSubscriber: RedisSubscriber,
-    ) {}
+        @inject(PrebuildManager) prebuildManager: PrebuildManager,
+    ) {
+        this.disposables.push(prebuildManager);
+    }
 
     public async init(app: express.Application) {
         log.setVersion(this.config.version);

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -348,12 +348,14 @@ export class Server {
     }
 
     public async stop() {
-        await this.debugApp.stop();
-        await this.stopServer(this.iamSessionAppServer);
-        await this.stopServer(this.monitoringHttpServer);
-        await this.stopServer(this.httpServer);
-        await this.stopServer(this.apiServer);
-        this.disposables.dispose();
+        await Promise.allSettled([
+            this.debugApp.stop(),
+            this.stopServer(this.iamSessionAppServer),
+            this.stopServer(this.monitoringHttpServer),
+            this.stopServer(this.httpServer),
+            this.stopServer(this.apiServer),
+            new Promise(() => this.disposables.dispose()),
+        ]).catch((err) => log.error("error while stopping server", { err }));
         log.info("server stopped.");
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -302,7 +302,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (client) {
             this.disposables.push(Disposable.create(() => (this.client = undefined)));
         }
-        this.disposables.push(this.shutdownTokenSource);
+        this.disposables.push(Disposable.create(() => this.shutdownTokenSource.cancel()));
         this.client = client;
         this.userID = userID;
         this.resourceAccessGuard = accessGuard;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -407,7 +407,9 @@ export class WorkspaceStarter {
         throw new StartInstanceError("serverShuttingDown", shutdownError);
     }
     private failOnShutdown(ctx: TraceContext, workspace: Workspace, instance?: WorkspaceInstance) {
-        const shutdownError = new Error("Service temporarily unavailable. Please retry in a few seconds.");
+        const shutdownError = new Error(
+            "Service temporarily unavailable. Please retry to start in a few seconds again.",
+        );
         if (instance) {
             this.doFailInstanceStart(ctx, shutdownError, workspace, instance).catch(() => {
                 // cannot happen


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e18356</samp>

Added cancellation support for workspace creation and start operations in the `GitpodServer` interface and implementation. Used the `CancellationToken` type from `vscode-jsonrpc` and `vscode-ws-jsonrpc` modules.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-393

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-restart-on-start</li>
	<li><b>🔗 URL</b> - <a href="https://ak-restart-on-start.preview.gitpod-dev.com/workspaces" target="_blank">ak-restart-on-start.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-restart_on_start-gha.15135</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
