### PR TITLE
[fga] WorkspaceService.controlAdmission

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -386,14 +386,19 @@ export class Authorizer {
         );
     }
 
-    async addWorkspaceToOrg(orgID: string, userID: string, workspaceID: string): Promise<void> {
+    async addWorkspaceToOrg(orgID: string, userID: string, workspaceID: string, shared: boolean): Promise<void> {
         if (await this.isDisabled(userID)) {
             return;
         }
-        await this.authorizer.writeRelationships(
+        const rels = [
             set(rel.workspace(workspaceID).org.organization(orgID)),
             set(rel.workspace(workspaceID).owner.user(userID)),
-        );
+        ];
+        if (shared) {
+            rels.push(set(rel.workspace(workspaceID).shared.user("*")));
+        }
+
+        await this.authorizer.writeRelationships(...rels);
     }
 
     async removeWorkspaceFromOrg(orgID: string, userID: string, workspaceID: string): Promise<void> {
@@ -403,7 +408,16 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             remove(rel.workspace(workspaceID).org.organization(orgID)),
             remove(rel.workspace(workspaceID).owner.user(userID)),
+            remove(rel.workspace(workspaceID).shared.user("*")),
         );
+    }
+
+    async setWorkspaceIsShared(userID: string, workspaceID: string, shared: boolean): Promise<void> {
+        if (await this.isDisabled(userID)) {
+            return;
+        }
+        const op = shared ? set : remove;
+        await this.authorizer.writeRelationships(op(rel.workspace(workspaceID).shared.user("*")));
     }
 
     async bulkCreateWorkspaceInOrg(ids: { orgID: string; userID: string; workspaceID: string }[]): Promise<void> {

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -395,7 +395,7 @@ export class Authorizer {
             set(rel.workspace(workspaceID).owner.user(userID)),
         ];
         if (shared) {
-            rels.push(set(rel.workspace(workspaceID).shared.user("*")));
+            rels.push(set(rel.workspace(workspaceID).shared.anyUser));
         }
 
         await this.authorizer.writeRelationships(...rels);
@@ -408,7 +408,7 @@ export class Authorizer {
         await this.authorizer.writeRelationships(
             remove(rel.workspace(workspaceID).org.organization(orgID)),
             remove(rel.workspace(workspaceID).owner.user(userID)),
-            remove(rel.workspace(workspaceID).shared.user("*")),
+            remove(rel.workspace(workspaceID).shared.anyUser),
         );
     }
 
@@ -417,7 +417,7 @@ export class Authorizer {
             return;
         }
         const op = shared ? set : remove;
-        await this.authorizer.writeRelationships(op(rel.workspace(workspaceID).shared.user("*")));
+        await this.authorizer.writeRelationships(op(rel.workspace(workspaceID).shared.anyUser));
     }
 
     async bulkCreateWorkspaceInOrg(ids: { orgID: string; userID: string; workspaceID: string }[]): Promise<void> {

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -431,13 +431,13 @@ export const rel = {
                     relation: "shared",
                 };
                 return {
-                    user(objectId: string) {
+                    get anyUser() {
                         return {
                             ...result2,
                             subject: {
                                 object: {
                                     objectType: "user",
-                                    objectId: objectId,
+                                    objectId: "*",
                                 },
                             },
                         } as v1.Relationship;

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -89,7 +89,7 @@ export type ProjectPermission =
 
 export type WorkspaceResourceType = "workspace";
 
-export type WorkspaceRelation = "org" | "owner";
+export type WorkspaceRelation = "org" | "owner" | "shared";
 
 export type WorkspacePermission = "access" | "start" | "stop" | "delete" | "read_info";
 
@@ -409,6 +409,26 @@ export const rel = {
                 const result2 = {
                     ...result,
                     relation: "owner",
+                };
+                return {
+                    user(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get shared() {
+                const result2 = {
+                    ...result,
+                    relation: "shared",
                 };
                 return {
                     user(objectId: string) {

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -120,6 +120,16 @@ describe("WorkspaceService", async () => {
     it("owner can start own workspace", async () => {
         const workspaceService = container.get(WorkspaceService);
         const workspace = await createTestWorkspace(workspaceService, org, owner, project);
+
+        const result = await workspaceService.startWorkspace({}, owner, workspace.id);
+        expect(result.workspaceURL).to.equal(`https://${workspace.id}.ws.gitpod.io`);
+    });
+
+    it("owner can start own workspace - shared", async () => {
+        const workspaceService = container.get(WorkspaceService);
+        const workspace = await createTestWorkspace(workspaceService, org, owner, project);
+        await workspaceService.controlAdmission(owner.id, workspace.id, "everyone");
+
         const result = await workspaceService.startWorkspace({}, owner, workspace.id);
         expect(result.workspaceURL).to.equal(`https://${workspace.id}.ws.gitpod.io`);
     });
@@ -130,9 +140,23 @@ describe("WorkspaceService", async () => {
         await expectError(ErrorCodes.NOT_FOUND, workspaceService.startWorkspace({}, stranger, workspace.id));
     });
 
+    it("stanger cannot start owner workspace - shared", async () => {
+        const workspaceService = container.get(WorkspaceService);
+        const workspace = await createTestWorkspace(workspaceService, org, owner, project);
+        await workspaceService.controlAdmission(owner.id, workspace.id, "everyone");
+        await expectError(ErrorCodes.PERMISSION_DENIED, workspaceService.startWorkspace({}, stranger, workspace.id));
+    });
+
     it("org member cannot start owner workspace", async () => {
         const workspaceService = container.get(WorkspaceService);
         const workspace = await createTestWorkspace(workspaceService, org, owner, project);
+        await expectError(ErrorCodes.PERMISSION_DENIED, workspaceService.startWorkspace({}, member, workspace.id));
+    });
+
+    it("org member cannot start owner workspace - shared", async () => {
+        const workspaceService = container.get(WorkspaceService);
+        const workspace = await createTestWorkspace(workspaceService, org, owner, project);
+        await workspaceService.controlAdmission(owner.id, workspace.id, "everyone");
         await expectError(ErrorCodes.PERMISSION_DENIED, workspaceService.startWorkspace({}, member, workspace.id));
     });
 
@@ -162,7 +186,24 @@ describe("WorkspaceService", async () => {
         const foundWorkspace = await svc.getWorkspace(owner.id, ws.id);
         expect(foundWorkspace?.id).to.equal(ws.id);
 
+        await expectError(ErrorCodes.PERMISSION_DENIED, svc.getWorkspace(member.id, ws.id));
         await expectError(ErrorCodes.NOT_FOUND, svc.getWorkspace(stranger.id, ws.id));
+    });
+
+    it("should getWorkspace - shared", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await svc.controlAdmission(owner.id, ws.id, "everyone");
+
+        const foundWorkspace = await svc.getWorkspace(owner.id, ws.id);
+        expect(foundWorkspace?.id, "owner has access to shared workspace").to.equal(ws.id);
+
+        const memberFoundWorkspace = await svc.getWorkspace(member.id, ws.id);
+        expect(memberFoundWorkspace?.id, "member has access to shared workspace").to.equal(ws.id);
+
+        const strangerFoundWorkspace = await svc.getWorkspace(stranger.id, ws.id);
+        expect(strangerFoundWorkspace?.id, "stranger has access to shared workspace").to.equal(ws.id);
     });
 
     it("should getOwnerToken", async () => {
@@ -173,6 +214,12 @@ describe("WorkspaceService", async () => {
             ErrorCodes.NOT_FOUND,
             svc.getOwnerToken(owner.id, ws.id),
             "NOT_FOUND for non-running workspace",
+        );
+
+        await expectError(
+            ErrorCodes.PERMISSION_DENIED,
+            svc.getOwnerToken(member.id, ws.id),
+            "NOT_FOUND if member asks for the owner token",
         );
 
         await expectError(
@@ -196,14 +243,42 @@ describe("WorkspaceService", async () => {
         );
     });
 
+    it("should getIDECredentials - shared", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await svc.controlAdmission(owner.id, ws.id, "everyone");
+
+        const ideCredentials = await svc.getIDECredentials(owner.id, ws.id);
+        expect(ideCredentials, "IDE credentials should be present").to.not.be.undefined;
+
+        const stragnerIdeCredentials = await svc.getIDECredentials(stranger.id, ws.id);
+        expect(stragnerIdeCredentials, "IDE credentials should be present").to.not.be.undefined;
+    });
+
     it("should stopWorkspace", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
 
-        await svc.stopWorkspace(owner.id, ws.id, "test stopping stopped workspace");
+        await svc.stopWorkspace(owner.id, ws.id, "test");
         await expectError(
             ErrorCodes.NOT_FOUND,
-            svc.stopWorkspace(stranger.id, ws.id, "test stranger stopping stopped workspace"),
+            svc.stopWorkspace(stranger.id, ws.id, "test"),
+            "test stranger stopping stopped workspace",
+        );
+    });
+
+    it("should stopWorkspace - shared", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await svc.controlAdmission(owner.id, ws.id, "everyone");
+
+        await svc.stopWorkspace(owner.id, ws.id, "test");
+        await expectError(
+            ErrorCodes.PERMISSION_DENIED,
+            svc.stopWorkspace(stranger.id, ws.id, "test"),
+            "test stranger stopping stopped workspace",
         );
     });
 
@@ -234,6 +309,32 @@ describe("WorkspaceService", async () => {
 
         await expectError(
             ErrorCodes.NOT_FOUND,
+            svc.hardDeleteWorkspace(stranger.id, ws.id),
+            "stranger can't hard-delete workspace",
+        );
+
+        await svc.hardDeleteWorkspace(owner.id, ws.id);
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.getWorkspace(owner.id, ws.id),
+            "getWorkspace should return NOT_FOUND after hard-deletion",
+        );
+    });
+
+    it("should hardDeleteWorkspace - shared", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+
+        await svc.controlAdmission(owner.id, ws.id, "everyone");
+
+        await expectError(
+            ErrorCodes.PERMISSION_DENIED,
+            svc.hardDeleteWorkspace(member.id, ws.id),
+            "member can't hard-delete workspace",
+        );
+
+        await expectError(
+            ErrorCodes.PERMISSION_DENIED,
             svc.hardDeleteWorkspace(stranger.id, ws.id),
             "stranger can't hard-delete workspace",
         );
@@ -357,13 +458,43 @@ describe("WorkspaceService", async () => {
     it("should watchWorkspaceImageBuildLogs", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
-
-        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, {
+        const client = {
             onWorkspaceImageBuildLogs: (
                 info: WorkspaceImageBuild.StateInfo,
                 content: WorkspaceImageBuild.LogContent | undefined,
             ) => {},
-        }); // returns without error in case of non-running workspace
+        };
+
+        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, client); // returns without error in case of non-running workspace
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.watchWorkspaceImageBuildLogs(member.id, ws.id, client),
+            "should fail for member on not-shared workspace",
+        );
+
+        await expectError(
+            ErrorCodes.NOT_FOUND,
+            svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, client),
+            "should fail for stranger on not-shared workspace",
+        );
+    });
+
+    it("should watchWorkspaceImageBuildLogs", async () => {
+        const svc = container.get(WorkspaceService);
+        const ws = await createTestWorkspace(svc, org, owner, project);
+        const client = {
+            onWorkspaceImageBuildLogs: (
+                info: WorkspaceImageBuild.StateInfo,
+                content: WorkspaceImageBuild.LogContent | undefined,
+            ) => {},
+        };
+
+        await svc.controlAdmission(owner.id, ws.id, "everyone");
+
+        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, client); // returns without error in case of non-running workspace
+        await svc.watchWorkspaceImageBuildLogs(member.id, ws.id, client);
+        await svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, client);
     });
 
     it("should sendHeartBeat", async () => {
@@ -389,7 +520,7 @@ describe("WorkspaceService", async () => {
         expect(wsActual.shareable, "owner should be able to share by default").to.equal(true);
     });
 
-    it("should controlAdmission negative", async () => {
+    it("should controlAdmission - non-owner", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
 

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -468,7 +468,7 @@ describe("WorkspaceService", async () => {
         await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, client); // returns without error in case of non-running workspace
 
         await expectError(
-            ErrorCodes.NOT_FOUND,
+            ErrorCodes.PERMISSION_DENIED,
             svc.watchWorkspaceImageBuildLogs(member.id, ws.id, client),
             "should fail for member on not-shared workspace",
         );
@@ -480,7 +480,7 @@ describe("WorkspaceService", async () => {
         );
     });
 
-    it("should watchWorkspaceImageBuildLogs", async () => {
+    it("should watchWorkspaceImageBuildLogs - shared", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
         const client = {

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -105,10 +105,12 @@ schema: |-
     relation org: organization
     // The user that created the workspace
     relation owner: user
+    // Whether this workspace is shared (globally)
+    relation shared: user:*
 
     // Whether a user can access a workspace (with an IDE)
-    //+ (hasAccessToRepository && isPrebuild) + everyoneIfIsShared
-    permission access = owner
+    //+ (hasAccessToRepository && isPrebuild)
+    permission access = owner + shared
 
     // Note: All of this is modelled after current behavior.
     // There are a lot of improvements we can make here in the light of Organizations, but we explicitly do that as a separate step
@@ -117,8 +119,8 @@ schema: |-
     permission delete = owner
 
     // Whether a user can read basic info/metadata of a workspace
-    //+ (hasAccessToRepository && isPrebuild) + everyoneIfIsShared
-    permission read_info = owner + org->member
+    //+ (hasAccessToRepository && isPrebuild)
+    permission read_info = owner + shared + org->member
   }
 # relationships to be used for assertions & validation
 relationships: |-
@@ -150,6 +152,12 @@ relationships: |-
   project:project_2#org@organization:org_2
   // user_1 is viewer of project_2
   project:project_2#viewer@user:user_1
+
+  workspace:workspace_1#org@organization:org_1
+  workspace:workspace_1#owner@user:user_1
+  workspace:workspace_2_shared#org@organization:org_1
+  workspace:workspace_2_shared#owner@user:user_1
+  workspace:workspace_2_shared#shared@user:*
 
 # validation should assert that a particular relation exists between an entity, and a subject
 # validations are not used to assert that a permission exists
@@ -203,6 +211,11 @@ assertions:
     - organization:org_1#write_git_provider@user:user_admin
     # installation admin can create an org
     - installation:installation_0#create_organization@user:user_admin
+    # owner can access their workspaces
+    - workspace:workspace_1#access@user:user_1
+    - workspace:workspace_2_shared#access@user:user_1
+    # stranger can access other's workspaces
+    - workspace:workspace_2_shared#access@user:user_2
   assertFalse:
     # user 10 cannot access project_1
     - project:project_1#read_info@user:user_10
@@ -222,3 +235,5 @@ assertions:
     - organization:org_1#delete@user:user_1
     # org members can not delete project
     - project:project_1#delete@user:user_1
+    # stranger can't access other's non-shared workspace
+    - workspace:workspace_1#access@user:user_2


### PR DESCRIPTION
## Description

This introduced WorkspaceService.controlAdmission, incl. workspace sharing implemented with FGA

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73ce811</samp>

This pull request adds a new feature to allow sharing workspaces with any user in an organization. It modifies the authorization logic and database schema for workspaces, and adds new methods and tests to the `WorkspaceService` and `Authorizer` classes. It also updates the Spicedb schema and permissions to support the new `shared` relation.

</details>

## Related Issue(s)
Relates to: EXP-207

## How to test
 - create user's 1 and 2
 - user 1: start a workspace, and enable sharing :heavy_check_mark: 
 - user 2: open the share link, and see how you can properly interact with the workspace :heavy_check_mark: 
 - user 1: disable workspace sharing :heavy_check_mark: 
 - user 2: re-load the workspace page, and note how you lost access :heavy_check_mark: 
 
## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-share-ws</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-share-ws.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-share-ws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-share-ws-gha.15657</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
