### PR TITLE
[fga] WorkspaceService port ops

### DIFF
--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -6,7 +6,14 @@
 
 import { TypeORM } from "@gitpod/gitpod-db/lib";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
-import { CommitContext, Organization, Project, User, WorkspaceConfig } from "@gitpod/gitpod-protocol";
+import {
+    CommitContext,
+    Organization,
+    Project,
+    User,
+    WorkspaceConfig,
+    WorkspaceInstancePort,
+} from "@gitpod/gitpod-protocol";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import * as chai from "chai";
@@ -258,6 +265,42 @@ describe("WorkspaceService", async () => {
         expect(ws2.description).to.equal(desc);
 
         await expectError(ErrorCodes.NOT_FOUND, svc.setDescription(stranger.id, ws.id, desc));
+    });
+
+    it("should getOpenPorts", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.getOpenPorts(owner.id, ws.id),
+            "should fail on non-running workspace",
+        );
+    });
+
+    it("should openPort", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        const port: WorkspaceInstancePort = {
+            port: 8080,
+        };
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.openPort(owner.id, ws.id, port),
+            "should fail on non-running workspace",
+        );
+    });
+
+    it("should closePort", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.closePort(owner.id, ws.id, 8080),
+            "should fail on non-running workspace",
+        );
     });
 });
 


### PR DESCRIPTION
## Description

Moves `openPort`, `closePort` and `getOpenPorts` to `WorkspaceService`, guarded by the `access` permission.

Why access? The old perm system called used operatio "update", but the actual check was identical to "get".

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e4c6aa</samp>

Refactor port-related methods in `GitpodServerImpl` to use `WorkspaceService` and add tests for port operations.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to: EXP-207

## How to test
 - sign up with user 1 and 2 (in a different session/browser)
   - unblock user 2
 - enable `centralizedPermissions` for user 2 and user 1
 - user 1: start a workspace with a service serving a private port
   - note that the ports view works :heavy_check_mark: 
 - user 2: try to access the port
   - note that you see a blank page :heavy_check_mark: 
 - user 1: make that port public :heavy_check_mark: 
 - user 2: reload, and see the page being loaded :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-ports</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-ports.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-ports.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-ports-gha.15500</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
