### PR TITLE
Improve dashboard loading page

### DIFF
--- a/components/dashboard/src/app/AppLoading.tsx
+++ b/components/dashboard/src/app/AppLoading.tsx
@@ -5,7 +5,6 @@
  */
 
 import { FunctionComponent, useEffect, useState } from "react";
-import { Heading3, Subheading } from "../components/typography/headings";
 import gitpodIcon from "../icons/gitpod.svg";
 import { Delayed } from "../components/Delayed";
 
@@ -24,22 +23,37 @@ export const AppLoading: FunctionComponent = () => {
     const connectionProblems = useDelay(25000);
     return (
         <Delayed wait={3000}>
-            <div className="flex flex-col justify-center items-center w-full h-screen space-y-4">
-                <img src={gitpodIcon} alt="Gitpod's logo" className={"h-16 flex-shrink-0 animate-fade-in"} />
+            <div className="flex flex-col justify-center items-center w-full h-screen space-y-4 bg-gray-100 dark:bg-gray-900">
+                <img
+                    src={gitpodIcon}
+                    alt="Gitpod's logo"
+                    className={"h-8 flex-shrink-0 animate-fade-in filter-grayscale"}
+                />
                 {connectionProblems ? (
-                    <Heading3 className={done ? "" : "invisible"}>This is taking longer than it should</Heading3>
+                    <p className={done ? "" : "invisible"}>
+                        <span className="text-gray-600 dark:text-gray-300 font-semibold text-md">
+                            <span className="text-gitpod-red">[ERROR]</span> Could not load dashboard
+                        </span>
+                    </p>
                 ) : (
-                    <Heading3 className={done ? "animate-fade-in" : "invisible"}>
-                        Just getting a few more things ready
-                    </Heading3>
+                    <p className={done ? "animate-fade-in" : "invisible"}>
+                        <span className="text-gray-500 dark:text-gray-300 font-semibold text-md">
+                            Loading dashboard...
+                        </span>
+                    </p>
                 )}
                 {connectionProblems ? (
-                    <Subheading className={done ? "max-w-xl text-center" : "invisible"}>
-                        It seems like you are having connection issues. Please check your network connection. Sometimes
-                        this problem can also be caused by a slow browser with too many tabs and/or extensions.
-                    </Subheading>
+                    <p className={done ? "max-w-xl text-center" : "invisible"}>
+                        <span className="text-gray-400 dark:text-gray-500">
+                            Check your network connection or try restarting your browser.
+                        </span>
+                    </p>
                 ) : (
-                    <Subheading className={done ? "animate-fade-in" : "invisible"}>hang in there...</Subheading>
+                    <p className={done ? "animate-fade-in" : "invisible"}>
+                        <span className="text-gray-400 dark:text-gray-500">
+                            This is taking longer than it expected.
+                        </span>
+                    </p>
                 )}
             </div>
         </Delayed>


### PR DESCRIPTION
## Description

⚠️ WIP

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb8be91</samp>

Redesigned and simplified the `AppLoading` component for the dashboard. Cleaned up unused code in `AppLoading.tsx`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
