### PR TITLE
[fga] project visibility and prebuild perms

### DIFF
--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -80,6 +80,8 @@ export namespace Project {
         changeUrl?: string;
         changeHash: string;
     }
+
+    export type Visibility = "public" | "org-public" | "private";
 }
 
 export type PartialProject = DeepPartial<Project> & Pick<Project, "id">;

--- a/components/server/debug.sh
+++ b/components/server/debug.sh
@@ -14,7 +14,7 @@ function restore {
 trap restore EXIT
 
 echo "Add the inspect flag and debug port to the configuration"
-jq '.spec.template.spec.containers[0].command = ["yarn", "start-inspect"]' original_deployment_$deploymentName.json > new_deployment_$deploymentName.json
+jq '.spec.template.spec.containers[0].command = ["/usr/bin/node", "--inspect=0.0.0.0:9229", "./dist/main.js"]' original_deployment_$deploymentName.json > new_deployment_$deploymentName.json
 
 echo "Apply the new configuration"
 kubectl apply -f new_deployment_$deploymentName.json
@@ -23,5 +23,9 @@ rm new_deployment_$deploymentName.json
 echo "Scale down to one pod"
 kubectl scale deployment $deploymentName --replicas=1
 
-echo "Forward the port $debugPort to localhost. Waiting for a debugger to attach ..."
-kubectl port-forward deployment/$deploymentName $debugPort
+echo "Wait for the pod to be ready"
+kubectl wait --for=condition=ready pod -l component=$deploymentName
+
+podName=$(kubectl get pods -l component=$deploymentName -o=jsonpath='{.items[0].metadata.name}')
+echo "Forward $podName port $debugPort to localhost. Waiting for a debugger to attach ..."
+kubectl port-forward pod/"$podName" $debugPort

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -56,6 +56,7 @@ export type OrganizationRelation = "installation" | "member" | "owner";
 
 export type OrganizationPermission =
     | "installation_admin"
+    | "installation_member"
     | "read_info"
     | "write_info"
     | "delete"
@@ -77,7 +78,14 @@ export type ProjectResourceType = "project";
 
 export type ProjectRelation = "org" | "editor" | "viewer";
 
-export type ProjectPermission = "read_info" | "write_info" | "delete" | "read_env_var" | "write_env_var";
+export type ProjectPermission =
+    | "read_info"
+    | "write_info"
+    | "delete"
+    | "read_env_var"
+    | "write_env_var"
+    | "read_prebuild"
+    | "write_prebuild";
 
 export type WorkspaceResourceType = "workspace";
 
@@ -341,13 +349,25 @@ export const rel = {
                             },
                         } as v1.Relationship;
                     },
-                    organization(objectId: string) {
+                    organization_member(objectId: string) {
                         return {
                             ...result2,
                             subject: {
                                 object: {
                                     objectType: "organization",
                                     objectId: objectId,
+                                },
+                                optionalRelation: "member",
+                            },
+                        } as v1.Relationship;
+                    },
+                    get anyUser() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: "*",
                                 },
                             },
                         } as v1.Relationship;

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -74,6 +74,20 @@ describe("ProjectsService", async () => {
         await expectError(ErrorCodes.NOT_FOUND, () => ps.getProjects(stranger.id, org.id));
     });
 
+    it("should setVisibility", async () => {
+        const ps = container.get(ProjectsService);
+        const project = await createTestProject(ps, org, owner);
+
+        await expectError(ErrorCodes.NOT_FOUND, () => ps.getProject(stranger.id, project.id));
+        await expectError(ErrorCodes.NOT_FOUND, () => ps.getProjects(stranger.id, org.id));
+        await ps.setVisibility(owner.id, project.id, "public");
+
+        const foundProject = await ps.getProject(stranger.id, project.id);
+        expect(foundProject?.id).to.equal(project.id);
+        // listing by org still doesn't woprk because strangers don't have access to the org
+        await expectError(ErrorCodes.NOT_FOUND, () => ps.getProjects(stranger.id, org.id));
+    });
+
     it("should deleteProject", async () => {
         const ps = container.get(ProjectsService);
         const project = await createTestProject(ps, org, owner);

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -21,7 +21,7 @@ schema: |-
 
     permission read_tokens = self
     permission write_tokens = self
-    
+
     permission read_env_var = self
     permission write_env_var = self
   }
@@ -48,6 +48,7 @@ schema: |-
 
     // synthetic permission for installation->admin (because https://github.com/authzed/spicedb/issues/15)
     permission installation_admin = installation->admin
+    permission installation_member = installation->member
 
     // General operations on organization
     permission read_info = member + owner + installation->admin
@@ -84,16 +85,20 @@ schema: |-
     relation editor: user
 
     // A subject is a viewer, if:
-    //  * the user is directly assigned as a viewer
-    //  * the project has granted access to everyone in an organization
-    relation viewer: user | organization#member
+    //  * the users with access are directly assigned as a viewer
+    //  * the project has granted access to all members in an organization
+    //  * the project has granted access to _any_ user on this installation
+    relation viewer: user | organization#member | user:*
 
-    permission read_info = viewer + org->member + editor + org->owner + org->installation_admin
+    permission read_info = viewer + editor + org->owner + org->installation_admin
     permission write_info = editor + org->owner + org->installation_admin
     permission delete = editor + org->owner + org->installation_admin
 
-    permission read_env_var = viewer + org->member + editor + org->owner + org->installation_admin
+    permission read_env_var = viewer + editor + org->owner + org->installation_admin
     permission write_env_var = editor + org->owner + org->installation_admin
+
+    permission read_prebuild = viewer + editor + org->owner + org->installation_admin
+    permission write_prebuild = editor + org->owner
   }
 
   definition workspace {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Introduction of project visibilities:
 - private
 - org-public (default)
 - public

This change doesn't add any UI. Projects have `org-public` visibility. 
I have added this [issue](https://linear.app/gitpod/issue/EXP-471/project-visibility) for follow-up work, such as adding a settings option in the UI.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14f1884</samp>

This pull request adds and improves features for project visibility and prebuild permissions, using the SpiceDB service and schema. It updates the `Authorizer`, `ProjectsService`, and `GitpodServerImpl` classes, as well as the `gitpod-protocol` and `spicedb` modules, to handle the new visibility and permission logic. It also adds tests and fixes some formatting issues.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-468

## How to test
<!-- Provide steps to test this PR -->

1) Start a workspace using https://se-project-vis.preview.gitpod-dev.com/#https://github.com/svenefftinge/2048-in-terminal
There is a project with a prebuild for this repo in my org, but your workspace should not get one.

I.e. you should **not!!!** see this message in the first terminal:
<img width="375" alt="Screenshot 2023-08-18 at 10 40 58" src="https://github.com/gitpod-io/gitpod/assets/372735/50078e20-1e39-4404-a9d3-a68f3e9d5113">

2) Join my org (https://se-project-vis.preview.gitpod-dev.com/orgs/join?inviteId=0b8713e6-97f4-4a9d-9836-06344d23ab38) and create another workspace on https://se-project-vis.preview.gitpod-dev.com/#https://github.com/svenefftinge/2048-in-terminal
Now you should get a workspace with a prebuild.

I.e. you should see this message in the first terminal:
<img width="375" alt="Screenshot 2023-08-18 at 10 40 58" src="https://github.com/gitpod-io/gitpod/assets/372735/50078e20-1e39-4404-a9d3-a68f3e9d5113">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-project-vis</li>
        <li><b>🔗 URL</b> - <a href="https://se-project-vis.preview.gitpod-dev.com/workspaces" target="_blank">se-project-vis.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
