### PR TITLE
[wip] SpiceDB reconnect behavior

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -34,7 +34,7 @@
     "/src"
   ],
   "dependencies": {
-    "@authzed/authzed-node": "^0.10.0",
+    "@authzed/authzed-node": "^0.12.1",
     "@bufbuild/connect": "^0.8.1",
     "@bufbuild/connect-express": "^0.8.1",
     "@gitbeaker/node": "^35.7.0",

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -24,13 +24,14 @@ import {
 } from "./definitions";
 import { SpiceDBAuthorizer } from "./spicedb-authorizer";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export function createInitializingAuthorizer(spiceDbAuthorizer: SpiceDBAuthorizer): Authorizer {
     const target = new Authorizer(spiceDbAuthorizer);
     const initialized = (async () => {
         await target.addInstallationAdminRole(BUILTIN_INSTLLATION_ADMIN_USER_ID);
         await target.addUser(BUILTIN_INSTLLATION_ADMIN_USER_ID);
-    })();
+    })().catch((err) => log.error("Failed to initialize authorizer", err));
     return new Proxy(target, {
         get(target, propKey, receiver) {
             const originalMethod = target[propKey as keyof typeof target];
@@ -481,6 +482,7 @@ export class Authorizer {
                     optionalSubjectId: relation.subject.object.objectId,
                 },
             },
+            optionalLimit: 0,
         });
         if (relationships.length === 0) {
             return undefined;
@@ -505,6 +507,7 @@ export class Authorizer {
                     optionalSubjectId: relation.subject.object.objectId,
                 },
             },
+            optionalLimit: 0,
         });
         return relationships.map((r) => r.relationship!);
     }

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -5,12 +5,24 @@
  */
 
 import { v1 } from "@authzed/authzed-node";
+import { IClientCallMetrics, createClientCallMetricsInterceptor } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import * as grpc from "@grpc/grpc-js";
 
-export const SpiceDBClient = Symbol("SpiceDBClient");
-export type SpiceDBClient = v1.ZedPromiseClientInterface | undefined;
+export const SpiceDBClientProvider = Symbol("SpiceDBClientProvider");
 
-export function spicedbClientFromEnv(): SpiceDBClient {
+export interface SpiceDBClientConfig {
+    address: string;
+    token: string;
+}
+
+export type SpiceDBClient = v1.ZedPromiseClientInterface;
+type Client = v1.ZedClientInterface & grpc.Client;
+export interface SpiceDBClientProvider {
+    getClient(): SpiceDBClient;
+}
+
+export function spiceDBConfigFromEnv(): SpiceDBClientConfig | undefined {
     const token = process.env["SPICEDB_PRESHARED_KEY"];
     if (!token) {
         log.error("[spicedb] No preshared key configured.");
@@ -22,6 +34,69 @@ export function spicedbClientFromEnv(): SpiceDBClient {
         log.error("[spicedb] No service address configured.");
         return undefined;
     }
+    return {
+        address,
+        token,
+    };
+}
 
-    return v1.NewClient(token, address, v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS).promises;
+function spicedbClientFromConfig(config: SpiceDBClientConfig): Client {
+    const clientOptions: grpc.ClientOptions = {
+        "grpc.client_idle_timeout_ms": 10000, // this ensures a connection is not stuck in the "READY" state for too long. Required for the reconnect logic below.
+        "grpc.max_reconnect_backoff_ms": 5000, // default: 12000
+    };
+
+    return v1.NewClient(
+        config.token,
+        config.address,
+        v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS,
+        undefined,
+        clientOptions,
+    ) as Client;
+}
+
+export class CachingSpiceDBClientProvider implements SpiceDBClientProvider {
+    private client: Client | undefined;
+
+    private readonly interceptors: grpc.Interceptor[] = [];
+
+    constructor(
+        private readonly _clientConfig: SpiceDBClientConfig,
+        private readonly clientCallMetrics?: IClientCallMetrics | undefined,
+    ) {
+        if (this.clientCallMetrics) {
+            this.interceptors.push(createClientCallMetricsInterceptor(this.clientCallMetrics));
+        }
+    }
+
+    getClient(): SpiceDBClient {
+        let client = this.client;
+        if (!client) {
+            client = spicedbClientFromConfig(this.clientConfig);
+        } else if (client.getChannel().getConnectivityState(true) !== grpc.connectivityState.READY) {
+            // (gpl): We need this check and explicit re-connect because we observe a ~120s connection timeout without it.
+            // It's not entirely clear where that timeout comes from, but likely from the underlying transport, that is not exposed by grpc/grpc-js
+            client.close();
+
+            log.warn("[spicedb] Lost connection to SpiceDB - reconnecting...");
+
+            client = spicedbClientFromConfig(this.clientConfig);
+        }
+        this.client = client;
+
+        return client.promises;
+    }
+
+    protected get clientConfig() {
+        const config = this._clientConfig;
+        if (this.interceptors) {
+            return {
+                ...config,
+                options: {
+                    interceptors: [...this.interceptors],
+                },
+            };
+        }
+        return config;
+    }
 }

--- a/install/installer/pkg/components/spicedb/deployment.go
+++ b/install/installer/pkg/components/spicedb/deployment.go
@@ -155,10 +155,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 										},
 									},
 									InitialDelaySeconds: 5,
-									PeriodSeconds:       30,
-									FailureThreshold:    5,
-									SuccessThreshold:    1,
-									TimeoutSeconds:      3,
+									// try again every 10 seconds
+									PeriodSeconds: 10,
+									// fail after 6 * 10 + 5 = 65 seconds
+									FailureThreshold: 6,
+									SuccessThreshold: 1,
+									TimeoutSeconds:   3,
 								},
 								VolumeMounts: []v1.VolumeMount{
 									bootstrapVolumeMount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,12 +29,12 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@authzed/authzed-node@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.10.0.tgz#623e4911fde221bb526e7f2e9ca335d9f3b9072d"
-  integrity sha512-TnAnatcU5dHvyGqrWoZzPNaO1opPpVU1y7P5LrJsV2j54y0xvx/OFhYtfeguMxHSz2kpbdCuIvIKJuB8WFbRRA==
+"@authzed/authzed-node@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.12.1.tgz#0c28395a64f9b1ecf33faf67259e32a9a3bce300"
+  integrity sha512-BVHLaPfiHQw1Vz+199m9i4xltT3YyFhqVHtkYPIQ28q8a7iJpnXmFRZIWuTMJcxJI01wtAxJYFuRJq3ktFe6qw==
   dependencies:
-    "@grpc/grpc-js" "^1.2.8"
+    "@grpc/grpc-js" "^1.8.3"
     "@protobuf-ts/runtime" "^2.8.1"
     "@protobuf-ts/runtime-rpc" "^2.8.1"
     google-protobuf "^3.15.3"
@@ -2222,18 +2222,10 @@
     qs "^6.10.1"
     xcase "^2.0.1"
 
-"@grpc/grpc-js@1.8.8":
+"@grpc/grpc-js@1.8.8", "@grpc/grpc-js@^1.8.3":
   version "1.8.8"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.8.tgz#a7c6765d0302f47ba67c0ce3cb79718d6b028248"
   integrity sha512-4gfDqMLXTrorvYTKA1jL22zLvVwiHJ73t6Re1OHwdCFRjdGTDOVtSJuaWhtHaivyeDGg0LeCkmU77MTKoV3wPA==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/node" ">=12.12.47"
-
-"@grpc/grpc-js@^1.2.8":
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.7.tgz#2154fc0134462ad45f4134e8b54682a25ed05956"
-  integrity sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"


### PR DESCRIPTION
## Description

Before, `server` waited at least 120s before establishing a gRPC connection to SpiceDB again.
This PR:
 - upgrades the SpiceDB client to `0.12.1` which exposes gRPC Client- and ChannelOptions
 - "manually" reconnects on-request if the channel is not "READY" (translates to: not subchannel is ready) ([source](https://github.com/gitpod-io/gitpod/blob/f3fe53ea6590f1532dd31119e9bc6021fe38f5d1/components/server/src/authorization/spicedb.ts#L79-L87))
   - we do sth similar for ws-manager, for instance ([source](https://github.com/gitpod-io/gitpod/blob/0e2ec6cd247e68b45451ee3f0556ef7d20703dcd/components/ws-manager-api/typescript/src/client-provider.ts#L112-L116))
 - adds a `deadline` of `8s` to each call against SpiceDB to ensure we are not starving
 - make the ReadinessProbe on the pods more responsive: before, if initialization was too slow, we would only check readiness each `30s`
 - also, it adds ClientCallMetrics as we have them for other grpc clients: https://github.com/gitpod-io/gitpod/pull/18570/commits/f3fe53ea6590f1532dd31119e9bc6021fe38f5d1

:information_source: SpiceDB config is required now, and `server` fails to start if there is no config in the env vars.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57c33a4</samp>

Add performance logging to SpiceDB client calls in `spicedb-authorizer.ts`. This helps to measure and optimize the latency of authorization checks and updates.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-379

## How to test
 - open a workspace on this PR
 - signup, and prepare to create a new workspace
 - `kubectl delete pod spicedb-...`
 - hit "create workspace"
   - the first 1-2 tries should return "not found" errors :heavy_check_mark: 
   - after ~20s the workspace starts with some delay :heavy_check_mark: 
  
## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-fga-reconnect</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-fga-reconnect.preview.gitpod-dev.com/workspaces" target="_blank">gpl-fga-reconnect.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-fga-reconnect-gha.15771</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
