### PR TITLE
[ws-manager-mk2] Scrub status fields, add vscode launch.json

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -154,7 +154,7 @@ type PortSpec struct {
 type WorkspaceStatus struct {
 	PodStarts  int    `json:"podStarts"`
 	URL        string `json:"url,omitempty"`
-	OwnerToken string `json:"ownerToken,omitempty"`
+	OwnerToken string `json:"ownerToken,omitempty" scrub:"redact"`
 
 	// +kubebuilder:default=Unknown
 	Phase WorkspacePhase `json:"phase,omitempty"`

--- a/components/ws-manager-mk2/.vscode/launch.json
+++ b/components/ws-manager-mk2/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/main.go",
+            "args": ["--config", "example-config.json"]
+        }
+    ]
+}

--- a/components/ws-manager-mk2/example-config.json
+++ b/components/ws-manager-mk2/example-config.json
@@ -2,22 +2,8 @@
   "manager": {
     "namespace": "staging-cw-io-limit-hack",
     "schedulerName": "",
+    "secretsNamespace": "workspace-secrets",
     "seccompProfile": "localhost/workspace_default_cw-ws-manager-mk2.1.json",
-    "container": {
-      "workspace": {
-        "image": "OVERWRITTEN-IN-REQUEST",
-        "requests": {
-          "cpu": "1",
-          "memory": "2Gi",
-          "ephemeral-storage": ""
-        },
-        "limits": {
-          "cpu": "",
-          "memory": "",
-          "ephemeral-storage": ""
-        }
-      }
-    },
     "timeouts": {
       "startup": "1h0m0s",
       "initialization": "30m0s",
@@ -32,7 +18,6 @@
     "initProbe": {
       "timeout": "1s"
     },
-    "podTemplate": {},
     "urlTemplate": "https://{{ .Prefix }}.ws.foo.com",
     "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.foo.com",
     "workspaceHostPath": "/var/gitpod/workspaces",
@@ -57,9 +42,7 @@
       "gcloud": {
         "credentialsFile": "",
         "region": "",
-        "projectId": "",
-        "parallelUpload": 0,
-        "maximumBackupCount": 0
+        "projectId": ""
       },
       "minio": {
         "endpoint": "minio.default.svc.cluster.local:9000",
@@ -67,12 +50,7 @@
         "accessKeyFile": "",
         "secretKey": "ClclNAidlUwP2ESwEsXt",
         "secretKeyFile": "",
-        "region": "local",
-        "parallelUpload": 6
-      },
-      "backupTrail": {
-        "enabled": true,
-        "maxLength": 3
+        "region": "local"
       },
       "blobQuota": 5368709120
     }

--- a/components/ws-manager-mk2/ws-manager-mk2.code-workspace
+++ b/components/ws-manager-mk2/ws-manager-mk2.code-workspace
@@ -2,9 +2,9 @@
     "folders": [
        { "path": "../common-go" },
        { "path": "../ws-daemon" },
-       { "path": "../ws-manager" },
        { "path": "../ws-manager-api" },
        { "path": "../ws-manager-mk2" },
+       { "path": "../scrubber" },
        { "path": "../server" },
        { "path": "../../test" },
        { "path": "../../dev/gpctl" },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Scrub status log fields in ws-manager-mk2 to exclude the ownerToken
* Configure launch.json and make example config work, used to run mk2 locally with a debugger
* Remove mk1 (`ws-manager`) from code-workspace

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
