### PR TITLE
[fga] check some admin functions

### DIFF
--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -21,7 +21,7 @@ export interface TeamDB extends TransactionalDB<TeamDB> {
         limit: number,
         orderBy: keyof Team,
         orderDir: "ASC" | "DESC",
-        searchTerm: string,
+        searchTerm?: string,
     ): Promise<{ total: number; rows: Team[] }>;
     findTeamById(teamId: string): Promise<Team | undefined>;
     findTeamByMembershipId(membershipId: string): Promise<Team | undefined>;

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -65,9 +65,13 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
         searchTerm?: string,
     ): Promise<{ total: number; rows: Team[] }> {
         const teamRepo = await this.getTeamRepo();
-        const queryBuilder = teamRepo
-            .createQueryBuilder("team")
-            .where("LOWER(team.name) LIKE LOWER(:searchTerm)", { searchTerm: `%${searchTerm}%` })
+        let queryBuilder = teamRepo.createQueryBuilder("team");
+        if (searchTerm) {
+            queryBuilder = queryBuilder.where("LOWER(team.name) LIKE LOWER(:searchTerm)", {
+                searchTerm: `%${searchTerm}%`,
+            });
+        }
+        queryBuilder = queryBuilder
             .andWhere("deleted = 0")
             .andWhere("markedDeleted = 0")
             .skip(offset)

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -8,7 +8,7 @@
 
 import { v1 } from "@authzed/authzed-node";
 
-const InstallationID = "1";
+export const InstallationID = "1";
 
 export type ResourceType =
     | UserResourceType
@@ -37,6 +37,7 @@ export type UserPermission =
     | "write_info"
     | "delete"
     | "make_admin"
+    | "admin_control"
     | "read_ssh"
     | "write_ssh"
     | "read_tokens"
@@ -48,7 +49,7 @@ export type InstallationResourceType = "installation";
 
 export type InstallationRelation = "member" | "admin";
 
-export type InstallationPermission = "create_organization";
+export type InstallationPermission = "create_organization" | "configure";
 
 export type OrganizationResourceType = "organization";
 

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -202,4 +202,20 @@ describe("OrganizationService", async () => {
         expect(members.length).to.eq(1);
         expect(members.some((m) => m.userId === owner.id && m.role === "owner")).to.be.true;
     });
+
+    it("should listOrganizations", async () => {
+        const strangerOrg = await os.createOrganization(stranger.id, "stranger-org");
+        let orgs = await os.listOrganizations(owner.id, {});
+        expect(orgs.rows[0].id).to.eq(org.id);
+        expect(orgs.total).to.eq(1);
+
+        orgs = await os.listOrganizations(stranger.id, {});
+        expect(orgs.rows[0].id).to.eq(strangerOrg.id);
+        expect(orgs.total).to.eq(1);
+
+        orgs = await os.listOrganizations(admin.id, {});
+        expect(orgs.rows.some((org) => org.id === org.id)).to.be.true;
+        expect(orgs.rows.some((org) => org.id === strangerOrg.id)).to.be.true;
+        expect(orgs.total).to.eq(2);
+    });
 });

--- a/components/spicedb/codegen/codegen.go
+++ b/components/spicedb/codegen/codegen.go
@@ -127,7 +127,7 @@ func GenerateDefinition(schema *compiler.CompiledSchema) string {
 
 		import { v1 } from "@authzed/authzed-node";
 
-		const InstallationID = "1";
+		export const InstallationID = "1";
 
 		` + resource + `;
 

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -14,7 +14,11 @@ schema: |-
     permission read_info = self + organization->member + organization->owner + installation->admin
     permission write_info = self
     permission delete = self
+
     permission make_admin = installation->admin + organization->installation_admin
+
+    // administrate is for changes such as blocking or verifiying, i.e. things that only admins can do on user
+    permission admin_control = installation->admin + organization->installation_admin
 
     permission read_ssh = self
     permission write_ssh = self
@@ -36,6 +40,8 @@ schema: |-
     // orgs can only be created by installation-level users
     permission create_organization = member + admin
 
+    // any global runtime configurations, such as the list of blocked repositories
+    permission configure = admin
   }
 
   definition organization {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

adds permission checks for:

- [x]  `adminBlockUser(req: AdminBlockUserRequest)`
- [x]  `adminVerifyUser(id: string)`
- [x]  `adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest)`
- [x]  `adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest)`
- [x]  `adminCreateBlockedRepository(urlRegexp: string, blockUser: boolean)`
- [x]  `adminDeleteBlockedRepository(id: number)`
- [x]  `adminGetBlockedRepositories(req: AdminGetListRequest<BlockedRepository>)`
- [x]  `adminGetTeams(req: AdminGetListRequest<Team>)`
- [x] `adminGetBillingMode(attributionId: string)`
- [x]  `adminGetBlockedEmailDomains()`
- [x]  `adminSaveBlockedEmailDomain(entry: EmailDomainFilterEntry)`

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8f8742</samp>

This pull request adds installation-level and user-level permission checks using Spicedb and the `Authorizer` service. It also refactors some methods in the `GitpodServerImpl` and the `TeamDB` classes, and adds new tests and schema definitions for the new permissions.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-more-fga</li>
	<li><b>🔗 URL</b> - <a href="https://se-more-fga.preview.gitpod-dev.com/workspaces" target="_blank">se-more-fga.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-more-fga-gha.15734</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
