### PR TITLE
[bridge] Control all WorkspaceInstances, incl. type "prebuild"

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -430,7 +430,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
 
     public async findRegularRunningInstances(userId?: string): Promise<WorkspaceInstance[]> {
         const infos = await this.findRunningInstancesWithWorkspaces(undefined, userId);
-        return infos.filter((info) => info.workspace.type === "regular").map((wsinfo) => wsinfo.latestInstance);
+        return infos.map((wsinfo) => wsinfo.latestInstance);
     }
 
     public async findRunningInstancesWithWorkspaces(


### PR DESCRIPTION
## Description

When we fixed status handling for Prebuilds, we did not thoroughly check if they are picked up as well.
The DB helper we used had a filter on "regular" from it's previous job.

The controllers runs every 60 seconds ([source](https://github.com/gitpod-io/gitpod/blob/4cb8fd08b453b5a31b91d1d60cdd6985a12db8c3/install/installer/pkg/components/ws-manager-bridge/configmap.go#L22)), which should definitely be fast enough.
We could think about triggering it [onReconnect](https://github.com/gitpod-io/gitpod/blob/66df7ffb04439351dfce0783d32066a4fd57bb2c/components/ws-manager-bridge/src/bridge.ts#L116) as well, but I don't think we need that complexity.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9ff62a</samp>

Simplify query for regular workspaces in `workspace-db-impl.ts`. This is part of a refactoring to support different workspace types.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of EXP-524

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
