### PR TITLE
[server] add `searchString` to `getRepositoriesForAutomatedPrebuilds` – EXP-461

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -44,7 +44,7 @@ import {
     OrganizationSettings,
 } from "./teams-projects-protocol";
 import { JsonRpcProxy, JsonRpcServer } from "./messaging/proxy-factory";
-import { Disposable, CancellationTokenSource } from "vscode-jsonrpc";
+import { Disposable, CancellationTokenSource, CancellationToken } from "vscode-jsonrpc";
 import { HeadlessLogUrls } from "./headless-workspace-log";
 import {
     WorkspaceInstance,
@@ -175,7 +175,10 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getOnboardingState(): Promise<GitpodServer.OnboardingState>;
 
     // Projects
-    getProviderRepositoriesForUser(params: GetProviderRepositoriesParams): Promise<ProviderRepository[]>;
+    getProviderRepositoriesForUser(
+        params: GetProviderRepositoriesParams,
+        cancellationToken?: CancellationToken,
+    ): Promise<ProviderRepository[]>;
     createProject(params: CreateProjectParams): Promise<Project>;
     deleteProject(projectId: string): Promise<void>;
     getTeamProjects(teamId: string): Promise<Project[]>;
@@ -291,6 +294,7 @@ export interface FindPrebuildsParams {
 export interface GetProviderRepositoriesParams {
     provider: string;
     hints?: { installationId: string } | object;
+    searchString?: string;
 }
 export interface ProviderRepository {
     name: string;

--- a/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
@@ -28,7 +28,7 @@ class TestBitbucketServerApi {
         id: "MyBitbucketServer",
         type: "BitbucketServer",
         verified: true,
-        host: "bitbucket.gitpod-self-hosted.com",
+        host: "bitbucket.gitpod-dev.com",
         oauth: {} as any,
     };
 
@@ -77,12 +77,12 @@ class TestBitbucketServerApi {
         };
     }
 
-    @test async test_currentUsername_ok() {
+    @test.skip async test_currentUsername_ok() {
         const result = await this.api.currentUsername(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!);
         expect(result).to.equal("AlexTugarev");
     }
 
-    @test async test_getUserProfile_ok() {
+    @test.skip async test_getUserProfile_ok() {
         const result = await this.api.getUserProfile(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, "AlexTugarev");
         expect(result).to.deep.include({
             id: 105, // Identity.authId
@@ -92,17 +92,126 @@ class TestBitbucketServerApi {
         });
     }
 
-    @test async test_getRepos_ok() {
+    @test async test_getRepos_no_searchString() {
         const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
             permission: "REPO_READ",
         });
-        expect(result.length).to.be.equal(28);
+        expect(result.length).to.be.equal(9177);
 
-        // TestBitbucketServerApi
-        // BBS: GET https://7990-alextugarev-bbs-6v0gqcpgvj7.ws-eu102.gitpod.io/rest/api/1.0/repos?permission=REPO_READ&start=0 - OK
-        // BBS: GET https://7990-alextugarev-bbs-6v0gqcpgvj7.ws-eu102.gitpod.io/rest/api/1.0/repos?permission=REPO_READ&start=27 - OK
-        //     ✓ test_getRepos_ok (87ms)
-        //   1 passing (93ms)
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=1002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=2002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=3002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=4002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=5002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=6002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=7002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=8002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=9002&limit=1000 - OK
+        //     ✓ test_getRepos_no_searchString (3746ms)
+    }
+
+    @test async test_getRepos_cap_no_searchstring() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            cap: 3,
+        });
+        expect(result.length).to.be.equal(3000);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=1002&limit=1000 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=2002&limit=1000 - OK
+        //     ✓ test_getRepos_cap_no_searchstring (1007ms)
+    }
+
+    @test async test_getRepos_searchString() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "zero",
+        });
+        expect(result.length).to.be.equal(1000);
+        expect(result[0].links.clone[0].href).to.equal("https://bitbucket.gitpod-dev.com/scm/tes/zero-minus-1.git");
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=zero - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=zero - OK
+        //      ✓ test_getRepos_searchString (552ms)
+    }
+
+    @test async test_getRepos_searchString_2() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "zero-minus-1",
+        });
+        expect(result.length).to.be.equal(112);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=zero-minus-1 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=zero-minus-1 - OK
+        //     ✓ test_getRepos_searchString_2 (172ms)
+    }
+
+    @test async test_getRepos_searchString_works_for_prefix_only() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "-minus-1",
+        });
+        expect(result.length).to.be.equal(0);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=zero-minus-1 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=zero-minus-1 - OK
+        //     ✓ test_getRepos_searchString_works_for_prefix_only (172ms)
+    }
+
+    @test async test_getRepos_searchString_wildcards_are_not_supported() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "*-minus-1",
+        });
+        expect(result.length).to.be.equal(0);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=zero-minus-1 - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=zero-minus-1 - OK
+        //     ✓ test_getRepos_searchString_wildcards_are_not_supported (172ms)
+    }
+
+    @test async test_getRepos_searchString_single_char_is_ignored() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "t",
+        });
+        expect(result.length).to.be.equal(9177);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=1000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=2000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=3000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=4000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=5000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=6000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=7000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=8000&name=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=1000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=2000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=3000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=4000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=5000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=6000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=7000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=8000&projectname=t - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=9000&projectname=t - OK
+        //     ✓ test_getRepos_searchString_single_char_is_ignored (7329ms)
+    }
+
+    @test async test_getRepos_searchString_unmatched() {
+        const result = await this.api.getRepos(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, {
+            permission: "REPO_READ",
+            searchString: "RANDOM_asd8sdh7s8hsdhvisduh",
+        });
+        expect(result.length).to.be.equal(0);
+
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&name=RANDOM_asd8sdh7s8hsdhvisduh - OK
+        // BBS: GET https://bitbucket.gitpod-dev.com/rest/api/1.0/repos?permission=REPO_READ&limit=1000&start=0&projectname=RANDOM_asd8sdh7s8hsdhvisduh - OK
+        //      ✓ test_getRepos_searchString_unmatched (126ms)
     }
 }
 

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -290,22 +290,53 @@ export class BitbucketServerApi {
         userOrToken: User | string,
         query: {
             permission?: "REPO_READ" | "REPO_WRITE" | "REPO_ADMIN";
+            /**
+             * If projects and repositorys are matched by by name, otherwise it returns the first n repositories.
+             */
             searchString?: string;
+            /**
+             * Maximum number of pagination request. Defaults to 10
+             */
+            cap?: number;
+            /**
+             * Limit or results per pagination request. Defaults to 1000
+             */
+            limit?: number;
         },
     ) {
+        const cap = (query?.cap || 0) > 0 ? query.cap! : 10;
+        const limit = `limit=${(query?.limit || 0) > 0 ? query.limit! : 1000}&`;
         const permission = query.permission ? `permission=${query.permission}&` : "";
-        const runQuery = async (params: string) =>
-            this.runQuery<BitbucketServer.Paginated<BitbucketServer.Repository>>(
-                userOrToken,
-                `/repos?${permission}${params}`,
-            );
+        const runQuery = async (params: string) => {
+            const result: BitbucketServer.Repository[] = [];
+            let isLastPage = false;
+            let start = 0;
+            let requestsLeft = cap;
+            while (!isLastPage && requestsLeft > 0) {
+                const pageResult = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.Repository>>(
+                    userOrToken,
+                    `/repos?${permission}${limit}start=${start}&${params}`,
+                );
+                requestsLeft = requestsLeft - 1;
+                if (pageResult.values) {
+                    result.push(...pageResult.values);
+                }
+                isLastPage =
+                    typeof pageResult.isLastPage === "undefined" || // a fuse to prevent infinite loop
+                    !!pageResult.isLastPage;
+                if (pageResult.nextPageStart) {
+                    start = pageResult.nextPageStart;
+                }
+            }
+            return result;
+        };
 
         if (query.searchString?.trim()) {
             const result: BitbucketServer.Repository[] = [];
             const ids = new Set<number>(); // used to deduplicate
-            for (const param of ["name", "projectname", "projectkey"]) {
-                const pageResult = await runQuery(`limit=1000&${param}=${query.searchString}`);
-                for (const repo of pageResult.values || []) {
+            for (const param of ["name", "projectname"]) {
+                const pageResult = await runQuery(`${param}=${query.searchString}`);
+                for (const repo of pageResult) {
                     if (!ids.has(repo.id)) {
                         ids.add(repo.id);
                         result.push(repo);
@@ -314,8 +345,7 @@ export class BitbucketServerApi {
             }
             return result;
         } else {
-            const pageResult = await runQuery(`limit=1000`);
-            return pageResult.values || [];
+            return await runQuery(`limit=1000`);
         }
     }
 

--- a/components/server/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.ts
@@ -13,6 +13,7 @@ import { BitbucketServerContextParser } from "../bitbucket-server/bitbucket-serv
 import { Config } from "../config";
 import { TokenService } from "../user/token-service";
 import { BitbucketServerApp } from "./bitbucket-server-app";
+import { CancellationToken } from "vscode-jsonrpc";
 
 @injectable()
 export class BitbucketServerService extends RepositoryService {
@@ -24,8 +25,11 @@ export class BitbucketServerService extends RepositoryService {
     @inject(TokenService) protected tokenService: TokenService;
     @inject(BitbucketServerContextParser) protected contextParser: BitbucketServerContextParser;
 
-    async getRepositoriesForAutomatedPrebuilds(user: User, searchString?: string): Promise<ProviderRepository[]> {
-        const repos = await this.api.getRepos(user, { permission: "REPO_ADMIN", searchString });
+    async getRepositoriesForAutomatedPrebuilds(
+        user: User,
+        params: { searchString: string; cancellationToken?: CancellationToken },
+    ): Promise<ProviderRepository[]> {
+        const repos = await this.api.getRepos(user, { permission: "REPO_ADMIN", ...params });
         return repos.map((r) => {
             const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href!;
             // const webUrl = r.links?.self[0]?.href?.replace("/browse", "");

--- a/components/server/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.ts
@@ -24,8 +24,8 @@ export class BitbucketServerService extends RepositoryService {
     @inject(TokenService) protected tokenService: TokenService;
     @inject(BitbucketServerContextParser) protected contextParser: BitbucketServerContextParser;
 
-    async getRepositoriesForAutomatedPrebuilds(user: User): Promise<ProviderRepository[]> {
-        const repos = await this.api.getRepos(user, { permission: "REPO_ADMIN" });
+    async getRepositoriesForAutomatedPrebuilds(user: User, searchString?: string): Promise<ProviderRepository[]> {
+        const repos = await this.api.getRepos(user, { permission: "REPO_ADMIN", searchString });
         return repos.map((r) => {
             const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href!;
             // const webUrl = r.links?.self[0]?.href?.replace("/browse", "");

--- a/components/server/src/repohost/repo-service.ts
+++ b/components/server/src/repohost/repo-service.ts
@@ -6,10 +6,14 @@
 
 import { ProviderRepository, User } from "@gitpod/gitpod-protocol";
 import { injectable } from "inversify";
+import { CancellationToken } from "vscode-jsonrpc";
 
 @injectable()
 export class RepositoryService {
-    async getRepositoriesForAutomatedPrebuilds(user: User, searchString?: string): Promise<ProviderRepository[]> {
+    async getRepositoriesForAutomatedPrebuilds(
+        user: User,
+        params: { searchString?: string; cancellationToken?: CancellationToken },
+    ): Promise<ProviderRepository[]> {
         return [];
     }
 

--- a/components/server/src/repohost/repo-service.ts
+++ b/components/server/src/repohost/repo-service.ts
@@ -9,7 +9,7 @@ import { injectable } from "inversify";
 
 @injectable()
 export class RepositoryService {
-    async getRepositoriesForAutomatedPrebuilds(user: User): Promise<ProviderRepository[]> {
+    async getRepositoriesForAutomatedPrebuilds(user: User, searchString?: string): Promise<ProviderRepository[]> {
         return [];
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -114,7 +114,7 @@ import {
 import { inject, injectable } from "inversify";
 import { URL } from "url";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
-import { Disposable } from "vscode-jsonrpc";
+import { Disposable, CancellationToken } from "vscode-jsonrpc";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { AuthProviderService } from "../auth/auth-provider-service";
 import { HostContextProvider } from "../auth/host-context-provider";
@@ -1465,6 +1465,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getProviderRepositoriesForUser(
         ctx: TraceContext,
         params: { provider: string; hints?: object; searchString?: string },
+        cancellationToken?: CancellationToken,
     ): Promise<ProviderRepository[]> {
         traceAPIParams(ctx, { params });
 
@@ -1480,7 +1481,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const hostContext = this.hostContextProvider.get(providerHost);
             if (hostContext?.services) {
                 repositories.push(
-                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user)),
+                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user, {})),
                 );
             }
         } else if (providerHost === "bitbucket.org" && provider) {
@@ -1489,10 +1490,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const hostContext = this.hostContextProvider.get(providerHost);
             if (hostContext?.services) {
                 repositories.push(
-                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(
-                        user,
-                        params.searchString,
-                    )),
+                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user, {
+                        searchString: params.searchString,
+                        cancellationToken,
+                    })),
                 );
             }
         } else if (provider?.authProviderType === "GitLab") {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1464,7 +1464,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     // Projects
     async getProviderRepositoriesForUser(
         ctx: TraceContext,
-        params: { provider: string; hints?: object },
+        params: { provider: string; hints?: object; searchString?: string },
     ): Promise<ProviderRepository[]> {
         traceAPIParams(ctx, { params });
 
@@ -1489,7 +1489,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const hostContext = this.hostContextProvider.get(providerHost);
             if (hostContext?.services) {
                 repositories.push(
-                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user)),
+                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(
+                        user,
+                        params.searchString,
+                    )),
                 );
             }
         } else if (provider?.authProviderType === "GitLab") {


### PR DESCRIPTION
## Description
<img width="1212" alt="Screenshot 2023-08-17 at 10 38 27" src="https://github.com/gitpod-io/gitpod/assets/914497/aded1d18-7daf-4fe9-ab93-e0963337d534">

This PR fixes an issue with hitting rate-limits when querying repositories of BBS. 

<img width="1143" alt="Screenshot 2023-08-17 at 11 04 14" src="https://github.com/gitpod-io/gitpod/assets/914497/2e8ce044-d544-4e2e-8ea2-b5b37060093c">


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7bb548</samp>

This pull request adds a feature to search for Bitbucket Server repositories by name, project name, or project key in the Gitpod dashboard. It modifies the `getRepos` method of the `BitbucketServerApi` class and the `getProviderRepositoriesForUser` and `getRepositoriesForAutomatedPrebuilds` methods of the `GitpodServerImpl`, `RepositoryService`, and `BitbucketServerService` classes. It also adds a `searchString` parameter to the relevant API and service methods.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-461

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-searchstring</li>
	<li><b>🔗 URL</b> - <a href="https://at-searchstring.preview.gitpod-dev.com/workspaces" target="_blank">at-searchstring.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-searchString-gha.15552</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
