### PR TITLE
[server] Make PrebuildManager use WorkspaceService.startWorkspace (to remove code duplication)

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -140,10 +140,8 @@ export async function getWorkspaceClassForInstance(
     ctx: TraceContext,
     workspace: Workspace,
     previousInstance: WorkspaceInstance | undefined,
-    user: User,
     project: Project | undefined,
     workspaceClassOverride: string | undefined,
-    entitlementService: EntitlementService,
     config: WorkspaceClassesConfig,
 ): Promise<string> {
     const span = TraceContext.startSpan("getWorkspaceClassForInstance", ctx);
@@ -900,10 +898,8 @@ export class WorkspaceStarter {
                 ctx,
                 workspace,
                 previousInstance,
-                user,
                 project,
                 workspaceClassOverride,
-                this.entitlementService,
                 this.config.workspaceClasses,
             );
 


### PR DESCRIPTION
## Description

Make PrebuildManager use WorkspaceService instead of WorkspaceStarter directly

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6ee7c6</samp>

This pull request improves the code quality and logic of the server component that handles starting workspaces. It removes unused code, refactors common types and methods, and adds some checks for workspace instances.

</details>

## Related Issue(s)
Related: EXP-549

## How to test
 - create a project with prebuild configured
 - see that prebuild gets triggered and executes fine

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status
🏷️ Name - gpl-ws-starter-3
🔗 URL - [gpl-ws-starter-3.preview.gitpod-dev.com/workspaces](https://gpl-ws-starter-3.preview.gitpod-dev.com/workspaces).
📚 Documentation - See our [internal documentation](https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39) for information on how to interact with your preview environment.
📦 Version - gpl-ws-starter-3-gha.16386
🗒️ Logs - [GCP Logs Explorer](https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-ws-starter-3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev)

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
