### PR TITLE
[WIP][fga] WorkspaceService: watchWorkspaceImageBuildLogsm getHeadlessLog, WorkspaceService.sendHeartBeat

### DIFF
--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -32,11 +32,7 @@ import { HostContextProvider } from "./auth/host-context-provider";
 import { CodeSyncService } from "./code-sync/code-sync-service";
 import { increaseHttpRequestCounter, observeHttpRequestDuration, setGitpodVersion } from "./prometheus-metrics";
 import { OAuthController } from "./oauth-server/oauth-controller";
-import {
-    HeadlessLogController,
-    HEADLESS_LOGS_PATH_PREFIX,
-    HEADLESS_LOG_DOWNLOAD_PATH_PREFIX,
-} from "./workspace/headless-log-controller";
+import { HeadlessLogController } from "./workspace/headless-log-controller";
 import { NewsletterSubscriptionController } from "./user/newsletter-subscription-controller";
 import { Config } from "./config";
 import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
@@ -51,6 +47,7 @@ import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
 import { JobRunner } from "./jobs/runner";
 import { RedisSubscriber } from "./messaging/redis-subscriber";
+import { HEADLESS_LOGS_PATH_PREFIX, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./workspace/headless-log-service";
 
 @injectable()
 export class Server {

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -26,7 +26,12 @@ import {
 import { DBWithTracing, TracedWorkspaceDB } from "@gitpod/gitpod-db/lib/traced-db";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
 import { TeamDB } from "@gitpod/gitpod-db/lib/team-db";
-import { HeadlessLogService, HeadlessLogEndpoint } from "./headless-log-service";
+import {
+    HeadlessLogService,
+    HeadlessLogEndpoint,
+    HEADLESS_LOGS_PATH_PREFIX,
+    HEADLESS_LOG_DOWNLOAD_PATH_PREFIX,
+} from "./headless-log-service";
 import * as opentracing from "opentracing";
 import { asyncHandler } from "../express-util";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
@@ -37,9 +42,6 @@ import { ProjectsService } from "../projects/projects-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
-
-export const HEADLESS_LOGS_PATH_PREFIX = "/headless-logs";
-export const HEADLESS_LOG_DOWNLOAD_PATH_PREFIX = "/headless-log-download";
 
 @injectable()
 export class HeadlessLogController {

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -31,8 +31,10 @@ import {
     LogDownloadURLRequest,
     LogDownloadURLResponse,
 } from "@gitpod/content-service/lib/headless-log_pb";
-import { HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./headless-log-controller";
 import { CachingHeadlessLogServiceClientProvider } from "../util/content-service-sugar";
+
+export const HEADLESS_LOGS_PATH_PREFIX = "/headless-logs";
+export const HEADLESS_LOG_DOWNLOAD_PATH_PREFIX = "/headless-log-download";
 
 export type HeadlessLogEndpoint = {
     url: string;

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -12,6 +12,7 @@ import {
     Project,
     User,
     WorkspaceConfig,
+    WorkspaceImageBuild,
     WorkspaceInstancePort,
 } from "@gitpod/gitpod-protocol";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
@@ -340,6 +341,29 @@ describe("WorkspaceService", async () => {
             svc.setWorkspaceTimeout(owner.id, ws.id, "180m"),
             "should fail on non-running workspace",
         );
+    });
+
+    it("should getHeadlessLog", async () => {
+        const svc = container.get(WorkspaceService);
+        await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.getHeadlessLog(owner.id, "non-existing-instanceId"),
+            "should fail on non-running workspace",
+        );
+    });
+
+    it("should watchWorkspaceImageBuildLogs", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, {
+            onWorkspaceImageBuildLogs: (
+                info: WorkspaceImageBuild.StateInfo,
+                content: WorkspaceImageBuild.LogContent | undefined,
+            ) => {},
+        }); // returns without error in case of non-running workspace
     });
 });
 

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -365,6 +365,19 @@ describe("WorkspaceService", async () => {
             ) => {},
         }); // returns without error in case of non-running workspace
     });
+
+    it("should sendHeartBeat", async () => {
+        const svc = container.get(WorkspaceService);
+        await createTestWorkspace(svc, org, owner, project);
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.sendHeartBeat(owner.id, {
+                instanceId: "non-existing-instanceId",
+            }),
+            "should fail on non-running workspace",
+        );
+    });
 });
 
 async function createTestWorkspace(svc: WorkspaceService, org: Organization, owner: User, project: Project) {


### PR DESCRIPTION
## Description
Ticks the FGA boxes for the following methods:

- watchWorkspaceImageBuildLogs
- getHeadlessLog
- WorkspaceService.sendHeartBeat



<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b55df37</samp>

Refactored headless log and workspace image build logic to use `WorkspaceService` class. Moved constants and types to appropriate modules. Simplified and deprecated old methods in `GitpodServerImpl`. Added tests for `WorkspaceService`.

</details>

## Related Issue(s)
Parts of [EXP-207](https://linear.app/gitpod/issue/EXP-207)
Based on: https://github.com/gitpod-io/gitpod/pull/18535

## How to test
- signup as regular users 1 and 2, and enable [centralizedPermissions](url) for your userIDs on ConfigCat
- user 1: start a workspace
- user 1: open devtools and run `await window._gp.gitpodService.server.sendHeartBeat("your-instance-id")` :heavy_check_mark: 
- user 2: open devtools, and run  `await window._gp.gitpodService.server.sendHeartBeat("same-instance-id")`: should fail with `Error: Workspace xyz not found.` :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-ws-misc-2</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-ws-misc-2.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-ws-misc-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-ws-misc-2-gha.15554</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
