### PR TITLE
[server] Don't allow switching to FGA-based auth for requests with explicit function/resource guards

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -212,7 +212,8 @@ export class Authorizer {
         }
     }
 
-    private async isDisabled(userId: string): Promise<boolean> {
+    // TODO(gpl) Make private after FGA rollout
+    public async isDisabled(userId: string): Promise<boolean> {
         return !(await getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
             user: {
                 id: userId,

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -21,7 +21,6 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(stripeClientRequestsCompletedDurationSeconds);
     registry.registerMetric(imageBuildsStartedTotal);
     registry.registerMetric(imageBuildsCompletedTotal);
-    registry.registerMetric(centralizedPermissionsValidationsTotal);
     registry.registerMetric(spicedbClientLatency);
     registry.registerMetric(dashboardErrorBoundary);
     registry.registerMetric(jwtCookieIssued);
@@ -227,16 +226,6 @@ export const imageBuildsCompletedTotal = new prometheusClient.Counter({
 
 export function increaseImageBuildsCompletedTotal(outcome: "succeeded" | "failed") {
     imageBuildsCompletedTotal.inc({ outcome });
-}
-
-const centralizedPermissionsValidationsTotal = new prometheusClient.Counter({
-    name: "gitpod_perms_centralized_validations_total",
-    help: "counter of centralized permission checks validations against existing system",
-    labelNames: ["operation", "matches_expectation"],
-});
-
-export function reportCentralizedPermsValidation(operation: string, matches: boolean) {
-    centralizedPermissionsValidationsTotal.inc({ operation, matches_expectation: String(matches) });
 }
 
 export const fgaRelationsUpdateClientLatency = new prometheusClient.Histogram({

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -332,3 +332,14 @@ export const updateSubscribersRegistered = new prometheusClient.Gauge({
     help: "Gauge of subscribers registered",
     labelNames: ["type"],
 });
+
+export const guardAccessChecksTotal = new prometheusClient.Counter({
+    name: "gitpod_guard_access_checks_total",
+    help: "Counter for the number of guard access checks we do by type",
+    labelNames: ["type"],
+});
+
+export type GuardAccessCheckType = "fga" | "resource-access" | "resource-access-explicit-guard";
+export function reportGuardAccessCheck(type: GuardAccessCheckType) {
+    guardAccessChecksTotal.labels(type).inc();
+}

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -604,7 +604,7 @@ export class UserController {
 
     private createGitpodServer(user: User, resourceGuard: ResourceAccessGuard) {
         const server = this.serverFactory();
-        server.initialize(undefined, user.id, resourceGuard, ClientMetadata.from(user.id), undefined, {});
+        server.initialize(undefined, user.id, resourceGuard, false, ClientMetadata.from(user.id), undefined, {});
         return server;
     }
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -76,9 +76,9 @@ export class UserService {
         }
     }
 
-    async findUserById(userId: string, id: string): Promise<User> {
-        if (userId !== id) {
-            await this.authorizer.checkPermissionOnUser(userId, "read_info", id);
+    async findUserById(requestorId: string, id: string): Promise<User> {
+        if (requestorId !== id) {
+            await this.authorizer.checkPermissionOnUser(requestorId, "read_info", id);
         }
         const result = await this.userDb.findUserById(id);
         if (!result) {

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -230,6 +230,11 @@ export class WebsocketConnectionManager implements ConnectionHandler {
             resourceGuard = { canAccess: async () => false };
         }
 
+        // Is this a request that requires explicit access guard?
+        const withExplicitAccessGuard =
+            !!(expressReq as WithResourceAccessGuard).resourceGuard ||
+            !!(expressReq as WithFunctionAccessGuard).functionGuard;
+
         const clientHeaderFields: ClientHeaderFields = {
             ip: clientIp(expressReq),
             userAgent: expressReq.headers["user-agent"],
@@ -245,6 +250,7 @@ export class WebsocketConnectionManager implements ConnectionHandler {
             client,
             user?.id,
             resourceGuard,
+            withExplicitAccessGuard,
             clientContext.clientMetadata,
             connectionCtx,
             clientHeaderFields,


### PR DESCRIPTION
## Description

In https://github.com/gitpod-io/gitpod/pull/18519 we skip the old access checks if `centralizedPermissions` is enabled for that user.
But because we did not replace the old FunctionGuard/ResourceGuard based BearerTokens, yet, we have to make an exception for those.

Also, this PR adds a metric so we gain insights into how often we use the different code paths.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48e0176</samp>

This pull request adds metrics and feature flags for fine-grained authorization of resource access in the Gitpod server. It also introduces a new parameter to control whether to use an explicit access guard for websocket connections. The changes affect the files `websocket-connection-manager.ts`, `gitpod-server-impl.ts`, `prometheus-metrics.ts`, and `user-controller.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-449
Depends on: https://github.com/gitpod-io/gitpod/pull/18519 

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
