### PR TITLE
[image-builder-mk3] log errors for auth

### DIFF
--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -129,6 +129,8 @@ func (ca CompositeAuth) Authenticate(ctx context.Context, registry string) (auth
 		}
 		if !res.Empty() {
 			return res, nil
+		} else {
+			log.WithField("registry", registry).Warn("response was empty for CompositeAuth authenticate")
 		}
 	}
 	return &Authentication{}, nil

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -46,6 +46,7 @@ func NewDockerConfigFileAuth(fn string) (*DockerConfigFileAuth, error) {
 		res.loadFromFile(fn)
 	})
 	if err != nil {
+		log.WithError(err).WithField("path", fn).Error("error watching file")
 		return nil, err
 	}
 
@@ -64,6 +65,7 @@ func (a *DockerConfigFileAuth) loadFromFile(fn string) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("error loading Docker config from %s: %w", fn, err)
+			log.WithError(err).WithField("path", fn).Error("failed loading from file")
 		}
 	}()
 
@@ -75,6 +77,7 @@ func (a *DockerConfigFileAuth) loadFromFile(fn string) (err error) {
 	_, _ = hash.Write(cntnt)
 	newHash := fmt.Sprintf("%x", hash.Sum(nil))
 	if a.hash == newHash {
+		log.Infof("nothing has changed: %s", fn)
 		return nil
 	}
 
@@ -91,6 +94,7 @@ func (a *DockerConfigFileAuth) loadFromFile(fn string) (err error) {
 	a.C = cfg
 	a.hash = newHash
 
+	log.Infof("file has changed: %s", fn)
 	return nil
 }
 
@@ -98,6 +102,7 @@ func (a *DockerConfigFileAuth) loadFromFile(fn string) (err error) {
 func (a *DockerConfigFileAuth) Authenticate(ctx context.Context, registry string) (auth *Authentication, err error) {
 	ac, err := a.C.GetAuthConfig(registry)
 	if err != nil {
+		log.WithError(err).WithField("registry", registry).Error("failed DockerConfigFileAuth Authenticate")
 		return nil, err
 	}
 
@@ -119,6 +124,7 @@ func (ca CompositeAuth) Authenticate(ctx context.Context, registry string) (auth
 	for _, ath := range ca {
 		res, err := ath.Authenticate(ctx, registry)
 		if err != nil {
+			log.WithError(err).WithField("registry", registry).Errorf("failed CompositeAuth Authenticate")
 			return nil, err
 		}
 		if !res.Empty() {
@@ -154,6 +160,13 @@ func (ath *ECRAuthenticator) Authenticate(ctx context.Context, registry string) 
 		return nil, nil
 	}
 
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("error with ECR authenticate: %w", err)
+			log.WithError(err).WithField("registry", registry).Error("failed ECR authenticate")
+		}
+	}()
+
 	ath.ecrAuthLock.Lock()
 	defer ath.ecrAuthLock.Unlock()
 	if time.Since(ath.ecrAuthLastRefreshTime) > ecrTokenRefreshTime {
@@ -162,7 +175,8 @@ func (ath *ECRAuthenticator) Authenticate(ctx context.Context, registry string) 
 			return nil, err
 		}
 		if len(tknout.AuthorizationData) == 0 {
-			return nil, fmt.Errorf("no ECR authorization data received")
+			err = fmt.Errorf("no ECR authorization data received")
+			return nil, err
 		}
 
 		pwd, err := base64.StdEncoding.DecodeString(aws.ToString(tknout.AuthorizationData[0].AuthorizationToken))
@@ -172,12 +186,15 @@ func (ath *ECRAuthenticator) Authenticate(ctx context.Context, registry string) 
 
 		ath.ecrAuth = string(pwd)
 		ath.ecrAuthLastRefreshTime = time.Now()
-		log.Debug("refreshed ECR token")
+		log.Info("refreshed ECR token")
+	} else {
+		log.Info("no ECR token refresh necessary")
 	}
 
 	segs := strings.Split(ath.ecrAuth, ":")
 	if len(segs) != 2 {
-		return nil, fmt.Errorf("cannot understand ECR token. Expected 2 segments, got %d", len(segs))
+		err = fmt.Errorf("cannot understand ECR token. Expected 2 segments, got %d", len(segs))
+		return nil, err
 	}
 	return &Authentication{
 		Username: segs[0],
@@ -299,6 +316,7 @@ func (a AllowedAuthFor) GetAuthFor(ctx context.Context, auth RegistryAuthenticat
 
 	ref, err := reference.ParseNormalizedNamed(refstr)
 	if err != nil {
+		log.WithError(err).Errorf("failed parsing normalized name")
 		return nil, xerrors.Errorf("cannot parse image ref: %v", err)
 	}
 	reg := reference.Domain(ref)
@@ -359,6 +377,8 @@ func (a AllowedAuthFor) additionalAuth(domain string) *Authentication {
 			res.Username = segs[0]
 			res.Password = strings.Join(segs[1:], ":")
 		}
+	} else {
+		log.Errorf("failed getting additional auth")
 	}
 	return res
 }
@@ -386,7 +406,7 @@ func (a AllowedAuthFor) GetImageBuildAuthFor(ctx context.Context, auth RegistryA
 	for _, reg := range additionalRegistries {
 		ath, err := auth.Authenticate(ctx, reg)
 		if err != nil {
-			log.WithError(err).WithField("registry", reg).Warn("cannot get authentication for additioanl registry for image build")
+			log.WithError(err).WithField("registry", reg).Warn("cannot get authentication for additional registry for image build")
 			continue
 		}
 		if ath.Empty() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This will help us troubleshoot:
* credential reload via watch
* potential ECR authN issues
* potential additionalAuth issues


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8082e76</samp>

Improve error logging in image-builder-mk3 auth package. Add log messages with error and file or image name in `auth.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to ENG-757

## How to test
<!-- Provide steps to test this PR -->
1. Assert you have a `kubectx` for your preview env
2. Backup the existing pull secret: `kubectl get secrets gcp-sa-registry-auth -o yaml > /tmp/secret-backup.yaml`
3. Setup some test data, you can use the original secret, FAKE_VALID_TOKEN, or FAKE_INVALID_TOKEN (below):
```
set -x

# passes docker cli validation, but cannot actually log in
export FAKE_VALID_TOKEN=$(cat << 'EOF'
_json_key:{
  "type": "service_account",
  "project_id": "123",
  "private_key_id": "0",
  "private_key": "-----BEGIN PRIVATE KEY-----\0\n-----END PRIVATE KEY-----\n",
  "client_email": "foo.com",
  "client_id": "0",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foo"
}
EOF
)

# fails docker cli validation
export FAKE_INVALID_TOKEN=$(echo -n "foo" | base64 -w0)

export AUTH_TOKEN=$(echo -n ${FAKE_INVALID_TOKEN} | base64 -w0)

cat << EOF > config.json
{
    "auths": {
        "eu.gcr.io": {
            "auth": "${AUTH_TOKEN}"
        },
        "europe-docker.pkg.dev": {
            "auth": "${AUTH_TOKEN}"
        }
    }
}
EOF

kubectl create secret generic gcp-sa-registry-auth \
    --from-file=.dockerconfigjson=config.json \
    --type=kubernetes.io/dockerconfigjson \
    -o yaml --dry-run=client | kubectl apply --server-side --force-conflicts -f -
```
4. Follow the logs to observe the watch and errors: `kubectl logs --follow deployment/image-builder-mk3`
5. Reset the secret back from the backup: `kubectl apply --server-side --force-conflicts -f /tmp/secret-backup.yaml`

**Test Scenarios**

Success (restored from the backup):
```
2023-08-29T20:27:02.17122308Z  INFO "reloading file after change"
2023-08-29T20:27:02.171413799Z  INFO "reloading auth from Docker config"
2023-08-29T20:27:02.17151425Z  INFO "file has changed: /config/pull-secret/pull-secret.json"
```

A token that has invalid format, FAKE_INVALID_TOKEN (this error is from docker cli [here](https://github.com/docker/cli/blob/f74f88445f8b23fe4804f1072e5f376cfbe46487/cli/config/configfile/file.go#L248)):
```
2023-08-29T20:29:33.114833864Z  INFO "reloading file after change"
2023-08-29T20:29:33.114961164Z  INFO "reloading auth from Docker config"
2023-08-29T20:29:33.115032464Z  ERROR "failed loading from file"
error loading Docker config from /config/pull-secret/pull-secret.json: Invalid auth configuration file
```

A token that appears valid, FAKE_VALID_TOKEN (passed field validation, contains junk):
```
2023-08-29T21:19:02.915601783Z  INFO "reloading file after change"
2023-08-29T21:19:02.915748863Z  INFO "reloading auth from Docker config"
2023-08-29T21:19:02.915811433Z  INFO "file has changed: /config/pull-secret/pull-secret.json"
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-ad00490fcae</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-ad00490fcae.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-ad00490fcae.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-add-auth-err-logs-gha.16102</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-ad00490fcae%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
