### PR TITLE
[ws-manager-mk2] remove experimental mode feature

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -131,8 +131,6 @@ type Configuration struct {
 	// TimeoutMaxConcurrentReconciles configures the max amount of concurrent workspace reconciliations on
 	// the timeout controller.
 	TimeoutMaxConcurrentReconciles int `json:"timeoutMaxConcurrentReconciles,omitempty"`
-	// ExperimentalMode controls if experimental features are enabled
-	ExperimentalMode bool `json:"experimentalMode"`
 	// EnableCustomSSLCertificate controls if we need to support custom SSL certificates for git operations
 	EnableCustomSSLCertificate bool `json:"enableCustomSSLCertificate"`
 }

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -348,18 +348,6 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 		},
 	}
 
-	if sctx.Config.ExperimentalMode {
-		matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
-			Key:      "gitpod.io/experimental",
-			Operator: corev1.NodeSelectorOpExists,
-		})
-	} else {
-		matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
-			Key:      "gitpod.io/experimental",
-			Operator: corev1.NodeSelectorOpDoesNotExist,
-		})
-	}
-
 	affinity := &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308111617"
+  default     = "gitpod-k3s-202308150341"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308111617"
+  default     = "gitpod-k3s-202308150341"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -18,9 +18,7 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
   --kubelet-arg cgroup-driver=systemd \
-  --kubelet-arg feature-gates=LocalStorageCapacityIsolation=true \
   --kubelet-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
-  --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolation=true \
   --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
   --cluster-init
 

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308111617"
+  default     = "gitpod-k3s-202308150341"
 }
 
 variable "cert_issuer" {

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -61,6 +61,9 @@
             "path": "components/ws-daemon"
         },
         {
+            "path": "components/ws-manager-api"
+        },
+        {
             "path": "components/ws-manager-mk2"
         },
         {

--- a/install/installer/pkg/components/ws-manager-mk2/configmap.go
+++ b/install/installer/pkg/components/ws-manager-mk2/configmap.go
@@ -77,7 +77,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	var schedulerName string
-	var experimentalMode bool
 	gitpodHostURL := "https://" + ctx.Config.Domain
 	workspaceClusterHost := fmt.Sprintf("ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
 	workspaceURLTemplate := fmt.Sprintf("https://{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain)
@@ -141,8 +140,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			workspacePortURLTemplate = ucfg.Workspace.WorkspacePortURLTemplate
 		}
 		rateLimits = ucfg.Workspace.WSManagerRateLimits
-
-		experimentalMode = ucfg.Workspace.UseMk2ExperimentalMode
 
 		return nil
 	})
@@ -214,7 +211,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			RegistryFacadeHost:               fmt.Sprintf("reg.%s:%d", ctx.Config.Domain, common.RegistryFacadeServicePort),
 			WorkspaceMaxConcurrentReconciles: 25,
 			TimeoutMaxConcurrentReconciles:   15,
-			ExperimentalMode:                 experimentalMode,
 		},
 		Content: struct {
 			Storage storageconfig.StorageConfig `json:"storage"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -125,7 +125,6 @@ type WorkspaceConfig struct {
 	} `json:"contentService"`
 
 	EnableProtectedSecrets *bool `json:"enableProtectedSecrets"`
-	UseMk2ExperimentalMode bool  `json:"useMk2ExperimentalMode,omitempty"`
 }
 
 type WorkspaceClass struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove experimentalMode for ws-manager-mk2. 

Also updates the VM image with changes from https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/246.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0570d2e</samp>

This pull request removes the feature flag and related code for the experimental workspace manager mk2, which is now the default and only workspace manager in Gitpod. It simplifies the configuration and pod creation logic for the workspace components.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-21
Related to ENG-639

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace
2. Run `curl lama.sh | sh` and assert you can browse to the port it exposes
3. Ensure `curl --connect-timeout 10 -s -H "Metadata-Flavor: Google" 'http://169.254.169.254/computeMetadata/v1/instance/'` times out, and the exit status is 28. 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-eng-666</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-eng-666.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-eng-666.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-ENG-666-gha.15301</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
