### PR TITLE
[server] properly drain connections on SIGTERM

### DIFF
--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -13,6 +13,7 @@ import * as net from "net";
 import { WsLayer } from "./ws-layer";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { increaseHttpRequestCounter } from "../prometheus-metrics";
+import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol/lib/util/disposable";
 
 export type HttpServer = http.Server | https.Server;
 export type RouteMatcher = string | RegExp;
@@ -40,6 +41,8 @@ export class WsExpressHandler {
     protected readonly wss: websocket.Server;
     protected readonly routes: Route[] = [];
 
+    private readonly disposables = new DisposableCollection();
+
     constructor(protected readonly httpServer: HttpServer, protected readonly verifyClient?: WsConnectionFilter) {
         this.wss = new websocket.Server({
             verifyClient,
@@ -65,6 +68,10 @@ export class WsExpressHandler {
     ): void {
         const stack = WsLayer.createStack(...handlers);
         const dispatch = (ws: websocket, request: express.Request) => {
+            const toTerminate = Disposable.create(() => ws.terminate());
+            const cancelTerminate = this.disposables.push(toTerminate);
+            ws.on("close", () => cancelTerminate.dispose());
+
             handler(ws, request);
             stack
                 .dispatch(ws, request)
@@ -106,5 +113,22 @@ export class WsExpressHandler {
             return !!pathname && matcher.test(pathname);
         }
         return pathname === matcher;
+    }
+
+    /**
+     * Stop accepting new connections, returns when all connections are closed.
+     */
+    dispose(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.wss.close((err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+            // terminate all connections
+            this.disposables.dispose();
+        });
     }
 }

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -210,6 +210,7 @@ export class Server {
 
             const wsPingPongHandler = new WsConnectionHandler();
             const wsHandler = new WsExpressHandler(httpServer, verifyClient);
+            this.disposables.push(wsHandler);
             wsHandler.ws(
                 websocketConnectionHandler.path,
                 (ws, request) => {
@@ -344,12 +345,14 @@ export class Server {
     }
 
     public async stop() {
-        await this.debugApp.stop();
-        await this.stopServer(this.iamSessionAppServer);
-        await this.stopServer(this.monitoringHttpServer);
-        await this.stopServer(this.httpServer);
-        await this.stopServer(this.apiServer);
-        this.disposables.dispose();
+        await Promise.allSettled([
+            this.debugApp.stop(),
+            this.stopServer(this.iamSessionAppServer),
+            this.stopServer(this.monitoringHttpServer),
+            this.stopServer(this.httpServer),
+            this.stopServer(this.apiServer),
+            new Promise(() => this.disposables.dispose()),
+        ]).catch((err) => log.error("error while stopping server", { err }));
         log.info("server stopped.");
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- draing all http and ws endpoints in parallel, not sequential, otherwise first endpoint can block till not drained, preventing draining others
- terminate web socket connections

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e16238</samp>

This pull request adds WebSocket support to the server component and improves its cleanup logic. It refactors the `WsExpressHandler` class to use disposables and modifies the `Server` class to handle and dispose of WebSocket connections and wait for all servers and applications to stop gracefully.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

- Restart a server while using dashboard. WS should be closed immediately now don't be blocked for 30 secs.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-drain-s6de913315b</li>
	<li><b>🔗 URL</b> - <a href="https://ak-drain-s6de913315b.preview.gitpod-dev.com/workspaces" target="_blank">ak-drain-s6de913315b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-drain_server_propertly-gha.15630</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
