### PR TITLE
Brad/exp 458 fe allow pasting in a git clone url to create project as

### DIFF
--- a/components/dashboard/src/data/git-providers/github-queries.ts
+++ b/components/dashboard/src/data/git-providers/github-queries.ts
@@ -36,6 +36,7 @@ export const useAreGithubWebhooksUnauthorized = (providerHost: string) => {
         return false;
     }
 
+    // Finally, check token for the right scopes - if missing, then uanuthorized
     if (!token || !token.scopes.includes("repo")) {
         return true;
     }

--- a/components/dashboard/src/data/git-providers/github-queries.ts
+++ b/components/dashboard/src/data/git-providers/github-queries.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useAuthProviders } from "../auth-providers/auth-provider-query";
+import { useCurrentUser } from "../../user-context";
+
+export const useIsGithubAppEnabled = () => {
+    return useQuery(["github-app-enabled"], async () => {
+        return await getGitpodService().server.isGitHubAppEnabled();
+    });
+};
+
+export const useAreGithubWebhooksUnauthorized = (providerHost: string) => {
+    const { data: authProviders } = useAuthProviders();
+    const { data: isGitHubAppEnabled } = useIsGithubAppEnabled();
+    const { data: token } = useGetGitToken(providerHost);
+
+    // If the app is enabled, authorized
+    if (isGitHubAppEnabled) {
+        return false;
+    }
+
+    // If we don't have auth providers or the provider host, we can't check yet, treat as authorized
+    if (!authProviders || !providerHost) {
+        return false;
+    }
+
+    // Find matching auth provider - if none, treat as authorized
+    const ap = authProviders?.find((ap) => ap.host === providerHost);
+    if (!ap || ap.authProviderType !== "GitHub") {
+        return false;
+    }
+
+    if (!token || !token.scopes.includes("repo")) {
+        return true;
+    }
+};
+
+export const useGetGitToken = (providerHost: string) => {
+    const user = useCurrentUser();
+
+    return useQuery(
+        ["git-token", { userId: user?.id }, { providerHost }],
+        async () => {
+            return await getGitpodService().server.getToken({ host: providerHost });
+        },
+        {
+            enabled: !!user && !!providerHost,
+        },
+    );
+};

--- a/components/dashboard/src/data/git-providers/provider-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/provider-repositories-query.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentUser } from "../../user-context";
+
+type UseProviderRepositoriesQueryArgs = {
+    provider: string;
+    installationId?: string;
+};
+export const useProviderRepositoriesForUser = ({ provider, installationId }: UseProviderRepositoriesQueryArgs) => {
+    const user = useCurrentUser();
+
+    return useQuery(
+        ["provider-repositories", { userId: user?.id }, { provider, installationId }],
+        async () => {
+            return await getGitpodService().server.getProviderRepositoriesForUser({
+                provider,
+                hints: { installationId },
+            });
+        },
+        {
+            enabled: !!provider,
+        },
+    );
+};

--- a/components/dashboard/src/data/git-providers/provider-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/provider-repositories-query.ts
@@ -7,6 +7,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentUser } from "../../user-context";
+import { CancellationTokenSource } from "vscode-jsonrpc";
 
 type UseProviderRepositoriesQueryArgs = {
     provider: string;
@@ -17,11 +18,22 @@ export const useProviderRepositoriesForUser = ({ provider, installationId }: Use
 
     return useQuery(
         ["provider-repositories", { userId: user?.id }, { provider, installationId }],
-        async () => {
-            return await getGitpodService().server.getProviderRepositoriesForUser({
-                provider,
-                hints: { installationId },
+        async ({ signal }) => {
+            // jsonrpc cancellation token that we subscribe to the abort signal provided by react-query
+            const cancelToken = new CancellationTokenSource();
+
+            signal?.addEventListener("abort", () => {
+                cancelToken.cancel();
             });
+
+            return await getGitpodService().server.getProviderRepositoriesForUser(
+                {
+                    provider,
+                    hints: { installationId },
+                },
+                // @ts-ignore - not sure why types don't support this
+                cancelToken.token,
+            );
         },
         {
             enabled: !!provider,

--- a/components/dashboard/src/data/projects/create-project-mutation.ts
+++ b/components/dashboard/src/data/projects/create-project-mutation.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentOrg } from "../organizations/orgs-query";
+import { useRefreshProjects } from "./list-projects-query";
+import { CreateProjectParams, Project } from "@gitpod/gitpod-protocol";
+
+type CreateProjectArgs = Omit<CreateProjectParams, "teamId">;
+
+export const useCreateProject = () => {
+    const refreshProjects = useRefreshProjects();
+    const { data: org } = useCurrentOrg();
+
+    return useMutation<Project, Error, CreateProjectArgs>(
+        async ({ name, slug, cloneUrl, appInstallationId }) => {
+            if (!org) {
+                throw new Error("No org currently selected");
+            }
+
+            return await getGitpodService().server.createProject({
+                name,
+                slug,
+                cloneUrl,
+                teamId: org.id,
+                appInstallationId,
+            });
+        },
+        {
+            onSuccess: (project) => {
+                if (org) {
+                    refreshProjects(org.id);
+                }
+
+                // Kick off a prebuild for the new project
+                getGitpodService().server.triggerPrebuild(project.id, null);
+            },
+        },
+    );
+};

--- a/components/dashboard/src/data/projects/create-project-mutation.ts
+++ b/components/dashboard/src/data/projects/create-project-mutation.ts
@@ -10,7 +10,7 @@ import { useCurrentOrg } from "../organizations/orgs-query";
 import { useRefreshProjects } from "./list-projects-query";
 import { CreateProjectParams, Project } from "@gitpod/gitpod-protocol";
 
-type CreateProjectArgs = Omit<CreateProjectParams, "teamId">;
+export type CreateProjectArgs = Omit<CreateProjectParams, "teamId">;
 
 export const useCreateProject = () => {
     const refreshProjects = useRefreshProjects();

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -4,72 +4,31 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import {
-    AuthProviderInfo,
-    Disposable,
-    DisposableCollection,
-    Project,
-    ProviderRepository,
-    Team,
-} from "@gitpod/gitpod-protocol";
-import dayjs from "dayjs";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { trackEvent } from "../Analytics";
-import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
+import { AuthProviderInfo, Project } from "@gitpod/gitpod-protocol";
+import { FC, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import ErrorMessage from "../components/ErrorMessage";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
-import { useRefreshProjects } from "../data/projects/list-projects-query";
-import CaretDown from "../icons/CaretDown.svg";
-import Plus from "../icons/Plus.svg";
-import search from "../icons/search.svg";
-import Spinner from "../icons/Spinner.svg";
-import Switch from "../icons/Switch.svg";
 import exclamation from "../images/exclamation.svg";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "../provider-utils";
-import { getGitpodService, gitpodHostUrl } from "../service/service";
-import { UserContext } from "../user-context";
-import { projectsPathNew } from "./projects.routes";
+import { getGitpodService } from "../service/service";
+import { UserContext, useCurrentUser } from "../user-context";
 import { Heading1, Subheading } from "../components/typography/headings";
 import { useAuthProviders } from "../data/auth-providers/auth-provider-query";
 import { AuthorizeGit, useNeedsGitAuthorization } from "../components/AuthorizeGit";
-import { useToast } from "../components/toasts/Toasts";
-import { CancellationTokenSource, CancellationToken } from "vscode-jsonrpc";
+import { NewProjectRepoSelection } from "./new-project/NewProjectRepoSelection";
+import { NewProjectSubheading } from "./new-project/NewProjectSubheading";
+import { Button } from "../components/Button";
 
 export default function NewProject() {
     const currentTeam = useCurrentOrg()?.data;
-    const { user, setUser } = useContext(UserContext);
-    const refreshProjects = useRefreshProjects();
-    const needsGitAuth = useNeedsGitAuthorization();
-
-    const [selectedProviderHost, setSelectedProviderHost] = useState<string | undefined>();
-    const [reposInAccounts, setReposInAccounts] = useState<ProviderRepository[]>([]);
-    const [repoSearchFilter, setRepoSearchFilter] = useState<string>("");
-    const [selectedAccount, setSelectedAccount] = useState<string | undefined>(undefined);
-    const [showGitProviders, setShowGitProviders] = useState<boolean>(false);
-    const [selectedRepo, setSelectedRepo] = useState<ProviderRepository | undefined>(undefined);
-    const [loaded, setLoaded] = useState<boolean>(false);
-
-    const [project, setProject] = useState<Project | undefined>();
-
+    const user = useCurrentUser();
     const authProviders = useAuthProviders();
-    const [isGitHubAppEnabled, setIsGitHubAppEnabled] = useState<boolean>();
-    const [isGitHubWebhooksUnauthorized, setIsGitHubWebhooksUnauthorized] = useState<boolean>();
-    const { toast } = useToast();
-    const toDispose = useMemo(() => new DisposableCollection(), []);
 
-    useEffect(() => {
-        const { server } = getGitpodService();
-        Promise.all([server.isGitHubAppEnabled().then((v) => () => setIsGitHubAppEnabled(v))]).then((setters) =>
-            setters.forEach((s) => s()),
-        );
-        return () => {
-            if (!toDispose.disposed) {
-                toDispose.dispose();
-            }
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    // State this component manages
+    const [selectedProviderHost, setSelectedProviderHost] = useState<string>();
+    const [project, setProject] = useState<Project>();
 
+    // Defaults selectedProviderHost if not set yet
     useEffect(() => {
         if (user && authProviders.data && selectedProviderHost === undefined) {
             for (let i = user.identities.length - 1; i >= 0; i--) {
@@ -88,444 +47,7 @@ export default function NewProject() {
         }
     }, [user, authProviders.data, selectedProviderHost]);
 
-    useEffect(() => {
-        setIsGitHubWebhooksUnauthorized(false);
-        if (!authProviders.data || !selectedProviderHost || isGitHubAppEnabled) {
-            return;
-        }
-        const ap = authProviders.data?.find((ap) => ap.host === selectedProviderHost);
-        if (!ap || ap.authProviderType !== "GitHub") {
-            return;
-        }
-        getGitpodService()
-            .server.getToken({ host: ap.host })
-            .then((token) => {
-                if (!token || !token.scopes.includes("repo")) {
-                    setIsGitHubWebhooksUnauthorized(true);
-                }
-            });
-    }, [authProviders.data, isGitHubAppEnabled, selectedProviderHost]);
-
-    useEffect(() => {
-        if (selectedRepo && user && currentTeam) {
-            createProject(currentTeam, selectedRepo);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedRepo, currentTeam, user]);
-
-    useEffect(() => {
-        if (reposInAccounts.length === 0) {
-            setSelectedAccount(undefined);
-        } else {
-            const first = reposInAccounts[0];
-            if (!!first.installationUpdatedAt) {
-                const mostRecent = reposInAccounts.reduce((prev, current) =>
-                    (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current,
-                );
-                setSelectedAccount(mostRecent.account);
-            } else {
-                setSelectedAccount(first.account);
-            }
-        }
-    }, [reposInAccounts]);
-
-    useEffect(() => {
-        setRepoSearchFilter("");
-    }, [selectedAccount]);
-
-    const updateReposInAccounts = useCallback(
-        async (cancellationToken: CancellationToken, installationId?: string) => {
-            setLoaded(false);
-            setReposInAccounts([]);
-            if (!selectedProviderHost) {
-                return [];
-            }
-            try {
-                const repos = await getGitpodService().server.getProviderRepositoriesForUser(
-                    {
-                        provider: selectedProviderHost,
-                        hints: { installationId },
-                    },
-                    cancellationToken,
-                );
-                setReposInAccounts(repos);
-                setLoaded(true);
-            } catch (error) {
-                console.log(error);
-                setLoaded(true);
-                toast(error?.message || "Oh no, there was a problem with fetching repositories.");
-            }
-        },
-        [selectedProviderHost, toast],
-    );
-
-    useEffect(() => {
-        if (!selectedProviderHost) {
-            return;
-        }
-        const cancellation = new CancellationTokenSource();
-        toDispose.push(Disposable.create(() => cancellation.cancel()));
-        (async () => {
-            await updateReposInAccounts(cancellation.token);
-        })();
-        return () => cancellation.cancel();
-    }, [selectedProviderHost, updateReposInAccounts, toDispose]);
-
-    useEffect(() => {
-        if (project) {
-            getGitpodService().server.triggerPrebuild(project.id, null);
-        }
-    }, [project]);
-
-    const isGitHub = () => selectedProviderHost === "github.com";
-
-    const reconfigure = () => {
-        openReconfigureWindow({
-            account: selectedAccount,
-            onSuccess: (p: { installationId: string; setupAction?: string }) => {
-                updateReposInAccounts(CancellationToken.None, p.installationId);
-                trackEvent("organisation_authorised", {
-                    installation_id: p.installationId,
-                    setup_action: p.setupAction,
-                });
-            },
-        });
-    };
-
-    const authorize = () => {
-        const ap = authProviders.data?.find((ap) => ap.host === selectedProviderHost);
-        if (!ap) {
-            return;
-        }
-        openAuthorizeWindow({
-            host: ap.host,
-            scopes: ap.authProviderType === "GitHub" ? ["repo"] : ap.requirements?.default,
-            onSuccess: async () => {
-                if (ap.authProviderType === "GitHub") {
-                    setIsGitHubWebhooksUnauthorized(false);
-                }
-            },
-            onError: (payload) => {
-                console.error("Authorization failed", selectedProviderHost, payload);
-            },
-        });
-    };
-
-    // TODO: Look into making this a react-query mutation
-    const createProject = useCallback(
-        async (team: Team, repo: ProviderRepository) => {
-            if (!selectedProviderHost) {
-                return;
-            }
-            const repoSlug = repo.path || repo.name;
-
-            try {
-                const project = await getGitpodService().server.createProject({
-                    name: repo.name,
-                    slug: repoSlug,
-                    cloneUrl: repo.cloneUrl,
-                    teamId: team.id,
-                    appInstallationId: String(repo.installationId),
-                });
-
-                // TODO: After converting this to a mutation, we can handle invalidating/updating the query in a side effect
-                refreshProjects(project.teamId);
-
-                setProject(project);
-            } catch (error) {
-                const message = (error && error?.message) || "Failed to create new project.";
-                window.alert(message);
-            }
-        },
-        [refreshProjects, selectedProviderHost],
-    );
-
-    const toSimpleName = (fullName: string) => {
-        const splitted = fullName.split("/");
-        if (splitted.length < 2) {
-            return fullName;
-        }
-        return splitted.shift() && splitted.join("/");
-    };
-
-    const accounts = new Map<string, { avatarUrl: string }>();
-    reposInAccounts.forEach((r) => {
-        if (!accounts.has(r.account)) {
-            accounts.set(r.account, { avatarUrl: r.accountAvatarUrl });
-        } else if (!accounts.get(r.account)?.avatarUrl && r.accountAvatarUrl) {
-            accounts.get(r.account)!.avatarUrl = r.accountAvatarUrl;
-        }
-    });
-
-    const getDropDownEntries = (accounts: Map<string, { avatarUrl: string }>) => {
-        const renderItemContent = (label: string, icon: string, addClasses?: string) => (
-            <div className="w-full flex">
-                <img src={icon} className="rounded-full w-6 h-6 my-auto" alt="icon" />
-                <span className={"pl-2 text-gray-600 dark:text-gray-100 text-base " + (addClasses || "")}>{label}</span>
-            </div>
-        );
-        const result: ContextMenuEntry[] = [];
-
-        if (!selectedAccount && user && user.name && user.avatarUrl) {
-            result.push({
-                title: "user",
-                customContent: renderItemContent(user?.name, user?.avatarUrl),
-                separator: true,
-            });
-        }
-        for (const [account, props] of accounts.entries()) {
-            result.push({
-                title: account,
-                customContent: renderItemContent(account, props.avatarUrl, "font-semibold"),
-                separator: true,
-                onClick: () => setSelectedAccount(account),
-            });
-        }
-        if (isGitHub() && isGitHubAppEnabled) {
-            result.push({
-                title: "Add another GitHub account",
-                customContent: renderItemContent("Add GitHub Orgs or Account", Plus),
-                separator: true,
-                onClick: () => reconfigure(),
-            });
-        }
-        result.push({
-            title: "Select another Git Provider to continue with",
-            customContent: renderItemContent("Select Git Provider", Switch),
-            onClick: () => setShowGitProviders(true),
-        });
-
-        return result;
-    };
-
-    const renderSelectRepository = () => {
-        // Don't list GitHub projects if we cannot install webhooks on them (project creation would eventually fail)
-        const noReposAvailable = reposInAccounts.length === 0 || isGitHubWebhooksUnauthorized;
-        const filteredRepos = isGitHubWebhooksUnauthorized
-            ? []
-            : Array.from(reposInAccounts).filter(
-                  (r) =>
-                      r.account === selectedAccount &&
-                      `${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase().trim()),
-              );
-        const icon = selectedAccount && accounts.get(selectedAccount)?.avatarUrl;
-
-        const showSearchInput = !!repoSearchFilter || filteredRepos.length > 0;
-
-        const userLink = (r: ProviderRepository) => {
-            return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`;
-        };
-
-        const projectText = () => {
-            return (
-                <Subheading className="text-center">
-                    Projects allow you to manage prebuilds and workspaces for your repository.{" "}
-                    <a
-                        href="https://www.gitpod.io/docs/configure/projects"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="gp-link"
-                    >
-                        Learn more
-                    </a>
-                </Subheading>
-            );
-        };
-
-        const renderRepos = () => (
-            <>
-                {projectText()}
-                <p className="text-gray-500 text-center text-base mt-12">
-                    {loaded && noReposAvailable ? "Select account on " : "Select a Git repository on "}
-                    <b>{selectedProviderHost}</b> (
-                    <button className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>
-                        change
-                    </button>
-                    )
-                </p>
-                <div className={`mt-2 flex-col ${noReposAvailable && isGitHub() ? "w-96" : ""}`}>
-                    <div className="px-8 flex flex-col space-y-2" data-analytics='{"label":"Identity"}'>
-                        <ContextMenu
-                            customClasses="w-full left-0 cursor-pointer"
-                            menuEntries={getDropDownEntries(accounts)}
-                        >
-                            <div className="w-full">
-                                {!selectedAccount && user && user.name && user.avatarUrl && (
-                                    <>
-                                        <img
-                                            src={user?.avatarUrl}
-                                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
-                                            alt="user avatar"
-                                        />
-                                        <input
-                                            className="w-full px-12 cursor-pointer font-semibold"
-                                            readOnly
-                                            type="text"
-                                            value={user?.name}
-                                        ></input>
-                                    </>
-                                )}
-                                {selectedAccount && (
-                                    <>
-                                        <img
-                                            src={icon ? icon : ""}
-                                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
-                                            alt="icon"
-                                        />
-                                        <input
-                                            className="w-full px-12 cursor-pointer font-semibold"
-                                            readOnly
-                                            type="text"
-                                            value={selectedAccount}
-                                        ></input>
-                                    </>
-                                )}
-                                <img
-                                    src={CaretDown}
-                                    title="Select Account"
-                                    className="filter-grayscale absolute top-1/2 right-3"
-                                    alt="down caret icon"
-                                />
-                            </div>
-                        </ContextMenu>
-                        {showSearchInput && (
-                            <div className="w-full relative h-10 my-auto">
-                                <img
-                                    src={search}
-                                    title="Search"
-                                    className="filter-grayscale absolute top-1/3 left-3"
-                                    alt="search icon"
-                                />
-                                <input
-                                    className="w-96 pl-10 border-0"
-                                    type="search"
-                                    placeholder="Search Repositories"
-                                    value={repoSearchFilter}
-                                    onChange={(e) => setRepoSearchFilter(e.target.value)}
-                                ></input>
-                            </div>
-                        )}
-                    </div>
-                    <div className="p-6 flex-col">
-                        {filteredRepos.length > 0 && (
-                            <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
-                                {filteredRepos.map((r, index) => (
-                                    <div
-                                        key={`repo-${index}-${r.account}-${r.name}`}
-                                        className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group"
-                                        title={r.cloneUrl}
-                                    >
-                                        <div className="flex-grow">
-                                            <div
-                                                className={
-                                                    "text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap" +
-                                                    (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")
-                                                }
-                                            >
-                                                {toSimpleName(r.name)}
-                                            </div>
-                                            {r.updatedAt && <p>Updated {dayjs(r.updatedAt).fromNow()}</p>}
-                                        </div>
-                                        <div className="flex justify-end">
-                                            <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
-                                                {!r.inUse ? (
-                                                    <button className="primary" onClick={() => setSelectedRepo(r)}>
-                                                        Select
-                                                    </button>
-                                                ) : (
-                                                    <p className="text-gray-500 font-medium">
-                                                        <a rel="noopener" className="gp-link" href={userLink(r)}>
-                                                            @{r.inUse.userName}
-                                                        </a>{" "}
-                                                        already
-                                                        <br />
-                                                        added this repo
-                                                    </p>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                        {!noReposAvailable && filteredRepos.length === 0 && <p className="text-center">No Results</p>}
-                        {loaded && noReposAvailable && isGitHub() && (
-                            <div>
-                                <div className="px-12 py-20 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
-                                    <span className="dark:text-gray-400">
-                                        Additional authorization is required for Gitpod to watch your GitHub
-                                        repositories and trigger prebuilds.
-                                    </span>
-                                    <br />
-                                    {isGitHubWebhooksUnauthorized ? (
-                                        <button className="mt-6" onClick={() => authorize()}>
-                                            Authorize GitHub
-                                        </button>
-                                    ) : (
-                                        <button className="mt-6" onClick={() => reconfigure()}>
-                                            Configure Gitpod App
-                                        </button>
-                                    )}
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                </div>
-                {reposInAccounts.length > 0 && isGitHub() && isGitHubAppEnabled && (
-                    <div>
-                        <div className="text-gray-500 text-center w-96 mx-8">
-                            Repository not found?{" "}
-                            <button
-                                onClick={(e) => reconfigure()}
-                                className="gp-link text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600"
-                            >
-                                Reconfigure
-                            </button>
-                        </div>
-                    </div>
-                )}
-            </>
-        );
-
-        const renderLoadingState = () => (
-            <div>
-                {projectText()}
-                <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
-                    <div>
-                        <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
-                            <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm">
-                                <img className="h-4 w-4 animate-spin" src={Spinner} alt="loading spinner" />
-                                <span>Fetching repositories...</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-
-        const onGitProviderSeleted = async (host: string, updateUser?: boolean) => {
-            if (updateUser) {
-                setUser(await getGitpodService().server.getLoggedInUser());
-            }
-            setShowGitProviders(false);
-            setSelectedProviderHost(host);
-        };
-        if (needsGitAuth) {
-            return <AuthorizeGit />;
-        }
-
-        if (!loaded) {
-            return renderLoadingState();
-        }
-
-        if (showGitProviders) {
-            return <GitProviders onHostSelected={onGitProviderSeleted} authProviders={authProviders.data || []} />;
-        }
-
-        return renderRepos();
-    };
-
-    const onNewWorkspace = async () => {
+    const onNewWorkspace = useCallback(async () => {
         const redirectToNewWorkspace = () => {
             // instead of `history.push` we want forcibly to redirect here in order to avoid a following redirect from `/` -> `/projects` (cf. App.tsx)
             const url = new URL(window.location.toString());
@@ -534,95 +56,147 @@ export default function NewProject() {
             window.location.href = url.toString();
         };
         redirectToNewWorkspace();
-    };
+    }, [project?.cloneUrl]);
 
-    if (!project) {
-        return (
-            <div className="flex flex-col w-96 mt-24 mx-auto items-center">
-                <Heading1>New Project</Heading1>
-
-                {!selectedRepo && renderSelectRepository()}
-            </div>
-        );
-    } else {
-        const projectLink = `/projects/${Project.slug(project!)}`;
-        const location = !currentTeam ? (
-            ""
-        ) : (
-            <span>
-                {" "}
-                in organization{" "}
-                <a className="gp-link" href={`/projects`}>
-                    {currentTeam?.name}
-                </a>
-            </span>
-        );
-
+    // Show that project was created
+    if (project) {
         return (
             <div className="flex flex-col w-96 mt-24 mx-auto items-center">
                 <Heading1>Project Created</Heading1>
-
                 <Subheading className="mt-2 text-center">
                     Created{" "}
-                    <a className="gp-link" href={projectLink}>
+                    <a className="gp-link" href={`/projects/${Project.slug(project!)}`}>
                         {project.name}
                     </a>{" "}
-                    {location}
+                    {!currentTeam ? (
+                        ""
+                    ) : (
+                        <span>
+                            {" "}
+                            in organization{" "}
+                            <a className="gp-link" href={`/projects`}>
+                                {currentTeam?.name}
+                            </a>
+                        </span>
+                    )}
                 </Subheading>
 
                 <div className="mt-12">
-                    <button onClick={onNewWorkspace}>New Workspace</button>
+                    <Button onClick={onNewWorkspace}>New Workspace</Button>
                 </div>
             </div>
         );
     }
+
+    return (
+        <div className="flex flex-col w-96 mt-24 mx-auto items-center">
+            <Heading1>New Project</Heading1>
+            <NewProjectSubheading />
+
+            <NewProjectMainContent
+                selectedProviderHost={selectedProviderHost}
+                onProviderSelected={setSelectedProviderHost}
+                onProjectCreated={setProject}
+            />
+        </div>
+    );
 }
 
-function GitProviders(props: {
+type NewProjectMainContentProps = {
+    selectedProviderHost?: string;
+    onProviderSelected: (host: string, updateUser?: boolean) => void;
+    onProjectCreated: (project: Project) => void;
+};
+const NewProjectMainContent: FC<NewProjectMainContentProps> = ({
+    selectedProviderHost,
+    onProviderSelected,
+    onProjectCreated,
+}) => {
+    const { setUser } = useContext(UserContext);
+    const authProviders = useAuthProviders();
+    const needsGitAuth = useNeedsGitAuthorization();
+    const [showGitProviders, setShowGitProviders] = useState(false);
+
+    const onGitProviderSeleted = useCallback(
+        async (host: string, updateUser?: boolean) => {
+            // TODO: Can we push this down into where sends updateUser=true?
+            if (updateUser) {
+                setUser(await getGitpodService().server.getLoggedInUser());
+            }
+            setShowGitProviders(false);
+            onProviderSelected(host);
+        },
+        [onProviderSelected, setUser],
+    );
+
+    if (needsGitAuth) {
+        return <AuthorizeGit />;
+    }
+
+    if (showGitProviders) {
+        return <GitProviders onHostSelected={onGitProviderSeleted} authProviders={authProviders.data || []} />;
+    }
+
+    return (
+        <NewProjectRepoSelection
+            selectedProviderHost={selectedProviderHost}
+            onProjectCreated={onProjectCreated}
+            onChangeGitProvider={() => setShowGitProviders(true)}
+        />
+    );
+};
+
+const GitProviders: FC<{
     authProviders: AuthProviderInfo[];
     onHostSelected: (host: string, updateUser?: boolean) => void;
-}) {
+}> = ({ authProviders, onHostSelected }) => {
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
-    const selectProvider = async (ap: AuthProviderInfo) => {
-        setErrorMessage(undefined);
+    const selectProvider = useCallback(
+        async (ap: AuthProviderInfo) => {
+            setErrorMessage(undefined);
 
-        const token = await getGitpodService().server.getToken({ host: ap.host });
-        if (token && !(ap.authProviderType === "GitHub" && !token.scopes.includes("repo"))) {
-            props.onHostSelected(ap.host);
-            return;
-        }
-        await openAuthorizeWindow({
-            host: ap.host,
-            scopes: ap.authProviderType === "GitHub" ? ["repo"] : ap.requirements?.default,
-            onSuccess: async () => {
-                props.onHostSelected(ap.host, true);
-            },
-            onError: (payload) => {
-                let errorMessage: string;
-                if (typeof payload === "string") {
-                    errorMessage = payload;
-                } else {
-                    errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
-                    if (payload.error === "email_taken") {
-                        errorMessage = `Email address already used in another account. Please log in with ${
-                            (payload as any).host
-                        }.`;
+            const token = await getGitpodService().server.getToken({ host: ap.host });
+            if (token && !(ap.authProviderType === "GitHub" && !token.scopes.includes("repo"))) {
+                onHostSelected(ap.host);
+                return;
+            }
+            await openAuthorizeWindow({
+                host: ap.host,
+                scopes: ap.authProviderType === "GitHub" ? ["repo"] : ap.requirements?.default,
+                onSuccess: async () => {
+                    onHostSelected(ap.host, true);
+                },
+                onError: (payload) => {
+                    let errorMessage: string;
+                    if (typeof payload === "string") {
+                        errorMessage = payload;
+                    } else {
+                        errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
+                        if (payload.error === "email_taken") {
+                            errorMessage = `Email address already used in another account. Please log in with ${
+                                (payload as any).host
+                            }.`;
+                        }
                     }
-                }
-                setErrorMessage(errorMessage);
-            },
-        });
-    };
+                    setErrorMessage(errorMessage);
+                },
+            });
+        },
+        [onHostSelected],
+    );
 
-    const filteredProviders = () =>
-        props.authProviders.filter(
-            (p) =>
-                p.authProviderType === "GitHub" ||
-                p.host === "bitbucket.org" ||
-                p.authProviderType === "GitLab" ||
-                p.authProviderType === "BitbucketServer",
-        );
+    const filteredProviders = useMemo(
+        () =>
+            authProviders.filter(
+                (p) =>
+                    p.authProviderType === "GitHub" ||
+                    p.host === "bitbucket.org" ||
+                    p.authProviderType === "GitLab" ||
+                    p.authProviderType === "BitbucketServer",
+            ),
+        [authProviders],
+    );
 
     return (
         <div className="mt-8 border rounded-t-xl border-gray-100 dark:border-gray-800 flex-col">
@@ -631,10 +205,10 @@ function GitProviders(props: {
                     Select a Git provider first and continue with your repositories.
                 </div>
                 <div className="mt-6 flex flex-col space-y-3 items-center pb-8">
-                    {filteredProviders().map((ap) => {
+                    {filteredProviders.map((ap) => {
                         return (
                             <button
-                                key={"button" + ap.host}
+                                key={ap.host}
                                 className="btn-login flex-none w-56 h-10 p-0 inline-flex"
                                 onClick={() => selectProvider(ap)}
                             >
@@ -651,67 +225,4 @@ function GitProviders(props: {
             </div>
         </div>
     );
-}
-
-async function openReconfigureWindow(params: { account?: string; onSuccess: (p: any) => void }) {
-    const { account, onSuccess } = params;
-    const state = btoa(JSON.stringify({ from: "/reconfigure", next: projectsPathNew }));
-    const url = gitpodHostUrl
-        .withApi({
-            pathname: "/apps/github/reconfigure",
-            search: `account=${account}&state=${encodeURIComponent(state)}`,
-        })
-        .toString();
-
-    const width = 800;
-    const height = 800;
-    const left = window.screen.width / 2 - width / 2;
-    const top = window.screen.height / 2 - height / 2;
-
-    // Optimistically assume that the new window was opened.
-    window.open(
-        url,
-        "gitpod-github-window",
-        `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`,
-    );
-
-    const eventListener = (event: MessageEvent) => {
-        // todo: check event.origin
-
-        const killWindow = () => {
-            window.removeEventListener("message", eventListener);
-
-            if (event.source && "close" in event.source && event.source.close) {
-                console.log(`Received Window Result. Closing Window.`);
-                event.source.close();
-            }
-        };
-
-        if (typeof event.data === "string" && event.data.startsWith("payload:")) {
-            killWindow();
-            try {
-                let payload: { installationId: string; setupAction?: string } = JSON.parse(
-                    atob(event.data.substring("payload:".length)),
-                );
-                onSuccess && onSuccess(payload);
-            } catch (error) {
-                console.log(error);
-            }
-        }
-        if (typeof event.data === "string" && event.data.startsWith("error:")) {
-            let error: string | { error: string; description?: string } = atob(event.data.substring("error:".length));
-            try {
-                const payload = JSON.parse(error);
-                if (typeof payload === "object" && payload.error) {
-                    error = { error: payload.error, description: payload.description };
-                }
-            } catch (error) {
-                console.log(error);
-            }
-
-            killWindow();
-            // onError && onError(error);
-        }
-    };
-    window.addEventListener("message", eventListener);
-}
+};

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -58,7 +58,7 @@ export default function NewProject() {
         redirectToNewWorkspace();
     }, [project?.cloneUrl]);
 
-    // Show that project was created
+    // Show that the project was created
     if (project) {
         return (
             <div className="flex flex-col w-96 mt-24 mx-auto items-center">

--- a/components/dashboard/src/projects/new-project/NewProjectAccountSelector.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectAccountSelector.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { useIsGithubAppEnabled } from "../../data/git-providers/github-queries";
+import ContextMenu, { ContextMenuEntry } from "../../components/ContextMenu";
+import classNames from "classnames";
+import CaretDown from "../../icons/CaretDown.svg";
+import Plus from "../../icons/Plus.svg";
+import Switch from "../../icons/Switch.svg";
+import { useCurrentUser } from "../../user-context";
+
+type Props = {
+    selectedAccount?: string;
+    selectedProviderHost?: string;
+    accounts: Map<string, { avatarUrl: string }>;
+    onAccountSelected: (account: string) => void;
+    onAddGitHubAccount: () => void;
+    onSelectGitProvider: () => void;
+};
+export const NewProjectAccountSelector: FC<Props> = ({
+    selectedAccount,
+    selectedProviderHost,
+    accounts,
+    onAccountSelected,
+    onAddGitHubAccount,
+    onSelectGitProvider,
+}) => {
+    const user = useCurrentUser();
+    const { data: isGitHubAppEnabled } = useIsGithubAppEnabled();
+    const isGitHub = selectedProviderHost === "github.com";
+
+    const icon = selectedAccount && accounts.get(selectedAccount)?.avatarUrl;
+
+    const menuEntries = useDropdownMenuEntries({
+        accounts,
+        selectedAccount,
+        includeAddGitHubAccount: isGitHub && isGitHubAppEnabled,
+        onAccountSelected,
+        onAddGitHubAccount,
+        onSelectGitProvider,
+    });
+
+    return (
+        <ContextMenu customClasses="w-full left-0 cursor-pointer" menuEntries={menuEntries}>
+            <div className="w-full">
+                {!selectedAccount && user && user.name && user.avatarUrl && (
+                    <>
+                        <img
+                            src={user?.avatarUrl}
+                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
+                            alt="user avatar"
+                        />
+                        <input
+                            className="w-full px-12 cursor-pointer font-semibold"
+                            readOnly
+                            type="text"
+                            value={user?.name}
+                        ></input>
+                    </>
+                )}
+                {selectedAccount && (
+                    <>
+                        <img
+                            src={icon ? icon : ""}
+                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
+                            alt="icon"
+                        />
+                        <input
+                            className="w-full px-12 cursor-pointer font-semibold"
+                            readOnly
+                            type="text"
+                            value={selectedAccount}
+                        ></input>
+                    </>
+                )}
+                <img
+                    src={CaretDown}
+                    title="Select Account"
+                    className="filter-grayscale absolute top-1/2 right-3"
+                    alt="down caret icon"
+                />
+            </div>
+        </ContextMenu>
+    );
+};
+
+type UseDropdownMenuEntriesArgs = {
+    accounts: Map<string, { avatarUrl: string }>;
+    selectedAccount?: string;
+    includeAddGitHubAccount?: boolean;
+    onAccountSelected: (account: string) => void;
+    onAddGitHubAccount: () => void;
+    onSelectGitProvider: () => void;
+};
+const useDropdownMenuEntries = ({
+    accounts,
+    selectedAccount,
+    includeAddGitHubAccount,
+    onAccountSelected,
+    onAddGitHubAccount,
+    onSelectGitProvider,
+}: UseDropdownMenuEntriesArgs) => {
+    const user = useCurrentUser();
+
+    const result: ContextMenuEntry[] = [];
+
+    if (!selectedAccount && user && user.name && user.avatarUrl) {
+        result.push({
+            title: "user",
+            customContent: <DropdownMenuItem label={user?.name} icon={user?.avatarUrl} />,
+            separator: true,
+        });
+    }
+    for (const [account, props] of accounts.entries()) {
+        result.push({
+            title: account,
+            customContent: <DropdownMenuItem label={account} icon={props.avatarUrl} className="font-semibold" />,
+            separator: true,
+            onClick: () => onAccountSelected(account),
+        });
+    }
+    if (includeAddGitHubAccount) {
+        result.push({
+            title: "Add another GitHub account",
+            customContent: <DropdownMenuItem label="Add GitHub Orgs or Account" icon={Plus} />,
+            separator: true,
+            onClick: onAddGitHubAccount,
+        });
+    }
+    result.push({
+        title: "Select another Git Provider to continue with",
+        customContent: <DropdownMenuItem label="Select Git Provider" icon={Switch} />,
+        onClick: onSelectGitProvider,
+    });
+
+    return result;
+};
+
+const DropdownMenuItem: FC<{ label: string; icon: string; className?: string }> = ({ label, icon, className }) => {
+    return (
+        <div className="w-full flex">
+            <img src={icon} className="rounded-full w-6 h-6 my-auto" alt="icon" />
+            <span className={classNames("pl-2 text-gray-600 dark:text-gray-100 text-base", className)}>{label}</span>
+        </div>
+    );
+};

--- a/components/dashboard/src/projects/new-project/NewProjectAuthRequired.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectAuthRequired.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback } from "react";
+import { useAuthProviders } from "../../data/auth-providers/auth-provider-query";
+import { openAuthorizeWindow } from "../../provider-utils";
+
+type Props = {
+    selectedProviderHost: string;
+    areGitHubWebhooksUnauthorized?: boolean;
+    onReconfigure: () => void;
+};
+export const NewProjectAuthRequired: FC<Props> = ({
+    selectedProviderHost,
+    areGitHubWebhooksUnauthorized = false,
+    onReconfigure,
+}) => {
+    const authProviders = useAuthProviders();
+
+    const handleAuthorize = useCallback(() => {
+        const ap = authProviders.data?.find((ap) => ap.host === selectedProviderHost);
+        if (!ap) {
+            return;
+        }
+        openAuthorizeWindow({
+            host: ap.host,
+            scopes: ap.authProviderType === "GitHub" ? ["repo"] : ap.requirements?.default,
+            onSuccess: async () => {
+                // TODO: Verify this works correctly
+                if (ap.authProviderType === "GitHub") {
+                    authProviders.refetch();
+                }
+            },
+            onError: (payload) => {
+                console.error("Authorization failed", selectedProviderHost, payload);
+            },
+        });
+    }, [authProviders, selectedProviderHost]);
+
+    return (
+        <div>
+            <div className="px-12 py-20 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
+                <span className="dark:text-gray-400">
+                    Additional authorization is required for Gitpod to watch your GitHub repositories and trigger
+                    prebuilds.
+                </span>
+                <br />
+                {areGitHubWebhooksUnauthorized ? (
+                    <button className="mt-6" onClick={handleAuthorize}>
+                        Authorize GitHub
+                    </button>
+                ) : (
+                    <button className="mt-6" onClick={onReconfigure}>
+                        Configure Gitpod App
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
@@ -20,7 +20,7 @@ export const NewProjectCreateFromURL: FC<Props> = ({ repoSearchFilter, isCreatin
     const { toast } = useToast();
 
     const normalizedURL = useMemo(() => {
-        let url = repoSearchFilter.toLowerCase().trim();
+        let url = repoSearchFilter.toLocaleLowerCase().trim();
 
         // Just parse out the origin/pathname to remove any query params or hash
         try {
@@ -35,7 +35,7 @@ export const NewProjectCreateFromURL: FC<Props> = ({ repoSearchFilter, isCreatin
     }, [repoSearchFilter]);
 
     const showCreateFromURL = useMemo(() => {
-        // TODO: Only accounts for https urls, need to account for ssh clone urls too?
+        // TODO: Only accounts for https urls currently
         const looksLikeURL = isURL(normalizedURL, {
             require_protocol: true,
             protocols: ["https"],
@@ -59,14 +59,14 @@ export const NewProjectCreateFromURL: FC<Props> = ({ repoSearchFilter, isCreatin
             // Repo is last segment
             const repo = segments.pop();
             // owner is everything else
-            const owner = segments.join("/");
+            const owner = segments.join("-");
 
-            if (!owner && !repo) {
+            if (!repo) {
                 throw new Error();
             }
 
-            name = repo || owner;
-            slug = (repo || owner).toLowerCase();
+            name = repo;
+            slug = [repo, owner].filter(Boolean).join("-").toLowerCase();
         } catch (e) {
             toast("Sorry, it looks like we can't handle that URL. Is it a valid git clone URL?");
             return;

--- a/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback, useMemo } from "react";
+import isURL from "validator/lib/isURL";
+import { CreateProjectArgs } from "../../data/projects/create-project-mutation";
+import { Subheading } from "../../components/typography/headings";
+import { Button } from "../../components/Button";
+import { useToast } from "../../components/toasts/Toasts";
+
+type Props = {
+    repoSearchFilter: string;
+    isCreating: boolean;
+    onCreateProject: (args: CreateProjectArgs) => void;
+};
+export const NewProjectCreateFromURL: FC<Props> = ({ repoSearchFilter, isCreating, onCreateProject }) => {
+    const { toast } = useToast();
+    const showCreateFromURL = useMemo(() => {
+        // TODO: Only accounts for https urls, need to account for ssh clone urls too?
+        const looksLikeURL = isURL(repoSearchFilter, {
+            require_protocol: true,
+            protocols: ["https"],
+        });
+
+        const hasTrailingGit = /\.git$/.test(repoSearchFilter);
+
+        return looksLikeURL && hasTrailingGit;
+    }, [repoSearchFilter]);
+
+    const normalizedURL = useMemo(() => {
+        let url = repoSearchFilter.toLowerCase().trim();
+
+        return url;
+    }, [repoSearchFilter]);
+
+    const handleCreate = useCallback(() => {
+        let name = "";
+        let slug = "";
+
+        try {
+            // try and parse the url for owner/repo path parts
+            console.log("url: ", normalizedURL.substring(0, normalizedURL.length - 4));
+            const [owner, repo] = new URL(normalizedURL.substring(0, normalizedURL.length - 4)).pathname.split("/");
+            if (!owner && !repo) {
+                throw new Error();
+            }
+            name = repo || owner;
+            slug = repo || owner;
+        } catch (e) {
+            toast("Sorry, it looks like we can't handle that URL. Is it a valid git clone url?");
+            return;
+        }
+
+        onCreateProject({
+            name,
+            slug,
+            cloneUrl: normalizedURL,
+            appInstallationId: "",
+        });
+    }, [normalizedURL, onCreateProject, toast]);
+
+    if (!showCreateFromURL) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-col items-center">
+            <Subheading>Create project from Git clone url?</Subheading>
+
+            <pre className="my-2 font-mono text-sm">{normalizedURL}</pre>
+
+            <Button onClick={handleCreate} loading={isCreating}>
+                Create Project
+            </Button>
+        </div>
+    );
+};

--- a/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectCreateFromURL.tsx
@@ -68,7 +68,7 @@ export const NewProjectCreateFromURL: FC<Props> = ({ repoSearchFilter, isCreatin
 
     return (
         <div className="flex flex-col items-center">
-            <Subheading>Create project from Git clone url?</Subheading>
+            <Subheading>Create project from Git clone URL?</Subheading>
 
             <pre className="my-2 font-mono text-sm">{normalizedURL}</pre>
 

--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -7,13 +7,15 @@
 import { ProviderRepository } from "@gitpod/gitpod-protocol";
 import dayjs from "dayjs";
 import { FC } from "react";
+import { Button } from "../../components/Button";
 
 type Props = {
     filteredRepos: ProviderRepository[];
     noReposAvailable: boolean;
+    isCreating: boolean;
     onRepoSelected: (repo: ProviderRepository) => void;
 };
-export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable, onRepoSelected }) => {
+export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable, isCreating, onRepoSelected }) => {
     return (
         <>
             {filteredRepos.length > 0 && (
@@ -38,9 +40,9 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                             <div className="flex justify-end">
                                 <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
                                     {!r.inUse ? (
-                                        <button className="primary" onClick={() => onRepoSelected(r)}>
+                                        <Button onClick={() => onRepoSelected(r)} loading={isCreating}>
                                             Select
-                                        </button>
+                                        </Button>
                                     ) : (
                                         <p className="text-gray-500 font-medium">
                                             <a rel="noopener" className="gp-link" href={userLink(r)}>

--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { ProviderRepository } from "@gitpod/gitpod-protocol";
+import dayjs from "dayjs";
+import { FC } from "react";
+
+type Props = {
+    filteredRepos: ProviderRepository[];
+    noReposAvailable: boolean;
+    onRepoSelected: (repo: ProviderRepository) => void;
+};
+export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable, onRepoSelected }) => {
+    return (
+        <div className="p-6 flex-col">
+            {filteredRepos.length > 0 && (
+                <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
+                    {filteredRepos.map((r, index) => (
+                        <div
+                            key={`repo-${index}-${r.account}-${r.name}`}
+                            className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                            title={r.cloneUrl}
+                        >
+                            <div className="flex-grow">
+                                <div
+                                    className={
+                                        "text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap" +
+                                        (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")
+                                    }
+                                >
+                                    {toSimpleName(r.name)}
+                                </div>
+                                {r.updatedAt && <p>Updated {dayjs(r.updatedAt).fromNow()}</p>}
+                            </div>
+                            <div className="flex justify-end">
+                                <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
+                                    {!r.inUse ? (
+                                        <button className="primary" onClick={() => onRepoSelected(r)}>
+                                            Select
+                                        </button>
+                                    ) : (
+                                        <p className="text-gray-500 font-medium">
+                                            <a rel="noopener" className="gp-link" href={userLink(r)}>
+                                                @{r.inUse.userName}
+                                            </a>{" "}
+                                            already
+                                            <br />
+                                            added this repo
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {!noReposAvailable && filteredRepos.length === 0 && <p className="text-center">No Results</p>}
+        </div>
+    );
+};
+
+const toSimpleName = (fullName: string) => {
+    const splitted = fullName.split("/");
+    if (splitted.length < 2) {
+        return fullName;
+    }
+    return splitted.shift() && splitted.join("/");
+};
+
+const userLink = (r: ProviderRepository) => {
+    return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`;
+};

--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable, onRepoSelected }) => {
     return (
-        <div className="p-6 flex-col">
+        <>
             {filteredRepos.length > 0 && (
                 <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
                     {filteredRepos.map((r, index) => (
@@ -58,7 +58,7 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                 </div>
             )}
             {!noReposAvailable && filteredRepos.length === 0 && <p className="text-center">No Results</p>}
-        </div>
+        </>
     );
 };
 

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Project } from "@gitpod/gitpod-protocol";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { useAreGithubWebhooksUnauthorized, useIsGithubAppEnabled } from "../../data/git-providers/github-queries";
+import { LinkButton } from "../../components/LinkButton";
+import Spinner from "../../icons/Spinner.svg";
+import { trackEvent } from "../../Analytics";
+import { NewProjectSearchInput } from "./NewProjectSearchInput";
+import { NewProjectAccountSelector } from "./NewProjectAccountSelector";
+import { NewProjectRepoList } from "./NewProjectRepoList";
+import { useCreateProject } from "../../data/projects/create-project-mutation";
+import { NewProjectAuthRequired } from "./NewProjectAuthRequired";
+import { useToast } from "../../components/toasts/Toasts";
+import { useProviderRepositoriesForUser } from "../../data/git-providers/provider-repositories-query";
+import { NewProjectSubheading } from "./NewProjectSubheading";
+import { openReconfigureWindow } from "./reconfigure-github";
+
+type Props = {
+    selectedProviderHost?: string;
+    onProjectCreated: (project: Project) => void;
+    onChangeGitProvider: () => void;
+};
+export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onProjectCreated, onChangeGitProvider }) => {
+    const { toast } = useToast();
+    const { data: isGitHubAppEnabled } = useIsGithubAppEnabled();
+    const areGitHubWebhooksUnauthorized = useAreGithubWebhooksUnauthorized(selectedProviderHost || "");
+    const createProject = useCreateProject();
+
+    // Component state managed by this component
+    const [selectedAccount, _setSelectedAccount] = useState<string>();
+    const [repoSearchFilter, setRepoSearchFilter] = useState("");
+    const [installationId, setInstallationId] = useState<string>();
+
+    // Main query for listing repos given the current state
+    const { data: reposInAccounts, isLoading } = useProviderRepositoriesForUser({
+        provider: selectedProviderHost || "",
+        installationId,
+    });
+
+    // Wrap setting selected account so we can clear the repo search filter at the same time
+    const updateSelectedAccount = useCallback((account?: string) => {
+        _setSelectedAccount(account);
+        setRepoSearchFilter("");
+    }, []);
+
+    // Memoized & derived values
+    const noReposAvailable = !!(reposInAccounts?.length === 0 || areGitHubWebhooksUnauthorized);
+    const isGitHub = selectedProviderHost === "github.com";
+
+    const accounts = useMemo(() => {
+        const accounts = new Map<string, { avatarUrl: string }>();
+
+        reposInAccounts?.forEach((r) => {
+            if (!accounts.has(r.account)) {
+                accounts.set(r.account, { avatarUrl: r.accountAvatarUrl });
+            } else if (!accounts.get(r.account)?.avatarUrl && r.accountAvatarUrl) {
+                accounts.get(r.account)!.avatarUrl = r.accountAvatarUrl;
+            }
+        });
+
+        return accounts;
+    }, [reposInAccounts]);
+
+    const filteredRepos = useMemo(() => {
+        return areGitHubWebhooksUnauthorized
+            ? []
+            : Array.from(reposInAccounts || []).filter(
+                  (r) =>
+                      r.account === selectedAccount &&
+                      `${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase().trim()),
+              );
+    }, [areGitHubWebhooksUnauthorized, repoSearchFilter, reposInAccounts, selectedAccount]);
+
+    const reconfigure = useCallback(() => {
+        openReconfigureWindow({
+            account: selectedAccount,
+            onSuccess: (p: { installationId: string; setupAction?: string }) => {
+                setInstallationId(p.installationId);
+
+                trackEvent("organisation_authorised", {
+                    installation_id: p.installationId,
+                    setup_action: p.setupAction,
+                });
+            },
+        });
+    }, [selectedAccount]);
+
+    // Creates the project
+    const handleRepoSelected = useCallback(
+        (repo) => {
+            createProject.mutate(
+                {
+                    name: repo.name,
+                    cloneUrl: repo.cloneUrl,
+                    slug: repo.path || repo.name,
+                    appInstallationId: String(repo.installationId),
+                },
+                {
+                    onSuccess: (project) => {
+                        onProjectCreated(project);
+                    },
+                    onError: (error) => {
+                        toast(error?.message ?? "Failed to create new project.");
+                    },
+                },
+            );
+        },
+        [createProject, onProjectCreated, toast],
+    );
+
+    // Adjusts selectedAccount when repos change
+    useEffect(() => {
+        if (reposInAccounts?.length === 0) {
+            updateSelectedAccount(undefined);
+        } else {
+            const first = reposInAccounts?.[0];
+            if (!!first?.installationUpdatedAt) {
+                const mostRecent = reposInAccounts?.reduce((prev, current) =>
+                    (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current,
+                );
+                updateSelectedAccount(mostRecent?.account);
+            } else {
+                updateSelectedAccount(first?.account);
+            }
+        }
+    }, [reposInAccounts, updateSelectedAccount]);
+
+    if (isLoading) {
+        return <ReposLoading />;
+    }
+
+    return (
+        <>
+            <p className="text-gray-500 text-center text-base mt-12">
+                {!isLoading && noReposAvailable ? "Select account on " : "Select a Git repository on "}
+                <b>{selectedProviderHost}</b> (<LinkButton onClick={onChangeGitProvider}>change</LinkButton>)
+            </p>
+            <div className={`mt-2 flex-col ${noReposAvailable && isGitHub ? "w-96" : ""}`}>
+                <div className="px-8 flex flex-col space-y-2" data-analytics='{"label":"Identity"}'>
+                    <NewProjectAccountSelector
+                        accounts={accounts}
+                        selectedAccount={selectedAccount}
+                        selectedProviderHost={selectedProviderHost}
+                        onAccountSelected={updateSelectedAccount}
+                        onAddGitHubAccount={reconfigure}
+                        onSelectGitProvider={onChangeGitProvider}
+                    />
+                    <NewProjectSearchInput searchFilter={repoSearchFilter} onSearchFilterChange={setRepoSearchFilter} />
+                </div>
+                <div className="p-6 flex-col">
+                    <NewProjectRepoList
+                        filteredRepos={filteredRepos}
+                        noReposAvailable={noReposAvailable}
+                        onRepoSelected={handleRepoSelected}
+                    />
+                    {!isLoading && noReposAvailable && isGitHub && (
+                        <NewProjectAuthRequired
+                            selectedProviderHost={selectedProviderHost}
+                            areGitHubWebhooksUnauthorized={areGitHubWebhooksUnauthorized}
+                            onReconfigure={reconfigure}
+                        />
+                    )}
+                </div>
+            </div>
+            {reposInAccounts && reposInAccounts.length > 0 && isGitHub && isGitHubAppEnabled && (
+                <div>
+                    <div className="text-gray-500 text-center w-96 mx-8">
+                        Repository not found?{" "}
+                        <button
+                            onClick={(e) => reconfigure()}
+                            className="gp-link text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600"
+                        >
+                            Reconfigure
+                        </button>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+};
+
+const ReposLoading: FC = () => (
+    <div>
+        <NewProjectSubheading />
+        <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
+            <div>
+                <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
+                    <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm">
+                        <img className="h-4 w-4 animate-spin" src={Spinner} alt="loading spinner" />
+                        <span>Fetching repositories...</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+);

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -158,6 +158,7 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
                 </div>
                 <div className="p-6 flex-col">
                     <NewProjectRepoList
+                        isCreating={createProject.isLoading}
                         filteredRepos={filteredRepos}
                         noReposAvailable={noReposAvailable}
                         onRepoSelected={handleRepoSelected}

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -32,7 +32,7 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
     const createProject = useCreateProject();
 
     // Component state managed by this component
-    const [selectedAccount, _setSelectedAccount] = useState<string>();
+    const [selectedAccount, setSelectedAccount] = useState<string>();
     const [repoSearchFilter, setRepoSearchFilter] = useState("");
     const [installationId, setInstallationId] = useState<string>();
 
@@ -43,8 +43,8 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
     });
 
     // Wrap setting selected account so we can clear the repo search filter at the same time
-    const updateSelectedAccount = useCallback((account?: string) => {
-        _setSelectedAccount(account);
+    const setSelectedAccountAndClearSearch = useCallback((account?: string) => {
+        setSelectedAccount(account);
         setRepoSearchFilter("");
     }, []);
 
@@ -117,22 +117,22 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
         [onCreateProject],
     );
 
-    // Adjusts selectedAccount when repos change
+    // Adjusts selectedAccount when repos change if we don't have a selected account
     useEffect(() => {
         if (reposInAccounts?.length === 0) {
-            updateSelectedAccount(undefined);
-        } else {
+            setSelectedAccountAndClearSearch(undefined);
+        } else if (!selectedAccount) {
             const first = reposInAccounts?.[0];
             if (!!first?.installationUpdatedAt) {
                 const mostRecent = reposInAccounts?.reduce((prev, current) =>
                     (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current,
                 );
-                updateSelectedAccount(mostRecent?.account);
+                setSelectedAccountAndClearSearch(mostRecent?.account);
             } else {
-                updateSelectedAccount(first?.account);
+                setSelectedAccountAndClearSearch(first?.account);
             }
         }
-    }, [reposInAccounts, updateSelectedAccount]);
+    }, [reposInAccounts, selectedAccount, setSelectedAccountAndClearSearch]);
 
     if (isLoading) {
         return <ReposLoading />;
@@ -150,7 +150,7 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
                         accounts={accounts}
                         selectedAccount={selectedAccount}
                         selectedProviderHost={selectedProviderHost}
-                        onAccountSelected={updateSelectedAccount}
+                        onAccountSelected={setSelectedAccountAndClearSearch}
                         onAddGitHubAccount={reconfigure}
                         onSelectGitProvider={onChangeGitProvider}
                     />

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -17,7 +17,6 @@ import { CreateProjectArgs, useCreateProject } from "../../data/projects/create-
 import { NewProjectAuthRequired } from "./NewProjectAuthRequired";
 import { useToast } from "../../components/toasts/Toasts";
 import { useProviderRepositoriesForUser } from "../../data/git-providers/provider-repositories-query";
-import { NewProjectSubheading } from "./NewProjectSubheading";
 import { openReconfigureWindow } from "./reconfigure-github";
 import { NewProjectCreateFromURL } from "./NewProjectCreateFromURL";
 
@@ -197,15 +196,12 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProviderHost, onPro
 };
 
 const ReposLoading: FC = () => (
-    <div>
-        <NewProjectSubheading />
-        <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
-            <div>
-                <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
-                    <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm">
-                        <img className="h-4 w-4 animate-spin" src={Spinner} alt="loading spinner" />
-                        <span>Fetching repositories...</span>
-                    </div>
+    <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
+        <div>
+            <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
+                <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm">
+                    <img className="h-4 w-4 animate-spin" src={Spinner} alt="loading spinner" />
+                    <span>Fetching repositories...</span>
                 </div>
             </div>
         </div>

--- a/components/dashboard/src/projects/new-project/NewProjectSearchInput.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectSearchInput.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import SearchImg from "../../icons/search.svg";
+
+type Props = {
+    searchFilter: string;
+    onSearchFilterChange: (value: string) => void;
+};
+export const NewProjectSearchInput: FC<Props> = ({ searchFilter, onSearchFilterChange }) => {
+    return (
+        <div className="w-full relative h-10 my-auto">
+            <img
+                src={SearchImg}
+                title="Search"
+                className="filter-grayscale absolute top-1/3 left-3"
+                alt="search icon"
+            />
+            <input
+                className="w-96 pl-10 border-0"
+                type="search"
+                placeholder="Search Repositories"
+                value={searchFilter}
+                onChange={(e) => onSearchFilterChange(e.target.value)}
+            ></input>
+        </div>
+    );
+};

--- a/components/dashboard/src/projects/new-project/NewProjectSearchInput.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectSearchInput.tsx
@@ -21,12 +21,12 @@ export const NewProjectSearchInput: FC<Props> = ({ searchFilter, onSearchFilterC
                 alt="search icon"
             />
             <input
-                className="w-96 pl-10 border-0"
+                className="w-96 pl-10 border-0 max-w-full"
                 type="search"
                 placeholder="Search Repositories"
                 value={searchFilter}
                 onChange={(e) => onSearchFilterChange(e.target.value)}
-            ></input>
+            />
         </div>
     );
 };

--- a/components/dashboard/src/projects/new-project/NewProjectSubheading.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectSubheading.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Subheading } from "../../components/typography/headings";
+
+export const NewProjectSubheading: FC = () => {
+    return (
+        <Subheading className="text-center">
+            Projects allow you to manage prebuilds and workspaces for your repository.{" "}
+            <a
+                href="https://www.gitpod.io/docs/configure/projects"
+                target="_blank"
+                rel="noreferrer"
+                className="gp-link"
+            >
+                Learn more
+            </a>
+        </Subheading>
+    );
+};

--- a/components/dashboard/src/projects/new-project/reconfigure-github.ts
+++ b/components/dashboard/src/projects/new-project/reconfigure-github.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { gitpodHostUrl } from "../../service/service";
+import { projectsPathNew } from "../projects.routes";
+
+export async function openReconfigureWindow(params: { account?: string; onSuccess: (p: any) => void }) {
+    const { account, onSuccess } = params;
+    const state = btoa(JSON.stringify({ from: "/reconfigure", next: projectsPathNew }));
+    const url = gitpodHostUrl
+        .withApi({
+            pathname: "/apps/github/reconfigure",
+            search: `account=${account}&state=${encodeURIComponent(state)}`,
+        })
+        .toString();
+
+    const width = 800;
+    const height = 800;
+    const left = window.screen.width / 2 - width / 2;
+    const top = window.screen.height / 2 - height / 2;
+
+    // Optimistically assume that the new window was opened.
+    window.open(
+        url,
+        "gitpod-github-window",
+        `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`,
+    );
+
+    const eventListener = (event: MessageEvent) => {
+        // todo: check event.origin
+
+        const killWindow = () => {
+            window.removeEventListener("message", eventListener);
+
+            if (event.source && "close" in event.source && event.source.close) {
+                console.log(`Received Window Result. Closing Window.`);
+                event.source.close();
+            }
+        };
+
+        if (typeof event.data === "string" && event.data.startsWith("payload:")) {
+            killWindow();
+            try {
+                let payload: { installationId: string; setupAction?: string } = JSON.parse(
+                    atob(event.data.substring("payload:".length)),
+                );
+                onSuccess && onSuccess(payload);
+            } catch (error) {
+                console.log(error);
+            }
+        }
+        if (typeof event.data === "string" && event.data.startsWith("error:")) {
+            let error: string | { error: string; description?: string } = atob(event.data.substring("error:".length));
+            try {
+                const payload = JSON.parse(error);
+                if (typeof payload === "object" && payload.error) {
+                    error = { error: payload.error, description: payload.description };
+                }
+            } catch (error) {
+                console.log(error);
+            }
+
+            killWindow();
+            // onError && onError(error);
+        }
+    };
+    window.addEventListener("message", eventListener);
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The primary aim for this PR was to allow pasting in a git clone url when creating a project, and allowing the user to create w/ that clone url if there isn't a repo that matches their search, and if the url looks like a clone url. In case there are problems loading the repositories, this provides a workaround.

![image](https://github.com/gitpod-io/gitpod/assets/367275/f3323cd1-944a-4830-b59f-f650145c6ce3)

**_Notes:_**
The `NewProject.tsx`  file has a lot going on it, which made it quite difficult to modify some of the functionality w/o effecting the rest. There were like 8 useEffects() and several layers of nested rendering functions. I ended up refactoring most of that component and breaking it out into more manageable pieces, as well as prepping some of the queries/mutations to let us build an incremental repo search for this UI as a followup.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a8b7a2</samp>

This pull request adds several new files with TypeScript code that implement the user interface and the data fetching logic for creating projects from GitHub repositories. It defines custom React hooks for querying and mutating GitHub-related data, and React components for rendering the different elements of the new project creation flow. It also provides a utility function for reconfiguring the GitHub app if needed.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-458

## How to test
<!-- Provide steps to test this PR -->
* Try and create new projects on the Preview Environment. 
* Try pasting in git clone urls and creating that way

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-4a012c26733</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-4a012c26733.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-4a012c26733.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-458-fe-allow-pasting-in-a-git-clone-url-to-create-project-as-gha.15508</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
