### PR TITLE
Update page titles

### DIFF
--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -25,7 +25,7 @@ export interface TabEntry {
 
 export default function Header(p: HeaderProps) {
     const location = useLocation();
-    useDocumentTitle(`${p.title} — Gitpod`);
+    useDocumentTitle(`${p.title}`);
     return (
         <div className="app-container border-gray-200 dark:border-gray-800">
             <div className="flex pb-8 pt-6">

--- a/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
+++ b/components/dashboard/src/dedicated-setup/DedicatedSetup.tsx
@@ -26,7 +26,7 @@ type Props = {
     onComplete: () => void;
 };
 const DedicatedSetup: FC<Props> = ({ onComplete }) => {
-    useDocumentTitle("Welcome - Gitpod");
+    useDocumentTitle("Welcome");
     const currentOrg = useCurrentOrg();
     const oidcClients = useOIDCClientsQuery();
 

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -35,7 +35,7 @@ export default function JoinTeamPage() {
         })();
     }, [history, inviteId, orgInvalidator]);
 
-    useDocumentTitle("Joining Organization — Gitpod");
+    useDocumentTitle("Joining Organization");
 
     return joinError ? <div className="mt-16 text-center text-gitpod-red">{String(joinError)}</div> : <></>;
 }


### PR DESCRIPTION
## Description

Although we updated the page titles in https://github.com/gitpod-io/gitpod/pull/17603 (Cc @svenefftinge @easyCZ) and then in https://github.com/gitpod-io/gitpod/pull/18267 (Cc @filiptronicek), the `— Gitpod` suffix is still there.

This is an attempt to remove some remaining suffixes, see WEB-626 (Cc @chrifro).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1d6663</samp>

Remove "— Gitpod" suffix from document titles in dashboard components. This is part of a UI and branding improvement for the dashboard.

</details>

## How to test
<!-- Provide steps to test this PR -->

> Navigate through the dashboard and notice there's no `— Gitpod` suffix anywhere in the pages.


#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-191516e4e7</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-191516e4e7.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-191516e4e7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-update-page-titles-gha.16083</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gt-update-191516e4e7%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
