### PR TITLE
[preview] use k3s 1.26

### DIFF
--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308150341"
+  default     = "gitpod-k3s-202308221555"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308150341"
+  default     = "gitpod-k3s-202308221555"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202308150341"
+  default     = "gitpod-k3s-202308221555"
 }
 
 variable "cert_issuer" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Relates to ENG-680

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0578868</samp>

This pull request refactors the `image` variable for the Gitpod preview environment on GCP. It updates the default image to the latest version, moves the variable definition to the `gce` module, and removes unused references to the variable.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Observe [typical](https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/248#discussion_r1302026885) and [large](https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/248#discussion_r1301900386) VMs have expected free space for containerd and workspaces.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-g338a766054</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-g338a766054.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-g338a766054.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-gen104-image-gha.15824</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview 
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
