### PR TITLE
Avoid ws-manager-mk2 metrics duplication

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -139,24 +139,14 @@ func (m *controllerMetrics) countWorkspaceStartFailures(log *logr.Logger, ws *wo
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalStartsFailureCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace startup failure", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalStartsFailureCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countWorkspaceFailure(log *logr.Logger, ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalFailuresCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace failure", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalFailuresCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countWorkspaceStop(log *logr.Logger, ws *workspacev1.Workspace) {
@@ -182,60 +172,35 @@ func (m *controllerMetrics) countWorkspaceStop(log *logr.Logger, ws *workspacev1
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalStopsCounterVec.GetMetricWithLabelValues(reason, tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace stop", "reason", "unknown", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalStopsCounterVec.WithLabelValues(reason, tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countTotalBackups(log *logr.Logger, ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalBackupCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace backup", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalBackupCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countTotalBackupFailures(log *logr.Logger, ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalBackupFailureCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace backup failure", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalBackupFailureCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countTotalRestores(log *logr.Logger, ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalRestoreCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace restore", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalRestoreCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) countTotalRestoreFailures(log *logr.Logger, ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
-	counter, err := m.totalRestoreFailureCounterVec.GetMetricWithLabelValues(tpe, class)
-	if err != nil {
-		log.Error(err, "could not count workspace restore failure", "type", tpe, "class", class)
-	}
-
-	counter.Inc()
+	m.totalRestoreFailureCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
 func (m *controllerMetrics) containsWorkspace(ws *workspacev1.Workspace) bool {

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -102,6 +102,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	SetupIndexer(k8sManager)
+
 	conf := newTestConfig()
 	maintenance := &fakeMaintenance{enabled: false}
 	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("workspace"), &conf, metrics.Registry, maintenance)


### PR DESCRIPTION
## Description

Only the leader replica maintains the workspace metrics.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e1c129</samp>

Improve leader election and workspace reconciler logic in `ws-manager-mk2`. Delay the reconciler initialization until the leader is elected and run it in a separate goroutine.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-metrics</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-metrics.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-metrics.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-metrics-gha.16200</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-metrics%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
