### PR TITLE
[dashboard] initialize project name

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -38,14 +38,29 @@ export default function ProjectSettingsView() {
     const { setProject } = useContext(ProjectContext);
     const { project } = useCurrentProject();
     const [showRemoveModal, setShowRemoveModal] = useState(false);
-    const [projectName, setProjectName] = useState(project?.name || "");
-    let badProjectName = projectName.length > 0 ? undefined : "Project name can not be blank.";
-    if (projectName.length > 32) {
-        badProjectName = "Project name can not be longer than 32 characters.";
+    const [isDirty, setIsDirty] = useState(false);
+    const [projectName, internalSetProjectName] = useState(project?.name || "");
+    if (!projectName && project && !isDirty) {
+        internalSetProjectName(project.name);
+    }
+    let badProjectName: string | undefined;
+    if (project) {
+        badProjectName = projectName.length > 0 ? undefined : "Project name can not be blank.";
+        if (projectName.length > 32) {
+            badProjectName = "Project name can not be longer than 32 characters.";
+        }
     }
     const history = useHistory();
     const refreshProjects = useRefreshProjects();
     const toast = useToast();
+
+    const setProjectName = useCallback(
+        (projectName: string) => {
+            setIsDirty(true);
+            internalSetProjectName(projectName);
+        },
+        [setIsDirty, internalSetProjectName],
+    );
 
     const updateProjectName = useCallback(
         async (e: React.FormEvent) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When loading the project settings it sometimes is initialized with an empty string, because the project was not loaded already. This fixes this.

<img width="1000" alt="Screenshot 2023-09-04 at 11 39 09" src="https://github.com/gitpod-io/gitpod/assets/372735/9b18cdff-94b5-4372-8210-cb366d24989a">


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e702e8</samp>

Fix project name input bug in `ProjectSettings.tsx`. Use state variables to track and update the project name and its modification status.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- [join org](https://se-init-project-name.preview.gitpod-dev.com/orgs/join?inviteId=00cfa8da-2c3e-402d-97bb-a889853ce412)
- [got to projects settings](https://se-init-project-name.preview.gitpod-dev.com/projects/2048-in-terminal-42445170-1d92-4a44-ae65-c3ce2a77b887/settings)
- ensure it looks like this (i.e. name is set):

<img width="939" alt="Screenshot 2023-09-04 at 13 19 55" src="https://github.com/gitpod-io/gitpod/assets/372735/234e1c79-3b10-4702-ad65-a5972ee6a292">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-init-project-name</li>
	<li><b>🔗 URL</b> - <a href="https://se-init-project-name.preview.gitpod-dev.com/workspaces" target="_blank">se-init-project-name.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-init-project-name-gha.16396</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-init-project-name%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
