### PR TITLE
[dashboard] remove vscode SSH warning

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -40,7 +40,6 @@ import { useDirtyState } from "../hooks/use-dirty-state";
 import { LinkButton } from "../components/LinkButton";
 import { InputField } from "../components/forms/InputField";
 import Alert from "../components/Alert";
-import { useFeatureFlag } from "../data/featureflag-query";
 
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
@@ -419,7 +418,6 @@ export function CreateWorkspacePage() {
                     </Button>
                 </div>
 
-                {selectedIde === "code-desktop" && <LocalSSHWarning className="mx-6 mt-3 rounded-lg overflow-hidden" />}
                 {workspaceContext.data && (
                     <RememberOptions
                         disabled={workspaceContext.isLoading || createWorkspaceMutation.isStarting}
@@ -444,40 +442,6 @@ export function CreateWorkspacePage() {
                     </div>
                 )}
             </div>
-        </div>
-    );
-}
-
-function LocalSSHWarning(props: { className: string }) {
-    const isLocalSSHProxyEnabled = useFeatureFlag("gitpod_desktop_use_local_ssh_proxy");
-
-    if (!isLocalSSHProxyEnabled) {
-        return null;
-    }
-
-    return (
-        <div className={props.className}>
-            <Alert light className="bg-gray-100 dark:bg-gray-800" type="info">
-                Choosing VS Code for Desktop will add a single entry to your local SSH configuration. Gitpod won't
-                interfere with your existing SSH configurations.&nbsp;
-                <a
-                    className="gp-link"
-                    href="https://www.gitpod.io/docs/references/ides-and-editors/vscode#connecting-to-vs-code-desktop"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    Learn more
-                </a>
-                &nbsp;&middot;&nbsp;
-                <a
-                    className="gp-link"
-                    href="https://github.com/gitpod-io/gitpod/issues/18109"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    Send feedback
-                </a>
-            </Alert>
         </div>
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Removes the warnig around add ean entry to user's SSH config when using VS Code desktop

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6556efc</samp>

Removed local SSH proxy code from `CreateWorkspacePage.tsx`. Simplified the UI and logic for creating workspaces.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

