### PR TITLE
[fga] more FGA checks and service use

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -32,7 +32,7 @@ export type UserResourceType = "user";
 
 export type UserRelation = "self" | "organization" | "installation";
 
-export type UserPermission = "read_info" | "write_info" | "make_admin" | "read_ssh" | "write_ssh";
+export type UserPermission = "read_info" | "write_info" | "delete" | "make_admin" | "read_ssh" | "write_ssh";
 
 export type InstallationResourceType = "installation";
 

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -14,7 +14,6 @@ import {
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { BillingTier } from "@gitpod/gitpod-protocol/lib/protocol";
 import { inject, injectable } from "inversify";
-import { Config } from "../config";
 import { BillingModes } from "./billing-mode";
 import { EntitlementServiceUBP } from "./entitlement-service-ubp";
 import { VerificationService } from "../auth/verification-service";
@@ -94,10 +93,11 @@ export interface EntitlementService {
  */
 @injectable()
 export class EntitlementServiceImpl implements EntitlementService {
-    @inject(Config) protected readonly config: Config;
-    @inject(BillingModes) protected readonly billingModes: BillingModes;
-    @inject(EntitlementServiceUBP) protected readonly ubp: EntitlementServiceUBP;
-    @inject(VerificationService) protected readonly verificationService: VerificationService;
+    constructor(
+        @inject(BillingModes) private readonly billingModes: BillingModes,
+        @inject(EntitlementServiceUBP) private readonly ubp: EntitlementServiceUBP,
+        @inject(VerificationService) private readonly verificationService: VerificationService,
+    ) {}
 
     async mayStartWorkspace(
         user: User,

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -237,6 +237,28 @@ describe("WorkspaceService", async () => {
             "getWorkspace should return NOT_FOUND after hard-deletion",
         );
     });
+
+    it("should setPinned", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(ErrorCodes.NOT_FOUND, svc.setPinned(stranger.id, ws.id, true));
+        await svc.setPinned(owner.id, ws.id, true);
+        const ws2 = await svc.getWorkspace(owner.id, ws.id);
+        expect(ws2.pinned, "workspace should be pinned").to.equal(true);
+    });
+
+    it("should setDescription", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+        const desc = "Some description";
+
+        await svc.setDescription(owner.id, ws.id, desc);
+        const ws2 = await svc.getWorkspace(owner.id, ws.id);
+        expect(ws2.description).to.equal(desc);
+
+        await expectError(ErrorCodes.NOT_FOUND, svc.setDescription(stranger.id, ws.id, desc));
+    });
 });
 
 async function createTestWorkspace(svc: WorkspaceService, org: Organization, owner: User, project: Project) {

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -88,6 +88,15 @@ export class WorkspaceService {
         return this.doGetWorkspace(userId, workspaceId);
     }
 
+    async getCurrentInstance(userId: string, workspaceId: string): Promise<WorkspaceInstance | undefined> {
+        await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
+        const result = await this.db.findCurrentInstance(workspaceId);
+        if (!result) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "No workspace instance found.", { workspaceId });
+        }
+        return result;
+    }
+
     // Internal method for allowing for additional DBs to be passed in
     private async doGetWorkspace(userId: string, workspaceId: string, db: WorkspaceDB = this.db): Promise<Workspace> {
         await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
@@ -377,5 +386,15 @@ export class WorkspaceService {
         log.info(logCtx, "[guessWorkspaceRegion] Workspace with region selection", regionLogContext);
 
         return targetRegion;
+    }
+
+    public async setPinned(userId: string, workspaceId: string, pinned: boolean): Promise<void> {
+        await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
+        await this.db.updatePartial(workspaceId, { pinned });
+    }
+
+    public async setDescription(userId: string, workspaceId: string, description: string) {
+        await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
+        await this.db.updatePartial(workspaceId, { description });
     }
 }

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -13,6 +13,7 @@ schema: |-
     // permissions
     permission read_info = self + organization->member + organization->owner + installation->admin
     permission write_info = self
+    permission delete = self
     permission make_admin = installation->admin + organization->installation_admin
 
     permission read_ssh = self


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ac3eb7</samp>

This pull request implements the user deletion feature and refactors some of the server components to improve authorization and code quality. It adds a new `delete` permission to the `UserPermission` type and the `User` schema in `SpiceDB`, and uses the `Authorizer` and the `WorkspaceService` for permission checks and workspace operations. It also adds new tests for the `WorkspaceService` methods and refactors some of the existing code to use dependency injection and remove redundancy.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
