### PR TITLE
[fga] WorkspaceService: workspace timeout + classes + git status (misc I)

### DIFF
--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -322,6 +322,25 @@ describe("WorkspaceService", async () => {
             "should fail on non-running workspace",
         );
     });
+
+    it("should getWorkspaceTimeout", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        const actual = await svc.getWorkspaceTimeout(owner.id, ws.id);
+        expect(actual, "even stopped workspace get a default response").to.not.be.undefined;
+    });
+
+    it("should setWorkspaceTimeout", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.setWorkspaceTimeout(owner.id, ws.id, "180m"),
+            "should fail on non-running workspace",
+        );
+    });
 });
 
 async function createTestWorkspace(svc: WorkspaceService, org: Organization, owner: User, project: Project) {

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -302,6 +302,26 @@ describe("WorkspaceService", async () => {
             "should fail on non-running workspace",
         );
     });
+
+    it("should updateGitStatus", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.updateGitStatus(owner.id, ws.id, {
+                branch: "main",
+                uncommitedFiles: ["new-unit.ts"],
+                latestCommit: "asdf",
+                totalUncommitedFiles: 1,
+                totalUntrackedFiles: 1,
+                unpushedCommits: [],
+                untrackedFiles: ["new-unit.ts"],
+                totalUnpushedCommits: 0,
+            }),
+            "should fail on non-running workspace",
+        );
+    });
 });
 
 async function createTestWorkspace(svc: WorkspaceService, org: Organization, owner: User, project: Project) {


### PR DESCRIPTION
## Description
Ticks the FGA boxes for the following methods:
- setWorkspaceTimeout(workspaceId: string, duration: WorkspaceTimeoutDuration)
- getWorkspaceTimeout(workspaceId: string)
- maySetTimeout()
- getSupportedWorkspaceClasses()
- updateGitStatus(workspaceId: string, status: Required<WorkspaceInstanceRepoStatus> | undefined)[ ] 

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Parts of EXP-207

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
