### PR TITLE
Revert "Enable leader election in ws-manager-mk2"

### DIFF
--- a/components/ws-manager-mk2/cmd/sample-workspace/main.go
+++ b/components/ws-manager-mk2/cmd/sample-workspace/main.go
@@ -10,11 +10,10 @@ import (
 	"log"
 	"time"
 
+	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
-
-	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 )
 
 func main() {

--- a/components/ws-manager-mk2/config/manager/manager.yaml
+++ b/components/ws-manager-mk2/config/manager/manager.yaml
@@ -33,6 +33,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -68,9 +68,13 @@ func init() {
 }
 
 func main() {
+	var enableLeaderElection bool
 	var configFN string
 	var jsonLog bool
 	var verbose bool
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&configFN, "config", "", "Path to the config file")
 	flag.BoolVar(&jsonLog, "json-log", true, "produce JSON log output on verbose level")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
@@ -121,7 +125,7 @@ func main() {
 		MetricsBindAddress:     cfg.Prometheus.Addr,
 		Port:                   9443,
 		HealthProbeBindAddress: cfg.Health.Addr,
-		LeaderElection:         true,
+		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ws-manager-mk2-leader.gitpod.io",
 		NewCache:               cache.MultiNamespacedCacheBuilder([]string{cfg.Manager.Namespace, cfg.Manager.SecretsNamespace}),
 	})

--- a/install/installer/pkg/components/ws-manager-mk2/deployment.go
+++ b/install/installer/pkg/components/ws-manager-mk2/deployment.go
@@ -5,6 +5,10 @@
 package wsmanagermk2
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -12,11 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-
-	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -59,6 +58,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Name: Component,
 			Args: []string{
 				"--config", "/config/config.json",
+				"--leader-elect",
 			},
 			Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManagerMk2.Version),
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -176,7 +176,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(2),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Reverts gitpod-io/gitpod#18419

The GRPC server is started even when the replica is not the leader and the maintenance configmap is not watched, only read once. This introduces an edge case when the maintenance mode is triggered, and we deploy a new version. The standby replica never gets the configmap update