### PR TITLE
[image-builder-bob] retry on bad request

### DIFF
--- a/components/image-builder-bob/pkg/proxy/proxy.go
+++ b/components/image-builder-bob/pkg/proxy/proxy.go
@@ -185,6 +185,10 @@ func (proxy *Proxy) reverse(alias string) *httputil.ReverseProxy {
 			}
 			return true, nil
 		}
+		if resp.StatusCode == http.StatusBadRequest {
+			log.WithField("URL", resp.Request.URL.String()).Warn("bad request")
+			return true, nil
+		}
 
 		return false, nil
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Image builds sometimes fail on push due to bad request. Users have reported that they can generally retry again w/o issue. Let's automate the retry as part of bob, to see if it helps avoid transient issues.

The default retry for RetryWaitMin is 1s.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 234746b</samp>

Fix a typo and add retry logic in `proxy.go`. This enhances the image builder's proxy component.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
xref: ENG-757
xref: https://github.com/gitpod-io/gitpod/pull/18611

## How to test
<!-- Provide steps to test this PR -->
Do an image build in preview, https://github.com/kylos101/dotfiles/ is a lovely choice.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-retry-400</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-retry-400.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-retry-400.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-retry-400-gha.16174</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-retry-400%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
