### PR TITLE
Update kumquat colors

### DIFF
--- a/components/dashboard/src/admin/BlockedEmailDomains.tsx
+++ b/components/dashboard/src/admin/BlockedEmailDomains.tsx
@@ -170,7 +170,7 @@ function BlockedDomainEntry(props: {
         },
     ];
     return (
-        <div className="rounded whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+        <div className="rounded whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
             <div className="flex flex-col w-9/12 truncate">
                 <span className="mr-3 text-lg text-gray-600 truncate">{props.br.domain}</span>
             </div>
@@ -248,7 +248,7 @@ function Details(props: {
     return (
         <div className="border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
             {props.error ? (
-                <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{props.error}</div>
+                <div className="bg-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{props.error}</div>
             ) : null}
             <div>
                 <h4>Domain (may contain '%' as wild card)</h4>

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -175,7 +175,7 @@ function BlockedRepositoryEntry(props: { br: BlockedRepository; confirmedDelete:
         },
     ];
     return (
-        <div className="rounded whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+        <div className="rounded whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
             <div className="flex flex-col w-9/12 truncate">
                 <span className="mr-3 text-lg text-gray-600 truncate">{props.br.urlRegexp}</span>
             </div>
@@ -273,7 +273,7 @@ function Details(props: {
     return (
         <div className="border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
             {props.error ? (
-                <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{props.error}</div>
+                <div className="bg-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{props.error}</div>
             ) : null}
             <div>
                 <h4>Repository URL RegEx</h4>

--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -140,7 +140,7 @@ export function ProjectsSearch() {
                 to={"/admin/projects/" + p.project.id}
                 data-analytics='{"button_type":"sidebar_menu"}'
             >
-                <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+                <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
                     <div className="flex flex-col w-4/12 truncate">
                         <div className="font-medium text-gray-800 dark:text-gray-100 truncate">{p.project.name}</div>
                     </div>

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -138,7 +138,7 @@ export function TeamsSearch() {
                 to={"/admin/orgs/" + props.team.id}
                 data-analytics='{"button_type":"sidebar_menu"}'
             >
-                <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+                <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
                     <div className="flex flex-col w-7/12 truncate">
                         <div className="font-medium text-gray-800 dark:text-gray-100 truncate max-w-sm">
                             {props.team.name}

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -132,7 +132,7 @@ function UserEntry(p: { user: User }) {
     const email = User.getPrimaryEmail(p.user) || "---";
     return (
         <Link key={p.user.id} to={"/admin/users/" + p.user.id} data-analytics='{"button_type":"sidebar_menu"}'>
-            <div className="rounded-xl whitespace-nowrap flex space-x-2 py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+            <div className="rounded-xl whitespace-nowrap flex space-x-2 py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
                 <div className="pr-3 self-center w-1/12">
                     <img className="rounded-full" src={p.user.avatarUrl} alt={p.user.fullName || p.user.name} />
                 </div>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -172,7 +172,7 @@ function WorkspaceEntry(p: { ws: WorkspaceAndInstance }) {
             to={"/admin/workspaces/" + p.ws.workspaceId}
             data-analytics='{"button_type":"sidebar_menu"}'
         >
-            <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+            <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
                 <div className="pr-3 self-center w-8">
                     <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(p.ws)} />
                 </div>

--- a/components/dashboard/src/components/ItemsList.tsx
+++ b/components/dashboard/src/components/ItemsList.tsx
@@ -14,7 +14,7 @@ export function Item(props: { children?: React.ReactNode; className?: string; he
     // cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700
     const solidClassName = props.solid ? "bg-gray-100 dark:bg-gray-800" : "hover:bg-gray-100 dark:hover:bg-gray-800";
     const headerClassName = "text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800";
-    const notHeaderClassName = "rounded-xl focus:bg-gitpod-kumquat-light " + solidClassName;
+    const notHeaderClassName = "rounded-xl focus:bg-kumquat-light " + solidClassName;
     return (
         <div
             className={`flex flex-grow flex-row w-full p-3 justify-between transition ease-in-out ${

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -128,7 +128,7 @@ export default function ProjectsPage() {
                         {!searchFilter && (
                             <div
                                 key="new-project"
-                                className="h-52 border-dashed border-2 border-gray-100 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                                className="h-52 border-dashed border-2 border-gray-100 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl focus:bg-kumquat-light transition ease-in-out group"
                             >
                                 <Link to={projectsPathNew} data-analytics='{"button_type":"card"}'>
                                     <div className="flex h-full">

--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -23,7 +23,7 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                     {filteredRepos.map((r, index) => (
                         <div
                             key={`repo-${index}-${r.account}-${r.name}`}
-                            className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                            className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light transition ease-in-out group"
                             title={r.cloneUrl}
                         >
                             <div className="flex-grow">

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -639,7 +639,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 statusMessage = (
                     <div>
                         <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 bg-gray-100 dark:bg-gray-800">
-                            <div className="rounded-full w-3 h-3 text-sm bg-gitpod-kumquat">&nbsp;</div>
+                            <div className="rounded-full w-3 h-3 text-sm bg-kumquat-ripe">&nbsp;</div>
                             <div>
                                 <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
                                     {this.state.workspaceInstance.workspaceId}

--- a/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
+++ b/components/dashboard/src/teams/sso/OIDCClientListItem.tsx
@@ -85,7 +85,7 @@ export const OIDCClientListItem: FC<Props> = ({ clientConfig, hasActiveConfig, o
                                 (clientConfig.active
                                     ? "bg-green-500"
                                     : clientConfig.verified
-                                    ? "bg-gitpod-kumquat"
+                                    ? "bg-kumquat-ripe"
                                     : "bg-gray-400")
                             }
                         >

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -55,7 +55,7 @@ function AddEnvVarModal(p: EnvVarModalProps) {
             <ModalHeader>{isNew ? "New" : "Edit"} Variable</ModalHeader>
             <ModalBody>
                 {error ? (
-                    <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{error}</div>
+                    <div className="bg-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{error}</div>
                 ) : null}
                 <div>
                     <h4>Name</h4>

--- a/components/dashboard/src/user-settings/TokenEntry.tsx
+++ b/components/dashboard/src/user-settings/TokenEntry.tsx
@@ -35,7 +35,7 @@ function TokenEntry(props: TokenEntryProps) {
     };
 
     return (
-        <div className="rounded-xl whitespace-nowrap flex space-x-2 py-4 px-4 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+        <div className="rounded-xl whitespace-nowrap flex space-x-2 py-4 px-4 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-kumquat-light group">
             <div className="flex items-center pr-3 w-4/12">
                 <span className="truncate">{props.token.name || ""}</span>
             </div>

--- a/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
@@ -48,9 +48,7 @@ export const RenameWorkspaceModal: FunctionComponent<Props> = ({ workspace, onCl
             <ModalHeader>Rename Workspace Description</ModalHeader>
             <ModalBody>
                 {errorMessage.length > 0 ? (
-                    <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">
-                        {errorMessage}
-                    </div>
+                    <div className="bg-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{errorMessage}</div>
                 ) : null}
                 <input
                     autoFocus

--- a/components/dashboard/src/workspaces/WorkspaceStatusIndicator.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceStatusIndicator.tsx
@@ -33,7 +33,7 @@ export function WorkspaceStatusIndicator({ instance }: { instance?: WorkspaceIns
             break;
         }
         default: {
-            stateClassName += " bg-gitpod-kumquat animate-pulse";
+            stateClassName += " bg-kumquat-ripe animate-pulse";
             break;
         }
     }


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/18319, to replace the kumquat color variables used.

Thanks @jeanp413 for noticing! ⚾ 

See [relevant discussion](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1693324295436819) (internal).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a0e1f6</samp>

This pull request updates various UI components in the dashboard to use a new color variable `kumquat` instead of the old one `gitpod-kumquat`. This improves the consistency and accessibility of the color scheme. The affected components include blocked email domains, blocked repositories, projects search, teams search, user search, workspaces search, items list, new project repo list, projects, start workspace, OIDC client list item, environment variables, token entry, rename workspace modal, and workspace status indicator.

</details>

## How to test

Start a workspace and seethe pulsating kumuqat dot on the workspaces list. 🍊 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gt-update-d7257b6fd7</li>
	<li><b>🔗 URL</b> - <a href="https://gt-update-d7257b6fd7.preview.gitpod-dev.com/workspaces" target="_blank">gt-update-d7257b6fd7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gt-update-kumquat-colors-gha.16125</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gt-update-d7257b6fd7%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
