### PR TITLE
Adds support for additional auth in docker build

### DIFF
--- a/components/image-builder-bob/cmd/daemon.go
+++ b/components/image-builder-bob/cmd/daemon.go
@@ -34,7 +34,7 @@ var daemonCmd = &cobra.Command{
 		}
 
 		skt := args[0]
-		cl, teardown, err := builder.StartBuildkit(skt)
+		cl, teardown, err := builder.StartBuildkit(skt, os.Getenv("WORKSPACEKIT_BOBPROXY_ADDITIONALAUTH"))
 		if err != nil {
 			log.WithError(err).Fatal("cannot start daemon")
 		}

--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -72,7 +72,7 @@ var proxyCmd = &cobra.Command{
 				Tag:  targettag,
 				Auth: auth,
 			},
-		})
+		}, auth)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/components/image-builder-bob/pkg/builder/config.go
+++ b/components/image-builder-bob/pkg/builder/config.go
@@ -5,9 +5,6 @@
 package builder
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +33,6 @@ func GetConfigFromEnv() (*Config, error) {
 		BaseRef:            os.Getenv("BOB_BASE_REF"),
 		BaseContext:        os.Getenv("THEIA_WORKSPACE_ROOT"),
 		BuildBase:          os.Getenv("BOB_BUILD_BASE") == "true",
-		BaseLayerAuth:      os.Getenv("BOB_BASELAYER_AUTH"),
 		WorkspaceLayerAuth: os.Getenv("BOB_WSLAYER_AUTH"),
 		Dockerfile:         os.Getenv("BOB_DOCKERFILE_PATH"),
 		ContextDir:         os.Getenv("BOB_CONTEXT_DIR"),
@@ -67,60 +63,5 @@ func GetConfigFromEnv() (*Config, error) {
 		}
 	}
 
-	var authKey = os.Getenv("BOB_AUTH_KEY")
-	if authKey != "" {
-		if len(authKey) != 32 {
-			return nil, xerrors.Errorf("BOB_AUTH_KEY must be exactly 32 bytes long")
-		}
-
-		// we have an authkey, hence assume that the auth fields are base64 encoded and encrypted
-		if cfg.BaseLayerAuth != "" {
-			dec, err := base64.RawStdEncoding.DecodeString(cfg.BaseLayerAuth)
-			if err != nil {
-				return nil, xerrors.Errorf("BOB_BASELAYER_AUTH is not base64 encoded but BOB_AUTH_KEY is present")
-			}
-			cfg.BaseLayerAuth, err = decrypt(dec, authKey)
-			if err != nil {
-				return nil, xerrors.Errorf("cannot decrypt BOB_BASELAYER_AUTH: %w", err)
-			}
-		}
-		if cfg.WorkspaceLayerAuth != "" {
-			dec, err := base64.RawStdEncoding.DecodeString(cfg.WorkspaceLayerAuth)
-			if err != nil {
-				return nil, xerrors.Errorf("BOB_WSLAYER_AUTH is not base64 encoded but BOB_AUTH_KEY is present")
-			}
-			cfg.WorkspaceLayerAuth, err = decrypt(dec, authKey)
-			if err != nil {
-				return nil, xerrors.Errorf("cannot decrypt BOB_WSLAYER_AUTH: %w", err)
-			}
-		}
-	}
-
 	return cfg, nil
-}
-
-// source: https://astaxie.gitbooks.io/build-web-application-with-golang/en/09.6.html
-func decrypt(ciphertext []byte, key string) (string, error) {
-	c, err := aes.NewCipher([]byte(key))
-	if err != nil {
-		return "", err
-	}
-
-	gcm, err := cipher.NewGCM(c)
-	if err != nil {
-		return "", err
-	}
-
-	nonceSize := gcm.NonceSize()
-	if len(ciphertext) < nonceSize {
-		return "", xerrors.Errorf("ciphertext too short")
-	}
-
-	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
-	res, err := gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return "", err
-	}
-
-	return string(res), nil
 }

--- a/components/image-builder-bob/pkg/builder/config.go
+++ b/components/image-builder-bob/pkg/builder/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	BaseRef            string
 	BaseContext        string
 	BuildBase          bool
-	BaseLayerAuth      string
 	WorkspaceLayerAuth string
 	Dockerfile         string
 	ContextDir         string
@@ -61,6 +60,9 @@ func GetConfigFromEnv() (*Config, error) {
 		if stat, err := os.Stat(cfg.Dockerfile); err != nil || stat.IsDir() {
 			return nil, xerrors.Errorf("BOB_DOCKERFILE_PATH does not exist or isn't a file")
 		}
+	}
+	if cfg.WorkspaceLayerAuth == "" {
+		cfg.WorkspaceLayerAuth = "[]"
 	}
 
 	return cfg, nil

--- a/components/image-builder-bob/pkg/proxy/proxy.go
+++ b/components/image-builder-bob/pkg/proxy/proxy.go
@@ -171,6 +171,10 @@ func (proxy *Proxy) reverse(alias string, namespace string) *httputil.ReversePro
 	var host string
 	if !ok {
 		// we don't have an alias, hence don't know what to do other than try and proxy.
+		if namespace == "" {
+			// At this poing things will probably fail.
+			return nil
+		}
 		host = namespace
 	} else {
 		host = repo.Host

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -375,6 +375,10 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 					{Name: "BOB_BUILD_BASE", Value: buildBase},
 					{Name: "BOB_DOCKERFILE_PATH", Value: dockerfilePath},
 					{Name: "BOB_CONTEXT_DIR", Value: contextPath},
+					{
+						Name:  "BOB_WSLAYER_AUTH",
+						Value: string(additionalAuth),
+					},
 					{Name: "GITPOD_TASKS", Value: `[{"name": "build", "init": "sudo -E /app/bob build"}]`},
 					{Name: "WORKSPACEKIT_RING2_ENCLAVE", Value: "/app/bob proxy"},
 					{Name: "WORKSPACEKIT_BOBPROXY_BASEREF", Value: baseref},


### PR DESCRIPTION
## Description
Adds support for additional auth in Docker builds.

Currently users wishing to reference private docker registries in their Dockerfiles have been unable to do so, since the auth isn't passed through to the WSLayer. The auth is however passed through to the BOB, but only for the purpose of pulling a whole image from the Private Registry, not for building a Dockerfile from it.

This MR add in support by passing that same Auth through to the WSLayer so that Private Registries can be used by users in their Dockerfiles.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 274bde6</samp>

Refactored the authentication mechanism for the image builder workspace layer to use a shared secret and a nonce. Added the `BOB_WSLAYER_AUTH` environment variable to the `buildkitd` container spec in `orchestrator.go`. Removed unused code from the `builder` package.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #18315

## How to test
<!-- Provide steps to test this PR -->

Launch a workspace that contains a .gitpod.Dockerfile as it's image, and have that be based on an image hosted in a private Docker registry. Specify the correct credentials in you GITPOD_IMAGE_AUTH env as per normal.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
