### PR TITLE
Support managed redis

### DIFF
--- a/components/gitpod-db/src/redis/client.ts
+++ b/components/gitpod-db/src/redis/client.ts
@@ -6,12 +6,20 @@
 
 import { Redis } from "ioredis";
 
-export function newRedisClient(opts: { host: string; port: number; connectionName: string }): Redis {
+export function newRedisClient(opts: {
+    host: string;
+    port: number;
+    connectionName: string;
+    username?: string | undefined;
+    password?: string | undefined;
+}): Redis {
     return new Redis({
         port: opts.port,
         host: opts.host,
         enableReadyCheck: true,
         keepAlive: 10 * 1000,
         connectionName: opts.connectionName,
+        username: opts.username,
+        password: opts.password,
     });
 }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -369,7 +369,9 @@ export const productionContainerModule = new ContainerModule(
         bind(Redis).toDynamicValue((ctx) => {
             const config = ctx.container.get<Config>(Config);
             const [host, port] = config.redis.address.split(":");
-            return newRedisClient({ host, port: Number(port), connectionName: "server" });
+            const username = process.env.REDIS_USERNAME;
+            const password = process.env.REDIS_PASSWORD;
+            return newRedisClient({ host, port: Number(port), connectionName: "server", username, password });
         });
 
         bind(RedisMutex).toSelf().inSingletonScope();

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -88,7 +88,9 @@ export const containerModule = new ContainerModule((bind) => {
     bind(Redis).toDynamicValue((ctx) => {
         const config = ctx.container.get<Configuration>(Configuration);
         const [host, port] = config.redis.address.split(":");
-        return newRedisClient({ host, port: Number(port), connectionName: "server" });
+        const username = process.env.REDIS_USERNAME;
+        const password = process.env.REDIS_PASSWORD;
+        return newRedisClient({ host, port: Number(port), connectionName: "server", username, password });
     });
     bind(RedisPublisher).toSelf().inSingletonScope();
 });

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -192,6 +192,15 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	_, _, authCfg := auth.GetConfig(ctx)
 
+	redisConfig := redis.GetConfiguration(ctx)
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Redis != nil {
+			redisConfig.Address = cfg.WebApp.Redis.Address
+		}
+
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -289,7 +298,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		ShowSetupModal:          showSetupModal,
 		Auth:                    authCfg,
-		Redis:                   redis.GetConfiguration(ctx),
+		Redis:                   redisConfig,
 		IsSingleOrgInstallation: isSingleOrgInstallation,
 	}
 

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -118,6 +118,28 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Redis != nil {
+			env = append(env, corev1.EnvVar{
+				Name:  "REDIS_USERNAME",
+				Value: cfg.WebApp.Redis.Username,
+			})
+
+			env = append(env, corev1.EnvVar{
+				Name: "REDIS_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: cfg.WebApp.Redis.SecretRef,
+						},
+						Key: "password",
+					},
+				},
+			})
+		}
+		return nil
+	})
+
 	volumes := make([]corev1.Volume, 0)
 	volumeMounts := make([]corev1.VolumeMount, 0)
 

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -182,6 +182,12 @@ type SpiceDBConfig struct {
 	SecretRef string `json:"secretRef"`
 }
 
+type RedisConfig struct {
+	Address   string `json:"address,omitempty"`
+	Username  string `json:"username,omitempty"`
+	SecretRef string `json:"secretRef,omitempty"`
+}
+
 type WebAppConfig struct {
 	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
 
@@ -202,6 +208,7 @@ type WebAppConfig struct {
 	IAM                          *IAMConfig             `json:"iam,omitempty"`
 	SpiceDB                      *SpiceDBConfig         `json:"spicedb,omitempty"`
 	CertmanagerNamespaceOverride string                 `json:"certmanagerNamespaceOverride,omitempty"`
+	Redis                        *RedisConfig           `json:"redis"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
Add support for managed Redis like AWS ElastiCache.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6bb79f</samp>

Added support for Redis authentication in server and ws-manager-bridge components. Updated installer to allow configuring Redis username and password in web app component and pass them to the server pod. Modified `newRedisClient` function and related files to handle Redis credentials.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-739, [part of no downtime AMI upgrades](https://linear.app/gitpod/project/no-downtime-ami-upgrades-for-meta-and-services-nodes-ad464683ace4/ENG)

## How to test
- Start a workspace in the preview environment
- Check that redis integration still works
- This is only for ensuring that no regressions are introduced. The actual testing with a managed redis service can be performed once the changes in Dedicated have been implemented.


#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fo-managed-redis</li>
	<li><b>🔗 URL</b> - <a href="https://fo-managed-redis.preview.gitpod-dev.com/workspaces" target="_blank">fo-managed-redis.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fo-managed-redis-gha.15910</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
