### PR TITLE
undo limit to fetch the first 100 user repos for New Workspace – EXP-554

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -131,11 +131,3 @@ function saveSearchData(searchData: string[]): void {
         console.warn("Could not save search data into local storage", error);
     }
 }
-
-export function refreshSearchData() {
-    getGitpodService()
-        .server.getSuggestedContextURLs()
-        .then((urls) => {
-            saveSearchData(urls);
-        });
-}

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -40,35 +40,44 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
 
     const getElements = useCallback(
         (searchString: string) => {
-            const result = [...suggestedContextURLs];
+            let result: string[];
             searchString = searchString.trim();
-            try {
-                // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
-                new URL(searchString);
-                if (!result.includes(searchString)) {
-                    result.push(searchString);
+            if (searchString.length > 1) {
+                result = suggestedContextURLs.filter((e) => e.toLowerCase().indexOf(searchString.toLowerCase()) !== -1);
+                if (result.length > 200) {
+                    result = result.slice(0, 200);
                 }
-            } catch {}
-            return result
-                .filter((e) => e.toLowerCase().indexOf(searchString.toLowerCase()) !== -1)
-                .map(
-                    (e) =>
-                        ({
-                            id: e,
-                            element: (
-                                <div className="flex-col ml-1 mt-1 flex-grow">
-                                    <div className="flex">
-                                        <div className="text-gray-700 dark:text-gray-300 font-semibold">
-                                            {stripOffProtocol(e)}
-                                        </div>
-                                        <div className="ml-1 text-gray-400">{}</div>
+                if (result.length === 0) {
+                    try {
+                        // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
+                        new URL(searchString);
+                        if (!suggestedContextURLs.includes(searchString)) {
+                            result.push(searchString);
+                        }
+                    } catch {}
+                }
+            } else {
+                result = suggestedContextURLs.slice(0, 200);
+            }
+
+            return result.map(
+                (e) =>
+                    ({
+                        id: e,
+                        element: (
+                            <div className="flex-col ml-1 mt-1 flex-grow">
+                                <div className="flex">
+                                    <div className="text-gray-700 dark:text-gray-300 font-semibold">
+                                        {stripOffProtocol(e)}
                                     </div>
-                                    <div className="flex text-xs text-gray-400">{}</div>
+                                    <div className="ml-1 text-gray-400">{}</div>
                                 </div>
-                            ),
-                            isSelectable: true,
-                        } as DropDown2Element),
-                );
+                                <div className="flex text-xs text-gray-400">{}</div>
+                            </div>
+                        ),
+                        isSelectable: true,
+                    } as DropDown2Element),
+            );
         },
         [suggestedContextURLs],
     );

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -4,11 +4,10 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { UserContext } from "../user-context";
 import { getGitpodService } from "../service/service";
 import { trackLocation } from "../Analytics";
-import { refreshSearchData } from "../components/RepositoryFinder";
 import { useQuery } from "@tanstack/react-query";
 import { noPersistence } from "../data/setup";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -20,7 +19,7 @@ export const useUserLoader = () => {
 
     // For now, we're using the user context to store the user, but letting react-query handle the loading
     // In the future, we should remove the user context and use react-query to access the user
-    const { isLoading } = useQuery({
+    const userQuery = useQuery({
         queryKey: noPersistence(["current-user"]),
         queryFn: async () => {
             const user = await getGitpodService().server.getLoggedInUser();
@@ -41,14 +40,18 @@ export const useUserLoader = () => {
         retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
         cacheTime: 1000 * 60 * 60 * 1, // 1 hour
         staleTime: 1000 * 60 * 60 * 1, // 1 hour
-        onSuccess: (loadedUser) => {
-            setUser(loadedUser);
-            refreshSearchData();
-        },
+
         onSettled: (loadedUser) => {
             trackLocation(!!loadedUser);
         },
     });
 
-    return { user, loading: isLoading };
+    // onSuccess is deprecated: https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose
+    useEffect(() => {
+        if (userQuery.data) {
+            setUser(userQuery.data);
+        }
+    }, [userQuery.data, setUser]);
+
+    return { user, loading: userQuery.isLoading };
 };

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -146,9 +146,8 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
 
     async getUserRepos(user: User): Promise<string[]> {
         try {
-            // TODO: See if there's another api we could use here, such as recent repos for the user
-            // Only grab one page of up to 100 repos
-            const repos = await this.api.getRepos(user, { limit: 100, maxPages: 1, permission: "REPO_READ" });
+            // TODO: implement incremental search
+            const repos = await this.api.getRepos(user, { maxPages: 10, permission: "REPO_READ" });
             const result: string[] = [];
             repos.forEach((r) => {
                 const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;


### PR DESCRIPTION
This reverts https://github.com/gitpod-io/gitpod/pull/18566/commits/2f2b1abbf142e62d95c8c5f2f6ce87264421cbed effectively.

We've also discovered, that rending of many items in the drop down becomes a bottleneck. To make it still work nicely, this PR introduces a limit of items to be rendered on New Workspace list. This limit is applied after filtering, so that you'd be able to start typing and find even repositories not visible by scrolling down. 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f490b01</samp>

Increase the number of repos fetched from Bitbucket Server in the dashboard. Modify `getUserRepos` in `bitbucket-server-repository-provider.ts` to use pagination.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-554

## How to test
See all repositories are loaded on New Workspace page if you've a connection to testing BBS with ~10K repos.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-bbs-undo-limit</li>
	<li><b>🔗 URL</b> - <a href="https://at-bbs-undo-limit.preview.gitpod-dev.com/workspaces" target="_blank">at-bbs-undo-limit.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-bbs-undo-limit-gha.16332</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-bbs-undo-limit%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [x] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
