### PR TITLE
TEST

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -117,4 +117,10 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     usageAttributionId?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    controllerId: string;
 }

--- a/components/gitpod-db/src/typeorm/migration/1693552328801-WorkspaceInstanceControllerId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1693552328801-WorkspaceInstanceControllerId.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class WorkspaceInstanceControllerId1693552328801 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, "d_b_workspace_instance", "controllerId"))) {
+            await queryRunner.query(
+                "ALTER TABLE d_b_workspace_instance ADD COLUMN `controllerId` varchar(255) NOT NULL DEFAULT ''",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, "d_b_workspace_instance", "controllerId")) {
+            await queryRunner.query("ALTER TABLE d_b_workspace_instance DROP COLUMN `controllerId`");
+        }
+    }
+}

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -320,6 +320,7 @@ namespace TestData {
             ideImage: "unknown",
         },
         deleted: false,
+        controllerId: "default",
     };
 }
 

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -69,6 +69,7 @@ class WorkspaceDBSpec {
         },
         deleted: false,
         usageAttributionId: undefined,
+        controllerId: "default",
     };
     readonly wsi2: WorkspaceInstance = {
         workspaceId: this.ws.id,
@@ -93,6 +94,7 @@ class WorkspaceDBSpec {
         },
         deleted: false,
         usageAttributionId: undefined,
+        controllerId: "default",
     };
     readonly ws2: Workspace = {
         id: "2",
@@ -133,6 +135,7 @@ class WorkspaceDBSpec {
         },
         deleted: false,
         usageAttributionId: undefined,
+        controllerId: "default",
     };
 
     readonly ws3: Workspace = {
@@ -173,6 +176,7 @@ class WorkspaceDBSpec {
         },
         deleted: false,
         usageAttributionId: undefined,
+        controllerId: "default",
     };
 
     async before() {

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -130,7 +130,7 @@ export interface WorkspaceDB {
         query?: AdminGetWorkspacesQuery,
     ): Promise<{ total: number; rows: WorkspaceAndInstance[] }>;
     findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
-    findInstancesByPhase(...phases: string[]): Promise<WorkspaceInstance[]>;
+    findInstancesByPhase(phases: string[]): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
     getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -130,23 +130,11 @@ export interface WorkspaceDB {
         query?: AdminGetWorkspacesQuery,
     ): Promise<{ total: number; rows: WorkspaceAndInstance[] }>;
     findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
-    findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
+    findInstancesByPhase(...phases: string[]): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
     getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
-
-    findAllWorkspaceInstances(
-        offset: number,
-        limit: number,
-        orderBy: keyof WorkspaceInstance,
-        orderDir: "ASC" | "DESC",
-        ownerId?: string,
-        minCreationTime?: Date,
-        maxCreationTime?: Date,
-        onlyRunning?: boolean,
-        type?: WorkspaceType,
-    ): Promise<{ total: number; rows: WorkspaceInstance[] }>;
 
     findRegularRunningInstances(userId?: string): Promise<WorkspaceInstance[]>;
     findRunningInstancesWithWorkspaces(

--- a/components/gitpod-protocol/src/util/timeutil.ts
+++ b/components/gitpod-protocol/src/util/timeutil.ts
@@ -77,6 +77,10 @@ export function rightBefore(date: string): string {
     return new Date(new Date(date).getTime() - 1).toISOString();
 }
 
+export function durationLongerThanSeconds(time: number, durationSeconds: number, now: number = Date.now()): boolean {
+    return (now - time) / 1000 > durationSeconds;
+}
+
 export function millisecondsToHours(milliseconds: number): number {
     return milliseconds / 1000 / 60 / 60;
 }

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -70,6 +70,11 @@ export interface WorkspaceInstance {
      * (e.g. for usage analytics or billing purposes).
      */
     usageAttributionId?: string;
+
+    /**
+     * The id of the controller that is governing the start of this workspace instance
+     */
+    controllerId: string;
 }
 
 // WorkspaceInstanceStatus describes the current state of a workspace instance

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -716,6 +716,7 @@ class TestResourceAccess {
                 },
                 ideUrl: "https://some.where",
                 workspaceImage: "gitpod/workspace-full:latest",
+                controllerId: "default",
             };
         };
         const createPrebuild = (): PrebuiltWorkspace => {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -132,7 +132,7 @@ import { SSHKeyService } from "./user/sshkey-service";
 import { GitpodTokenService } from "./user/gitpod-token-service";
 import { EnvVarService } from "./user/env-var-service";
 import { ScmService } from "./projects/scm-service";
-import { WorkspaceStartController } from "./workspace/workspace-start-controller";
+import { WorkspaceStartController, DistributedWorkspaceStartController } from "./workspace/workspace-start-controller";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -363,7 +363,9 @@ export const productionContainerModule = new ContainerModule(
 
         // Periodic jobs
         bind(WorkspaceGarbageCollector).toSelf().inSingletonScope();
+        bind(DistributedWorkspaceStartController).toSelf().inSingletonScope();
         bind(WorkspaceStartController).toSelf().inSingletonScope();
+
         bind(TokenGarbageCollector).toSelf().inSingletonScope();
         bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
         bind(DatabaseGarbageCollector).toSelf().inSingletonScope();

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -132,6 +132,7 @@ import { SSHKeyService } from "./user/sshkey-service";
 import { GitpodTokenService } from "./user/gitpod-token-service";
 import { EnvVarService } from "./user/env-var-service";
 import { ScmService } from "./projects/scm-service";
+import { WorkspaceStartController } from "./workspace/workspace-start-controller";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -362,6 +363,7 @@ export const productionContainerModule = new ContainerModule(
 
         // Periodic jobs
         bind(WorkspaceGarbageCollector).toSelf().inSingletonScope();
+        bind(WorkspaceStartController).toSelf().inSingletonScope();
         bind(TokenGarbageCollector).toSelf().inSingletonScope();
         bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
         bind(DatabaseGarbageCollector).toSelf().inSingletonScope();

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -17,7 +17,7 @@ import { TokenGarbageCollector } from "./token-gc";
 import { WebhookEventGarbageCollector } from "./webhook-gc";
 import { WorkspaceGarbageCollector } from "./workspace-gc";
 import { SnapshotsJob } from "./snapshots";
-import { WorkspaceStartController } from "../workspace/workspace-start-controller";
+import { DistributedWorkspaceStartController } from "../workspace/workspace-start-controller";
 
 export const Job = Symbol("Job");
 
@@ -37,7 +37,8 @@ export class JobRunner {
     @inject(TokenGarbageCollector) protected tokenGC: TokenGarbageCollector;
     @inject(WebhookEventGarbageCollector) protected webhookGC: WebhookEventGarbageCollector;
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
-    @inject(WorkspaceStartController) protected workspaceStartController: WorkspaceStartController;
+    @inject(DistributedWorkspaceStartController)
+    protected workspaceStartController: DistributedWorkspaceStartController;
     @inject(SnapshotsJob) protected snapshotsJob: SnapshotsJob;
 
     public start(): DisposableCollection {

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -17,6 +17,7 @@ import { TokenGarbageCollector } from "./token-gc";
 import { WebhookEventGarbageCollector } from "./webhook-gc";
 import { WorkspaceGarbageCollector } from "./workspace-gc";
 import { SnapshotsJob } from "./snapshots";
+import { WorkspaceStartController } from "../workspace/workspace-start-controller";
 
 export const Job = Symbol("Job");
 
@@ -36,6 +37,7 @@ export class JobRunner {
     @inject(TokenGarbageCollector) protected tokenGC: TokenGarbageCollector;
     @inject(WebhookEventGarbageCollector) protected webhookGC: WebhookEventGarbageCollector;
     @inject(WorkspaceGarbageCollector) protected workspaceGC: WorkspaceGarbageCollector;
+    @inject(WorkspaceStartController) protected workspaceStartController: WorkspaceStartController;
     @inject(SnapshotsJob) protected snapshotsJob: SnapshotsJob;
 
     public start(): DisposableCollection {
@@ -47,6 +49,7 @@ export class JobRunner {
             this.tokenGC,
             this.webhookGC,
             this.workspaceGC,
+            this.workspaceStartController,
             this.snapshotsJob,
         ];
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -47,6 +47,7 @@ import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
 import { JobRunner } from "./jobs/runner";
 import { RedisSubscriber } from "./messaging/redis-subscriber";
 import { HEADLESS_LOGS_PATH_PREFIX, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./workspace/headless-log-service";
+import { WorkspaceStartController } from "./workspace/workspace-start-controller";
 
 @injectable()
 export class Server {
@@ -92,6 +93,7 @@ export class Server {
         @inject(IamSessionApp) private readonly iamSessionAppCreator: IamSessionApp,
         @inject(API) private readonly api: API,
         @inject(RedisSubscriber) private readonly redisSubscriber: RedisSubscriber,
+        @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
     ) {}
 
     public async init(app: express.Application) {
@@ -267,6 +269,9 @@ export class Server {
 
         // Start periodic jobs
         this.disposables.push(this.jobRunner.start());
+
+        // Start workspace start controller
+        this.disposables.push(this.workspaceStartController.start());
 
         this.app = app;
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -47,7 +47,7 @@ import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
 import { JobRunner } from "./jobs/runner";
 import { RedisSubscriber } from "./messaging/redis-subscriber";
 import { HEADLESS_LOGS_PATH_PREFIX, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./workspace/headless-log-service";
-import { WorkspaceStartController } from "./workspace/workspace-start-controller";
+import { DistributedWorkspaceStartController, WorkspaceStartController } from "./workspace/workspace-start-controller";
 
 @injectable()
 export class Server {
@@ -93,6 +93,8 @@ export class Server {
         @inject(IamSessionApp) private readonly iamSessionAppCreator: IamSessionApp,
         @inject(API) private readonly api: API,
         @inject(RedisSubscriber) private readonly redisSubscriber: RedisSubscriber,
+        @inject(DistributedWorkspaceStartController)
+        private readonly distributedWorkspaceStartController: DistributedWorkspaceStartController,
         @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
     ) {}
 
@@ -271,6 +273,7 @@ export class Server {
         this.disposables.push(this.jobRunner.start());
 
         // Start workspace start controller
+        this.disposables.push(this.distributedWorkspaceStartController.start());
         this.disposables.push(this.workspaceStartController.start());
 
         this.app = app;

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -61,7 +61,6 @@ import { goDurationToHumanReadable } from "@gitpod/gitpod-protocol/lib/util/time
 import { HeadlessLogEndpoint, HeadlessLogService } from "./headless-log-service";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { OrganizationService } from "../orgs/organization-service";
-import { WorkspaceStartController } from "./workspace-start-controller";
 
 export interface StartWorkspaceOptions extends StarterStartWorkspaceOptions {
     /**
@@ -79,7 +78,6 @@ export class WorkspaceService {
         @inject(WorkspaceFactory) private readonly factory: WorkspaceFactory,
         @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
         @inject(WorkspaceManagerClientProvider) private readonly clientProvider: WorkspaceManagerClientProvider,
-        @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
         @inject(WorkspaceDB) private readonly db: WorkspaceDB,
         @inject(EntitlementService) private readonly entitlementService: EntitlementService,
         @inject(EnvVarService) private readonly envVarService: EnvVarService,
@@ -503,7 +501,6 @@ export class WorkspaceService {
             user,
             await projectPromise,
             await envVarsPromise,
-            this.workspaceStartController.getControllerId(),
             options,
         );
         return result;

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -61,6 +61,7 @@ import { goDurationToHumanReadable } from "@gitpod/gitpod-protocol/lib/util/time
 import { HeadlessLogEndpoint, HeadlessLogService } from "./headless-log-service";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { OrganizationService } from "../orgs/organization-service";
+import { WorkspaceStartController } from "./workspace-start-controller";
 
 export interface StartWorkspaceOptions extends StarterStartWorkspaceOptions {
     /**
@@ -78,6 +79,7 @@ export class WorkspaceService {
         @inject(WorkspaceFactory) private readonly factory: WorkspaceFactory,
         @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
         @inject(WorkspaceManagerClientProvider) private readonly clientProvider: WorkspaceManagerClientProvider,
+        @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
         @inject(WorkspaceDB) private readonly db: WorkspaceDB,
         @inject(EntitlementService) private readonly entitlementService: EntitlementService,
         @inject(EnvVarService) private readonly envVarService: EnvVarService,
@@ -501,6 +503,7 @@ export class WorkspaceService {
             user,
             await projectPromise,
             await envVarsPromise,
+            this.workspaceStartController.getControllerId(),
             options,
         );
         return result;

--- a/components/server/src/workspace/workspace-start-controller.ts
+++ b/components/server/src/workspace/workspace-start-controller.ts
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable } from "inversify";
+import { Job } from "../jobs/runner";
+import { Config } from "../config";
+import { Redis } from "ioredis";
+import { UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { LogContext, log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import {
+    Disposable,
+    DisposableCollection,
+    Queue,
+    WorkspaceInstance,
+    WorkspaceInstancePhase,
+} from "@gitpod/gitpod-protocol";
+import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/timeutil";
+import { DescribeWorkspaceRequest, PromisifiedWorkspaceManagerClient } from "@gitpod/ws-manager/lib";
+import { WorkspaceStarter } from "./workspace-starter";
+import { EnvVarService } from "../user/env-var-service";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
+
+const REDIS_CONTROLLER_ID_PREFIX = "workspace-start-controller-id";
+const redisControllerIdKey = (id: string) => `${REDIS_CONTROLLER_ID_PREFIX}:${id}`;
+const stripRedisControllerIdPrefix = (key: string): string | undefined => {
+    if (!key.startsWith(REDIS_CONTROLLER_ID_PREFIX + ":")) {
+        return undefined;
+    }
+    return key.substring(REDIS_CONTROLLER_ID_PREFIX.length + 1);
+};
+
+const MANAGED_PHASES: WorkspaceInstancePhase[] = ["preparing", "building", "pending"];
+
+/**
+ * This class is responsible for making sure that workspace instances are started, even in the face of unexpected container shutdown.
+ *
+ * To do so, it implements a distributed controller:
+ *  - Every X seconds, _all_ server instances control the workspace instances they are responsible for.
+ *  - Every Y seconds, _one_ server instance checks if there are workspace instances without a controller (decided by a keepalive mechanism
+ *    using redis) and assumes controler over those as well.
+ */
+@injectable()
+export class WorkspaceStartController implements Job {
+    private readonly id: WorkspaceStartControllerId;
+
+    // Used for sequencing doControlStartingWorkspace()
+    private readonly queue = new Queue();
+    private readonly disposable = new DisposableCollection();
+
+    public readonly name = "workspace-start-controller";
+    // How often we check for uncontrolled instances (+ once on startup)
+    public readonly frequencyMs = 60 * 1000;
+
+    // How often we check "our" instances
+    private readonly controllerFrequencyMs = 10 * 1000;
+    private get redisExpiryTime() {
+        return (this.controllerFrequencyMs / 1000) * 1.5; // After this period without update we consider a controller dead
+    }
+
+    constructor(
+        @inject(Redis) private readonly redis: Redis,
+        @inject(Config) private readonly config: Config,
+        @inject(WorkspaceDB) private readonly workspaceDb: WorkspaceDB,
+        @inject(WorkspaceManagerClientProvider) private readonly clientProvider: WorkspaceManagerClientProvider,
+        @inject(EnvVarService) private readonly envVarService: EnvVarService,
+        @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
+        @inject(UserDB) private readonly userDb: UserDB,
+    ) {
+        this.id = WorkspaceStartControllerId.create(this.config);
+    }
+
+    public start(): Disposable {
+        this.disposable.push(repeat(() => this.controlAllOurStartingWorkspaces(), this.controllerFrequencyMs));
+        // We rely on the JobRunner to call run() on startup once immediately.
+        return Disposable.create(() => this.disposable.dispose());
+    }
+
+    /**
+     * This is the loop checking regularly (and on start) for uncontrolled instances, and claiming ownership of those.
+     */
+    public async run(): Promise<void> {
+        const controllerId = this.getControllerId();
+
+        const activeControllerIds = (await this.listAllActiveControllerIds()).map((id) =>
+            WorkspaceStartControllerId.toString(id),
+        );
+        log.info("[wsc] all active controller ids", { activeControllerIds: new TrustedValue(activeControllerIds) });
+
+        const instances = await this.workspaceDb.findInstancesByPhase(...MANAGED_PHASES);
+        for (let instance of instances) {
+            const alreadyTakenCareOf =
+                instance.controllerId && activeControllerIds.some((id) => id === instance.controllerId);
+            const fromPreviousSelf = WorkspaceStartControllerId.isPreviousIncarnation(
+                this.id,
+                WorkspaceStartControllerId.fromString(instance.controllerId),
+            );
+            if (alreadyTakenCareOf && !fromPreviousSelf) {
+                continue;
+            }
+
+            // No-one responsible yet/anymore: We take over
+            try {
+                log.info({ instanceId: instance.id }, "[wsc] taking over instance", {
+                    oldControllerId: instance.controllerId,
+                    newControllerId: controllerId,
+                });
+                instance = await this.workspaceDb.updateInstancePartial(instance.id, { controllerId });
+
+                const triggerImmediately = fromPreviousSelf;
+                this.doControlStartingWorkspace(instance, triggerImmediately).catch((err) =>
+                    log.error(
+                        { instanceId: instance.id },
+                        "[wsc] error controlling instance after taking it over",
+                        err,
+                        {
+                            oldControllerId: instance.controllerId,
+                            newControllerId: controllerId,
+                        },
+                    ),
+                ); // No need to await. Also, we don't want block the mutex for too long
+            } catch (err) {
+                log.warn({ instanceId: instance.id }, "[wsc] cannot set instance controller id", err, {
+                    oldControllerId: instance.controllerId,
+                    newControllerId: controllerId,
+                });
+            }
+        }
+    }
+
+    private async controlAllOurStartingWorkspaces() {
+        const controllerId = this.getControllerId();
+        // Mark ourselves as active
+        await this.redis.setex(redisControllerIdKey(controllerId), this.redisExpiryTime, controllerId);
+
+        const instances = await this.workspaceDb.findInstancesByPhase(...MANAGED_PHASES);
+        for (const instance of instances) {
+            if (instance.controllerId !== controllerId) {
+                continue; // Not our business
+            }
+
+            await this.doControlStartingWorkspace(instance);
+        }
+    }
+
+    /**
+     * The actual controlling part
+     */
+    private async doControlStartingWorkspace(instance: WorkspaceInstance, triggerImmediately: boolean = false) {
+        return this.queue.enqueue(async () => {
+            switch (instance.status.phase) {
+                case "preparing":
+                    this.retriggerStartWorkspace(instance).catch(log.error);
+                    return;
+
+                case "building":
+                    this.retriggerStartWorkspace(instance).catch(log.error);
+                    return;
+
+                case "pending":
+                    // !!! Note: during pending, the handover between app-cluster and ws-manager happens. !!!
+                    // This means:
+                    //  - there is a control loop on ws-manager-bridge that checks for an upper limit a instance may be in pending phase
+                    //  - it will take some time after calling ws-manager to see the first status update
+                    if (!triggerImmediately && durationLongerThanSeconds(Date.parse(instance.creationTime), 30)) {
+                        // In 99.9% this is due to timing, so we need to be a bit cautious here not to spam ourselves.
+                        return;
+                    }
+
+                    const exists = await this.existsWithWsManager(instance);
+                    if (exists) {
+                        // be a bit more patient and wait for the first status update
+                        return;
+                    }
+
+                    // Our time has come!
+                    this.retriggerStartWorkspace(instance).catch(log.error);
+
+                    return;
+
+                default:
+                    return;
+            }
+        });
+    }
+
+    /**
+     * This method will never throw, as it's not expected to be await'ed on.
+     * @param instance
+     */
+    private async retriggerStartWorkspace(instance: WorkspaceInstance) {
+        const span = TraceContext.startSpan("doRetriggerStartWorkspace");
+        const logCtx: LogContext = { instanceId: instance.id, workspaceId: instance.workspaceId };
+        try {
+            log.info(logCtx, "[wsc] re-triggering startWorkspace", {
+                controllerId: instance.controllerId,
+                phase: instance.status.phase,
+            });
+
+            const workspace = await this.workspaceDb.findById(instance.workspaceId);
+            if (!workspace) {
+                throw new Error("cannot find workspace for instance");
+            }
+            const user = await this.userDb.findUserById(workspace.ownerId);
+            if (!user) {
+                throw new Error("cannot find owner for workspace");
+            }
+
+            const envVars = await this.envVarService.resolveEnvVariables(
+                user.id,
+                workspace.projectId,
+                workspace.type,
+                workspace.context,
+            );
+            await this.workspaceStarter.buildImageAndStartWorkspace({ span }, user, workspace, instance, envVars);
+        } catch (err) {
+            TraceContext.setError({ span }, err);
+            log.error(logCtx, "[wsc] error re-triggering startWorkspace", err, {
+                controllerId: instance.controllerId,
+                phase: instance.status.phase,
+            });
+        } finally {
+            span.finish();
+        }
+    }
+
+    private async existsWithWsManager(instance: WorkspaceInstance): Promise<boolean> {
+        const client = await this.getClient({ instanceId: instance.id }, instance.region);
+        if (!client) return false;
+
+        const req = new DescribeWorkspaceRequest();
+        req.setId(instance.id);
+        try {
+            await client.describeWorkspace({}, req);
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    private async getClient(
+        logCtx: LogContext,
+        region: string,
+    ): Promise<PromisifiedWorkspaceManagerClient | undefined> {
+        try {
+            return await this.clientProvider.get(region);
+        } catch (err) {
+            log.warn(logCtx, "[wsc] cannot get ws-manager client", err, { region });
+            return undefined;
+        }
+    }
+
+    private async listAllActiveControllerIds(): Promise<WorkspaceStartControllerId[]> {
+        const keys = await new Promise<string[]>((resolve, reject) => {
+            const result: string[] = [];
+            this.redis
+                .scanStream({ match: redisControllerIdKey("*"), count: 20 })
+                .on("data", async (keys: string[]) => {
+                    result.push(...keys);
+                })
+                .on("error", reject)
+                .on("end", () => {
+                    resolve(result);
+                });
+        });
+
+        const allActiveIds = new Map<string, WorkspaceStartControllerId>();
+        allActiveIds.set(WorkspaceStartControllerId.toString(this.id), this.id); // we're are definitely active
+        for (const idStr of keys.map(stripRedisControllerIdPrefix)) {
+            if (!idStr) {
+                continue;
+            }
+            const id = WorkspaceStartControllerId.fromString(idStr);
+            if (!id) {
+                log.warn("[wsc] cannot parse controller id", { idStr });
+                continue;
+            }
+            allActiveIds.set(idStr, id);
+        }
+        return Array.from(allActiveIds.values());
+    }
+
+    public getControllerId(): string {
+        return WorkspaceStartControllerId.toString(this.id);
+    }
+}
+
+/**
+ * The properties we are after are:
+ *  - unique per controlled restart (kubectl delete pod/rollout restart) (HOSTNAME)
+ *  - human readable (this.config.version)
+ *  - unique per container restart (this.initializationTime)
+ * @returns
+ */
+interface WorkspaceStartControllerId {
+    hostname: string;
+    version: string;
+    initializationTime: string;
+}
+namespace WorkspaceStartControllerId {
+    const PREFIX = "wscid";
+    export function create(config: Config): WorkspaceStartControllerId {
+        return {
+            hostname: process.env.HOSTNAME || "unknown",
+            version: config.version,
+            initializationTime: new Date().toISOString(),
+        };
+    }
+    export function fromString(str: string): WorkspaceStartControllerId | undefined {
+        const [prefix, hostname, version, initializationTime] = str.split("_");
+        if (prefix !== PREFIX || !hostname || !version || !initializationTime) {
+            return undefined;
+        }
+        return { hostname, version, initializationTime };
+    }
+    export function toString(id: WorkspaceStartControllerId): string {
+        return `${PREFIX}_${id.hostname}_${id.version}_${id.initializationTime}`;
+    }
+    export function isPreviousIncarnation(
+        thisId: WorkspaceStartControllerId,
+        previousId: WorkspaceStartControllerId | undefined,
+    ): boolean {
+        if (!previousId) {
+            return false;
+        }
+
+        // We are the same pod+config as the other one, but we are newer.
+        return (
+            previousId.hostname === thisId.hostname &&
+            previousId.version === thisId.version &&
+            previousId.initializationTime < thisId.initializationTime
+        );
+    }
+}

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -19,6 +19,7 @@ import { ClientProvider } from "./wsman-subscriber";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
 import { PrebuildUpdater } from "./prebuild-updater";
 import { RedisPublisher } from "@gitpod/gitpod-db/lib";
+import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 
 export const WorkspaceInstanceController = Symbol("WorkspaceInstanceController");
 
@@ -306,7 +307,3 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         }
     }
 }
-
-const durationLongerThanSeconds = (time: number, durationSeconds: number, now: number = Date.now()) => {
-    return (now - time) / 1000 > durationSeconds;
-};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27b3f6e</samp>

This pull request introduces a new distributed workspace start mechanism that allows the server component to coordinate workspace instances across multiple regions and clusters. It adds a new `controllerId` property to the `WorkspaceInstance` interface and the `DBWorkspaceInstance` entity, and implements two new classes `DistributedWorkspaceStartController` and `WorkspaceStartController` that use a `WorkspaceStartRegistry` to manage the start operations. It also refactors some existing classes and adds some utility functions and tests.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
