### PR TITLE
[gitpod-cli] Add output for sync-await command

### DIFF
--- a/components/gitpod-cli/cmd/sync-await.go
+++ b/components/gitpod-cli/cmd/sync-await.go
@@ -25,6 +25,7 @@ var awaitSyncCmd = &cobra.Command{
 		id := hex.EncodeToString(h.Sum(nil))
 		lockFile := fmt.Sprintf("/tmp/gp-%s.done", id)
 
+		fmt.Printf("Awaiting '%s'... ", args[0])
 		ticker := time.NewTicker(1 * time.Second)
 		done := make(chan bool)
 		go func() {


### PR DESCRIPTION
## Description
When using multiple `sync-await` calls in gitpod task commands it's not always obvious, what the terminal is waiting for.
I propose to add a console output analog to the the `gp ports await` command for better usability.

## How to test
<!-- Provide steps to test this PR -->
Build the CLI, run `gitpod-cli sync-await my-process`. In the console you should see `Awaiting 'my-process'... `

## Documentation

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
