### PR TITLE
Added comments in the dev/addlicense directory files

### DIFF
--- a/dev/addlicense/main.go
+++ b/dev/addlicense/main.go
@@ -57,6 +57,7 @@ var (
 	remove    = flag.Bool("remove", false, "remove header mode: if a license header is present, we'll remove it")
 )
 
+// Processes and applies license headers based on CLI arguments.
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, helpText)
@@ -178,6 +179,7 @@ type file struct {
 	mode os.FileMode
 }
 
+// walk traverses the directory and sends file details to the provided channel.
 func walk(ch chan<- *file, start string) {
 	filepath.Walk(start, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
@@ -192,6 +194,7 @@ func walk(ch chan<- *file, start string) {
 	})
 }
 
+// addLicense adds a license header to a file if it doesn't already have one.
 func addLicense(path string, fmode os.FileMode, tmpl *template.Template, data *copyrightData) (bool, error) {
 	var lic []byte
 	var err error
@@ -217,6 +220,7 @@ func addLicense(path string, fmode os.FileMode, tmpl *template.Template, data *c
 	return true, os.WriteFile(path, b, fmode)
 }
 
+// removeLicense removes or updates the license header from a file.
 func removeLicense(path string, fmode os.FileMode, tmpl *template.Template, data *copyrightData) (haslic bool, modified bool, err error) {
 	var lic []byte
 	lic, err = licenseHeader(path, tmpl, data)
@@ -257,6 +261,7 @@ func fileHasLicense(path string) (bool, error) {
 	return true, nil
 }
 
+// licenseHeader determines the appropriate license header format based on the file extension.
 func licenseHeader(path string, tmpl *template.Template, data *copyrightData) ([]byte, error) {
 	var lic []byte
 	var err error
@@ -287,6 +292,7 @@ func licenseHeader(path string, tmpl *template.Template, data *copyrightData) ([
 	return lic, err
 }
 
+// fileExtension retrieves the file extension or the base name if there's no extension.
 func fileExtension(name string) string {
 	if v := filepath.Ext(name); v != "" {
 		return strings.ToLower(v)
@@ -303,6 +309,7 @@ var head = []string{
 	"<?php",                    // PHP opening tag
 }
 
+// hashBang detects and returns the shebang (or similar prefix) of a given byte slice, if present.
 func hashBang(b []byte) []byte {
 	var line []byte
 	for _, c := range b {
@@ -320,6 +327,7 @@ func hashBang(b []byte) []byte {
 	return nil
 }
 
+// hasLicense checks if a given byte slice contains a license identifier within its initial segment.
 func hasLicense(b []byte) bool {
 	n := 1000
 	if len(b) < 1000 {

--- a/dev/addlicense/tmpl.go
+++ b/dev/addlicense/tmpl.go
@@ -25,6 +25,7 @@ import (
 
 var licenseTemplate = make(map[string]*template.Template)
 
+// init initializes license templates.
 func init() {
 	// licenseTemplate["apache"] = template.Must(template.New("").Parse(tmplApache))
 	licenseTemplate["mit"] = template.Must(template.New("").Parse(tmplMIT))


### PR DESCRIPTION
## Description

I noticed that some of the functions in dev/addlicense directory were missing the comments, so I added them.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4ed139</samp>

This pull request improves the code quality and documentation of the `dev/addlicense` tool, which can add or remove license headers from files. It adds comments to explain the functions and logic in `main.go` and `tmpl.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
