### PR TITLE
[code] Fix gp-code build

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -16,18 +16,11 @@ WORKDIR /gp-code
 RUN yarn --cwd remote --frozen-lockfile --network-timeout 180000
 
 
-FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
-
-ARG NODE_VERSION=16.19.0
-ARG NVM_DIR="/root/.nvm"
-RUN mkdir -p $NVM_DIR \
-    && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | sh \
-    && . $NVM_DIR/nvm.sh \
-    && nvm alias default $NODE_VERSION
-ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+FROM gitpod/openvscode-server-linux-build-agent:bionic-x64 as code_builder
 
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
+ENV VSCODE_SKIP_NODE_VERSION_CHECK=1
 
 ARG CODE_COMMIT
 ARG CODE_QUALITY


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e866ef3</samp>

Update the base image and simplify the build process for the code builder stage in `components/ide/code/leeway.Dockerfile`. This change aligns with the upstream openvscode-server repository and improves the build performance and image size.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
