### PR TITLE
[spicedb] fix stale connection handling

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -10,7 +10,7 @@
         "src"
     ],
     "devDependencies": {
-        "@grpc/grpc-js": "1.8.8",
+        "@grpc/grpc-js": "1.9.1",
         "@testdeck/mocha": "^0.3.3",
         "@types/analytics-node": "^3.1.9",
         "@types/chai-subset": "^1.3.3",

--- a/components/ide-metrics-api/typescript-grpc/package.json
+++ b/components/ide-metrics-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/server/debug.sh
+++ b/components/server/debug.sh
@@ -26,6 +26,11 @@ kubectl scale deployment $deploymentName --replicas=1
 echo "Wait for the pod to be ready"
 kubectl wait --for=condition=ready pod -l component=$deploymentName
 
+while [[ $(kubectl get pods -l component=$deploymentName -o 'jsonpath={..status.phase}' | grep -o 'Running' | wc -w) -ne 1 ]]; do
+  echo "Waiting for scale down operation to complete..."
+  sleep 1
+done
+
 podName=$(kubectl get pods -l component=$deploymentName -o=jsonpath='{.items[0].metadata.name}')
 echo "Forward $podName port $debugPort to localhost. Waiting for a debugger to attach ..."
 kubectl port-forward pod/"$podName" $debugPort

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -136,5 +136,8 @@
     "ts-node": "^10.4.0",
     "typescript": "~4.4.2",
     "watch": "^1.0.2"
+  },
+  "resolutions": {
+    "@authzed/authzed-node/**/@grpc/grpc-js": "1.9.1"
   }
 }

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -21,6 +21,10 @@ export class SpiceDBAuthorizer {
         private readonly clientProvider: SpiceDBClientProvider,
     ) {}
 
+    private get client(): v1.ZedPromiseClientInterface {
+        return this.clientProvider.getClient();
+    }
+
     async check(
         req: v1.CheckPermissionRequest,
         experimentsFields: {
@@ -39,8 +43,7 @@ export class SpiceDBAuthorizer {
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {
-            const client = this.clientProvider.getClient();
-            const response = await client.checkPermission(req, this.callOptions);
+            const response = await this.client.checkPermission(req, this.callOptions);
             const permitted = response.permissionship === v1.CheckPermissionResponse_Permissionship.HAS_PERMISSION;
 
             return permitted;
@@ -59,8 +62,7 @@ export class SpiceDBAuthorizer {
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {
-            const client = this.clientProvider.getClient();
-            const response = await client.writeRelationships(
+            const response = await this.client.writeRelationships(
                 v1.WriteRelationshipsRequest.create({
                     updates,
                 }),
@@ -81,11 +83,16 @@ export class SpiceDBAuthorizer {
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {
-            const client = this.clientProvider.getClient();
-            const existing = await client.readRelationships(v1.ReadRelationshipsRequest.create(req), this.callOptions);
+            const existing = await this.client.readRelationships(
+                v1.ReadRelationshipsRequest.create(req),
+                this.callOptions,
+            );
             if (existing.length > 0) {
-                const response = await client.deleteRelationships(req, this.callOptions);
-                const after = await client.readRelationships(v1.ReadRelationshipsRequest.create(req), this.callOptions);
+                const response = await this.client.deleteRelationships(req, this.callOptions);
+                const after = await this.client.readRelationships(
+                    v1.ReadRelationshipsRequest.create(req),
+                    this.callOptions,
+                );
                 if (after.length > 0) {
                     log.error("[spicedb] Failed to delete relationships.", { existing, after, request: req });
                 }
@@ -108,11 +115,7 @@ export class SpiceDBAuthorizer {
     }
 
     async readRelationships(req: v1.ReadRelationshipsRequest): Promise<v1.ReadRelationshipsResponse[]> {
-        const client = this.clientProvider.getClient();
-        if (!client) {
-            return [];
-        }
-        return client.readRelationships(req, this.callOptions);
+        return this.client.readRelationships(req, this.callOptions);
     }
 
     /**

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -5,11 +5,8 @@
  */
 
 import { v1 } from "@authzed/authzed-node";
-import { IClientCallMetrics, createClientCallMetricsInterceptor } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as grpc from "@grpc/grpc-js";
-
-export const SpiceDBClientProvider = Symbol("SpiceDBClientProvider");
 
 export interface SpiceDBClientConfig {
     address: string;
@@ -18,9 +15,6 @@ export interface SpiceDBClientConfig {
 
 export type SpiceDBClient = v1.ZedPromiseClientInterface;
 type Client = v1.ZedClientInterface & grpc.Client;
-export interface SpiceDBClientProvider {
-    getClient(): SpiceDBClient;
-}
 
 export function spiceDBConfigFromEnv(): SpiceDBClientConfig | undefined {
     const token = process.env["SPICEDB_PRESHARED_KEY"];
@@ -40,63 +34,48 @@ export function spiceDBConfigFromEnv(): SpiceDBClientConfig | undefined {
     };
 }
 
-function spicedbClientFromConfig(config: SpiceDBClientConfig): Client {
-    const clientOptions: grpc.ClientOptions = {
-        "grpc.client_idle_timeout_ms": 10000, // this ensures a connection is not stuck in the "READY" state for too long. Required for the reconnect logic below.
-        "grpc.max_reconnect_backoff_ms": 5000, // default: 12000
-    };
-
-    return v1.NewClient(
-        config.token,
-        config.address,
-        v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS,
-        undefined,
-        clientOptions,
-    ) as Client;
-}
-
-export class CachingSpiceDBClientProvider implements SpiceDBClientProvider {
+export class SpiceDBClientProvider {
     private client: Client | undefined;
 
-    private readonly interceptors: grpc.Interceptor[] = [];
-
     constructor(
-        private readonly _clientConfig: SpiceDBClientConfig,
-        private readonly clientCallMetrics?: IClientCallMetrics | undefined,
-    ) {
-        if (this.clientCallMetrics) {
-            this.interceptors.push(createClientCallMetricsInterceptor(this.clientCallMetrics));
-        }
-    }
+        private readonly clientConfig: SpiceDBClientConfig,
+        private readonly interceptors: grpc.Interceptor[] = [],
+    ) {}
 
     getClient(): SpiceDBClient {
-        let client = this.client;
-        if (!client) {
-            client = spicedbClientFromConfig(this.clientConfig);
-        } else if (client.getChannel().getConnectivityState(true) !== grpc.connectivityState.READY) {
-            // (gpl): We need this check and explicit re-connect because we observe a ~120s connection timeout without it.
-            // It's not entirely clear where that timeout comes from, but likely from the underlying transport, that is not exposed by grpc/grpc-js
-            client.close();
+        if (!this.client) {
+            this.client = v1.NewClient(
+                this.clientConfig.token,
+                this.clientConfig.address,
+                v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS,
+                undefined, //
+                {
+                    // we ping frequently to check if the connection is still alive
+                    "grpc.keepalive_time_ms": 1000,
+                    "grpc.keepalive_timeout_ms": 1000,
 
-            log.warn("[spicedb] Lost connection to SpiceDB - reconnecting...");
+                    "grpc.max_reconnect_backoff_ms": 5000,
+                    "grpc.initial_reconnect_backoff_ms": 500,
+                    "grpc.service_config": JSON.stringify({
+                        methodConfig: [
+                            {
+                                name: [{}],
+                                retryPolicy: {
+                                    maxAttempts: 10,
+                                    initialBackoff: "0.1s",
+                                    maxBackoff: "5s",
+                                    backoffMultiplier: 2.0,
+                                    retryableStatusCodes: ["UNAVAILABLE", "DEADLINE_EXCEEDED"],
+                                },
+                            },
+                        ],
+                    }),
 
-            client = spicedbClientFromConfig(this.clientConfig);
-        }
-        this.client = client;
-
-        return client.promises;
-    }
-
-    protected get clientConfig() {
-        const config = this._clientConfig;
-        if (this.interceptors) {
-            return {
-                ...config,
-                options: {
-                    interceptors: [...this.interceptors],
+                    "grpc.enable_retries": 1, //TODO enabled by default
+                    interceptors: this.interceptors,
                 },
-            };
+            ) as Client;
         }
-        return config;
+        return this.client.promises;
     }
 }

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -13,7 +13,7 @@ import { v4 } from "uuid";
 import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider, HostContextProviderFactory } from "../auth/host-context-provider";
 import { HostContextProviderImpl } from "../auth/host-context-provider-impl";
-import { CachingSpiceDBClientProvider, SpiceDBClientProvider } from "../authorization/spicedb";
+import { SpiceDBClientProvider } from "../authorization/spicedb";
 import { Config } from "../config";
 import { StorageClient } from "../storage/storage-client";
 import { testContainer } from "@gitpod/gitpod-db/lib";
@@ -194,7 +194,7 @@ const mockApplyingContainerModule = new ContainerModule((bind, unbound, isbound,
                 token: v4(),
                 address: "localhost:50051",
             };
-            return new CachingSpiceDBClientProvider(config);
+            return new SpiceDBClientProvider(config);
         })
         .inSingletonScope();
 });

--- a/components/supervisor-api/typescript-grpc/package.json
+++ b/components/supervisor-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/usage-api/typescript/package.json
+++ b/components/usage-api/typescript/package.json
@@ -18,6 +18,7 @@
     "ts-proto": "^1.153.0"
   },
   "devDependencies": {
+    "@types/long": "4.0.0",
     "grpc-tools": "^1.12.4",
     "typescript": "~4.4.2",
     "typescript-formatter": "^7.2.2"

--- a/components/ws-daemon-api/typescript/package.json
+++ b/components/ws-daemon-api/typescript/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-bridge-api/typescript/package.json
+++ b/components/ws-manager-bridge-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.8.8",
+    "@grpc/grpc-js": "1.9.1",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/install/installer/pkg/components/spicedb/deployment.go
+++ b/install/installer/pkg/components/spicedb/deployment.go
@@ -154,13 +154,13 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 											Command: []string{"grpc_health_probe", "-v", fmt.Sprintf("-addr=localhost:%d", ContainerGRPCPort)},
 										},
 									},
-									InitialDelaySeconds: 5,
-									// try again every 10 seconds
-									PeriodSeconds: 10,
-									// fail after 6 * 10 + 5 = 65 seconds
-									FailureThreshold: 6,
+									InitialDelaySeconds: 1,
+									// try again every 2 seconds
+									PeriodSeconds: 2,
+									// fail after 30 * 2 + 1 = 61
+									FailureThreshold: 30,
 									SuccessThreshold: 1,
-									TimeoutSeconds:   3,
+									TimeoutSeconds:   1,
 								},
 								VolumeMounts: []v1.VolumeMount{
 									bootstrapVolumeMount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,24 +2215,23 @@
     "@gitbeaker/core" "^39.12.0"
     "@gitbeaker/requester-utils" "^39.12.0"
 
-"@grpc/grpc-js@1.8.8", "@grpc/grpc-js@^1.6.1", "@grpc/grpc-js@^1.8.3":
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.8.tgz#a7c6765d0302f47ba67c0ce3cb79718d6b028248"
-  integrity sha512-4gfDqMLXTrorvYTKA1jL22zLvVwiHJ73t6Re1OHwdCFRjdGTDOVtSJuaWhtHaivyeDGg0LeCkmU77MTKoV3wPA==
+"@grpc/grpc-js@1.9.1", "@grpc/grpc-js@^1.6.1", "@grpc/grpc-js@^1.8.3":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.1.tgz#d6df7943cd2875a4feaf725f85ff605c08ac245d"
+  integrity sha512-AvDEPQT4teS+J8++cTE5tku4rYCwpPwPguESJUummLs/Ug/O5Bouofnc1mxaDORmwA9QkrJ+PfRQ1Qs7adQgJg==
   dependencies:
-    "@grpc/proto-loader" "^0.7.0"
+    "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.7.0":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.2.tgz#fa63178853afe1473c50cff89fe572f7c8b20154"
-  integrity sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==
+"@grpc/proto-loader@^0.7.8":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.9.tgz#3ca68236f1a0d77566dafa53c715eb31d096279a"
+  integrity sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==
   dependencies:
-    "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
-    long "^4.0.0"
-    protobufjs "^7.0.0"
-    yargs "^16.2.0"
+    long "^5.0.0"
+    protobufjs "^7.2.4"
+    yargs "^17.7.2"
 
 "@hapi/bourne@^2.0.0":
   version "2.0.0"
@@ -3841,10 +3840,10 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz"
   integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
 
-"@types/long@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz"
-  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+"@types/long@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
 
 "@types/lru-cache@^5.1.0":
   version "5.1.1"
@@ -5811,6 +5810,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
@@ -10510,7 +10518,7 @@ lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-long@4.0.0, long@^4.0.0:
+long@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
@@ -12477,7 +12485,7 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-protobufjs@^7.0.0, protobufjs@^7.2.4:
+protobufjs@^7.2.4:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
@@ -15982,6 +15990,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^16.0.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
@@ -16007,6 +16020,19 @@ yargs@^17.0.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Fixes connection closes on connections that were about to connect (see [comment](https://linear.app/gitpod/issue/EXP-379#comment-ecb909fb)).
- Simplifies the writing up of the spicedb client povider
- reuse the GRPC connection options we use elsewhere for spicedb
- connects the metrics interceptor with the GRPC client connection

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bc6b86</samp>

This pull request refactors and improves the SpiceDB integration in the server component. It simplifies the code for creating and using the SpiceDB client, handles connection issues better, and adds metrics collection for the client calls. It affects the files `spicedb-authorizer.ts`, `spicedb.ts`, and `container-module.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-379
Fixes EXP-292

## How to test
<!-- Provide steps to test this PR -->
 - use the preview env and check the logs of `server` there should be (almost) no logs of `[spicedb] Lost connection to SpiceDB - reconnecting...`
 - run `kubectl rollout restart deployment/spicedb` and keep using the dashboard of the preview env. You should (barely) see an effect, but in the logs you'll see a few entries of the message above ☝️ .

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-spicedb-cons</li>
	<li><b>🔗 URL</b> - <a href="https://se-spicedb-cons.preview.gitpod-dev.com/workspaces" target="_blank">se-spicedb-cons.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-spicedb-cons-gha.16071</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-spicedb-cons%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
