### PR TITLE
mix suggested ctx urls and repo search results

### DIFF
--- a/components/dashboard/src/data/git-providers/provider-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/provider-repositories-query.ts
@@ -16,11 +16,13 @@ type UseProviderRepositoriesQueryArgs = {
     providerHost: string;
     installationId?: string;
     search?: string;
+    enabled?: boolean;
 };
 export const useProviderRepositoriesForUser = ({
     providerHost,
     installationId,
     search,
+    enabled = true,
 }: UseProviderRepositoriesQueryArgs) => {
     const user = useCurrentUser();
     const newProjectIncrementalRepoSearchBBS = useFeatureFlag("newProjectIncrementalRepoSearchBBS");
@@ -64,7 +66,7 @@ export const useProviderRepositoriesForUser = ({
             );
         },
         {
-            enabled: !!providerHost,
+            enabled: enabled && !!providerHost,
         },
     );
 };

--- a/components/dashboard/src/data/git-providers/repository-search-query.ts
+++ b/components/dashboard/src/data/git-providers/repository-search-query.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useProviderRepositoriesForUser } from "./provider-repositories-query";
+
+export const useSuggestedContextContextURLs = () => {
+    return useQuery(["suggested-context-urls"], async () => {
+        return await getGitpodService().server.getSuggestedContextURLs();
+    });
+};
+
+type UseRepositorySearchArgs = {
+    search?: string;
+};
+export const useRepositorySearch = ({ search = "" }: UseRepositorySearchArgs) => {
+    // irregarless of the search term, we always want to load the suggested context urls
+    const {
+        data: suggestedContextURLs,
+        isLoading: isSuggestedLoading,
+        error: suggestedError,
+    } = useSuggestedContextContextURLs();
+
+    // if suggested context urls doesn't have a match, we want to search git provider for a match
+    const {
+        data: searchResults,
+        isLoading: isSearchLoading,
+        error: searchError,
+    } = useProviderRepositoriesForUser({
+        search,
+        // TODO: how should we check all providers?
+        providerHost: "github.com",
+        enabled: !!search,
+    });
+
+    let results: string[];
+    const searchString = search.trim().toLowerCase();
+
+    // If the search string is empty, return a chunk of the first suggested context URLs
+    if (!searchString) {
+        results = suggestedContextURLs || [];
+    } else {
+        const suggestedMatches = suggestedContextURLs?.filter((url) => url.toLowerCase().includes(searchString)) ?? [];
+
+        const searchMatches = searchResults?.map((repo) => repo.cloneUrl) ?? [];
+
+        results = [...suggestedMatches, ...searchMatches];
+
+        // If there are no matches, and search string is a URL, "artificially" add it to the results.
+        if (results.length === 0) {
+            try {
+                new URL(searchString);
+                results.push(searchString);
+            } catch {}
+        }
+    }
+
+    return {
+        data: results.length > 200 ? results.slice(0, 200) : results,
+        isLoading: isSuggestedLoading || isSearchLoading,
+        error: suggestedError || searchError,
+    };
+};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Combines suggested ctx urls and repo search for the RepositoryFinder component

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0517cfa</samp>

Refactor and improve the `RepositoryFinder` component and its data fetching logic. Add custom hooks for fetching and caching suggested and provider context URLs, and use them in the component. Add an `enabled` option for the provider repositories query to optimize the data fetching. Add a new file `repository-search-query.ts` to contain the custom hooks.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-repo-00d081e5bb</li>
	<li><b>🔗 URL</b> - <a href="https://brad-repo-00d081e5bb.preview.gitpod-dev.com/workspaces" target="_blank">brad-repo-00d081e5bb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-repo-finder-search-gha.16479</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-repo-00d081e5bb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
