### PR TITLE
[image-builder-api] log more, traces aren't always available

### DIFF
--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -240,7 +240,6 @@ export class PromisifiedImageBuilderClient {
 
                 log.info("Needs image build?", {
                     status: resp.getStatus(),
-                    source: request.getSource(),
                     forceRebuild: request.getForceRebuild(),
                     triggeredBy: request.getTriggeredBy(),
                 });

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -124,7 +124,10 @@ export interface StagedBuildResponse {
 }
 
 export class PromisifiedImageBuilderClient {
-    constructor(public readonly client: ImageBuilderClient, protected readonly interceptor: grpc.Interceptor[]) {}
+    constructor(
+        public readonly client: ImageBuilderClient,
+        protected readonly interceptor: grpc.Interceptor[],
+    ) {}
 
     public isConnectionAlive() {
         const cs = this.client.getChannel().getConnectivityState(false);
@@ -235,6 +238,12 @@ export class PromisifiedImageBuilderClient {
                     }
                 }
 
+                log.info("Needs image build?", {
+                    status: resp.getStatus(),
+                    source: request.getSource(),
+                    forceRebuild: request.getForceRebuild(),
+                    triggeredBy: request.getTriggeredBy(),
+                });
                 if (resp.getStatus() == BuildStatus.RUNNING) {
                     resultResp.actuallyNeedsBuild = true;
                     result.resolve(resultResp);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -497,7 +497,7 @@ export class WorkspaceStarter {
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
         span.setTag("region_preference", region);
-        log.info("actuallyStartWorkspace interesting params", {
+        log.info("Attempting to start workspace", {
             instanceID: instance.id,
             userID: user.id,
             rethrow: rethrow,

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -497,6 +497,12 @@ export class WorkspaceStarter {
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
         span.setTag("region_preference", region);
+        log.info("actuallyStartWorkspace interesting params", {
+            instanceID: instance.id,
+            userID: user.id,
+            rethrow: rethrow,
+            forceRebuild: forceRebuild,
+        });
 
         try {
             // build workspace image


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some environments lack tracing. Do more logging to better understand image build flows in said environments.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa807d1</samp>

Improved logging and formatting of image builder API client. Added log messages to track image build requests and results in `sugar.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-orvnwvgjfwo</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-orvnwvgjfwo.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-orvnwvgjfwo.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-ORVnWVgJFwo-gha.15866</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
