### PR TITLE
[server] FGA checks for all admin*Workspace methods

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -92,7 +92,14 @@ export type WorkspaceResourceType = "workspace";
 
 export type WorkspaceRelation = "org" | "owner" | "shared";
 
-export type WorkspacePermission = "access" | "start" | "stop" | "delete" | "read_info" | "create_snapshot";
+export type WorkspacePermission =
+    | "access"
+    | "start"
+    | "stop"
+    | "delete"
+    | "read_info"
+    | "create_snapshot"
+    | "admin_control";
 
 export const rel = {
     user(id: string) {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2785,9 +2785,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<AdminGetListResult<WorkspaceAndInstance>> {
         traceAPIParams(ctx, { req });
 
-        await this.guardAdminAccess("adminGetWorkspaces", { req }, Permission.ADMIN_WORKSPACES);
+        const admin = await this.guardAdminAccess("adminGetWorkspaces", { req }, Permission.ADMIN_WORKSPACES);
 
-        return await this.workspaceDb
+        const wss = await this.workspaceDb
             .trace(ctx)
             .findAllWorkspaceAndInstances(
                 req.offset,
@@ -2796,12 +2796,27 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 req.orderDir === "asc" ? "ASC" : "DESC",
                 req,
             );
+
+        await Promise.all(
+            wss.rows.map(async (row) => {
+                if (!(await this.auth.hasPermissionOnWorkspace(admin.id, "access", row.workspaceId))) {
+                    wss.total--;
+                    wss.rows = wss.rows.filter((ws) => ws.workspaceId !== row.workspaceId);
+                }
+            }),
+        );
+        return wss;
     }
 
     async adminGetWorkspace(ctx: TraceContext, workspaceId: string): Promise<WorkspaceAndInstance> {
         traceAPIParams(ctx, { workspaceId });
 
-        await this.guardAdminAccess("adminGetWorkspace", { id: workspaceId }, Permission.ADMIN_WORKSPACES);
+        const admin = await this.guardAdminAccess(
+            "adminGetWorkspace",
+            { id: workspaceId },
+            Permission.ADMIN_WORKSPACES,
+        );
+        await this.auth.checkPermissionOnWorkspace(admin.id, "access", workspaceId);
 
         const result = await this.workspaceDb.trace(ctx).findWorkspaceAndInstance(workspaceId);
         if (!result) {
@@ -2813,7 +2828,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminGetWorkspaceInstances(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInstance[]> {
         traceAPIParams(ctx, { workspaceId });
 
-        await this.guardAdminAccess("adminGetWorkspaceInstances", { id: workspaceId }, Permission.ADMIN_WORKSPACES);
+        const admin = await this.guardAdminAccess(
+            "adminGetWorkspaceInstances",
+            { id: workspaceId },
+            Permission.ADMIN_WORKSPACES,
+        );
+        await this.auth.checkPermissionOnWorkspace(admin.id, "access", workspaceId);
 
         const result = await this.workspaceDb.trace(ctx).findInstances(workspaceId);
         return result || [];
@@ -2827,6 +2847,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             { id: workspaceId },
             Permission.ADMIN_WORKSPACES,
         );
+        await this.auth.checkPermissionOnWorkspace(admin.id, "admin_control", workspaceId);
 
         const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
         if (workspace) {
@@ -2844,11 +2865,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminRestoreSoftDeletedWorkspace(ctx: TraceContext, workspaceId: string): Promise<void> {
         traceAPIParams(ctx, { workspaceId });
 
-        await this.guardAdminAccess(
+        const admin = await this.guardAdminAccess(
             "adminRestoreSoftDeletedWorkspace",
             { id: workspaceId },
             Permission.ADMIN_WORKSPACES,
         );
+        await this.auth.checkPermissionOnWorkspace(admin.id, "admin_control", workspaceId);
 
         await this.workspaceDb.trace(ctx).transaction(async (db) => {
             const ws = await db.findById(workspaceId);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1988,7 +1988,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         // we use the workspacService which checks if the requesting user has access to the workspace. If that is the case they have access to snapshots as well.
         // below is the old permission check which would also check if the user has access to the snapshot itself. This is not the case anymore.
-        const workspace = await this.workspaceService.getWorkspace(user.id, workspaceId);
+        const { workspace } = await this.workspaceService.getWorkspace(user.id, workspaceId);
         if (workspace.ownerId !== user.id) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} does not exist.`);
         }

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -117,8 +117,7 @@ schema: |-
     relation shared: user:*
 
     // Whether a user can access a workspace (with an IDE)
-    //+ (hasAccessToRepository && isPrebuild)
-    permission access = owner + shared
+    permission access = owner + shared + org->installation_admin
 
     // Note: All of this is modelled after current behavior.
     // There are a lot of improvements we can make here in the light of Organizations, but we explicitly do that as a separate step
@@ -127,10 +126,12 @@ schema: |-
     permission delete = owner
 
     // Whether a user can read basic info/metadata of a workspace
-    //+ (hasAccessToRepository && isPrebuild)
     permission read_info = owner + shared + org->member
 
     permission create_snapshot = owner & org->snapshoter
+
+    // Whether someone is allowed to do administrative tasks on a workspace, e.g. un-delete etc.
+    permission admin_control = org->installation_admin
   }
 # relationships to be used for assertions & validation
 relationships: |-


### PR DESCRIPTION
## Description

Adds basic FGA checks for:
 - adminGetWorkspaces
 - adminGetWorkspace
 - adminGetWorkspaceInstances
 - adminForceStopWorkspace
 - adminRestoreSoftDeletedWorkspace

To implement some of these, I added a permission `workspace#admin_control` to the schema ([ref](https://github.com/gitpod-io/gitpod/compare/gpl/fga-get-ws...gpl/fga-admin-ws?expand=1#diff-69999e6d583968d5b2b70775d0dc480a0a0e4fe001ed7c8eb725518bf320303dR124)).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e87346d</samp>

This pull request adds a new `admin_control` permission for workspaces, which allows installation admins to perform administrative tasks on workspaces, such as restoring soft-deleted workspaces. The permission is implemented in the Spicedb schema, the `WorkspacePermission` type, and the `gitpod-server-impl.ts` methods.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-admin-ws</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-admin-ws.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-admin-ws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-admin-ws-gha.15786</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
