### PR TITLE
[fga] Introduce GitpodTokenService

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -32,7 +32,15 @@ export type UserResourceType = "user";
 
 export type UserRelation = "self" | "organization" | "installation";
 
-export type UserPermission = "read_info" | "write_info" | "delete" | "make_admin" | "read_ssh" | "write_ssh";
+export type UserPermission =
+    | "read_info"
+    | "write_info"
+    | "delete"
+    | "make_admin"
+    | "read_ssh"
+    | "write_ssh"
+    | "read_tokens"
+    | "write_tokens";
 
 export type InstallationResourceType = "installation";
 

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -130,6 +130,7 @@ import { UserService } from "./user/user-service";
 import { RelationshipUpdater } from "./authorization/relationship-updater";
 import { WorkspaceService } from "./workspace/workspace-service";
 import { SSHKeyService } from "./user/sshkey-service";
+import { GitpodTokenService } from "./user/gitpod-token-service";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -145,6 +146,7 @@ export const productionContainerModule = new ContainerModule(
         bind(AuthorizationService).to(AuthorizationServiceImpl).inSingletonScope();
 
         bind(SSHKeyService).toSelf().inSingletonScope();
+        bind(GitpodTokenService).toSelf().inSingletonScope();
 
         bind(TokenService).toSelf().inSingletonScope();
         bind(TokenProvider).toService(TokenService);

--- a/components/server/src/user/gitpod-token-service.spec.db.ts
+++ b/components/server/src/user/gitpod-token-service.spec.db.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TypeORM } from "@gitpod/gitpod-db/lib";
+import { GitpodTokenType, Organization, User } from "@gitpod/gitpod-protocol";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { OrganizationService } from "../orgs/organization-service";
+import { UserService } from "./user-service";
+import { expectError } from "../test/expect-utils";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { GitpodTokenService } from "./gitpod-token-service";
+
+const expect = chai.expect;
+
+describe("GitpodTokenService", async () => {
+    let container: Container;
+    let gs: GitpodTokenService;
+
+    let member: User;
+    let stranger: User;
+    let org: Organization;
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+
+        const orgService = container.get<OrganizationService>(OrganizationService);
+        org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
+        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
+
+        const userService = container.get<UserService>(UserService);
+        member = await userService.createUser({
+            organizationId: org.id,
+            identity: {
+                authId: "foo",
+                authName: "bar",
+                authProviderId: "github",
+                primaryEmail: "yolo@yolo.com",
+            },
+        });
+        await orgService.joinOrganization(member.id, invite.id);
+        stranger = await userService.createUser({
+            identity: {
+                authId: "foo2",
+                authName: "bar2",
+                authProviderId: "github",
+            },
+        });
+
+        gs = container.get(GitpodTokenService);
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    it("should generate a new gitpod token", async () => {
+        const resp1 = await gs.getGitpodTokens(member.id, member.id);
+        expect(resp1.length).to.equal(0);
+
+        await gs.generateNewGitpodToken(member.id, member.id, { name: "token1", type: GitpodTokenType.API_AUTH_TOKEN });
+
+        const resp2 = await gs.getGitpodTokens(member.id, member.id);
+        expect(resp2.length).to.equal(1);
+
+        await expectError(ErrorCodes.NOT_FOUND, gs.getGitpodTokens(stranger.id, member.id));
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            gs.generateNewGitpodToken(stranger.id, member.id, { name: "token2", type: GitpodTokenType.API_AUTH_TOKEN }),
+        );
+    });
+
+    it("should list gitpod tokens", async () => {
+        await gs.generateNewGitpodToken(member.id, member.id, { name: "token1", type: GitpodTokenType.API_AUTH_TOKEN });
+        await gs.generateNewGitpodToken(member.id, member.id, { name: "token2", type: GitpodTokenType.API_AUTH_TOKEN });
+
+        const tokens = await gs.getGitpodTokens(member.id, member.id);
+        expect(tokens.length).to.equal(2);
+        expect(tokens.some((t) => t.name === "token1")).to.be.true;
+        expect(tokens.some((t) => t.name === "token2")).to.be.true;
+
+        await expectError(ErrorCodes.NOT_FOUND, gs.getGitpodTokens(stranger.id, member.id));
+    });
+
+    it("should return gitpod token", async () => {
+        await gs.generateNewGitpodToken(member.id, member.id, {
+            name: "token1",
+            type: GitpodTokenType.API_AUTH_TOKEN,
+            scopes: ["user:email", "read:user"],
+        });
+
+        const tokens = await gs.getGitpodTokens(member.id, member.id);
+        expect(tokens.length).to.equal(1);
+
+        const token = await gs.findGitpodToken(member.id, member.id, tokens[0].tokenHash);
+        expect(token).to.not.be.undefined;
+
+        await expectError(ErrorCodes.NOT_FOUND, gs.findGitpodToken(stranger.id, member.id, tokens[0].tokenHash));
+    });
+
+    it("should delete gitpod tokens", async () => {
+        await gs.generateNewGitpodToken(member.id, member.id, {
+            name: "token1",
+            type: GitpodTokenType.API_AUTH_TOKEN,
+        });
+        await gs.generateNewGitpodToken(member.id, member.id, {
+            name: "token2",
+            type: GitpodTokenType.API_AUTH_TOKEN,
+        });
+
+        const tokens = await gs.getGitpodTokens(member.id, member.id);
+        expect(tokens.length).to.equal(2);
+
+        await gs.deleteGitpodToken(member.id, member.id, tokens[0].tokenHash);
+
+        const tokens2 = await gs.getGitpodTokens(member.id, member.id);
+        expect(tokens2.length).to.equal(1);
+
+        await expectError(ErrorCodes.NOT_FOUND, gs.deleteGitpodToken(stranger.id, member.id, tokens[1].tokenHash));
+    });
+});

--- a/components/server/src/user/gitpod-token-service.ts
+++ b/components/server/src/user/gitpod-token-service.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as crypto from "crypto";
+import { DBGitpodToken, UserDB } from "@gitpod/gitpod-db/lib";
+import { GitpodToken, GitpodTokenType } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Authorizer } from "../authorization/authorizer";
+
+@injectable()
+export class GitpodTokenService {
+    constructor(
+        @inject(UserDB) private readonly userDB: UserDB,
+        @inject(Authorizer) private readonly auth: Authorizer,
+    ) {}
+
+    async getGitpodTokens(requestorId: string, userId: string): Promise<GitpodToken[]> {
+        await this.auth.checkPermissionOnUser(requestorId, "read_tokens", userId);
+        const gitpodTokens = await this.userDB.findAllGitpodTokensOfUser(userId);
+        return gitpodTokens.filter((v) => !v.deleted);
+    }
+
+    async generateNewGitpodToken(
+        requestorId: string,
+        userId: string,
+        options: { name?: string; type: GitpodTokenType; scopes?: string[] },
+        oldPermissionCheck?: (dbToken: DBGitpodToken) => Promise<void>, // @deprecated
+    ): Promise<string> {
+        await this.auth.checkPermissionOnUser(requestorId, "write_tokens", userId);
+        const token = crypto.randomBytes(30).toString("hex");
+        const tokenHash = crypto.createHash("sha256").update(token, "utf8").digest("hex");
+        const dbToken: DBGitpodToken = {
+            tokenHash,
+            name: options.name,
+            type: options.type,
+            userId,
+            scopes: options.scopes || [],
+            created: new Date().toISOString(),
+        };
+        if (oldPermissionCheck) {
+            await oldPermissionCheck(dbToken);
+        }
+        await this.userDB.storeGitpodToken(dbToken);
+        return token;
+    }
+
+    async findGitpodToken(requestorId: string, userId: string, tokenHash: string): Promise<GitpodToken | undefined> {
+        await this.auth.checkPermissionOnUser(requestorId, "read_tokens", userId);
+        let token: GitpodToken | undefined;
+        try {
+            token = await this.userDB.findGitpodTokensOfUser(userId, tokenHash);
+        } catch (error) {
+            log.error({ userId }, "failed to resolve gitpod token: ", error);
+        }
+        if (token?.deleted) {
+            token = undefined;
+        }
+        return token;
+    }
+
+    async deleteGitpodToken(
+        requestorId: string,
+        userId: string,
+        tokenHash: string,
+        oldPermissionCheck?: (token: GitpodToken) => Promise<void>, // @deprecated
+    ): Promise<void> {
+        await this.auth.checkPermissionOnUser(requestorId, "write_tokens", userId);
+        const existingTokens = await this.getGitpodTokens(requestorId, userId);
+        const tkn = existingTokens.find((token) => token.tokenHash === tokenHash);
+        if (!tkn) {
+            throw new Error(`User ${requestorId} tries to delete a token ${tokenHash} that does not exist.`);
+        }
+        if (oldPermissionCheck) {
+            await oldPermissionCheck(tkn);
+        }
+        await this.userDB.deleteGitpodToken(tokenHash);
+    }
+}

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -18,6 +18,9 @@ schema: |-
 
     permission read_ssh = self
     permission write_ssh = self
+
+    permission read_tokens = self
+    permission write_tokens = self
   }
 
   // There's only one global installation


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64a3604</samp>

This pull request introduces a new server component, `GitpodTokenService`, to manage Gitpod tokens for API access. It also adds the corresponding permissions, `read_tokens` and `write_tokens`, to the Spicedb schema and the `UserPermission` type. The Gitpod server API methods related to Gitpod tokens are refactored to use the new service. Unit tests for the service are added as well.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/EXP-420

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
