### PR TITLE
[intellij] add previous version

### DIFF
--- a/components/ide-service-api/go/config/ideconfig.go
+++ b/components/ide-service-api/go/config/ideconfig.go
@@ -67,8 +67,6 @@ type IDEOption struct {
 	ImageLayers []string `json:"imageLayers,omitempty"`
 	// LatestImageLayers for latest additional ide layers and dependencies
 	LatestImageLayers []string `json:"latestImageLayers,omitempty"`
-	// VersionImageLayers for additional ide version, besides current stable and latest
-	VersionImageLayers [][]string `json:"versionImageLayers,omitempty"`
 }
 
 type IDEClient struct {

--- a/components/ide-service-api/go/config/ideconfig.go
+++ b/components/ide-service-api/go/config/ideconfig.go
@@ -67,6 +67,8 @@ type IDEOption struct {
 	ImageLayers []string `json:"imageLayers,omitempty"`
 	// LatestImageLayers for latest additional ide layers and dependencies
 	LatestImageLayers []string `json:"latestImageLayers,omitempty"`
+	// VersionImageLayers for additional ide version, besides current stable and latest
+	VersionImageLayers [][]string `json:"versionImageLayers,omitempty"`
 }
 
 type IDEClient struct {

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -148,13 +148,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "2022.3.4"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				pycharm: {
 					OrderKey:          "06",
@@ -168,13 +161,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "2022.3.3"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				phpstorm: {
 					OrderKey:          "07",
@@ -187,13 +173,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "2022.3.3"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				rubymine: {
 					OrderKey:          "08",
@@ -206,13 +185,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "2022.3.3"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				webstorm: {
 					OrderKey:          "09",
@@ -225,13 +197,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "2022.3.4"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				rider: {
 					OrderKey:          "10",
@@ -244,13 +209,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "2022.3.3"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				clion: {
 					OrderKey:          "11",
@@ -263,13 +221,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					VersionImageLayers: [][]string{
-						{
-							ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "2022.3.3"),
-							jbPluginPrevious,
-							jbLauncherImage,
-						},
-					},
 				},
 				xterm: {
 					OrderKey: "12",

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -51,6 +51,25 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	codeWebExtensionImage := ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, ide.CodeWebExtensionVersion)
 	jbPluginImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginImage.Version)
 	jbPluginLatestImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version)
+	/*
+		Upgrading JB Version:
+
+		1. Access the previous JB version at: https://github.com/gitpod-io/gitpod/tree/jb/previous
+		2. Upgrade Process:
+		   - Navigate to the update script:
+		     https://github.com/gitpod-io/gitpod/blob/jb/previous/components/ide/jetbrains/image/gha-update-image
+		   - Execute the script with the desired version as an argument. For example, to upgrade to versions below 231:
+		     node index.js 231
+		   - This action will update both the WORKSPACE.yaml and the backend plugin's target platform version.
+		3. Transfer the changes to gradle-latest.properties to avoid version incompatibilities with latest.
+		4. Resolve any incompatibility issues that arise with the plugin.
+		5. Commit and push your changes to GitHub. This will trigger the build job, generating new images.
+		6. Test the new images in preview environments with stable versions.
+		7. If everything works as expected, update the versions for the plugin and IDEs here where the previous plugin was used.
+
+		TODO: When should it happen? Once a year? Each time when a new major is released, move previous to next, i.e. tracking 1 year behind?
+	*/
+	jbPluginPrevious := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f")
 	jbLauncherImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version)
 	idecfg := ide_config.IDEConfig{
 		SupervisorImage: ctx.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
@@ -110,6 +129,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				goland: {
 					OrderKey:          "05",
@@ -122,6 +148,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "2022.3.4"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				pycharm: {
 					OrderKey:          "06",
@@ -135,6 +168,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				phpstorm: {
 					OrderKey:          "07",
@@ -147,6 +187,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				rubymine: {
 					OrderKey:          "08",
@@ -159,6 +206,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				webstorm: {
 					OrderKey:          "09",
@@ -171,6 +225,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "2022.3.4"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				rider: {
 					OrderKey:          "10",
@@ -183,6 +244,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				clion: {
 					OrderKey:          "11",
@@ -195,6 +263,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					VersionImageLayers: [][]string{
+						{
+							ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "2022.3.3"),
+							jbPluginPrevious,
+							jbLauncherImage,
+						},
+					},
 				},
 				xterm: {
 					OrderKey: "12",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds a new IDE which servers to track previous of IntelliJ. Images are generated in https://github.com/gitpod-io/gitpod/pull/18659

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ac243b</samp>

This pull request adds support for multiple IDE versions in the ide-service component. It updates the JetBrains IDE options to use the latest versions and the new backend plugin version, and it adds a new field `VersionImageLayers` to the `IDEOption` type to store the image layers for different IDE versions. It also modifies the `ide_config_configmap.go` file to use this new field and add comments for upgrade instructions.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Select different IntelliJ versions and see that they work. Please don't open big projects to avoid getting out of space.

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-previous-upgrade</li>
	<li><b>🔗 URL</b> - <a href="https://ak-previous-upgrade.preview.gitpod-dev.com/workspaces" target="_blank">ak-previous-upgrade.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-previous_upgrade-gha.16511</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-previous-upgrade%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
