### PR TITLE
[new-workspace] Fix recent repositories for BBS – EXP-411

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -855,20 +855,6 @@ export type WorkspaceSoftDeletion = "user" | "gc";
 export type WorkspaceType = "regular" | "prebuild";
 
 export namespace Workspace {
-    export function getFullRepositoryName(ws: Workspace): string | undefined {
-        if (CommitContext.is(ws.context)) {
-            return ws.context.repository.owner + "/" + ws.context.repository.name;
-        }
-        return undefined;
-    }
-
-    export function getFullRepositoryUrl(ws: Workspace): string | undefined {
-        if (CommitContext.is(ws.context)) {
-            return `https://${ws.context.repository.host}/${getFullRepositoryName(ws)}`;
-        }
-        return undefined;
-    }
-
     export function getPullRequestNumber(ws: Workspace): number | undefined {
         if (PullRequestContext.is(ws.context)) {
             return ws.context.nr;

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -122,6 +122,13 @@ class TestBitbucketServerRepositoryProvider {
             author: "Alex Tugarev",
         });
     }
+
+    @test async test_getUserRepos_ok() {
+        const result = await this.service.getUserRepos(this.user);
+        expect(result).to.contain(
+            "http://7990-alextugarev-bbs-6v0gqcpgvj7.ws-eu102.gitpod.io/scm/~alex.tugarev/user.repo.git",
+        );
+    }
 }
 
 module.exports = new TestBitbucketServerRepositoryProvider();

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -147,13 +147,16 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
     async getUserRepos(user: User): Promise<string[]> {
         try {
             const repos = await this.api.getRepos(user, { limit: 1000, permission: "REPO_READ" });
+            console.log(JSON.stringify(repos));
+            const result: string[] = [];
+            (repos.values || []).forEach((r) => {
+                const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;
+                if (cloneUrl) {
+                    result.push(cloneUrl.replace("http://", "https://"));
+                }
+            });
 
-            return (repos.values || [])
-                .map((r) => {
-                    const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href!;
-                    return cloneUrl;
-                })
-                .filter((u) => !!u);
+            return result;
         } catch (error) {
             log.error("BitbucketServerRepositoryProvider.getUserRepos", error);
             return [];

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1788,7 +1788,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             })
                 .then((workspaces) => {
                     workspaces.forEach((ws) => {
-                        const repoUrl = Workspace.getFullRepositoryUrl(ws.workspace);
+                        let repoUrl;
+                        if (CommitContext.is(ws.workspace.context)) {
+                            repoUrl = ws.workspace.context?.repository?.cloneUrl?.replace(/\.git$/, "");
+                        }
+                        if (!repoUrl) {
+                            repoUrl = ws.workspace.contextURL;
+                        }
                         if (repoUrl) {
                             const lastUse = WorkspaceInfo.lastActiveISODate(ws);
                             suggestions.push({ url: repoUrl, lastUse, priority: 10 });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-411

## How to test
* see that New Workspace is working as expected for GH/GL

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
