### PR TITLE
[proto] Add usage-api to leeway run components:generate-code-from-protobuf

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -148,7 +148,7 @@ scripts:
     srcs:
       - components/**/*
     script: |
-      GO_COMPONENTS=( local-app-api content-service-api image-builder-api registry-facade-api supervisor-api ws-daemon-api ws-manager-api ws-manager-bridge-api )
+      GO_COMPONENTS=( local-app-api content-service-api image-builder-api registry-facade-api supervisor-api ws-daemon-api ws-manager-api ws-manager-bridge-api usage-api )
 
       for COMPONENT in "${GO_COMPONENTS[@]}";do
         echo "Generating code for component $COMPONENT..."

--- a/components/usage-api/typescript/src/google/protobuf/timestamp.pb.ts
+++ b/components/usage-api/typescript/src/google/protobuf/timestamp.pb.ts
@@ -5,8 +5,8 @@
  */
 
 /* eslint-disable */
-import * as Long from "long";
 import * as _m0 from "protobufjs/minimal";
+import Long = require("long");
 
 export const protobufPackage = "google.protobuf";
 
@@ -133,22 +133,31 @@ export const Timestamp = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Timestamp {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.seconds = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.nanos = reader.int32();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -162,11 +171,18 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<Timestamp>): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<Timestamp>): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
@@ -184,10 +200,10 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 }
 
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
+declare const self: any | undefined;
+declare const window: any | undefined;
+declare const global: any | undefined;
+const tsProtoGlobalThis: any = (() => {
   if (typeof globalThis !== "undefined") {
     return globalThis;
   }
@@ -212,13 +228,11 @@ export type DeepPartial<T> = T extends Builtin ? T
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new tsProtoGlobalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/components/usage-api/typescript/src/usage/v1/billing.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/billing.pb.ts
@@ -5,9 +5,9 @@
  */
 
 /* eslint-disable */
-import * as Long from "long";
-import { CallContext, CallOptions } from "nice-grpc-common";
+import type { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";
+import Long = require("long");
 
 export const protobufPackage = "usage.v1";
 
@@ -32,8 +32,8 @@ export interface CancelSubscriptionResponse {
 }
 
 export interface GetStripeCustomerRequest {
-  attributionId: string | undefined;
-  stripeCustomerId: string | undefined;
+  attributionId?: string | undefined;
+  stripeCustomerId?: string | undefined;
 }
 
 export interface GetStripeCustomerResponse {
@@ -108,16 +108,17 @@ export const ReconcileInvoicesRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ReconcileInvoicesRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseReconcileInvoicesRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -131,6 +132,9 @@ export const ReconcileInvoicesRequest = {
     return obj;
   },
 
+  create(base?: DeepPartial<ReconcileInvoicesRequest>): ReconcileInvoicesRequest {
+    return ReconcileInvoicesRequest.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<ReconcileInvoicesRequest>): ReconcileInvoicesRequest {
     const message = createBaseReconcileInvoicesRequest();
     return message;
@@ -147,16 +151,17 @@ export const ReconcileInvoicesResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ReconcileInvoicesResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseReconcileInvoicesResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -170,6 +175,9 @@ export const ReconcileInvoicesResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<ReconcileInvoicesResponse>): ReconcileInvoicesResponse {
+    return ReconcileInvoicesResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<ReconcileInvoicesResponse>): ReconcileInvoicesResponse {
     const message = createBaseReconcileInvoicesResponse();
     return message;
@@ -189,19 +197,24 @@ export const FinalizeInvoiceRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): FinalizeInvoiceRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseFinalizeInvoiceRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.invoiceId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -212,10 +225,15 @@ export const FinalizeInvoiceRequest = {
 
   toJSON(message: FinalizeInvoiceRequest): unknown {
     const obj: any = {};
-    message.invoiceId !== undefined && (obj.invoiceId = message.invoiceId);
+    if (message.invoiceId !== "") {
+      obj.invoiceId = message.invoiceId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<FinalizeInvoiceRequest>): FinalizeInvoiceRequest {
+    return FinalizeInvoiceRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<FinalizeInvoiceRequest>): FinalizeInvoiceRequest {
     const message = createBaseFinalizeInvoiceRequest();
     message.invoiceId = object.invoiceId ?? "";
@@ -233,16 +251,17 @@ export const FinalizeInvoiceResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): FinalizeInvoiceResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseFinalizeInvoiceResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -256,6 +275,9 @@ export const FinalizeInvoiceResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<FinalizeInvoiceResponse>): FinalizeInvoiceResponse {
+    return FinalizeInvoiceResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<FinalizeInvoiceResponse>): FinalizeInvoiceResponse {
     const message = createBaseFinalizeInvoiceResponse();
     return message;
@@ -275,19 +297,24 @@ export const CancelSubscriptionRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CancelSubscriptionRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCancelSubscriptionRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.subscriptionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -298,10 +325,15 @@ export const CancelSubscriptionRequest = {
 
   toJSON(message: CancelSubscriptionRequest): unknown {
     const obj: any = {};
-    message.subscriptionId !== undefined && (obj.subscriptionId = message.subscriptionId);
+    if (message.subscriptionId !== "") {
+      obj.subscriptionId = message.subscriptionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CancelSubscriptionRequest>): CancelSubscriptionRequest {
+    return CancelSubscriptionRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CancelSubscriptionRequest>): CancelSubscriptionRequest {
     const message = createBaseCancelSubscriptionRequest();
     message.subscriptionId = object.subscriptionId ?? "";
@@ -319,16 +351,17 @@ export const CancelSubscriptionResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CancelSubscriptionResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCancelSubscriptionResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -342,6 +375,9 @@ export const CancelSubscriptionResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<CancelSubscriptionResponse>): CancelSubscriptionResponse {
+    return CancelSubscriptionResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<CancelSubscriptionResponse>): CancelSubscriptionResponse {
     const message = createBaseCancelSubscriptionResponse();
     return message;
@@ -364,22 +400,31 @@ export const GetStripeCustomerRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetStripeCustomerRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetStripeCustomerRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.stripeCustomerId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -393,11 +438,18 @@ export const GetStripeCustomerRequest = {
 
   toJSON(message: GetStripeCustomerRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.stripeCustomerId !== undefined && (obj.stripeCustomerId = message.stripeCustomerId);
+    if (message.attributionId !== undefined) {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.stripeCustomerId !== undefined) {
+      obj.stripeCustomerId = message.stripeCustomerId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetStripeCustomerRequest>): GetStripeCustomerRequest {
+    return GetStripeCustomerRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetStripeCustomerRequest>): GetStripeCustomerRequest {
     const message = createBaseGetStripeCustomerRequest();
     message.attributionId = object.attributionId ?? undefined;
@@ -422,22 +474,31 @@ export const GetStripeCustomerResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetStripeCustomerResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetStripeCustomerResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.customer = StripeCustomer.decode(reader, reader.uint32());
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -451,12 +512,18 @@ export const GetStripeCustomerResponse = {
 
   toJSON(message: GetStripeCustomerResponse): unknown {
     const obj: any = {};
-    message.customer !== undefined &&
-      (obj.customer = message.customer ? StripeCustomer.toJSON(message.customer) : undefined);
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    if (message.customer !== undefined) {
+      obj.customer = StripeCustomer.toJSON(message.customer);
+    }
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetStripeCustomerResponse>): GetStripeCustomerResponse {
+    return GetStripeCustomerResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetStripeCustomerResponse>): GetStripeCustomerResponse {
     const message = createBaseGetStripeCustomerResponse();
     message.customer = (object.customer !== undefined && object.customer !== null)
@@ -483,22 +550,31 @@ export const StripeCustomer = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): StripeCustomer {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStripeCustomer();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.id = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.currency = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -512,11 +588,18 @@ export const StripeCustomer = {
 
   toJSON(message: StripeCustomer): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.currency !== undefined && (obj.currency = message.currency);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
+    if (message.currency !== "") {
+      obj.currency = message.currency;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<StripeCustomer>): StripeCustomer {
+    return StripeCustomer.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<StripeCustomer>): StripeCustomer {
     const message = createBaseStripeCustomer();
     message.id = object.id ?? "";
@@ -550,31 +633,52 @@ export const CreateStripeCustomerRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateStripeCustomerRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateStripeCustomerRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.name = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.email = reader.string();
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.currency = reader.string();
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.billingCreatorUserId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -591,14 +695,27 @@ export const CreateStripeCustomerRequest = {
 
   toJSON(message: CreateStripeCustomerRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.name !== undefined && (obj.name = message.name);
-    message.email !== undefined && (obj.email = message.email);
-    message.currency !== undefined && (obj.currency = message.currency);
-    message.billingCreatorUserId !== undefined && (obj.billingCreatorUserId = message.billingCreatorUserId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.currency !== "") {
+      obj.currency = message.currency;
+    }
+    if (message.billingCreatorUserId !== "") {
+      obj.billingCreatorUserId = message.billingCreatorUserId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateStripeCustomerRequest>): CreateStripeCustomerRequest {
+    return CreateStripeCustomerRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateStripeCustomerRequest>): CreateStripeCustomerRequest {
     const message = createBaseCreateStripeCustomerRequest();
     message.attributionId = object.attributionId ?? "";
@@ -623,19 +740,24 @@ export const CreateStripeCustomerResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateStripeCustomerResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateStripeCustomerResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.customer = StripeCustomer.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -646,11 +768,15 @@ export const CreateStripeCustomerResponse = {
 
   toJSON(message: CreateStripeCustomerResponse): unknown {
     const obj: any = {};
-    message.customer !== undefined &&
-      (obj.customer = message.customer ? StripeCustomer.toJSON(message.customer) : undefined);
+    if (message.customer !== undefined) {
+      obj.customer = StripeCustomer.toJSON(message.customer);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateStripeCustomerResponse>): CreateStripeCustomerResponse {
+    return CreateStripeCustomerResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateStripeCustomerResponse>): CreateStripeCustomerResponse {
     const message = createBaseCreateStripeCustomerResponse();
     message.customer = (object.customer !== undefined && object.customer !== null)
@@ -673,19 +799,24 @@ export const CreateHoldPaymentIntentRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateHoldPaymentIntentRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateHoldPaymentIntentRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -696,10 +827,15 @@ export const CreateHoldPaymentIntentRequest = {
 
   toJSON(message: CreateHoldPaymentIntentRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateHoldPaymentIntentRequest>): CreateHoldPaymentIntentRequest {
+    return CreateHoldPaymentIntentRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateHoldPaymentIntentRequest>): CreateHoldPaymentIntentRequest {
     const message = createBaseCreateHoldPaymentIntentRequest();
     message.attributionId = object.attributionId ?? "";
@@ -723,22 +859,31 @@ export const CreateHoldPaymentIntentResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateHoldPaymentIntentResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateHoldPaymentIntentResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.paymentIntentId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.paymentIntentClientSecret = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -754,12 +899,18 @@ export const CreateHoldPaymentIntentResponse = {
 
   toJSON(message: CreateHoldPaymentIntentResponse): unknown {
     const obj: any = {};
-    message.paymentIntentId !== undefined && (obj.paymentIntentId = message.paymentIntentId);
-    message.paymentIntentClientSecret !== undefined &&
-      (obj.paymentIntentClientSecret = message.paymentIntentClientSecret);
+    if (message.paymentIntentId !== "") {
+      obj.paymentIntentId = message.paymentIntentId;
+    }
+    if (message.paymentIntentClientSecret !== "") {
+      obj.paymentIntentClientSecret = message.paymentIntentClientSecret;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateHoldPaymentIntentResponse>): CreateHoldPaymentIntentResponse {
+    return CreateHoldPaymentIntentResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateHoldPaymentIntentResponse>): CreateHoldPaymentIntentResponse {
     const message = createBaseCreateHoldPaymentIntentResponse();
     message.paymentIntentId = object.paymentIntentId ?? "";
@@ -787,25 +938,38 @@ export const CreateStripeSubscriptionRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateStripeSubscriptionRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateStripeSubscriptionRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.usageLimit = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.paymentIntentId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -820,12 +984,21 @@ export const CreateStripeSubscriptionRequest = {
 
   toJSON(message: CreateStripeSubscriptionRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.usageLimit !== undefined && (obj.usageLimit = Math.round(message.usageLimit));
-    message.paymentIntentId !== undefined && (obj.paymentIntentId = message.paymentIntentId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.usageLimit !== 0) {
+      obj.usageLimit = Math.round(message.usageLimit);
+    }
+    if (message.paymentIntentId !== "") {
+      obj.paymentIntentId = message.paymentIntentId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateStripeSubscriptionRequest>): CreateStripeSubscriptionRequest {
+    return CreateStripeSubscriptionRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateStripeSubscriptionRequest>): CreateStripeSubscriptionRequest {
     const message = createBaseCreateStripeSubscriptionRequest();
     message.attributionId = object.attributionId ?? "";
@@ -848,19 +1021,24 @@ export const CreateStripeSubscriptionResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CreateStripeSubscriptionResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateStripeSubscriptionResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.subscription = StripeSubscription.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -871,11 +1049,15 @@ export const CreateStripeSubscriptionResponse = {
 
   toJSON(message: CreateStripeSubscriptionResponse): unknown {
     const obj: any = {};
-    message.subscription !== undefined &&
-      (obj.subscription = message.subscription ? StripeSubscription.toJSON(message.subscription) : undefined);
+    if (message.subscription !== undefined) {
+      obj.subscription = StripeSubscription.toJSON(message.subscription);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CreateStripeSubscriptionResponse>): CreateStripeSubscriptionResponse {
+    return CreateStripeSubscriptionResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CreateStripeSubscriptionResponse>): CreateStripeSubscriptionResponse {
     const message = createBaseCreateStripeSubscriptionResponse();
     message.subscription = (object.subscription !== undefined && object.subscription !== null)
@@ -898,19 +1080,24 @@ export const StripeSubscription = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): StripeSubscription {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStripeSubscription();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.id = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -921,10 +1108,15 @@ export const StripeSubscription = {
 
   toJSON(message: StripeSubscription): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<StripeSubscription>): StripeSubscription {
+    return StripeSubscription.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<StripeSubscription>): StripeSubscription {
     const message = createBaseStripeSubscription();
     message.id = object.id ?? "";
@@ -945,19 +1137,24 @@ export const GetPriceInformationRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetPriceInformationRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetPriceInformationRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -968,10 +1165,15 @@ export const GetPriceInformationRequest = {
 
   toJSON(message: GetPriceInformationRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetPriceInformationRequest>): GetPriceInformationRequest {
+    return GetPriceInformationRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetPriceInformationRequest>): GetPriceInformationRequest {
     const message = createBaseGetPriceInformationRequest();
     message.attributionId = object.attributionId ?? "";
@@ -992,19 +1194,24 @@ export const GetPriceInformationResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetPriceInformationResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetPriceInformationResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.humanReadableDescription = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1017,10 +1224,15 @@ export const GetPriceInformationResponse = {
 
   toJSON(message: GetPriceInformationResponse): unknown {
     const obj: any = {};
-    message.humanReadableDescription !== undefined && (obj.humanReadableDescription = message.humanReadableDescription);
+    if (message.humanReadableDescription !== "") {
+      obj.humanReadableDescription = message.humanReadableDescription;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetPriceInformationResponse>): GetPriceInformationResponse {
+    return GetPriceInformationResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetPriceInformationResponse>): GetPriceInformationResponse {
     const message = createBaseGetPriceInformationResponse();
     message.humanReadableDescription = object.humanReadableDescription ?? "";
@@ -1041,19 +1253,24 @@ export const OnChargeDisputeRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): OnChargeDisputeRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseOnChargeDisputeRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.disputeId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1064,10 +1281,15 @@ export const OnChargeDisputeRequest = {
 
   toJSON(message: OnChargeDisputeRequest): unknown {
     const obj: any = {};
-    message.disputeId !== undefined && (obj.disputeId = message.disputeId);
+    if (message.disputeId !== "") {
+      obj.disputeId = message.disputeId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<OnChargeDisputeRequest>): OnChargeDisputeRequest {
+    return OnChargeDisputeRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<OnChargeDisputeRequest>): OnChargeDisputeRequest {
     const message = createBaseOnChargeDisputeRequest();
     message.disputeId = object.disputeId ?? "";
@@ -1085,16 +1307,17 @@ export const OnChargeDisputeResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): OnChargeDisputeResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseOnChargeDisputeResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1108,6 +1331,9 @@ export const OnChargeDisputeResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<OnChargeDisputeResponse>): OnChargeDisputeResponse {
+    return OnChargeDisputeResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<OnChargeDisputeResponse>): OnChargeDisputeResponse {
     const message = createBaseOnChargeDisputeResponse();
     return message;
@@ -1218,7 +1444,7 @@ export const BillingServiceDefinition = {
   },
 } as const;
 
-export interface BillingServiceServiceImplementation<CallContextExt = {}> {
+export interface BillingServiceImplementation<CallContextExt = {}> {
   /**
    * ReconcileInvoices retrieves current credit balance and reflects it in
    * billing system. Internal RPC, not intended for general consumption.
@@ -1353,10 +1579,10 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 }
 
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
+declare const self: any | undefined;
+declare const window: any | undefined;
+declare const global: any | undefined;
+const tsProtoGlobalThis: any = (() => {
   if (typeof globalThis !== "undefined") {
     return globalThis;
   }
@@ -1381,13 +1607,11 @@ export type DeepPartial<T> = T extends Builtin ? T
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new tsProtoGlobalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/components/usage-api/typescript/src/usage/v1/usage.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/usage.pb.ts
@@ -5,10 +5,10 @@
  */
 
 /* eslint-disable */
-import * as Long from "long";
-import { CallContext, CallOptions } from "nice-grpc-common";
+import type { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";
 import { Timestamp } from "../../google/protobuf/timestamp.pb";
+import Long = require("long");
 
 export const protobufPackage = "usage.v1";
 
@@ -280,22 +280,31 @@ export const ReconcileUsageRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ReconcileUsageRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseReconcileUsageRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.from = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.to = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -309,11 +318,18 @@ export const ReconcileUsageRequest = {
 
   toJSON(message: ReconcileUsageRequest): unknown {
     const obj: any = {};
-    message.from !== undefined && (obj.from = message.from.toISOString());
-    message.to !== undefined && (obj.to = message.to.toISOString());
+    if (message.from !== undefined) {
+      obj.from = message.from.toISOString();
+    }
+    if (message.to !== undefined) {
+      obj.to = message.to.toISOString();
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<ReconcileUsageRequest>): ReconcileUsageRequest {
+    return ReconcileUsageRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<ReconcileUsageRequest>): ReconcileUsageRequest {
     const message = createBaseReconcileUsageRequest();
     message.from = object.from ?? undefined;
@@ -332,16 +348,17 @@ export const ReconcileUsageResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ReconcileUsageResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseReconcileUsageResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -355,6 +372,9 @@ export const ReconcileUsageResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<ReconcileUsageResponse>): ReconcileUsageResponse {
+    return ReconcileUsageResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<ReconcileUsageResponse>): ReconcileUsageResponse {
     const message = createBaseReconcileUsageResponse();
     return message;
@@ -377,22 +397,31 @@ export const PaginatedRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): PaginatedRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBasePaginatedRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.perPage = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.page = longToNumber(reader.int64() as Long);
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -406,11 +435,18 @@ export const PaginatedRequest = {
 
   toJSON(message: PaginatedRequest): unknown {
     const obj: any = {};
-    message.perPage !== undefined && (obj.perPage = Math.round(message.perPage));
-    message.page !== undefined && (obj.page = Math.round(message.page));
+    if (message.perPage !== 0) {
+      obj.perPage = Math.round(message.perPage);
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<PaginatedRequest>): PaginatedRequest {
+    return PaginatedRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<PaginatedRequest>): PaginatedRequest {
     const message = createBasePaginatedRequest();
     message.perPage = object.perPage ?? 0;
@@ -441,28 +477,45 @@ export const PaginatedResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): PaginatedResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBasePaginatedResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.perPage = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.totalPages = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 4:
+          if (tag !== 32) {
+            break;
+          }
+
           message.total = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 5:
+          if (tag !== 40) {
+            break;
+          }
+
           message.page = longToNumber(reader.int64() as Long);
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -478,13 +531,24 @@ export const PaginatedResponse = {
 
   toJSON(message: PaginatedResponse): unknown {
     const obj: any = {};
-    message.perPage !== undefined && (obj.perPage = Math.round(message.perPage));
-    message.totalPages !== undefined && (obj.totalPages = Math.round(message.totalPages));
-    message.total !== undefined && (obj.total = Math.round(message.total));
-    message.page !== undefined && (obj.page = Math.round(message.page));
+    if (message.perPage !== 0) {
+      obj.perPage = Math.round(message.perPage);
+    }
+    if (message.totalPages !== 0) {
+      obj.totalPages = Math.round(message.totalPages);
+    }
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<PaginatedResponse>): PaginatedResponse {
+    return PaginatedResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<PaginatedResponse>): PaginatedResponse {
     const message = createBasePaginatedResponse();
     message.perPage = object.perPage ?? 0;
@@ -530,34 +594,59 @@ export const ListUsageRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ListUsageRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListUsageRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 6:
+          if (tag !== 50) {
+            break;
+          }
+
           message.userId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.from = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.to = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 4:
+          if (tag !== 32) {
+            break;
+          }
+
           message.order = listUsageRequest_OrderingFromJSON(reader.int32());
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.pagination = PaginatedRequest.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -577,16 +666,30 @@ export const ListUsageRequest = {
 
   toJSON(message: ListUsageRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.userId !== undefined && (obj.userId = message.userId);
-    message.from !== undefined && (obj.from = message.from.toISOString());
-    message.to !== undefined && (obj.to = message.to.toISOString());
-    message.order !== undefined && (obj.order = listUsageRequest_OrderingToJSON(message.order));
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination ? PaginatedRequest.toJSON(message.pagination) : undefined);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.userId !== "") {
+      obj.userId = message.userId;
+    }
+    if (message.from !== undefined) {
+      obj.from = message.from.toISOString();
+    }
+    if (message.to !== undefined) {
+      obj.to = message.to.toISOString();
+    }
+    if (message.order !== ListUsageRequest_Ordering.ORDERING_DESCENDING) {
+      obj.order = listUsageRequest_OrderingToJSON(message.order);
+    }
+    if (message.pagination !== undefined) {
+      obj.pagination = PaginatedRequest.toJSON(message.pagination);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<ListUsageRequest>): ListUsageRequest {
+    return ListUsageRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<ListUsageRequest>): ListUsageRequest {
     const message = createBaseListUsageRequest();
     message.attributionId = object.attributionId ?? "";
@@ -620,25 +723,38 @@ export const ListUsageResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ListUsageResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListUsageResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.usageEntries.push(Usage.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.pagination = PaginatedResponse.decode(reader, reader.uint32());
-          break;
+          continue;
         case 3:
+          if (tag !== 25) {
+            break;
+          }
+
           message.creditsUsed = reader.double();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -653,17 +769,21 @@ export const ListUsageResponse = {
 
   toJSON(message: ListUsageResponse): unknown {
     const obj: any = {};
-    if (message.usageEntries) {
-      obj.usageEntries = message.usageEntries.map((e) => e ? Usage.toJSON(e) : undefined);
-    } else {
-      obj.usageEntries = [];
+    if (message.usageEntries?.length) {
+      obj.usageEntries = message.usageEntries.map((e) => Usage.toJSON(e));
     }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination ? PaginatedResponse.toJSON(message.pagination) : undefined);
-    message.creditsUsed !== undefined && (obj.creditsUsed = message.creditsUsed);
+    if (message.pagination !== undefined) {
+      obj.pagination = PaginatedResponse.toJSON(message.pagination);
+    }
+    if (message.creditsUsed !== 0) {
+      obj.creditsUsed = message.creditsUsed;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<ListUsageResponse>): ListUsageResponse {
+    return ListUsageResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<ListUsageResponse>): ListUsageResponse {
     const message = createBaseListUsageResponse();
     message.usageEntries = object.usageEntries?.map((e) => Usage.fromPartial(e)) || [];
@@ -722,43 +842,80 @@ export const Usage = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Usage {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseUsage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.id = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.description = reader.string();
-          break;
+          continue;
         case 4:
+          if (tag !== 33) {
+            break;
+          }
+
           message.credits = reader.double();
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.effectiveTime = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 6:
+          if (tag !== 48) {
+            break;
+          }
+
           message.kind = usage_KindFromJSON(reader.int32());
-          break;
+          continue;
         case 7:
+          if (tag !== 58) {
+            break;
+          }
+
           message.workspaceInstanceId = reader.string();
-          break;
+          continue;
         case 8:
+          if (tag !== 64) {
+            break;
+          }
+
           message.draft = reader.bool();
-          break;
+          continue;
         case 9:
+          if (tag !== 74) {
+            break;
+          }
+
           message.metadata = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -779,18 +936,39 @@ export const Usage = {
 
   toJSON(message: Usage): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.description !== undefined && (obj.description = message.description);
-    message.credits !== undefined && (obj.credits = message.credits);
-    message.effectiveTime !== undefined && (obj.effectiveTime = message.effectiveTime.toISOString());
-    message.kind !== undefined && (obj.kind = usage_KindToJSON(message.kind));
-    message.workspaceInstanceId !== undefined && (obj.workspaceInstanceId = message.workspaceInstanceId);
-    message.draft !== undefined && (obj.draft = message.draft);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.credits !== 0) {
+      obj.credits = message.credits;
+    }
+    if (message.effectiveTime !== undefined) {
+      obj.effectiveTime = message.effectiveTime.toISOString();
+    }
+    if (message.kind !== Usage_Kind.KIND_WORKSPACE_INSTANCE) {
+      obj.kind = usage_KindToJSON(message.kind);
+    }
+    if (message.workspaceInstanceId !== "") {
+      obj.workspaceInstanceId = message.workspaceInstanceId;
+    }
+    if (message.draft === true) {
+      obj.draft = message.draft;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<Usage>): Usage {
+    return Usage.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<Usage>): Usage {
     const message = createBaseUsage();
     message.id = object.id ?? "";
@@ -819,19 +997,24 @@ export const SetCostCenterRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): SetCostCenterRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetCostCenterRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.costCenter = CostCenter.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -842,11 +1025,15 @@ export const SetCostCenterRequest = {
 
   toJSON(message: SetCostCenterRequest): unknown {
     const obj: any = {};
-    message.costCenter !== undefined &&
-      (obj.costCenter = message.costCenter ? CostCenter.toJSON(message.costCenter) : undefined);
+    if (message.costCenter !== undefined) {
+      obj.costCenter = CostCenter.toJSON(message.costCenter);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<SetCostCenterRequest>): SetCostCenterRequest {
+    return SetCostCenterRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<SetCostCenterRequest>): SetCostCenterRequest {
     const message = createBaseSetCostCenterRequest();
     message.costCenter = (object.costCenter !== undefined && object.costCenter !== null)
@@ -869,19 +1056,24 @@ export const SetCostCenterResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): SetCostCenterResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetCostCenterResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.costCenter = CostCenter.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -892,11 +1084,15 @@ export const SetCostCenterResponse = {
 
   toJSON(message: SetCostCenterResponse): unknown {
     const obj: any = {};
-    message.costCenter !== undefined &&
-      (obj.costCenter = message.costCenter ? CostCenter.toJSON(message.costCenter) : undefined);
+    if (message.costCenter !== undefined) {
+      obj.costCenter = CostCenter.toJSON(message.costCenter);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<SetCostCenterResponse>): SetCostCenterResponse {
+    return SetCostCenterResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<SetCostCenterResponse>): SetCostCenterResponse {
     const message = createBaseSetCostCenterResponse();
     message.costCenter = (object.costCenter !== undefined && object.costCenter !== null)
@@ -919,19 +1115,24 @@ export const GetBalanceRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetBalanceRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetBalanceRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -942,10 +1143,15 @@ export const GetBalanceRequest = {
 
   toJSON(message: GetBalanceRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetBalanceRequest>): GetBalanceRequest {
+    return GetBalanceRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetBalanceRequest>): GetBalanceRequest {
     const message = createBaseGetBalanceRequest();
     message.attributionId = object.attributionId ?? "";
@@ -966,19 +1172,24 @@ export const GetBalanceResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetBalanceResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetBalanceResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 4:
+          if (tag !== 33) {
+            break;
+          }
+
           message.credits = reader.double();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -989,10 +1200,15 @@ export const GetBalanceResponse = {
 
   toJSON(message: GetBalanceResponse): unknown {
     const obj: any = {};
-    message.credits !== undefined && (obj.credits = message.credits);
+    if (message.credits !== 0) {
+      obj.credits = message.credits;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetBalanceResponse>): GetBalanceResponse {
+    return GetBalanceResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetBalanceResponse>): GetBalanceResponse {
     const message = createBaseGetBalanceResponse();
     message.credits = object.credits ?? 0;
@@ -1013,19 +1229,24 @@ export const GetCostCenterRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetCostCenterRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetCostCenterRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1036,10 +1257,15 @@ export const GetCostCenterRequest = {
 
   toJSON(message: GetCostCenterRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetCostCenterRequest>): GetCostCenterRequest {
+    return GetCostCenterRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetCostCenterRequest>): GetCostCenterRequest {
     const message = createBaseGetCostCenterRequest();
     message.attributionId = object.attributionId ?? "";
@@ -1060,19 +1286,24 @@ export const GetCostCenterResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetCostCenterResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetCostCenterResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.costCenter = CostCenter.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1083,11 +1314,15 @@ export const GetCostCenterResponse = {
 
   toJSON(message: GetCostCenterResponse): unknown {
     const obj: any = {};
-    message.costCenter !== undefined &&
-      (obj.costCenter = message.costCenter ? CostCenter.toJSON(message.costCenter) : undefined);
+    if (message.costCenter !== undefined) {
+      obj.costCenter = CostCenter.toJSON(message.costCenter);
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<GetCostCenterResponse>): GetCostCenterResponse {
+    return GetCostCenterResponse.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<GetCostCenterResponse>): GetCostCenterResponse {
     const message = createBaseGetCostCenterResponse();
     message.costCenter = (object.costCenter !== undefined && object.costCenter !== null)
@@ -1128,31 +1363,52 @@ export const CostCenter = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CostCenter {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCostCenter();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.spendingLimit = reader.int32();
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.billingStrategy = costCenter_BillingStrategyFromJSON(reader.int32());
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.nextBillingTime = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.billingCycleStart = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1171,15 +1427,27 @@ export const CostCenter = {
 
   toJSON(message: CostCenter): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.spendingLimit !== undefined && (obj.spendingLimit = Math.round(message.spendingLimit));
-    message.billingStrategy !== undefined &&
-      (obj.billingStrategy = costCenter_BillingStrategyToJSON(message.billingStrategy));
-    message.nextBillingTime !== undefined && (obj.nextBillingTime = message.nextBillingTime.toISOString());
-    message.billingCycleStart !== undefined && (obj.billingCycleStart = message.billingCycleStart.toISOString());
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.spendingLimit !== 0) {
+      obj.spendingLimit = Math.round(message.spendingLimit);
+    }
+    if (message.billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE) {
+      obj.billingStrategy = costCenter_BillingStrategyToJSON(message.billingStrategy);
+    }
+    if (message.nextBillingTime !== undefined) {
+      obj.nextBillingTime = message.nextBillingTime.toISOString();
+    }
+    if (message.billingCycleStart !== undefined) {
+      obj.billingCycleStart = message.billingCycleStart.toISOString();
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<CostCenter>): CostCenter {
+    return CostCenter.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<CostCenter>): CostCenter {
     const message = createBaseCostCenter();
     message.attributionId = object.attributionId ?? "";
@@ -1201,16 +1469,17 @@ export const ResetUsageRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ResetUsageRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseResetUsageRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1224,6 +1493,9 @@ export const ResetUsageRequest = {
     return obj;
   },
 
+  create(base?: DeepPartial<ResetUsageRequest>): ResetUsageRequest {
+    return ResetUsageRequest.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<ResetUsageRequest>): ResetUsageRequest {
     const message = createBaseResetUsageRequest();
     return message;
@@ -1240,16 +1512,17 @@ export const ResetUsageResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ResetUsageResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseResetUsageResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1263,6 +1536,9 @@ export const ResetUsageResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<ResetUsageResponse>): ResetUsageResponse {
+    return ResetUsageResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<ResetUsageResponse>): ResetUsageResponse {
     const message = createBaseResetUsageResponse();
     return message;
@@ -1291,28 +1567,45 @@ export const AddUsageCreditNoteRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): AddUsageCreditNoteRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseAddUsageCreditNoteRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.attributionId = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.credits = reader.int32();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.description = reader.string();
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.userId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1328,13 +1621,24 @@ export const AddUsageCreditNoteRequest = {
 
   toJSON(message: AddUsageCreditNoteRequest): unknown {
     const obj: any = {};
-    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
-    message.credits !== undefined && (obj.credits = Math.round(message.credits));
-    message.description !== undefined && (obj.description = message.description);
-    message.userId !== undefined && (obj.userId = message.userId);
+    if (message.attributionId !== "") {
+      obj.attributionId = message.attributionId;
+    }
+    if (message.credits !== 0) {
+      obj.credits = Math.round(message.credits);
+    }
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.userId !== "") {
+      obj.userId = message.userId;
+    }
     return obj;
   },
 
+  create(base?: DeepPartial<AddUsageCreditNoteRequest>): AddUsageCreditNoteRequest {
+    return AddUsageCreditNoteRequest.fromPartial(base ?? {});
+  },
   fromPartial(object: DeepPartial<AddUsageCreditNoteRequest>): AddUsageCreditNoteRequest {
     const message = createBaseAddUsageCreditNoteRequest();
     message.attributionId = object.attributionId ?? "";
@@ -1355,16 +1659,17 @@ export const AddUsageCreditNoteResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): AddUsageCreditNoteResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseAddUsageCreditNoteResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1378,6 +1683,9 @@ export const AddUsageCreditNoteResponse = {
     return obj;
   },
 
+  create(base?: DeepPartial<AddUsageCreditNoteResponse>): AddUsageCreditNoteResponse {
+    return AddUsageCreditNoteResponse.fromPartial(base ?? {});
+  },
   fromPartial(_: DeepPartial<AddUsageCreditNoteResponse>): AddUsageCreditNoteResponse {
     const message = createBaseAddUsageCreditNoteResponse();
     return message;
@@ -1455,7 +1763,7 @@ export const UsageServiceDefinition = {
   },
 } as const;
 
-export interface UsageServiceServiceImplementation<CallContextExt = {}> {
+export interface UsageServiceImplementation<CallContextExt = {}> {
   /** GetCostCenter retrieves the active cost center for the given attributionID */
   getCostCenter(
     request: GetCostCenterRequest,
@@ -1534,10 +1842,10 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 }
 
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
+declare const self: any | undefined;
+declare const window: any | undefined;
+declare const global: any | undefined;
+const tsProtoGlobalThis: any = (() => {
   if (typeof globalThis !== "undefined") {
     return globalThis;
   }
@@ -1567,8 +1875,8 @@ function toTimestamp(date: Date): Timestamp {
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000;
-  millis += t.nanos / 1_000_000;
+  let millis = (t.seconds || 0) * 1_000;
+  millis += (t.nanos || 0) / 1_000_000;
   return new Date(millis);
 }
 
@@ -1584,13 +1892,11 @@ function fromJsonTimestamp(o: any): Date {
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new tsProtoGlobalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();


### PR DESCRIPTION
## Description

Not sure why, but I got an build error inside the generated code when running `yarn build`. Re-running `generate.sh` fixed it, and produced this output.

Likely related to recent protobufjs updates (and that we were missing `usage-api` in [this list](https://github.com/gitpod-io/gitpod/compare/gpl/fix-usage-build?expand=1#diff-d9857d58094e89535e27ce202db49ac46dee06fd67f94c017547f30f28bee633R151)).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87f9249</samp>

This pull request introduces a new usage-api component that provides usage metrics for Gitpod. It also fixes and improves the `Timestamp` message implementation in the TypeScript protobuf library.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
