### PR TITLE
Wiring up api repo searching for bitbucket server

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -51,6 +51,7 @@
     "@types/file-saver": "^2.0.5",
     "@types/jest": "^26.0.22",
     "@types/js-cookie": "^2.2.7",
+    "@types/lodash.debounce": "^4.0.7",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.3",

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -21,6 +21,7 @@
     "file-saver": "^2.0.5",
     "idb-keyval": "^6.2.0",
     "js-cookie": "^3.0.1",
+    "lodash.debounce": "^4.0.8",
     "monaco-editor": "^0.25.2",
     "p-throttle": "^5.1.0",
     "pretty-bytes": "^6.1.0",

--- a/components/dashboard/src/data/git-providers/provider-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/provider-repositories-query.ts
@@ -8,16 +8,25 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentUser } from "../../user-context";
 import { CancellationTokenSource } from "vscode-jsonrpc";
+import { useAuthProviders } from "../auth-providers/auth-provider-query";
+import { GetProviderRepositoriesParams } from "@gitpod/gitpod-protocol";
 
 type UseProviderRepositoriesQueryArgs = {
-    provider: string;
+    providerHost: string;
     installationId?: string;
+    search?: string;
 };
-export const useProviderRepositoriesForUser = ({ provider, installationId }: UseProviderRepositoriesQueryArgs) => {
+export const useProviderRepositoriesForUser = ({
+    providerHost,
+    installationId,
+    search,
+}: UseProviderRepositoriesQueryArgs) => {
     const user = useCurrentUser();
+    const { data: authProviders } = useAuthProviders();
+    const selectedProvider = authProviders?.find((p) => p.host === providerHost);
 
     return useQuery(
-        ["provider-repositories", { userId: user?.id }, { provider, installationId }],
+        ["provider-repositories", { userId: user?.id }, { providerHost, installationId }],
         async ({ signal }) => {
             // jsonrpc cancellation token that we subscribe to the abort signal provided by react-query
             const cancelToken = new CancellationTokenSource();
@@ -26,17 +35,26 @@ export const useProviderRepositoriesForUser = ({ provider, installationId }: Use
                 cancelToken.cancel();
             });
 
+            const params: GetProviderRepositoriesParams = {
+                provider: providerHost,
+                hints: { installationId },
+            };
+
+            // TODO: Have this be the default for all providers
+            if (selectedProvider?.authProviderType === "BitbucketServer") {
+                params.searchString = search;
+                params.limit = 50;
+                params.maxPages = 1;
+            }
+
             return await getGitpodService().server.getProviderRepositoriesForUser(
-                {
-                    provider,
-                    hints: { installationId },
-                },
+                params,
                 // @ts-ignore - not sure why types don't support this
                 cancelToken.token,
             );
         },
         {
-            enabled: !!provider,
+            enabled: !!providerHost,
         },
     );
 };

--- a/components/dashboard/src/hooks/use-state-with-debounce.ts
+++ b/components/dashboard/src/hooks/use-state-with-debounce.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import debounce from "lodash.debounce";
+
+export const useStateWithDebounce = <T>(initialValue: T, delay = 300): [T, (value: T) => void, T] => {
+    const [value, setValue] = useState<T>(initialValue);
+    const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
+
+    const debouncedSetValue = useMemo(() => {
+        return debounce(setDebouncedValue, delay);
+    }, [delay]);
+
+    useEffect(() => {
+        debouncedSetValue(value);
+    }, [value, debouncedSetValue]);
+
+    return [value, setValue, debouncedValue];
+};

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -295,6 +295,8 @@ export interface GetProviderRepositoriesParams {
     provider: string;
     hints?: { installationId: string } | object;
     searchString?: string;
+    limit?: number;
+    maxPages?: number;
 }
 export interface ProviderRepository {
     name: string;

--- a/components/server/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.ts
@@ -27,7 +27,7 @@ export class BitbucketServerService extends RepositoryService {
 
     async getRepositoriesForAutomatedPrebuilds(
         user: User,
-        params: { searchString: string; cancellationToken?: CancellationToken },
+        params: { searchString: string; limit?: number; cap?: number; cancellationToken?: CancellationToken },
     ): Promise<ProviderRepository[]> {
         const repos = await this.api.getRepos(user, { permission: "REPO_ADMIN", ...params });
         return repos.map((r) => {

--- a/components/server/src/repohost/repo-service.ts
+++ b/components/server/src/repohost/repo-service.ts
@@ -12,7 +12,7 @@ import { CancellationToken } from "vscode-jsonrpc";
 export class RepositoryService {
     async getRepositoriesForAutomatedPrebuilds(
         user: User,
-        params: { searchString?: string; cancellationToken?: CancellationToken },
+        params: { searchString?: string; limit?: number; cap?: number; cancellationToken?: CancellationToken },
     ): Promise<ProviderRepository[]> {
         return [];
     }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -66,6 +66,7 @@ import {
     PrebuildEvent,
     RoleOrPermission,
     WorkspaceInstanceRepoStatus,
+    GetProviderRepositoriesParams,
 } from "@gitpod/gitpod-protocol";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import {
@@ -1426,7 +1427,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     // Projects
     async getProviderRepositoriesForUser(
         ctx: TraceContext,
-        params: { provider: string; hints?: object; searchString?: string },
+        params: GetProviderRepositoriesParams,
         cancellationToken?: CancellationToken,
     ): Promise<ProviderRepository[]> {
         traceAPIParams(ctx, { params });
@@ -1455,6 +1456,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                     ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user, {
                         searchString: params.searchString,
                         cancellationToken,
+                        limit: params.limit,
+                        cap: params.maxPages,
                     })),
                 );
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,7 +3470,7 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@useorbital/client-types@^1.5.0":
+"@useorbital/client-types@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@useorbital/client-types/-/client-types-1.6.0.tgz#5ae0828964cb50962395b142578ec4c2c39806e8"
   integrity sha512-Lf490y3x1v8jFgEULuLRt7TmN/kSZeQ0hYS4Y6AfHijB6oBp/B0o1MWNrF11KqKY6ghs1CIZi5RxVOXsnd/geQ==
@@ -10539,7 +10539,23 @@ jsonify@~0.0.0:
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonwebtoken@^8.5.1, jsonwebtoken@^9.0.0:
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
+jsonwebtoken@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
   integrity sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==
@@ -10812,8 +10828,8 @@ lodash.clonedeep@^4.5.0:
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
-  resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.defaults@^4.2.0:
   version "4.2.0"
@@ -10830,10 +10846,35 @@ lodash.get@^4:
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
 lodash.isarguments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
   integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -10854,6 +10895,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.template@^4.5.0:
   version "4.5.0"
@@ -11235,14 +11281,26 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@3.0.5, minimatch@^3.0.4:
+minimatch@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
   integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@1.2.8, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,6 +2972,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.debounce@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz#0285879defb7cdb156ae633cecd62d5680eded9f"
+  integrity sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.176"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the new project page so searching for repos is done via the api for bitbucket server.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7144e28</samp>

Added repository search and pagination support for the new project creation flow. Updated the service interface and the backend implementations for fetching repositories for a user and a provider. Added a custom hook for debouncing the search input. Modified the `getProviderRepositoriesForUser` method and the `GetProviderRepositoriesParams` interface. Changed the `useProviderRepositoriesForUser` hook and the `NewProjectRepoSelection` component. Added the `useStateWithDebounce` hook. Updated the `getRepositoriesForAutomatedPrebuilds` method and the `RepositoryService` class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-460

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-4afb022447f</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-4afb022447f.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-4afb022447f.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-460-fe-add-typeahead-to-new-project-repo-select-gha.15748</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
