### PR TITLE
removing calc links since it doesn't exist anymore

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -323,12 +323,7 @@ export default function UsageBasedBillingConfig({ hideSubheading = false }: Prop
                             </div>
                             <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
                                 <div className="flex flex-col">
-                                    <span>
-                                        {priceInformation}{" "}
-                                        <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
-                                            Estimate costs
-                                        </a>
-                                    </span>
+                                    <span>{priceInformation}</span>
                                 </div>
                             </div>
                             <div className="flex justify-end mt-6 space-x-2">
@@ -356,12 +351,7 @@ export default function UsageBasedBillingConfig({ hideSubheading = false }: Prop
                             <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
                                 <Check className="m-0.5 w-8 h-5 text-orange-500" />
                                 <div className="flex flex-col">
-                                    <span>
-                                        {priceInformation}{" "}
-                                        <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
-                                            Estimate costs
-                                        </a>
-                                    </span>
+                                    <span>{priceInformation}</span>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the Pricing calculator link in the billing page of the dashboard since that doesn't resolve anymore (we removed it from the main website).

![image](https://github.com/gitpod-io/gitpod/assets/367275/c19ac0d9-203b-4161-a169-9f4912f78db0)
Removed Links

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f1e7e4</samp>

Removed an obsolete link from the dashboard UI. This improves the user experience and avoids confusion about the pricing model.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Check the billing page and ensure the links to the calc are not there.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
