### PR TITLE
[bbs] check webhooks permission in scm itself

### DIFF
--- a/components/server/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.ts
@@ -63,29 +63,8 @@ export class BitbucketServerService extends RepositoryService {
             console.log(`BBS: could not read webhooks.`, error, { error, cloneUrl });
             return false;
         }
-
-        if (repoKind === "users") {
-            const ownProfile = await this.api.getUserProfile(user, identity.authName);
-            if (owner === ownProfile.slug) {
-                return true;
-            }
-        }
-
-        let permission = await this.api.getPermission(user, { username: identity.authName, repoKind, owner, repoName });
-        if (!permission && repoKind === "projects") {
-            permission = await this.api.getPermission(user, { username: identity.authName, repoKind, owner });
-        }
-
-        if (this.hasPermissionToCreateWebhooks(permission)) {
-            return true;
-        }
-
-        console.log(`BBS: Not allowed to install webhooks.`, { permission });
-        return false;
-    }
-
-    protected hasPermissionToCreateWebhooks(permission: string | undefined) {
-        return permission && ["REPO_ADMIN", "PROJECT_ADMIN"].indexOf(permission) !== -1;
+        // return true once it can get webhooks, fallback to let SCM itself to check permission
+        return true;
     }
 
     async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79351cf</samp>

Remove webhook permission check for Bitbucket Server prebuilds. This fixes a bug that blocks users from enabling prebuilds on some repositories they have access to. The change affects the file `bitbucket-server-service.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/EXP-487

## How to test
<!-- Provide steps to test this PR -->
- Join org https://hw-bbs-ratelimit.preview.gitpod-dev.com/orgs/join?inviteId=2be78c42-9a07-4dfc-94e7-9571551f9cf0
- Use admin account, it should be able to create project for private repo https://bitbucket.gitpod-dev.com/projects/TES/repos/repo-1-of-100
- Use non-admin account, it should not able to create project for private repo ☝️ 
- Add **repo admin** permission for previous account, it should be able to create project

|Admin|Not-Admin|
|:-:|:-:|
|<img width="1470" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/243536d8-a968-4816-afac-53bf78f48eea">|<img width="1523" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/cf4cbda9-df04-4f50-a9bc-dc0028f36228">|



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-bbs-ratelimit</li>
	<li><b>🔗 URL</b> - <a href="https://hw-bbs-ratelimit.preview.gitpod-dev.com/workspaces" target="_blank">hw-bbs-ratelimit.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-bbs-ratelimit-gha.15807</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
