### PR TITLE
Add support for pod disruption budget

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -712,6 +712,10 @@ var (
 		APIVersion: "trust.cert-manager.io/v1alpha1",
 		Kind:       "Bundle",
 	}
+	TypePodDisruptionBudget = metav1.TypeMeta{
+		APIVersion: "policy/v1",
+		Kind:       "PodDisruptionBudget",
+	}
 )
 
 // validCookieChars contains all characters which may occur in an HTTP Cookie value (unicode \u0021 through \u007E),

--- a/install/installer/pkg/common/pod_disruption_budget.go
+++ b/install/installer/pkg/common/pod_disruption_budget.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	"fmt"
+
+	policy "k8s.io/api/policy/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func PodDisruptionBudget(ctx *RenderContext, component string, maxUnavailable int, selector *v1.LabelSelector) *policy.PodDisruptionBudget {
+	muCount := intstr.FromInt(maxUnavailable)
+
+	return &policy.PodDisruptionBudget{
+		TypeMeta: TypePodDisruptionBudget,
+		ObjectMeta: v1.ObjectMeta{
+			Name:      fmt.Sprintf("%v-pdb", component),
+			Namespace: ctx.Namespace,
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			MaxUnavailable: &muCount,
+			Selector:       selector,
+		},
+	}
+}

--- a/install/installer/pkg/components/blobserve/objects.go
+++ b/install/installer/pkg/components/blobserve/objects.go
@@ -11,6 +11,7 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
+	pdb,
 	common.GenerateService(Component, []common.ServicePort{
 		{
 			Name:          ServicePortName,

--- a/install/installer/pkg/components/blobserve/pdb.go
+++ b/install/installer/pkg/components/blobserve/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package blobserve
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/dashboard/objects.go
+++ b/install/installer/pkg/components/dashboard/objects.go
@@ -10,6 +10,7 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
+	pdb,
 	common.GenerateService(Component, []common.ServicePort{
 		{
 			Name:          PortName,

--- a/install/installer/pkg/components/dashboard/pdb.go
+++ b/install/installer/pkg/components/dashboard/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dashboard
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/node-labeler/objects.go
+++ b/install/installer/pkg/components/node-labeler/objects.go
@@ -15,6 +15,7 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	role,
 	rolebinding,
+	pdb,
 	common.DefaultServiceAccount(Component),
 	func(cfg *common.RenderContext) ([]runtime.Object, error) {
 		ports := []common.ServicePort{

--- a/install/installer/pkg/components/node-labeler/pdb.go
+++ b/install/installer/pkg/components/node-labeler/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package wsmanager
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/openvsx-proxy/objects.go
+++ b/install/installer/pkg/components/openvsx-proxy/objects.go
@@ -13,6 +13,7 @@ var Objects = common.CompositeRenderFunc(
 	networkpolicy,
 	rolebinding,
 	statefulset,
+	pdb,
 	service,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/openvsx-proxy/pdb.go
+++ b/install/installer/pkg/components/openvsx-proxy/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package openvsx_proxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/proxy/objects.go
+++ b/install/installer/pkg/components/proxy/objects.go
@@ -13,6 +13,7 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
+	pdb,
 	service,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/proxy/pdb.go
+++ b/install/installer/pkg/components/proxy/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -14,6 +14,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		configmap,
 		deployment,
 		rolebinding,
+		pdb,
 		common.DefaultServiceAccount(Component),
 		service,
 		networkpolicy,

--- a/install/installer/pkg/components/public-api-server/pdb.go
+++ b/install/installer/pkg/components/public-api-server/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/server/objects.go
+++ b/install/installer/pkg/components/server/objects.go
@@ -22,6 +22,7 @@ var Objects = common.CompositeRenderFunc(
 	func(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return Rolebinding(ctx, Component)
 	},
+	pdb,
 	common.GenerateService(Component, []common.ServicePort{
 		{
 			Name:          ContainerPortName,

--- a/install/installer/pkg/components/server/pdb.go
+++ b/install/installer/pkg/components/server/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/ws-manager-mk2/objects.go
+++ b/install/installer/pkg/components/ws-manager-mk2/objects.go
@@ -15,6 +15,7 @@ var Objects common.RenderFunc = func(cfg *common.RenderContext) ([]runtime.Objec
 		crd,
 		configmap,
 		deployment,
+		pdb,
 		networkpolicy,
 		role,
 		rolebinding,

--- a/install/installer/pkg/components/ws-manager-mk2/pdb.go
+++ b/install/installer/pkg/components/ws-manager-mk2/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package wsmanagermk2
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}

--- a/install/installer/pkg/components/ws-proxy/objects.go
+++ b/install/installer/pkg/components/ws-proxy/objects.go
@@ -16,6 +16,7 @@ var Objects = common.CompositeRenderFunc(
 	networkpolicy,
 	rolebinding,
 	role,
+	pdb,
 	func(cfg *common.RenderContext) ([]runtime.Object, error) {
 		ports := []common.ServicePort{
 			{

--- a/install/installer/pkg/components/ws-proxy/pdb.go
+++ b/install/installer/pkg/components/ws-proxy/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package wsproxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}


### PR DESCRIPTION
### Description

Enable pod disruption budget to avoid the migration of multiple replicas at the same time when we need to drain nodes.

fixes ENG-725

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44ab5ea</samp>

Add pod disruption budget for ws-manager-mk2 component. This improves the availability and resilience of the workspace management service by limiting the impact of voluntary pod disruptions.

</details>

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-pdb</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-pdb.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-pdb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-pdb-gha.15854</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
