### PR TITLE
[dashboard] Remove the auto start option

### DIFF
--- a/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
@@ -22,16 +22,6 @@ export const useCreateWorkspaceMutation = () => {
         onError: (error) => {
             setIsStarting(false);
         },
-        onSuccess: (result) => {
-            if (result && result.createdWorkspaceId) {
-                // successfully started a workspace, wait a bit before we allow to start another one
-                setTimeout(() => {
-                    setIsStarting(false);
-                }, 4000);
-            } else {
-                setIsStarting(false);
-            }
-        },
     });
     return {
         createWorkspace: (options: GitpodServer.CreateWorkspaceOptions) => {

--- a/components/dashboard/src/start/start-workspace-options.ts
+++ b/components/dashboard/src/start/start-workspace-options.ts
@@ -13,7 +13,7 @@ export interface StartWorkspaceOptions {
 }
 export namespace StartWorkspaceOptions {
     // The workspace class to use for the workspace. If not specified, the default workspace class is used.
-    export const WORKSPACE_CLASS = "workspaceClass";
+    export const WORKSPACE_CLASS = "workspaceclass";
 
     // The editor to use for the workspace. If not specified, the default editor is used.
     export const EDITOR = "editor";
@@ -22,7 +22,12 @@ export namespace StartWorkspaceOptions {
     export const AUTOSTART = "autostart";
 
     export function parseSearchParams(search: string): StartWorkspaceOptions {
-        const params = new URLSearchParams(search);
+        const original = new URLSearchParams(search);
+        const params = new URLSearchParams();
+        // translate to lower case
+        for (const [key, value] of original.entries()) {
+            params.set(key.toLowerCase(), value);
+        }
         const options: StartWorkspaceOptions = {};
         const workspaceClass = params.get(StartWorkspaceOptions.WORKSPACE_CLASS);
         if (workspaceClass) {
@@ -43,7 +48,7 @@ export namespace StartWorkspaceOptions {
             }
         }
         if (params.get(StartWorkspaceOptions.AUTOSTART)) {
-            options.autostart = params.get(StartWorkspaceOptions.AUTOSTART) === "true";
+            options.autostart = params.get(StartWorkspaceOptions.AUTOSTART) !== "false";
         }
         return options;
     }
@@ -58,8 +63,8 @@ export namespace StartWorkspaceOptions {
             const latest = options.ideSettings.useLatestVersion;
             params.set(StartWorkspaceOptions.EDITOR, latest ? ide + "-latest" : ide);
         }
-        if (options.autostart) {
-            params.set(StartWorkspaceOptions.AUTOSTART, "true");
+        if (options.autostart !== undefined) {
+            params.set(StartWorkspaceOptions.AUTOSTART, options.autostart.toString());
         }
         return params.toString();
     }

--- a/components/usage-api/typescript/src/google/protobuf/timestamp.pb.ts
+++ b/components/usage-api/typescript/src/google/protobuf/timestamp.pb.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-/* eslint-disable */
+// @ts-ignore
 import * as Long from "long";
 import * as _m0 from "protobufjs/minimal";
 

--- a/components/usage-api/typescript/src/usage/v1/billing.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/billing.pb.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-/* eslint-disable */
+// @ts-ignore
 import * as Long from "long";
 import { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";

--- a/components/usage-api/typescript/src/usage/v1/usage.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/usage.pb.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-/* eslint-disable */
+// @ts-ignore
 import * as Long from "long";
 import { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change removes the autostart option on the create workspace page. Instead we always auto start when you come with a contextUrl (unless you use the `?autostart=false` query param).

<img width="518" alt="Screenshot 2023-09-01 at 15 58 52" src="https://github.com/gitpod-io/gitpod/assets/372735/4d2697e1-ff11-4858-b01f-8eecbff1dd02">


This change also replaces the persistent warning for vscode in the create workspace screen with a toast containing the same information that is shown whenever you select VS Code Desktop (no matter where).

<img width="1095" alt="Screenshot 2023-09-01 at 15 58 29" src="https://github.com/gitpod-io/gitpod/assets/372735/c7407b6d-c2ea-49b7-8b6c-08cc1f6e230b">

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91fe550</samp>

This pull request improves the user experience and code quality of the dashboard component, and fixes some TypeScript errors in the usage API component. It adds a toast message for the experimental VS Code for Desktop option, changes the default and visibility of the `autostart` option, simplifies the workspace creation UI and logic, and removes an unnecessary callback from the workspace mutation hook. It also adds `// @ts-ignore` comments to the imports of `Long` in the generated protobuf files.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Start a workspace using a regular contexURL
 - https://se-no-autostart.preview.gitpod-dev.com/#https://github.com/svenefftinge/2048-in-terminal
 Start one with `autoStart=false`
 - https://se-no-autostart.preview.gitpod-dev.com/?autostart=false#https://github.com/svenefftinge/2048-in-terminal
 Go to the dashboard and manually start one
 - https://se-no-autostart.preview.gitpod-dev.com/new

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-no-autostart</li>
	<li><b>🔗 URL</b> - <a href="https://se-no-autostart.preview.gitpod-dev.com/workspaces" target="_blank">se-no-autostart.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-no-autostart-gha.16413</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-no-autostart%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
