### PR TITLE
[dashboard] unique project links

### DIFF
--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -7,7 +7,6 @@
 import { Project } from "@gitpod/gitpod-protocol";
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useHistory, useLocation, useRouteMatch } from "react-router";
-import { validate as uuidValidate } from "uuid";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { listAllProjects } from "../service/public-api";
 import { useCurrentUser } from "../user-context";
@@ -27,25 +26,41 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
     return <ProjectContext.Provider value={ctx}>{children}</ProjectContext.Provider>;
 };
 
-export function useProjectSlugs(): { projectSlug?: string; prebuildId?: string } {
-    const projectsRouteMatch = useRouteMatch<{ projectSlug?: string; prebuildId?: string }>(
-        "/projects/:projectSlug?/:prebuildId?",
-    );
+interface ProjectInfo {
+    id: string;
+    name?: string;
+}
+
+export function useProjectInfo(): ProjectInfo | undefined {
+    const projectsRouteMatch = useRouteMatch<{ projectSlug?: string }>("/projects/:projectSlug");
 
     return useMemo(() => {
         const projectSlug = projectsRouteMatch?.params.projectSlug;
-        const result: { projectSlug?: string; prebuildId?: string } = {};
-        const reservedProjectSlugs = ["new"];
-        if (!projectSlug || reservedProjectSlugs.includes(projectSlug)) {
-            return result;
+        if (!projectSlug) {
+            return undefined;
         }
-        result.projectSlug = projectSlug;
-        const prebuildId = projectsRouteMatch?.params.prebuildId;
-        if (prebuildId && uuidValidate(prebuildId)) {
-            result.prebuildId = projectsRouteMatch?.params.prebuildId;
+        const result = parseProjectSlug(projectSlug);
+        if (!result) {
+            return undefined;
         }
         return result;
-    }, [projectsRouteMatch?.params.projectSlug, projectsRouteMatch?.params.prebuildId]);
+    }, [projectsRouteMatch?.params.projectSlug]);
+}
+
+const pattern: RegExp = /^((.+)-)?([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$/;
+function parseProjectSlug(slug: string): ProjectInfo | undefined {
+    const match = slug.match(pattern);
+
+    if (match) {
+        const name = match[2];
+        const id = match[3];
+        return {
+            name,
+            id,
+        };
+    } else {
+        return undefined;
+    }
 }
 
 export function useCurrentProject(): { project: Project | undefined; loading: boolean } {
@@ -54,7 +69,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
     const user = useCurrentUser();
     const org = useCurrentOrg();
     const orgs = useOrganizations();
-    const slugs = useProjectSlugs();
+    const projectInfo = useProjectInfo();
     const location = useLocation();
     const history = useHistory();
 
@@ -65,7 +80,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
             // without a user we are still consider this loading
             return;
         }
-        if (!slugs.projectSlug) {
+        if (!projectInfo) {
             setProject(undefined);
             setLoading(false);
             return;
@@ -77,7 +92,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
             let projects = await listAllProjects({ orgId: org.data.id });
 
             // Find project matching with slug, otherwise with name
-            const project = projects.find((p) => Project.slug(p) === slugs.projectSlug);
+            const project = projects.find((p) => p.id === projectInfo.id);
             if (!project && orgs.data) {
                 // check other orgs
                 for (const t of orgs.data || []) {
@@ -85,7 +100,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
                         continue;
                     }
                     const projects = await listAllProjects({ orgId: t.id });
-                    const project = projects.find((p) => Project.slug(p) === slugs.projectSlug);
+                    const project = projects.find((p) => p.id === projectInfo.id);
                     if (project) {
                         // redirect to the other org
                         history.push(location.pathname + "?org=" + t.id);
@@ -95,7 +110,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
             setProject(project);
             setLoading(false);
         })();
-    }, [slugs.projectSlug, setProject, org.data, user, orgs.data, location, history]);
+    }, [setProject, org.data, user, orgs.data, location, history, projectInfo]);
 
     return { project, loading };
 }

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -52,7 +52,7 @@ export namespace Project {
     };
 
     export function slug(p: Project): string {
-        return p.slug || p.name || p.id;
+        return (p.slug || p.name) + "-" + p.id;
     }
 
     export interface Overview {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changes the URLs for projects to include the project id and use that to look up the actual project.

I did not add a backward-compatible resolver because I don't believe there are enough URLs out there that warrant additional complexity.

<img width="953" alt="Screenshot 2023-08-29 at 20 32 52" src="https://github.com/gitpod-io/gitpod/assets/372735/3ff29d23-7c63-444a-b28a-1333690929fe">


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49764cc</samp>

Refactored the project identification logic in the dashboard to use project ids instead of slugs, and moved the slug function from the `gitpod-protocol` package to the `project-context` file. This improves the performance, consistency, and simplicity of the code.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-275

## How to test
<!-- Provide steps to test this PR -->
- Create projects and navigate around.
- try changing the name bit in the URL
- import two projects with the same name (need to use e.g. gitlab and github as we cannot rename projects in the UI atm)
- you can also join my org https://se-project-slug.preview.gitpod-dev.com/orgs/join?inviteId=96019614-36a9-48b6-86d8-a29c4ea1e0e3

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-project-slug</li>
        <li><b>🔗 URL</b> - <a href="https://se-project-slug.preview.gitpod-dev.com/workspaces" target="_blank">se-project-slug.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-project-slug%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
