### PR TITLE
[fga] only migrate non-deleted workspaces

### DIFF
--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -284,11 +284,9 @@ describe("RelationshipUpdater", async () => {
     });
 
     it("should create relationships for all user workspaces", async function () {
-        this.timeout(20000);
-
         const user = await userDB.newUser();
         const org = await orgDB.createTeam(user.id, "MyOrg");
-        const totalWorkspaces = RelationshipUpdater.workspacesPageSize * 2.5;
+        const totalWorkspaces = 20;
         const expectedWorkspaces: Workspace[] = [];
         for (let i = 0; i < totalWorkspaces; i++) {
             const workspace = await workspaceDB.store({
@@ -302,6 +300,7 @@ describe("RelationshipUpdater", async () => {
                 context: {
                     title: "myTitle",
                 },
+                shareable: i % 5 === 0,
                 config: {},
             });
             expectedWorkspaces.push(workspace);
@@ -311,6 +310,9 @@ describe("RelationshipUpdater", async () => {
         for (const workspace of expectedWorkspaces) {
             await expected(rel.workspace(workspace.id).org.organization(org.id));
             await expected(rel.workspace(workspace.id).owner.user(user.id));
+            if (workspace.shareable) {
+                await expected(rel.workspace(workspace.id).shared.anyUser);
+            }
         }
     });
 

--- a/components/server/src/redis/mutex.ts
+++ b/components/server/src/redis/mutex.ts
@@ -20,7 +20,7 @@ export class RedisMutex {
 
             // The max number of times Redlock will attempt to lock a resource
             // before erroring.
-            retryCount: 3,
+            retryCount: 20,
 
             // the time in ms between attempts
             retryDelay: 200, // time in ms


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We only add relationships for workspaces that are reachable by users.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d510d70</samp>

This pull request refactors and improves the integration of SpiceDB, a service for managing authorization policies, with the Gitpod server. It simplifies the logic for adding workspaces to organizations, updates the relationship updater class and its test case, increases the locking reliability, and fixes a bug with restoring soft-deleted workspaces.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
