### PR TITLE
[fga] Skip old permission system if `centralizedPermissions` is enabled

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -213,11 +213,7 @@ export class Authorizer {
     }
 
     private async isDisabled(userId: string): Promise<boolean> {
-        return !(await getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
-            user: {
-                id: userId,
-            },
-        }));
+        return !(await isFgaAuthorizerEnabled(userId));
     }
 
     async addUser(userId: string, owningOrgId?: string) {
@@ -436,6 +432,15 @@ export class Authorizer {
         });
         return relationships.map((r) => r.relationship!);
     }
+}
+
+// TODO(gpl) remove after FGA rollout
+export async function isFgaAuthorizerEnabled(userId: string): Promise<boolean> {
+    return getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
+        user: {
+            id: userId,
+        },
+    });
 }
 
 function set(rs: v1.Relationship): v1.RelationshipUpdate {

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -21,7 +21,6 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(stripeClientRequestsCompletedDurationSeconds);
     registry.registerMetric(imageBuildsStartedTotal);
     registry.registerMetric(imageBuildsCompletedTotal);
-    registry.registerMetric(centralizedPermissionsValidationsTotal);
     registry.registerMetric(spicedbClientLatency);
     registry.registerMetric(dashboardErrorBoundary);
     registry.registerMetric(jwtCookieIssued);
@@ -229,16 +228,6 @@ export function increaseImageBuildsCompletedTotal(outcome: "succeeded" | "failed
     imageBuildsCompletedTotal.inc({ outcome });
 }
 
-const centralizedPermissionsValidationsTotal = new prometheusClient.Counter({
-    name: "gitpod_perms_centralized_validations_total",
-    help: "counter of centralized permission checks validations against existing system",
-    labelNames: ["operation", "matches_expectation"],
-});
-
-export function reportCentralizedPermsValidation(operation: string, matches: boolean) {
-    centralizedPermissionsValidationsTotal.inc({ operation, matches_expectation: String(matches) });
-}
-
 export const fgaRelationsUpdateClientLatency = new prometheusClient.Histogram({
     name: "gitpod_fga_relationship_update_seconds",
     help: "Histogram of completed relationship updates",
@@ -343,3 +332,14 @@ export const updateSubscribersRegistered = new prometheusClient.Gauge({
     help: "Gauge of subscribers registered",
     labelNames: ["type"],
 });
+
+export const guardAccessChecksTotal = new prometheusClient.Counter({
+    name: "gitpod_guard_access_checks_total",
+    help: "Counter for the number of guard access checks we do by type",
+    labelNames: ["type"],
+});
+
+export type GuardAccessCheckType = "fga" | "resource-access";
+export function reportGuardAccessCheck(type: GuardAccessCheckType) {
+    guardAccessChecksTotal.labels(type).inc();
+}

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -21,7 +21,12 @@ import { getRequestingClientInfo } from "../express-util";
 import { GitpodToken, GitpodTokenType, User } from "@gitpod/gitpod-protocol";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { reportJWTCookieIssued } from "../prometheus-metrics";
-import { OwnerResourceGuard, ResourceAccessGuard, ScopedResourceGuard } from "../auth/resource-access";
+import {
+    FGAResourceAccessGuard,
+    OwnerResourceGuard,
+    ResourceAccessGuard,
+    ScopedResourceGuard,
+} from "../auth/resource-access";
 import { OneTimeSecretServer } from "../one-time-secret-server";
 import { ClientMetadata } from "../websocket/websocket-connection-manager";
 import * as fs from "fs/promises";
@@ -387,7 +392,8 @@ export class UserController {
                     return;
                 }
                 const sessionId = req.body.sessionId;
-                const server = this.createGitpodServer(user, new OwnerResourceGuard(user.id));
+                const resourceGuard = new FGAResourceAccessGuard(user.id, new OwnerResourceGuard(user.id));
+                const server = this.createGitpodServer(user, resourceGuard);
                 try {
                     await server.sendHeartBeat({}, { wasClosed: true, instanceId: instanceID });
                     /** no await */ server

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -34,6 +34,7 @@ import {
     TeamMemberResourceGuard,
     WithResourceAccessGuard,
     RepositoryResourceGuard,
+    FGAResourceAccessGuard,
 } from "../auth/resource-access";
 import { clientIp, takeFirst } from "../express-util";
 import {
@@ -226,6 +227,7 @@ export class WebsocketConnectionManager implements ConnectionHandler {
                 new SharedWorkspaceAccessGuard(),
                 new RepositoryResourceGuard(user, this.hostContextProvider),
             ]);
+            resourceGuard = new FGAResourceAccessGuard(user.id, resourceGuard);
         } else {
             resourceGuard = { canAccess: async () => false };
         }


### PR DESCRIPTION
## Description
This introduces `FGAResourceAccessGuard` which skips the old permission system if `centralizedPermissions` is enabled for the given user. To that end it cleans up some of the old `guardAccess*` methods, and unifies usage, code patterns and feature-flag check.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cbf3d22</samp>

Refactored and cleaned up server code related to centralized permissions feature. Removed deprecated metrics code, added new access control method, and fixed user lookup logic.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-445, EXP-449

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-skip-access</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-skip-access.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-skip-access.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-skip-access-gha.15446</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
