### PR TITLE
[server] delete unused guard

### DIFF
--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -21,13 +21,11 @@ import {
     GuardedResourceKind,
     RepositoryResourceGuard,
     SharedWorkspaceAccessGuard,
-    GuardedCostCenter,
 } from "./resource-access";
 import { PrebuiltWorkspace, User, UserEnvVar, Workspace, WorkspaceType } from "@gitpod/gitpod-protocol/lib/protocol";
 import {
     OrgMemberInfo,
     Organization,
-    Team,
     TeamMemberInfo,
     TeamMemberRole,
     WorkspaceInstance,
@@ -240,145 +238,6 @@ class TestResourceAccess {
             expect(await res.canAccess(t.resource, "get")).to.be.eq(
                 t.isAllowed,
                 `"${t.name}" expected canAccess(resource, "get") === ${t.isAllowed}, but was ${res}`,
-            );
-        }
-    }
-
-    @test public async costCenterResourceGuard() {
-        const createUser = (): User => {
-            return {
-                id: "123",
-                name: "testuser",
-                creationDate: new Date(2000, 1, 1).toISOString(),
-                identities: [
-                    {
-                        authId: "123",
-                        authName: "testuser",
-                        authProviderId: "github.com",
-                    },
-                ],
-            };
-        };
-
-        const tests: {
-            name: string;
-            isOwner?: boolean;
-            teamRole?: TeamMemberRole;
-            operation: ResourceAccessOp;
-            expectation: boolean;
-        }[] = [
-            // member
-            {
-                name: "member - get",
-                teamRole: "member",
-                operation: "get",
-                expectation: true,
-            },
-            {
-                name: "member - update",
-                teamRole: "member",
-                operation: "update",
-                expectation: false,
-            },
-            {
-                name: "member - update",
-                teamRole: "member",
-                operation: "create",
-                expectation: false,
-            },
-            {
-                name: "member - delete",
-                teamRole: "member",
-                operation: "delete",
-                expectation: false,
-            },
-            // team owner
-            {
-                name: "team owner - get",
-                teamRole: "owner",
-                operation: "get",
-                expectation: true,
-            },
-            {
-                name: "team owner - update",
-                teamRole: "owner",
-                operation: "update",
-                expectation: true,
-            },
-            {
-                name: "team owner - update",
-                teamRole: "owner",
-                operation: "create",
-                expectation: true,
-            },
-            {
-                name: "team owner - delete",
-                teamRole: "owner",
-                operation: "delete",
-                expectation: true,
-            },
-            // owner
-            {
-                name: "owner - get",
-                isOwner: true,
-                operation: "get",
-                expectation: true,
-            },
-            {
-                name: "owner - update",
-                isOwner: true,
-                operation: "update",
-                expectation: true,
-            },
-            {
-                name: "owner - update",
-                isOwner: true,
-                operation: "create",
-                expectation: true,
-            },
-            {
-                name: "owner - delete",
-                isOwner: true,
-                operation: "delete",
-                expectation: true,
-            },
-        ];
-
-        for (const t of tests) {
-            const user = createUser();
-            const team: Team = {
-                id: "team-123",
-                name: "test-team",
-                creationTime: user.creationDate,
-            };
-            const resourceGuard = new CompositeResourceAccessGuard([
-                new OwnerResourceGuard(user.id),
-                new TeamMemberResourceGuard(user.id),
-                new SharedWorkspaceAccessGuard(),
-                new MockedRepositoryResourceGuard(true),
-            ]);
-
-            let owner: GuardedCostCenter["owner"] | undefined = undefined;
-            if (t.isOwner) {
-                owner = { kind: "user", userId: user.id };
-            } else if (!!t.teamRole) {
-                const teamMembers: TeamMemberInfo[] = [
-                    {
-                        userId: user.id,
-                        role: t.teamRole,
-                        memberSince: user.creationDate,
-                        ownedByOrganization: false,
-                    },
-                ];
-                owner = { kind: "team", team, members: teamMembers };
-            }
-            if (!owner) {
-                throw new Error("Bad test data: expected isOwner OR teamRole to be configured!");
-            }
-            const actual = await resourceGuard.canAccess({ kind: "costCenter", owner }, t.operation);
-            expect(actual).to.be.eq(
-                t.expectation,
-                `"${t.name}" expected canAccess(resource, "${t.operation}") === ${t.expectation}, but was ${actual}`,
             );
         }
     }

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -37,7 +37,6 @@ export type GuardedResource =
     | GuardedContentBlob
     | GuardEnvVar
     | GuardedTeam
-    | GuardedCostCenter
     | GuardedWorkspaceLog
     | GuardedPrebuild;
 
@@ -52,7 +51,6 @@ const ALL_GUARDED_RESOURCE_KINDS = new Set<GuardedResourceKind>([
     "contentBlob",
     "envVar",
     "team",
-    "costCenter",
     "workspaceLog",
 ]);
 export function isGuardedResourceKind(kind: any): kind is GuardedResourceKind {
@@ -105,24 +103,6 @@ export interface GuardedTeam {
     subject: Team;
     members: TeamMemberInfo[];
 }
-
-export interface GuardedCostCenter {
-    kind: "costCenter";
-    //subject: CostCenter;
-    owner: CostCenterOwner;
-    // team: Team;
-    // members: TeamMemberInfo[];
-}
-type CostCenterOwner =
-    | {
-          kind: "user";
-          userId: string;
-      }
-    | {
-          kind: "team";
-          team: Team;
-          members: TeamMemberInfo[];
-      };
 
 export interface GuardedGitpodToken {
     kind: "gitpodToken";
@@ -185,18 +165,6 @@ export class TeamMemberResourceGuard implements ResourceAccessGuard {
                 return await this.hasAccessToWorkspace(resource.subject, resource.teamMembers);
             case "prebuild":
                 return !!resource.teamMembers?.some((m) => m.userId === this.userId);
-            case "costCenter":
-                const owner = resource.owner;
-                if (owner.kind === "user") {
-                    // This is handled in the "OwnerResourceGuard"
-                    return false;
-                }
-                if (operation === "get") {
-                    return owner.members.some((m) => m.userId === this.userId);
-                }
-                // TODO(gpl) We should check whether we're looking at the right team for the right CostCenter here!
-                // Only team "owners" are allowed to write CostCenters
-                return owner.members.filter((m) => m.role === "owner").some((m) => m.userId === this.userId);
         }
         return false;
     }
@@ -254,13 +222,6 @@ export class OwnerResourceGuard implements ResourceAccessGuard {
                             (m) => m.userId === this.userId && m.role === "owner" && !m.ownedByOrganization,
                         );
                 }
-            case "costCenter":
-                const owner = resource.owner;
-                if (owner.kind === "team") {
-                    // This is handled in the "TeamMemberResourceGuard"
-                    return false;
-                }
-                return owner.userId === this.userId;
             case "workspaceLog":
                 return resource.subject.ownerId === this.userId;
             case "prebuild":


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Deletes an unused resource guard

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e12b98e</samp>

This pull request refactors the `resource-access` module and its tests to remove the obsolete concept of cost centers and teams, which were never used in production. This simplifies the codebase and the business logic for checking access rights.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
