### PR TITLE
[New Project] Show account name in repo list – EXP-553

### DIFF
--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -33,7 +33,7 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                                         (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")
                                     }
                                 >
-                                    {toSimpleName(r.name)}
+                                    {toSimpleName(r)}
                                 </div>
                                 {r.updatedAt && <p>Updated {dayjs(r.updatedAt).fromNow()}</p>}
                             </div>
@@ -45,12 +45,9 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                                         </Button>
                                     ) : (
                                         <p className="text-gray-500 font-medium">
-                                            <a rel="noopener" className="gp-link" href={userLink(r)}>
-                                                @{r.inUse.userName}
-                                            </a>{" "}
-                                            already
+                                            Project already
                                             <br />
-                                            added this repo
+                                            exists.
                                         </p>
                                     )}
                                 </div>
@@ -64,14 +61,6 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
     );
 };
 
-const toSimpleName = (fullName: string) => {
-    const splitted = fullName.split("/");
-    if (splitted.length < 2) {
-        return fullName;
-    }
-    return splitted.shift() && splitted.join("/");
-};
-
-const userLink = (r: ProviderRepository) => {
-    return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`;
+const toSimpleName = (repo: ProviderRepository) => {
+    return `${repo.account}/${repo.name}`;
 };

--- a/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoList.tsx
@@ -44,7 +44,7 @@ export const NewProjectRepoList: FC<Props> = ({ filteredRepos, noReposAvailable,
                                             Select
                                         </Button>
                                     ) : (
-                                        <p className="text-gray-500 font-medium">
+                                        <p className="text-gray-500">
                                             Project already
                                             <br />
                                             exists.

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -85,7 +85,7 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProvider, onProject
             : Array.from(reposInAccounts || []).filter(
                   (r) =>
                       (!selectedAccount || r.account === selectedAccount) &&
-                      `${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase().trim()),
+                      `${r.account}/${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase().trim()),
               );
     }, [areGitHubWebhooksUnauthorized, enableBBSIncrementalSearch, repoSearchFilter, reposInAccounts, selectedAccount]);
 
@@ -172,18 +172,12 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProvider, onProject
                             onSelectGitProvider={onChangeGitProvider}
                         />
                     )}
+                    <NewProjectSearchInput searchFilter={repoSearchFilter} onSearchFilterChange={setRepoSearchFilter} />
                     {enableBBSIncrementalSearch && (
                         <Alert type="info" className="text-sm -mx-4 my-2">
-                            <div>
-                                Repository search requires that search queries start with the first character(s) of the
-                                given repository name. Wildcard search is not supported.
-                            </div>
-                            <div className="mt-1">
-                                <strong>Example:</strong> For “my-repo” search “my-re”, instead of “repo”
-                            </div>
+                            <div>Bitbucket Server only supports prefix search.</div>
                         </Alert>
                     )}
-                    <NewProjectSearchInput searchFilter={repoSearchFilter} onSearchFilterChange={setRepoSearchFilter} />
                 </div>
                 <div className="p-6 flex-col">
                     {isLoading ? (

--- a/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
+++ b/components/dashboard/src/projects/new-project/NewProjectRepoSelection.tsx
@@ -175,7 +175,10 @@ export const NewProjectRepoSelection: FC<Props> = ({ selectedProvider, onProject
                     <NewProjectSearchInput searchFilter={repoSearchFilter} onSearchFilterChange={setRepoSearchFilter} />
                     {enableBBSIncrementalSearch && (
                         <Alert type="info" className="text-sm -mx-4 my-2">
-                            <div>Bitbucket Server only supports prefix search.</div>
+                            <div>
+                                <span className="font-semibold">Bitbucket Server</span> supports only prefix search for
+                                projects.
+                            </div>
                         </Alert>
                     )}
                 </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<img width="569" alt="Screenshot 2023-09-06 at 08 51 14" src="https://github.com/gitpod-io/gitpod/assets/914497/0914b282-80bf-4c44-87bb-ac96917c9a9e">

This PR prefixes entries in of repository selection list with the account name. Instead `gp-test` it would render `AlexTugarev2/gp-test` so that one could distinguish it form `SomeoneElse/gp-test`.

Drive-by fixed included:
* filtering of list also considers the account name
* `inUse` label is changed to `Project already exists.`, as the previously mentioned user wasn't computed properly, i.e. it took the first owner of the Org, which is mostly unexpected and wrong. 
* Simplified note on prefix search and aligned its position [as suggested](https://linear.app/gitpod/issue/EXP-553#comment-96de5c01) by @gtsiolis 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 823db0a</samp>

Improved UI and logic for selecting repositories from Bitbucket Server in the new project wizard. Simplified code and messages for displaying repository names.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-553

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-repo-list</li>
	<li><b>🔗 URL</b> - <a href="https://at-repo-list.preview.gitpod-dev.com/workspaces" target="_blank">at-repo-list.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-repo-list-gha.16487</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-repo-list%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [x] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
