### PR TITLE
[ws-proxy] Implement graceful shutdown

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -162,8 +162,8 @@ var runCmd = &cobra.Command{
 		ctrlCtx := ctrl.SetupSignalHandler()
 
 		go func() {
+			log.Infof("startint proxying on %s", cfg.Ingress.HTTPAddress)
 			proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), infoprov, signers).MustServe(ctrlCtx)
-			log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
 		}()
 
 		log.Info("🚪 ws-proxy is up and running")

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/bombsimon/logrusr/v2"
-	"github.com/gitpod-io/golang-crypto/ssh"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -36,6 +35,7 @@ import (
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/config"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/proxy"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/sshproxy"
+	"github.com/gitpod-io/golang-crypto/ssh"
 )
 
 var (
@@ -159,11 +159,15 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), infoprov, signers).MustServe()
-		log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
+		ctrlCtx := ctrl.SetupSignalHandler()
+
+		go func() {
+			proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), infoprov, signers).MustServe(ctrlCtx)
+			log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
+		}()
 
 		log.Info("🚪 ws-proxy is up and running")
-		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		if err := mgr.Start(ctrlCtx); err != nil {
 			log.WithError(err).Fatal(err, "problem starting ws-proxy")
 		}
 

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -6,11 +6,14 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
+	"errors"
 	stdlog "log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/klauspost/cpuid/v2"
@@ -49,13 +52,20 @@ func redirectToHTTPS(w http.ResponseWriter, r *http.Request) {
 }
 
 // MustServe starts the proxy and ends the process if doing so fails.
-func (p *WorkspaceProxy) MustServe() {
+func (p *WorkspaceProxy) MustServe(ctx context.Context) {
 	handler, err := p.Handler()
 	if err != nil {
 		log.WithError(err).Fatal("cannot initialize proxy - this is likely a configuration issue")
 		return
 	}
-	srv := &http.Server{
+
+	httpServer := &http.Server{
+		Addr:     p.Ingress.HTTPAddress,
+		Handler:  http.HandlerFunc(redirectToHTTPS),
+		ErrorLog: stdlog.New(logrusErrorWriter{}, "", 0),
+	}
+
+	httpsServer := &http.Server{
 		Addr:    p.Ingress.HTTPSAddress,
 		Handler: handler,
 		TLSConfig: &tls.Config{
@@ -77,17 +87,35 @@ func (p *WorkspaceProxy) MustServe() {
 		crt = filepath.Join(tproot, crt)
 		key = filepath.Join(tproot, key)
 	}
+
 	go func() {
-		err := http.ListenAndServe(p.Ingress.HTTPAddress, http.HandlerFunc(redirectToHTTPS))
-		if err != nil {
+		err := httpServer.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.WithError(err).Fatal("cannot start http proxy")
 		}
 	}()
 
-	err = srv.ListenAndServeTLS(crt, key)
+	go func() {
+		err = httpsServer.ListenAndServeTLS(crt, key)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.WithError(err).Fatal("cannot start proxy")
+			return
+		}
+	}()
+
+	<-ctx.Done()
+
+	shutDownCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	err = httpServer.Shutdown(shutDownCtx)
 	if err != nil {
-		log.WithError(err).Fatal("cannot start proxy")
-		return
+		log.WithError(err).Fatal("cannot stop HTTP server")
+	}
+
+	err = httpsServer.Shutdown(shutDownCtx)
+	if err != nil {
+		log.WithError(err).Fatal("cannot stop HTTPS server")
 	}
 }
 

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -60,10 +60,16 @@ func (p *WorkspaceProxy) MustServe(ctx context.Context) {
 	}
 
 	httpServer := &http.Server{
-		Addr:     p.Ingress.HTTPAddress,
-		Handler:  http.HandlerFunc(redirectToHTTPS),
-		ErrorLog: stdlog.New(logrusErrorWriter{}, "", 0),
+		Addr:              p.Ingress.HTTPAddress,
+		Handler:           http.HandlerFunc(redirectToHTTPS),
+		ErrorLog:          stdlog.New(logrusErrorWriter{}, "", 0),
+		ReadTimeout:       1 * time.Second,
+		WriteTimeout:      1 * time.Second,
+		IdleTimeout:       0,
+		ReadHeaderTimeout: 2 * time.Second,
 	}
+
+	httpServer.SetKeepAlivesEnabled(false)
 
 	httpsServer := &http.Server{
 		Addr:    p.Ingress.HTTPSAddress,

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -105,7 +105,7 @@ func (p *WorkspaceProxy) MustServe(ctx context.Context) {
 
 	<-ctx.Done()
 
-	shutDownCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	shutDownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	err = httpServer.Shutdown(shutDownCtx)

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -70,6 +70,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: pointer.Int64(31002),
 		},
+		TerminationGracePeriodSeconds: pointer.Int64(360),
 		Volumes: append([]corev1.Volume{
 			{
 				Name: "config",


### PR DESCRIPTION
<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7bf7f2</samp>

This pull request improves the reliability and performance of the workspace proxy by using contexts, goroutines, and graceful shutdowns. It also refactors some code in the `cmd` and `proxy` packages to simplify imports and logging.

</details>

## Related Issue(s)
Fixes ENG-724

## How to test
<!-- Provide steps to test this PR -->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-shutdown</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-shutdown.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-shutdown.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-shutdown-gha.15903</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
