### PR TITLE
Improve gp idp login aws

### DIFF
--- a/components/gitpod-cli/cmd/idp-login-aws.go
+++ b/components/gitpod-cli/cmd/idp-login-aws.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
 	"github.com/spf13/cobra"
 )
 
@@ -41,7 +42,12 @@ var idpLoginAwsCmd = &cobra.Command{
 			return err
 		}
 
-		awsCmd := exec.Command("aws", "sts", "assume-role-with-web-identity", "--role-arn", idpLoginAwsOpts.RoleARN, "--role-session-name", fmt.Sprintf("gitpod-%d", time.Now().Unix()), "--web-identity-token", tkn)
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			return err
+		}
+
+		awsCmd := exec.Command("aws", "sts", "assume-role-with-web-identity", "--role-arn", idpLoginAwsOpts.RoleARN, "--role-session-name", fmt.Sprintf("%s-%d", wsInfo.WorkspaceId, time.Now().Unix()), "--web-identity-token", tkn)
 		out, err := awsCmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%w: %s", err, string(out))


### PR DESCRIPTION
## Description
Minor improvements to `gp idp login aws`:
- enables the specification of the AWS profile instead of the credentials file. This makes integration with existing configurations easier.
- uses the workspace ID as session name which makes identifying and auditing user actions within AWS possible.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7d44e1</samp>

Simplify and improve `idp-login-aws` command of `gitpod-cli` tool. Use `gitpod` package, `aws configure` command, and `profile` option. Add workspace ID to role session name.

</details>

## How to test
Start a workspace and use `gp idp login aws`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - cw-gp-idp-aws</li>
	<li><b>🔗 URL</b> - <a href="https://cw-gp-idp-aws.preview.gitpod-dev.com/workspaces" target="_blank">cw-gp-idp-aws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - cw-gp-idp-aws-gha.16046</li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
