### PR TITLE
[bbs] update REPO_WRITE permission check EXP-521

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -122,31 +122,6 @@ export class BitbucketServerApi {
         return this.runQuery<BitbucketServer.Project>(userOrToken, `/projects/${projectSlug}`);
     }
 
-    async getPermission(
-        userOrToken: User | string,
-        params: { username: string; repoKind: BitbucketServer.RepoKind; owner: string; repoName?: string },
-    ): Promise<string | undefined> {
-        const { username, repoKind, owner, repoName } = params;
-        if (repoName) {
-            const repoPermissions = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.PermissionEntry>>(
-                userOrToken,
-                `/${repoKind}/${owner}/repos/${repoName}/permissions/users`,
-            );
-            const repoPermission = repoPermissions.values?.find((p) => p.user.name === username)?.permission;
-            if (repoPermission) {
-                return repoPermission;
-            }
-        }
-        if (repoKind === "projects") {
-            const projectPermissions = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.PermissionEntry>>(
-                userOrToken,
-                `/${repoKind}/${owner}/permissions/users`,
-            );
-            const projectPermission = projectPermissions.values?.find((p) => p.user.name === username)?.permission;
-            return projectPermission;
-        }
-    }
-
     protected get baseUrl(): string {
         return `https://${this.config.host}/rest/api/1.0`;
     }

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -122,6 +122,25 @@ export class BitbucketServerApi {
         return this.runQuery<BitbucketServer.Project>(userOrToken, `/projects/${projectSlug}`);
     }
 
+    async hasRepoPermission(
+        userOrToken: User | string,
+        params: {
+            permission: "REPO_READ" | "REPO_WRITE" | "REPO_ADMIN";
+            projectKey?: string;
+            repoName: string;
+            repoId: number;
+        },
+    ): Promise<boolean> {
+        const { repoName, projectKey, permission, repoId } = params;
+
+        const repos = await this.getRepos(userOrToken, {
+            permission,
+            name: repoName,
+            projectKey,
+        });
+        return repos.findIndex((r) => r.id === repoId) >= 0;
+    }
+
     protected get baseUrl(): string {
         return `https://${this.config.host}/rest/api/1.0`;
     }
@@ -325,6 +344,14 @@ export class BitbucketServerApi {
              * Limit or results per pagination request. Defaults to 1000
              */
             limit?: number;
+            /**
+             * projectKey is the original param of BBS APIs, will limit the resulting repository list to ones whose project's key matches this parameter's value
+             */
+            projectKey?: string;
+            /**
+             * name is the original param of BBS APIs, will limit the resulting repository list to ones whose name matches this parameter's value
+             */
+            name?: string;
 
             cancellationToken?: CancellationToken;
         },
@@ -378,12 +405,19 @@ export class BitbucketServerApi {
             return result;
         };
 
+        const baseParams: { [key: string]: string } = {};
+        if (query.projectKey) {
+            baseParams.projectkey = query.projectKey;
+        }
+        if (query.name) {
+            baseParams.name = query.name;
+        }
         if (query.searchString?.trim()) {
             const results: Map<number, BitbucketServer.Repository> = new Map();
 
             // Query by name & projectname in series to reduce chances of hitting rate limits
-            const nameResults = await fetchRepos({ name: query.searchString });
-            const projectResults = await fetchRepos({ projectname: query.searchString });
+            const nameResults = await fetchRepos(Object.assign({}, baseParams, { name: query.searchString }));
+            const projectResults = await fetchRepos(Object.assign({}, baseParams, { projectname: query.searchString }));
 
             for (const repo of [...nameResults, ...projectResults]) {
                 results.set(repo.id, repo);
@@ -391,7 +425,7 @@ export class BitbucketServerApi {
 
             return Array.from(results.values());
         } else {
-            return await fetchRepos();
+            return await fetchRepos(baseParams);
         }
     }
 

--- a/components/server/src/bitbucket-server/bitbucket-server-token-validator.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-token-validator.spec.ts
@@ -13,18 +13,22 @@ import { BitbucketServerTokenValidator } from "./bitbucket-server-token-validato
 import { AuthProviderParams } from "../auth/auth-provider";
 import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
 import { TokenProvider } from "../user/token-provider";
+import { IGitTokenValidatorParams } from "../workspace/git-token-validator";
 
-@suite(timeout(10000), retries(0), skip(ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER")))
+const shouldSkip =
+    ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ") &&
+    ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE") &&
+    ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_ADMIN");
+
+@suite(timeout(10000), retries(0), skip(shouldSkip))
 class TestBitbucketServerTokenValidator {
-    protected validator: BitbucketServerTokenValidator;
-
     static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
         id: "MyBitbucketServer",
         type: "BitbucketServer",
         verified: true,
         description: "",
         icon: "",
-        host: "bitbucket.gitpod-self-hosted.com",
+        host: "bitbucket.gitpod-dev.com",
         oauth: {
             callBackUrl: "",
             clientId: "not-used",
@@ -35,7 +39,16 @@ class TestBitbucketServerTokenValidator {
         },
     };
 
-    public before() {
+    // https://bitbucket.gitpod-dev.com/projects/TES/repos/read-write-permission/permissions
+    readonly checkParams: IGitTokenValidatorParams = {
+        host: TestBitbucketServerTokenValidator.AUTH_HOST_CONFIG.host!,
+        owner: "TES",
+        repo: "read-write-permission",
+        repoKind: "projects",
+        token: "undefined",
+    };
+
+    private getValidator(token: string) {
         const container = new Container();
         container.load(
             new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -45,7 +58,7 @@ class TestBitbucketServerTokenValidator {
                 bind(TokenProvider).toConstantValue(<TokenProvider>{
                     getTokenForHost: async () => {
                         return {
-                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            value: token || "undefined",
                             scopes: [],
                         };
                     },
@@ -53,17 +66,12 @@ class TestBitbucketServerTokenValidator {
                 bind(BitbucketServerApi).toSelf().inSingletonScope();
             }),
         );
-        this.validator = container.get(BitbucketServerTokenValidator);
+        return container.get(BitbucketServerTokenValidator);
     }
 
-    @test async test_checkWriteAccess_read_only() {
-        const result = await this.validator.checkWriteAccess({
-            host: "bitbucket.gitpod-self-hosted.com",
-            owner: "mil",
-            repo: "gitpod-large-image",
-            repoKind: "projects",
-            token: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!,
-        });
+    @test(skip(ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ"))) async test_checkWriteAccess_read_only() {
+        const token = process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ"]!;
+        const result = await this.getValidator(token).checkWriteAccess(Object.assign({}, this.checkParams, { token }));
         expect(result).to.deep.equal({
             found: true,
             isPrivateRepo: true,
@@ -71,17 +79,24 @@ class TestBitbucketServerTokenValidator {
         });
     }
 
-    @test async test_checkWriteAccess_write_permissions() {
-        const result = await this.validator.checkWriteAccess({
-            host: "bitbucket.gitpod-self-hosted.com",
-            owner: "alextugarev",
-            repo: "yolo",
-            repoKind: "users",
-            token: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!,
-        });
+    @test(skip(ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE")))
+    async test_checkWriteAccess_write_permissions() {
+        const token = process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE"]!;
+        const result = await this.getValidator(token).checkWriteAccess(Object.assign({}, this.checkParams, { token }));
         expect(result).to.deep.equal({
             found: true,
-            isPrivateRepo: false,
+            isPrivateRepo: true,
+            writeAccessToRepo: true,
+        });
+    }
+
+    @test(skip(ifEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER_ADMIN")))
+    async test_checkWriteAccess_admin_permissions() {
+        const token = process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER_ADMIN"]!;
+        const result = await this.getValidator(token).checkWriteAccess(Object.assign({}, this.checkParams, { token }));
+        expect(result).to.deep.equal({
+            found: true,
+            isPrivateRepo: true,
             writeAccessToRepo: true,
         });
     }

--- a/components/server/src/bitbucket-server/bitbucket-server-token-validator.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-token-validator.ts
@@ -30,21 +30,15 @@ export class BitbucketServerTokenValidator implements IGitTokenValidator {
             });
             found = true;
             isPrivateRepo = !repository.public;
+            writeAccessToRepo = await this.api.hasRepoPermission(token, {
+                permission: "REPO_WRITE",
+                projectKey: repository.project.key,
+                repoName: repository.name,
+                repoId: repository.id,
+            });
         } catch (error) {
             console.error(error);
         }
-
-        if (!found) {
-            return {
-                found,
-                isPrivateRepo,
-                writeAccessToRepo,
-            };
-        }
-
-        // We can't check REPO_WRITE permission on BitBucketServer since there's no open api for it if we don't change data
-        // Leave this check back to BBS it self when push
-        writeAccessToRepo = true;
 
         return {
             found,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe93d62</samp>

Simplified and improved Bitbucket Server token validation. Removed unused `getPermission` method from `BitbucketServerApi` class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-521

## How to test
<!-- Provide steps to test this PR -->
- Join org with BBS ingergration added (TODO)
- Authenticate your BBS account
- Try create workspace with https://bitbucket.gitpod-dev.com/projects/MYP/repos/my-repo/browse it should failed since this repo only admin has permission
- Use admin account to grant admin role to your account
- Try create workspace again, it should work without permission notification
- Revoke your permission, and use admin account to grant repo read permission to your account
- Try create worksapce again, it should work with permission notification, and failed to push

**Unit Tests**
```
# terminal 1
cd components/server
yarn watch

# terminal 2
cd components/server

# get access tokens from 1Password
export GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ=xx
export GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE=xx
export GITPOD_TEST_TOKEN_BITBUCKET_SERVER_ADMIN=xx
yarn test:unit
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-bbs-push-perm</li>
	<li><b>🔗 URL</b> - <a href="https://hw-bbs-push-perm.preview.gitpod-dev.com/workspaces" target="_blank">hw-bbs-push-perm.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-bbs-push-perm-gha.16093</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-bbs-push-perm%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
