### PR TITLE
[server] Separate instance creation from instance starting (again)

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -101,7 +101,7 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
         type: "simple-json",
         nullable: true,
     })
-    configuration?: WorkspaceInstanceConfiguration;
+    configuration: WorkspaceInstanceConfiguration;
 
     @Column("simple-json", { nullable: true })
     imageBuildInfo?: ImageBuildInfo;

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -31,15 +31,15 @@ export interface WorkspaceInstance {
     stoppedTime?: string;
 
     // ideUrl is the URL at which the workspace is available on the internet
-    // Note: this is nitially empty, filled during starting process!
+    // Note: this is initially empty, filled during starting process!
     ideUrl: string;
 
     // region is the name of the workspace cluster this instance runs in
-    // Note: this is nitially empty, filled during starting process!
+    // Note: this is initially empty, filled during starting process!
     region: string;
 
     // workspaceImage is the name of the Docker image this instance runs
-    // Note: this is nitially empty, filled during starting process!
+    // Note: this is initially empty, filled during starting process!
     workspaceImage: string;
 
     // status is the latest status of the instance that we're aware of
@@ -312,6 +312,9 @@ export interface WorkspaceInstanceConfiguration {
 
     // The region the user passed as a preference for this workspace
     regionPreference?: WorkspaceRegion;
+
+    // Whether this instance is started from a backup
+    fromBackup?: boolean;
 }
 
 /**

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -4,7 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { NamedWorkspaceFeatureFlag } from "./protocol";
+import { EnvVar, NamedWorkspaceFeatureFlag, TaskConfig } from "./protocol";
+import { WorkspaceRegion } from "./workspace-cluster";
 
 // WorkspaceInstance describes a part of a workspace's lifetime, specifically a single running session of it
 export interface WorkspaceInstance {
@@ -48,9 +49,7 @@ export interface WorkspaceInstance {
     gitStatus?: WorkspaceInstanceRepoStatus;
 
     // configuration captures the per-instance configuration variance of a workspace
-    // Beware: this field was added retroactively and not all instances have valid
-    //         values here.
-    configuration?: WorkspaceInstanceConfiguration;
+    configuration: WorkspaceInstanceConfiguration;
 
     // instance is hard-deleted on the database and about to be collected by periodic deleter
     readonly deleted?: boolean;
@@ -280,6 +279,11 @@ export interface ConfigurationIdeConfig {
     ide?: string;
 }
 
+export interface IdeSetup {
+    tasks?: TaskConfig[];
+    envvars?: EnvVar[];
+}
+
 // WorkspaceInstanceConfiguration contains all per-instance configuration
 export interface WorkspaceInstanceConfiguration {
     // theiaVersion is the version of Theia this workspace instance uses
@@ -296,18 +300,18 @@ export interface WorkspaceInstanceConfiguration {
     // including ide-desktop, desktop-plugin and so on
     ideImageLayers?: string[];
 
-    // desktopIdeImage is the ref of the desktop IDE image this instance uses.
-    // @deprected: replaced with the ideImageLayers field
-    desktopIdeImage?: string;
-
-    // desktopIdePluginImage is the ref of the desktop IDE plugin image this instance uses.
-    // @deprected: replaced with the desktopIdePluginImage field
-    desktopIdePluginImage?: string;
-
     // supervisorImage is the ref of the supervisor image this instance uses.
     supervisorImage?: string;
 
+    // ideSetup contains all piece that are necessary to get the IDE running
+    // TODO(gpl) ideally also contains the fields above: ideImage, ideImageLayers and supervisorImage
+    ideSetup?: IdeSetup;
+
+    // ideConfig contains user-controlled IDE configuration
     ideConfig?: ConfigurationIdeConfig;
+
+    // The region the user passed as a preference for this workspace
+    regionPreference?: WorkspaceRegion;
 }
 
 /**

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -706,6 +706,9 @@ class TestResourceAccess {
                 workspaceId,
                 creationTime: new Date(2000, 1, 2).toISOString(),
                 region: "local",
+                configuration: {
+                    ideImage: "gitpod/workspace-full:latest",
+                },
                 status: {
                     version: 1,
                     conditions: {},

--- a/components/server/src/ide-service.ts
+++ b/components/server/src/ide-service.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { IDESettings, TaskConfig, User, Workspace } from "@gitpod/gitpod-protocol";
+import { IDESettings, User, Workspace } from "@gitpod/gitpod-protocol";
 import { IDEClient, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import * as IdeServiceApi from "@gitpod/ide-service-api/lib/ide.pb";
 import {
@@ -101,21 +101,5 @@ export class IDEService {
             }
         }
         throw new Error("failed to resolve workspace IDE configuration");
-    }
-
-    resolveGitpodTasks(ws: Workspace, ideConfig: ResolveWorkspaceConfigResponse): TaskConfig[] {
-        const tasks: TaskConfig[] = [];
-        if (ws.config.tasks) {
-            tasks.push(...ws.config.tasks);
-        }
-        if (ideConfig.tasks) {
-            try {
-                const ideTasks: TaskConfig[] = JSON.parse(ideConfig.tasks);
-                tasks.push(...ideTasks);
-            } catch (e) {
-                console.error("failed get tasks from ide config:", e);
-            }
-        }
-        return tasks;
     }
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -45,6 +45,7 @@ import {
     RefType,
     SnapshotContext,
     StartWorkspaceResult,
+    TaskConfig,
     User,
     WithPrebuild,
     WithReferrerContext,
@@ -63,7 +64,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { LogContext, log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
-import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { TraceContext, TraceContextWithSpan } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import * as IdeServiceApi from "@gitpod/ide-service-api/lib/ide.pb";
 import {
@@ -129,7 +130,6 @@ import { SYSTEM_USER } from "../authorization/authorizer";
 import { ResolvedEnvVars } from "../user/env-var-service";
 
 export interface StartWorkspaceOptions extends GitpodServer.StartWorkspaceOptions {
-    rethrow?: boolean;
     excludeFeatureFlags?: NamedWorkspaceFeatureFlag[];
 }
 
@@ -308,6 +308,7 @@ export class WorkspaceStarter {
                 project,
                 options.excludeFeatureFlags || [],
                 ideConfig,
+                options.region,
                 options.workspaceClass,
             );
             // we run the actual creation of a new instance in a distributed lock, to make sure we always only start one instance per workspace.
@@ -321,67 +322,73 @@ export class WorkspaceStarter {
             span.log({ newInstance: instance.id });
             instanceId = instance.id;
 
-            const forceRebuild = !!workspace.context.forceImageBuild;
-
-            let needsImageBuild: boolean;
-            try {
-                // if we need to build the workspace image we must not wait for actuallyStartWorkspace to return as that would block the
-                // frontend until the image is built.
-                const additionalAuth = await this.getAdditionalImageAuth(envVars);
-                needsImageBuild =
-                    forceRebuild ||
-                    (await this.needsImageBuild({ span }, user, workspace, instance, additionalAuth, options?.region));
-                if (needsImageBuild) {
-                    instance.status.conditions = {
-                        neededImageBuild: true,
-                    };
-                }
-                span.setTag("needsImageBuild", needsImageBuild);
-            } catch (err) {
-                // if we fail to check if the workspace needs an image build (e.g. becuase the image builder is unavailable),
-                // we must properly fail the workspace instance, i.e. set its status to stopped, deal with prebuilds etc.
-                //
-                // Once we've reached actuallyStartWorkspace that function will take care of failing the instance.
-                await this.failInstanceStart({ span }, err, workspace, instance);
-                throw err;
-            }
-
-            // If the caller requested that errors be rethrown we must await the actual workspace start to be in the exception path.
-            // To this end we disable the needsImageBuild behaviour if rethrow is true.
-            if (needsImageBuild && !options.rethrow) {
-                this.actuallyStartWorkspace(
-                    { span },
-                    instance,
-                    workspace,
-                    user,
-                    lastValidWorkspaceInstance?.id ?? "",
-                    ideConfig,
-                    envVars,
-                    options.rethrow,
-                    forceRebuild,
-                    options?.region,
-                ).catch((err) => log.error("actuallyStartWorkspace", err));
-                return { instanceID: instance.id };
-            }
-
-            return await this.actuallyStartWorkspace(
+            const fromBackup = !!lastValidWorkspaceInstance?.id;
+            const result = await this.buildImageAndStartWorkspace(
                 { span },
-                instance,
-                workspace,
                 user,
-                lastValidWorkspaceInstance?.id ?? "",
-                ideConfig,
+                workspace,
+                instance,
                 envVars,
-                options.rethrow,
-                forceRebuild,
-                options?.region,
+                fromBackup,
             );
+            return result;
         } catch (e) {
             this.logAndTraceStartWorkspaceError({ span }, { userId: user.id, instanceId }, e);
             throw e;
         } finally {
             span.finish();
         }
+    }
+
+    private async buildImageAndStartWorkspace(
+        ctx: TraceContextWithSpan,
+        user: User,
+        workspace: Workspace,
+        instance: WorkspaceInstance,
+        envVars: ResolvedEnvVars,
+        fromBackup: boolean,
+    ): Promise<StartWorkspaceResult> {
+        const { span } = ctx;
+
+        const forceRebuild = !!workspace.context.forceImageBuild;
+        let needsImageBuild: boolean;
+        try {
+            // if we need to build the workspace image we must not wait for actuallyStartWorkspace to return as that would block the
+            // frontend until the image is built.
+            const additionalAuth = await this.getAdditionalImageAuth(envVars);
+            needsImageBuild =
+                forceRebuild || (await this.needsImageBuild(ctx, user, workspace, instance, additionalAuth));
+            if (needsImageBuild) {
+                instance.status.conditions = {
+                    neededImageBuild: true,
+                };
+            }
+            span.setTag("needsImageBuild", needsImageBuild);
+        } catch (err) {
+            // if we fail to check if the workspace needs an image build (e.g. becuase the image builder is unavailable),
+            // we must properly fail the workspace instance, i.e. set its status to stopped, deal with prebuilds etc.
+            //
+            // Once we've reached actuallyStartWorkspace that function will take care of failing the instance.
+            await this.failInstanceStart(ctx, err, workspace, instance);
+            throw err;
+        }
+
+        if (needsImageBuild) {
+            this.actuallyStartWorkspace({ span }, instance, workspace, user, fromBackup, envVars, forceRebuild).catch(
+                (err) => log.error("actuallyStartWorkspace", err),
+            );
+            return { instanceID: instance.id };
+        }
+
+        return await this.actuallyStartWorkspace(
+            { span },
+            instance,
+            workspace,
+            user,
+            fromBackup,
+            envVars,
+            forceRebuild,
+        );
     }
 
     private async resolveIDEConfiguration(
@@ -488,19 +495,16 @@ export class WorkspaceStarter {
         instance: WorkspaceInstance,
         workspace: Workspace,
         user: User,
-        lastValidWorkspaceInstanceId: string,
-        ideConfig: IdeServiceApi.ResolveWorkspaceConfigResponse,
+        fromBackup: boolean,
         envVars: ResolvedEnvVars,
-        rethrow?: boolean,
         forceRebuild?: boolean,
-        region?: WorkspaceRegion,
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
+        const region = instance.configuration.regionPreference;
         span.setTag("region_preference", region);
         log.info("Attempting to start workspace", {
             instanceID: instance.id,
             userID: user.id,
-            rethrow: rethrow,
             forceRebuild: forceRebuild,
         });
 
@@ -513,7 +517,6 @@ export class WorkspaceStarter {
                 workspace,
                 instance,
                 additionalAuth,
-                ideConfig,
                 forceRebuild,
                 forceRebuild,
                 region,
@@ -525,15 +528,7 @@ export class WorkspaceStarter {
             }
 
             // create spec
-            const spec = await this.createSpec(
-                { span },
-                user,
-                workspace,
-                instance,
-                lastValidWorkspaceInstanceId,
-                ideConfig,
-                envVars,
-            );
+            const spec = await this.createSpec({ span }, user, workspace, instance, fromBackup, envVars);
 
             // create start workspace request
             const metadata = await this.createMetadata(workspace);
@@ -646,11 +641,7 @@ export class WorkspaceStarter {
                 intervalHandle.dispose();
             }
         } catch (err) {
-            if (rethrow) {
-                throw err;
-            } else {
-                this.logAndTraceStartWorkspaceError({ span }, { userId: user.id, instanceId: instance.id }, err);
-            }
+            this.logAndTraceStartWorkspaceError({ span }, { userId: user.id, instanceId: instance.id }, err);
 
             return { instanceID: instance.id };
         } finally {
@@ -851,10 +842,18 @@ export class WorkspaceStarter {
         project: Project | undefined,
         excludeFeatureFlags: NamedWorkspaceFeatureFlag[],
         ideConfig: IdeServiceApi.ResolveWorkspaceConfigResponse,
+        regionPreference: WorkspaceRegion | undefined,
         workspaceClassOverride?: string,
     ): Promise<WorkspaceInstance> {
         const span = TraceContext.startSpan("newInstance", ctx);
         try {
+            let ideTasks: TaskConfig[] = [];
+            try {
+                ideTasks = JSON.parse(ideConfig.tasks);
+            } catch (e) {
+                console.error("failed get tasks from ide config:", e);
+            }
+
             const configuration: WorkspaceInstanceConfiguration = {
                 ideImage: ideConfig.webImage,
                 ideImageLayers: ideConfig.ideImageLayers,
@@ -864,6 +863,11 @@ export class WorkspaceStarter {
                     // it still need to notice user that this workspace is using latest IDE
                     useLatest: user.additionalData?.ideSettings?.useLatestVersion,
                 },
+                ideSetup: {
+                    envvars: ideConfig.envvars,
+                    tasks: ideTasks,
+                },
+                regionPreference,
             };
             if (ideConfig.ideSettings && ideConfig.ideSettings.trim() !== "") {
                 try {
@@ -1059,7 +1063,7 @@ export class WorkspaceStarter {
                         workspace,
                         workspace.context,
                         user,
-                        "",
+                        false,
                     );
                     source = initializer;
                     disp.push(disposable);
@@ -1103,11 +1107,15 @@ export class WorkspaceStarter {
         workspace: Workspace,
         instance: WorkspaceInstance,
         additionalAuth: Map<string, string>,
-        region?: WorkspaceRegion,
     ): Promise<boolean> {
         const span = TraceContext.startSpan("needsImageBuild", ctx);
         try {
-            const client = await this.getImageBuilderClient(user, workspace, instance, region);
+            const client = await this.getImageBuilderClient(
+                user,
+                workspace,
+                instance,
+                instance.configuration.regionPreference,
+            );
             const { src, auth, disposable } = await this.prepareBuildRequest(
                 { span },
                 workspace,
@@ -1155,7 +1163,6 @@ export class WorkspaceStarter {
         workspace: Workspace,
         instance: WorkspaceInstance,
         additionalAuth: Map<string, string>,
-        ideConfig: IdeServiceApi.ResolveWorkspaceConfigResponse,
         ignoreBaseImageresolvedAndRebuildBase: boolean = false,
         forceRebuild: boolean = false,
         region?: WorkspaceRegion,
@@ -1179,7 +1186,10 @@ export class WorkspaceStarter {
             req.setAuth(auth);
             req.setForceRebuild(forceRebuild);
             req.setTriggeredBy(user.id);
-            req.setSupervisorRef(ideConfig.supervisorImage);
+            const supervisorImage = instance.configuration?.supervisorImage;
+            if (supervisorImage) {
+                req.setSupervisorRef(supervisorImage);
+            }
 
             // Make sure we persist logInfo as soon as we retrieve it
             const imageBuildLogInfo = new Deferred<ImageBuildLogInfo>();
@@ -1254,7 +1264,6 @@ export class WorkspaceStarter {
                         workspace,
                         instance,
                         additionalAuth,
-                        ideConfig,
                         true,
                         forceRebuild,
                         region,
@@ -1345,8 +1354,7 @@ export class WorkspaceStarter {
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
-        lastValidWorkspaceInstanceId: string,
-        ideConfig: IdeServiceApi.ResolveWorkspaceConfigResponse,
+        fromBackup: boolean,
         envVars: ResolvedEnvVars,
     ): Promise<StartWorkspaceSpec> {
         const context = workspace.context;
@@ -1382,7 +1390,7 @@ export class WorkspaceStarter {
 
         log.debug("Workspace config", workspace.config);
 
-        const tasks = this.ideService.resolveGitpodTasks(workspace, ideConfig);
+        const tasks = resolveGitpodTasks(workspace, instance);
         if (tasks.length) {
             // The task config is interpreted by supervisor only, there's little point in transforming it into something
             // wsman understands and back into the very same structure.
@@ -1494,13 +1502,7 @@ export class WorkspaceStarter {
             }
         }
 
-        const initializerPromise = this.createInitializer(
-            traceCtx,
-            workspace,
-            workspace.context,
-            user,
-            lastValidWorkspaceInstanceId,
-        );
+        const initializerPromise = this.createInitializer(traceCtx, workspace, workspace.context, user, fromBackup);
         const userTimeoutPromise = this.entitlementService.getDefaultWorkspaceTimeout(
             user.id,
             workspace.organizationId,
@@ -1514,7 +1516,8 @@ export class WorkspaceStarter {
         const featureFlags = instance.configuration!.featureFlags || [];
 
         const sysEnvvars: EnvironmentVariable[] = [];
-        for (const e of ideConfig.envvars) {
+        const ideEnvVars = instance.configuration.ideSetup?.envvars || [];
+        for (const e of ideEnvVars) {
             const ev = new EnvironmentVariable();
             ev.setName(e.name);
             ev.setValue(e.value);
@@ -1529,10 +1532,10 @@ export class WorkspaceStarter {
         spec.setPortsList(ports);
         spec.setInitializer((await initializerPromise).initializer);
         const startWorkspaceSpecIDEImage = new IDEImage();
-        startWorkspaceSpecIDEImage.setWebRef(ideConfig.webImage);
-        startWorkspaceSpecIDEImage.setSupervisorRef(ideConfig.supervisorImage);
+        startWorkspaceSpecIDEImage.setWebRef(instance.configuration.ideImage);
+        startWorkspaceSpecIDEImage.setSupervisorRef(instance.configuration.supervisorImage || ""); // set for all new instances
         spec.setIdeImage(startWorkspaceSpecIDEImage);
-        spec.setIdeImageLayersList(ideConfig.ideImageLayers);
+        spec.setIdeImageLayersList(instance.configuration.ideImageLayers!);
         spec.setWorkspaceImage(instance.workspaceImage);
         spec.setWorkspaceLocation(workspace.config.workspaceLocation || checkoutLocation);
         spec.setFeatureFlagsList(this.toWorkspaceFeatureFlags(featureFlags));
@@ -1680,12 +1683,12 @@ export class WorkspaceStarter {
         workspace: Workspace,
         context: WorkspaceContext,
         user: User,
-        lastValidWorkspaceInstanceId: string,
+        fromBackup: boolean,
     ): Promise<{ initializer: WorkspaceInitializer; disposable: Disposable }> {
         let result = new WorkspaceInitializer();
         const disp = new DisposableCollection();
 
-        if (lastValidWorkspaceInstanceId != "") {
+        if (fromBackup) {
             const backup = new FromBackupInitializer();
             if (CommitContext.is(context)) {
                 backup.setCheckoutLocation(context.checkoutLocation || "");
@@ -1904,4 +1907,15 @@ export class WorkspaceStarter {
     ) {
         return this.imagebuilderClientProvider.getClient(user, workspace, instance, region);
     }
+}
+
+function resolveGitpodTasks(ws: Workspace, instance: WorkspaceInstance): TaskConfig[] {
+    const tasks: TaskConfig[] = [];
+    if (ws.config.tasks) {
+        tasks.push(...ws.config.tasks);
+    }
+    if (instance.configuration.ideSetup?.tasks) {
+        tasks.push(...instance.configuration.ideSetup.tasks);
+    }
+    return tasks;
 }


### PR DESCRIPTION
## Description

In preparation of making sure we don't break workspace starts during rollouts, this PR does some cleanup in WorkspaceStarter. Most importantly, we ensure that after a `WorkspaceInstance` is stored in the DB, we can start a workspace from it. :+1: (also, makes the code cleaner).

Short summary to make the changes easier to digest:
 - introduced `buildImageAndStartWorkspace` to "mark" that separation, but also for usage in upcoming PRs
 - remove `options.rethrow`: not used anymore
 - instead of piping `lastValidWorkspaceInstanceId` through multiple layers for a simple check, condense it into `fromBackup` right away
 - persist the parts of `ideConfig` that we need during workspace start into `instance.configuration.ideSetup`

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4fa9fd</samp>

This pull request adds a new interface for IDE setup, refactors the workspace-starter and ide-service modules, and makes the configuration field mandatory for workspace instances.

</details>

## Related Issue(s)
Related to EXP-549
Depends on: https://github.com/gitpod-io/gitpod/pull/18641

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-ws-starter-2</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-ws-starter-2.preview.gitpod-dev.com/workspaces" target="_blank">gpl-ws-starter-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-ws-starter-2-gha.16325</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-ws-starter-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
