### PR TITLE
[integrationtests] create org

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -371,8 +371,11 @@ func LaunchWorkspaceWithOptions(t *testing.T, ctx context.Context, opts *LaunchW
 		teams, _ := server.GetTeams(cctx)
 		var orgId string
 		if len(teams) == 0 {
-			// hack: there might be a better value to use here
-			orgId = u
+			team, err := server.CreateTeam(cctx, "test-team")
+			if err != nil {
+				return nil, nil, xerrors.Errorf("cannot create team: %w", err)
+			}
+			orgId = team.ID
 		} else {
 			orgId = teams[0].ID
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ad5e01</samp>

Improve integration tests for teams and projects by creating a test team and using its ID as the org ID when launching a workspace. Refactor `test/pkg/integration/workspace.go` to use the new approach.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-integradcfe29a398</li>
	<li><b>🔗 URL</b> - <a href="https://se-integradcfe29a398.preview.gitpod-dev.com/workspaces" target="_blank">se-integradcfe29a398.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-integration-tests-fix-gha.15693</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
