### PR TITLE
[server] terminate ws on shutdown

### DIFF
--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -108,8 +108,9 @@ export async function start(container: Container) {
 
     process.on("SIGTERM", async () => {
         log.info("SIGTERM received, stopping");
-        await server.stop();
         clearInterval(interval);
+        await server.stop();
+        process.exit(0);
     });
 
     const tracing = container.get(TracingManager);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Terminate websocket connections on SIGINT.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d5e1cc</samp>

This pull request enhances the cleanup and shutdown logic for the server and the websocket handler, using the `Disposable` pattern and adding more logging. It also fixes some minor bugs and import issues in `server.ts` and `ws-handler.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-476

## How to test
<!-- Provide steps to test this PR -->

- login into the preview environment
- start a workspace on this PR and set the kubectx to the preview
- follow the logs of the server pod
- delete the server pod and notice that it immediately terminates (you can tell from the logs)

kubectll will still show the old pod in terminating while the new pod is initializing.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-cancel-ws</li>
        <li><b>🔗 URL</b> - <a href="https://se-cancel-ws.preview.gitpod-dev.com/workspaces" target="_blank">se-cancel-ws.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
