### PR TITLE
Upgrade jsonwebtoken lib

### DIFF
--- a/components/gitpod-protocol/src/gitpod-file-parser.ts
+++ b/components/gitpod-protocol/src/gitpod-file-parser.ts
@@ -6,7 +6,7 @@
 
 import { injectable } from "inversify";
 import * as yaml from "js-yaml";
-import * as Ajv from "ajv";
+import Ajv from "ajv";
 import { log } from "./util/logging";
 import { WorkspaceConfig, PortRangeConfig } from "./protocol";
 

--- a/components/gitpod-protocol/src/messaging/node/connection.ts
+++ b/components/gitpod-protocol/src/messaging/node/connection.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import * as ws from "ws";
+import ws from "ws";
 import {
     IWebSocket,
     Logger,

--- a/components/gitpod-protocol/src/util/debug-app.ts
+++ b/components/gitpod-protocol/src/util/debug-app.ts
@@ -5,7 +5,7 @@
  */
 
 import * as http from "http";
-import * as express from "express";
+import express from "express";
 import { injectable, postConstruct } from "inversify";
 import { log, LogrusLogLevel } from "./logging";
 

--- a/components/gitpod-protocol/tsconfig.json
+++ b/components/gitpod-protocol/tsconfig.json
@@ -23,7 +23,8 @@
         "skipLibCheck": true,
         "rootDir": "src",
         "outDir": "lib",
-        "useUnknownInCatchVariables": false
+        "useUnknownInCatchVariables": false,
+        "esModuleInterop": true
     },
     "include": [
         "src"

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -88,7 +88,7 @@
     "redlock": "^5.0.0-beta.2",
     "reflect-metadata": "^0.1.10",
     "stripe": "^9.0.0",
-    "twilio": "^3.78.0",
+    "twilio": "^4.16.0",
     "uuid": "^8.3.2",
     "vscode-ws-jsonrpc": "^0.2.0",
     "ws": "^7.4.6"

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -5,7 +5,7 @@
  */
 
 import * as http from "http";
-import * as express from "express";
+import express from "express";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { inject, injectable } from "inversify";
 import { APITeamsService } from "./teams";

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { AuthProviderInfo, User, OAuth2Config, AuthProviderEntry } from "@gitpod/gitpod-protocol";
 
 import { UserEnvVarValue } from "@gitpod/gitpod-protocol";

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -7,9 +7,9 @@
 import { TeamDB } from "@gitpod/gitpod-db/lib";
 import { User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import * as express from "express";
+import express from "express";
 import { inject, injectable, postConstruct } from "inversify";
-import * as passport from "passport";
+import passport from "passport";
 import { Config } from "../config";
 import { reportLoginCompleted } from "../prometheus-metrics";
 import { TokenProvider } from "../user/token-provider";

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -8,7 +8,7 @@ import { UserDB, PersonalAccessTokenDB } from "@gitpod/gitpod-db/lib";
 import { GitpodTokenType, User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as crypto from "crypto";
-import * as express from "express";
+import express from "express";
 import { IncomingHttpHeaders } from "http";
 import { inject, injectable } from "inversify";
 import { Config } from "../config";

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -5,9 +5,9 @@
  */
 
 import { injectable, inject, postConstruct } from "inversify";
-import * as express from "express";
-import * as passport from "passport";
-import * as OAuth2Strategy from "passport-oauth2";
+import express from "express";
+import passport from "passport";
+import OAuth2Strategy from "passport-oauth2";
 import { UserDB } from "@gitpod/gitpod-db/lib";
 import { AuthProviderInfo, Identity, Token, User } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/server/src/auth/jwt.ts
+++ b/components/server/src/auth/jwt.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as jsonwebtoken from "jsonwebtoken";
+import jsonwebtoken from "jsonwebtoken";
 import { Config } from "../config";
 import { inject, injectable, postConstruct } from "inversify";
 import { AuthFlow } from "./auth-provider";
@@ -130,7 +130,7 @@ export async function verify(
             if (err || !decoded) {
                 return reject(err);
             }
-            resolve(decoded);
+            resolve(decoded as jsonwebtoken.JwtPayload);
         });
     });
 }

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -5,7 +5,7 @@
  */
 
 import { inject, injectable } from "inversify";
-import * as express from "express";
+import express from "express";
 import { User } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -6,7 +6,7 @@
 
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import * as express from "express";
+import express from "express";
 import { inject, injectable } from "inversify";
 import { AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -7,7 +7,7 @@
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Bitbucket } from "bitbucket";
-import * as express from "express";
+import express from "express";
 import { injectable } from "inversify";
 import { AuthUserSetup } from "../auth/auth-provider";
 import { GenericAuthProvider } from "../auth/generic-auth-provider";

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -8,7 +8,7 @@ import { status } from "@grpc/grpc-js";
 import fetch from "node-fetch";
 import { User } from "@gitpod/gitpod-protocol/lib/protocol";
 import * as util from "util";
-import * as express from "express";
+import express from "express";
 import { inject, injectable } from "inversify";
 import { BearerAuth } from "../auth/bearer-authenticator";
 import { isWithFunctionAccessGuard } from "../auth/function-access";

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -5,7 +5,7 @@
  */
 
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
-import * as express from "express";
+import express from "express";
 import { injectable } from "inversify";
 import { Strategy as DummyStrategy } from "passport-dummy";
 import { AuthProvider } from "../auth/auth-provider";

--- a/components/server/src/dev/passport-dummy.d.ts
+++ b/components/server/src/dev/passport-dummy.d.ts
@@ -5,7 +5,7 @@
  */
 
 declare module "passport-dummy" {
-    import * as passport from "passport";
+    import passport from "passport";
 
     export class Strategy extends passport.Strategy {
         constructor(verify: (done: (error: any, user: any) => void) => void);

--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -5,7 +5,7 @@
  */
 
 import { URL } from "url";
-import * as express from "express";
+import express from "express";
 import * as crypto from "crypto";
 
 export const query = (...tuples: [string, string][]) => {

--- a/components/server/src/express/ws-connection-handler.ts
+++ b/components/server/src/express/ws-connection-handler.ts
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
-import * as websocket from "ws";
+import express from "express";
+import websocket from "ws";
 import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as websocket from "ws";
-import * as express from "express";
+import WebSocket from "ws";
+import express from "express";
 import * as http from "http";
 import * as https from "https";
 import * as url from "url";
@@ -24,27 +24,27 @@ export interface WsNextFunction {
     (err?: any): MaybePromise;
 }
 export interface WsRequestHandler {
-    (ws: websocket, req: express.Request, next: WsNextFunction): MaybePromise;
+    (ws: WebSocket, req: express.Request, next: WsNextFunction): MaybePromise;
 }
 export interface WsErrorHandler {
-    (err: any | undefined, ws: websocket, req: express.Request, next: WsNextFunction): MaybePromise;
+    (err: any | undefined, ws: WebSocket, req: express.Request, next: WsNextFunction): MaybePromise;
 }
 export type WsHandler = WsRequestHandler | WsErrorHandler;
 
-export type WsConnectionFilter = websocket.VerifyClientCallbackAsync | websocket.VerifyClientCallbackSync;
+export type WsConnectionFilter = WebSocket.VerifyClientCallbackAsync | WebSocket.VerifyClientCallbackSync;
 
 interface Route {
     matcher: RouteMatcher;
-    handler: (ws: websocket, req: express.Request) => void;
+    handler: (ws: WebSocket, req: express.Request) => void;
 }
 
 export class WsExpressHandler implements Disposable {
-    protected readonly wss: websocket.Server;
+    protected readonly wss: WebSocket.Server;
     protected readonly routes: Route[] = [];
     private disposables = new DisposableCollection();
 
     constructor(protected readonly httpServer: HttpServer, protected readonly verifyClient?: WsConnectionFilter) {
-        this.wss = new websocket.Server({
+        this.wss = new WebSocket.Server({
             verifyClient,
             noServer: true,
             // disabling to reduce memory consumption, cf.
@@ -78,11 +78,11 @@ export class WsExpressHandler implements Disposable {
 
     ws(
         matcher: RouteMatcher,
-        handler: (ws: websocket, request: express.Request) => void,
+        handler: (ws: WebSocket, request: express.Request) => void,
         ...handlers: WsHandler[]
     ): void {
         const stack = WsLayer.createStack(...handlers);
-        const dispatch = (ws: websocket, request: express.Request) => {
+        const dispatch = (ws: WebSocket, request: express.Request) => {
             handler(ws, request);
             stack
                 .dispatch(ws, request)

--- a/components/server/src/express/ws-layer.spec.ts
+++ b/components/server/src/express/ws-layer.spec.ts
@@ -6,8 +6,8 @@
 
 require("reflect-metadata");
 
-import * as ws from "ws";
-import * as express from "express";
+import ws from "ws";
+import express from "express";
 
 import { suite, test } from "@testdeck/mocha";
 import * as chai from "chai";

--- a/components/server/src/express/ws-layer.ts
+++ b/components/server/src/express/ws-layer.ts
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as websocket from "ws";
-import * as express from "express";
+import websocket from "ws";
+import express from "express";
 import { WsHandler, WsRequestHandler, WsErrorHandler, WsNextFunction, MaybePromise } from "./ws-handler";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable } from "inversify";
-import * as express from "express";
+import express from "express";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitHubScope } from "./scopes";

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { injectable } from "inversify";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -12,9 +12,9 @@ import { Config } from "../config";
 import { Authenticator } from "../auth/authenticator";
 import { UserAuthentication } from "../user/user-authentication";
 
-import * as passport from "passport";
-import * as express from "express";
-import * as request from "supertest";
+import passport from "passport";
+import express from "express";
+import request from "supertest";
 
 import * as chai from "chai";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import * as express from "express";
+import express from "express";
 import { SessionHandler } from "../session-handler";
 import { Authenticator } from "../auth/authenticator";
 import { UserAuthentication } from "../user/user-authentication";

--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -51,7 +51,7 @@ if (typeof (Symbol as any).asyncIterator === "undefined") {
     (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol("asyncIterator");
 }
 
-import * as express from "express";
+import express from "express";
 import { Container } from "inversify";
 import { Server } from "./server";
 import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/server/src/liveness/liveness-controller.ts
+++ b/components/server/src/liveness/liveness-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import * as express from "express";
+import express from "express";
 import * as prom from "prom-client";
 import { Config } from "../config";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/server/src/monitoring-endpoints.ts
+++ b/components/server/src/monitoring-endpoints.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { injectable } from "inversify";
 import * as prometheusClient from "prom-client";
 import { redisMetricsRegistry, registerDBMetrics } from "@gitpod/gitpod-db/lib";

--- a/components/server/src/oauth-server/oauth-controller.ts
+++ b/components/server/src/oauth-server/oauth-controller.ts
@@ -10,7 +10,7 @@ import { User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { OAuthRequest, OAuthResponse } from "@jmondi/oauth2-server";
 import { handleExpressResponse, handleExpressError } from "@jmondi/oauth2-server/dist/adapters/express";
-import * as express from "express";
+import express from "express";
 import { inject, injectable } from "inversify";
 import { URL } from "url";
 import { Config } from "../config";

--- a/components/server/src/one-time-secret-server.ts
+++ b/components/server/src/one-time-secret-server.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import * as express from "express";
+import express from "express";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { OneTimeSecretDB, DBWithTracing, TracedOneTimeSecretDB } from "@gitpod/gitpod-db/lib";
 import { Disposable } from "@gitpod/gitpod-protocol";

--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { postConstruct, injectable, inject } from "inversify";
 import { ProjectDB, TeamDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { User, StartPrebuildResult, CommitContext, CommitInfo, Project, WebhookEvent } from "@gitpod/gitpod-protocol";

--- a/components/server/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/src/prebuilds/bitbucket-server-app.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { postConstruct, injectable, inject } from "inversify";
 import { ProjectDB, TeamDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { PrebuildManager } from "./prebuild-manager";

--- a/components/server/src/prebuilds/github-app-rules.ts
+++ b/components/server/src/prebuilds/github-app-rules.ts
@@ -6,7 +6,7 @@
 
 import { injectable } from "inversify";
 import { WorkspaceConfig, GithubAppConfig } from "@gitpod/gitpod-protocol";
-import * as deepmerge from "deepmerge";
+import deepmerge from "deepmerge";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 const defaultConfig: GithubAppConfig = {

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -19,7 +19,7 @@ import {
     TeamDB,
     WebhookEventDB,
 } from "@gitpod/gitpod-db/lib";
-import * as express from "express";
+import express from "express";
 import { log, LogContext, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
 import {
     WorkspaceConfig,

--- a/components/server/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/src/prebuilds/github-enterprise-app.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { createHmac, timingSafeEqual } from "crypto";
 import { Buffer } from "buffer";
 import { postConstruct, injectable, inject } from "inversify";

--- a/components/server/src/prebuilds/gitlab-app.ts
+++ b/components/server/src/prebuilds/gitlab-app.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { postConstruct, injectable, inject } from "inversify";
 import { ProjectDB, TeamDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
 import { Project, User, StartPrebuildResult, CommitContext, CommitInfo, WebhookEvent } from "@gitpod/gitpod-protocol";

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -5,10 +5,10 @@
  */
 
 import * as http from "http";
-import * as express from "express";
-import * as ws from "ws";
+import express from "express";
+import WebSocket from "ws";
 import * as bodyParser from "body-parser";
-import * as cookieParser from "cookie-parser";
+import cookieParser from "cookie-parser";
 import { injectable, inject } from "inversify";
 import * as prom from "prom-client";
 import { SessionHandler } from "./session-handler";
@@ -161,7 +161,7 @@ export class Server {
             /**
              * Verify the web socket handshake request.
              */
-            const verifyClient: ws.VerifyClientCallbackAsync = async (info, callback) => {
+            const verifyClient: WebSocket.VerifyClientCallbackAsync = async (info, callback) => {
                 let authenticatedUsingBearerToken = false;
                 if (info.req.url === "/v1") {
                     // Connection attempt with Bearer-Token: be less strict for now
@@ -216,7 +216,7 @@ export class Server {
                 this.sessionHandler.websocket(),
                 ...initSessionHandlers,
                 wsPingPongHandler.handler(),
-                (ws: ws, req: express.Request) => {
+                (ws: WebSocket, req: express.Request) => {
                     websocketConnectionHandler.onConnection((req as any).wsConnection, req);
                 },
             );
@@ -227,7 +227,7 @@ export class Server {
                     (request as any).wsConnection = createWebSocketConnection(websocket, console);
                 },
                 wsPingPongHandler.handler(),
-                (ws: ws, req: express.Request) => {
+                (ws: WebSocket, req: express.Request) => {
                     websocketConnectionHandler.onConnection((req as any).wsConnection, req);
                 },
             );

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -4,9 +4,9 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { inject, injectable } from "inversify";
-import * as websocket from "ws";
+import websocket from "ws";
 
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { AuthJWT } from "./auth/jwt";

--- a/components/server/src/test/authentication-github.spec.ts
+++ b/components/server/src/test/authentication-github.spec.ts
@@ -9,7 +9,7 @@ import { suite, test } from "@testdeck/mocha";
 import * as chai from "chai";
 import chaiHttp = require("chai-http");
 import * as http from "http";
-import * as express from "express";
+import express from "express";
 import { Server } from "../server";
 import { Container } from "inversify";
 import { productionContainerModule } from "../container-module";

--- a/components/server/src/user/newsletter-subscription-controller.ts
+++ b/components/server/src/user/newsletter-subscription-controller.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import * as express from "express";
+import express from "express";
 import { inject, injectable } from "inversify";
 import { UserDB } from "@gitpod/gitpod-db/lib";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -8,7 +8,7 @@ import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
 import { OneTimeSecretDB, TeamDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "@gitpod/gitpod-db/lib/user-db";
-import * as express from "express";
+import express from "express";
 import { Authenticator } from "../auth/authenticator";
 import { Config } from "../config";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";

--- a/components/server/src/util/grpc-web-ws-transport.ts
+++ b/components/server/src/util/grpc-web-ws-transport.ts
@@ -29,7 +29,7 @@ import {
     TransportFactory,
     TransportOptions,
 } from "@improbable-eng/grpc-web/dist/typings/transports/Transport";
-import * as WebSocket from "ws";
+import WebSocket from "ws";
 
 enum WebsocketSignal {
     FINISH_SEND = 1,

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -21,7 +21,7 @@ import {
 } from "@gitpod/gitpod-protocol/lib/messaging/proxy-factory";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { EventEmitter } from "events";
-import * as express from "express";
+import express from "express";
 import { ErrorCodes as RPCErrorCodes, MessageConnection, ResponseError } from "vscode-jsonrpc";
 import { AllAccessFunctionGuard, FunctionAccessGuard, WithFunctionAccessGuard } from "../auth/function-access";
 import { HostContextProvider } from "../auth/host-context-provider";

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { inject, injectable } from "inversify";
-import * as express from "express";
+import express from "express";
 import {
     HEADLESS_LOG_STREAM_STATUS_CODE,
     Queue,

--- a/components/server/src/workspace/workspace-download-service.ts
+++ b/components/server/src/workspace/workspace-download-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import * as express from "express";
+import express from "express";
 import { TracedWorkspaceDB, DBWithTracing, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Permission, User } from "@gitpod/gitpod-protocol";

--- a/components/server/tsconfig.json
+++ b/components/server/tsconfig.json
@@ -20,6 +20,7 @@
         "declarationMap": true,
         "skipLibCheck": true,
         "useUnknownInCatchVariables": false,
+        "esModuleInterop": true,
         "typeRoots": [
             "./src/typings"
         ]

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     },
     "resolutions": {
         "minimatch": "3.0.5",
-        "minimist": "1.2.8",
-        "jsonwebtoken": "^9.0.0"
+        "minimist": "1.2.8"
     },
     "scripts": {
         "build": "leeway exec --filter-type yarn --components -- yarn build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,7 +309,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.20.7", "@babel/parser@^7.22.10", "@babel/parser@^7.22.5", "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.20.7", "@babel/parser@^7.22.10", "@babel/parser@^7.22.5":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.10.tgz#e37634f9a12a1716136c44624ef54283cabd3f55"
   integrity sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==
@@ -3117,10 +3117,10 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jsonwebtoken@^8.3.3":
-  version "8.5.5"
-  resolved "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.5.tgz"
-  integrity sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==
+"@types/jsonwebtoken@^9.0.0":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#9eeb56c76dd555039be2a3972218de5bd3b8d83e"
+  integrity sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==
   dependencies:
     "@types/node" "*"
 
@@ -5734,10 +5734,10 @@ dayjs@^1.11.5:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
   integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
 
-dayjs@^1.8.29:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"
-  integrity sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==
+dayjs@^1.11.9:
+  version "1.11.9"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
+  integrity sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==
 
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
@@ -9316,7 +9316,7 @@ jsonpointer@^5.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
-jsonwebtoken@^8.5.1, jsonwebtoken@^9.0.0:
+jsonwebtoken@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
   integrity sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==
@@ -10748,11 +10748,6 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-pop-iterate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pop-iterate/-/pop-iterate-1.0.1.tgz#ceacfdab4abf353d7a0f2aaa2c1fc7b3f9413ba3"
-  integrity sha512-HRCx4+KJE30JhX84wBN4+vja9bNfysxg1y28l0DuJmkoaICiv2ZSilKddbS48pq50P8d2erAhqDLbp47yv3MbQ==
-
 postcss-attribute-case-insensitive@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.2.tgz#03d761b24afc04c09e757e92ff53716ae8ea2741"
@@ -11557,15 +11552,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@2.0.x:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/q/-/q-2.0.3.tgz#75b8db0255a1a5af82f58c3f3aaa1efec7d0d134"
-  integrity sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==
-  dependencies:
-    asap "^2.0.0"
-    pop-iterate "^1.0.1"
-    weak-map "^1.0.5"
-
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
@@ -12359,11 +12345,6 @@ rollup@^2.43.1:
   integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
-
-rootpath@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/rootpath/-/rootpath-0.1.2.tgz#5b379a87dca906e9b91d690a599439bef267ea6b"
-  integrity sha512-R3wLbuAYejpxQjL/SjXo1Cjv4wcJECnMRT/FlcCfTwCBhaji9rWaRCoVEQ1SPiTJ4kKK+yh+bZLAV7SCafoDDw==
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -13672,19 +13653,16 @@ tween-functions@^1.2.0:
   resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
   integrity sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==
 
-twilio@^3.78.0:
-  version "3.78.0"
-  resolved "https://registry.yarnpkg.com/twilio/-/twilio-3.78.0.tgz#d03913d13dd9b74fc39fada686e001b9bdef6235"
-  integrity sha512-XowaxcOeLVNnvxx3t81seLZ/hE/N4z6yt9Vg+KtGhj81gf2ghUa57cr5QtqsI06qnknsGcId5I9X4mRoxZ4nMg==
+twilio@^4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/twilio/-/twilio-4.16.0.tgz#5fdbc674add02df9a35d52af078d4c748f0b6137"
+  integrity sha512-hY3ol03QrDKowKS4Px6BrCYyrQfv7IyCz4AjiwIZIes/iwievPGyewKHaAzKKLZp1hRWmhGu26aWyhPyfTXudA==
   dependencies:
     axios "^0.26.1"
-    dayjs "^1.8.29"
+    dayjs "^1.11.9"
     https-proxy-agent "^5.0.0"
-    jsonwebtoken "^8.5.1"
-    lodash "^4.17.21"
-    q "2.0.x"
+    jsonwebtoken "^9.0.0"
     qs "^6.9.4"
-    rootpath "^0.1.2"
     scmp "^2.1.0"
     url-parse "^1.5.9"
     xmlbuilder "^13.0.2"
@@ -13917,12 +13895,12 @@ unique-string@^2.0.0:
     crypto-random-string "^2.0.0"
 
 universal-github-app-jwt@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz"
-  integrity sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.1.1.tgz#d57cee49020662a95ca750a057e758a1a7190e6e"
+  integrity sha512-G33RTLrIBMFmlDV4u4CBF7dh71eWwykck4XgaxaIVeZKOYZRAAxvcGMRFTUclVY6xoUPQvO4Ne5wKGxYm/Yy9w==
   dependencies:
-    "@types/jsonwebtoken" "^8.3.3"
-    jsonwebtoken "^8.5.1"
+    "@types/jsonwebtoken" "^9.0.0"
+    jsonwebtoken "^9.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"
@@ -14153,11 +14131,6 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
-
-weak-map@^1.0.5:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.8.tgz#394c18a9e8262e790544ed8b55c6a4ddad1cb1a3"
-  integrity sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==
 
 web-vitals@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Twilio package depends on jsonwebtoken so we need to update it too

#### Why so many files are changed, why we need `esModuleInterop`?
Currently importing commonjs modules work using the `import * as` syntax because the typings of those modules have a  [namespace hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11479#discussion_r80380378)
The updated Twilio module don't have this hack in the index.d.ts entry so the ts compiler complains about it.
To properly fix it we need to enable `esModuleInterop` flag in the compiler and fix the imports, see 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c3a6c8</samp>

This pull request updates the imports and types of several modules to use the default exports instead of the namespace imports, as recommended by the respective documentation. This improves the compatibility and quality of the code that uses these modules, and avoids potential issues with the interop between CommonJS and ES modules. The pull request also adds the esModuleInterop flag to the tsconfig.json file, and updates the twilio dependency to the latest version.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-primary-zebra</li>
	<li><b>🔗 URL</b> - <a href="https://jp-primary-zebra.preview.gitpod-dev.com/workspaces" target="_blank">jp-primary-zebra.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-primary-zebra-gha.16349</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-primary-zebra%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
