### PR TITLE
Reconcile startWorkspace

### DIFF
--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -130,23 +130,11 @@ export interface WorkspaceDB {
         query?: AdminGetWorkspacesQuery,
     ): Promise<{ total: number; rows: WorkspaceAndInstance[] }>;
     findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
-    findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
+    findInstancesByPhase(phases: string[]): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
     getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
-
-    findAllWorkspaceInstances(
-        offset: number,
-        limit: number,
-        orderBy: keyof WorkspaceInstance,
-        orderDir: "ASC" | "DESC",
-        ownerId?: string,
-        minCreationTime?: Date,
-        maxCreationTime?: Date,
-        onlyRunning?: boolean,
-        type?: WorkspaceType,
-    ): Promise<{ total: number; rows: WorkspaceInstance[] }>;
 
     findRegularRunningInstances(userId?: string): Promise<WorkspaceInstance[]>;
     findRunningInstancesWithWorkspaces(

--- a/components/gitpod-protocol/src/util/timeutil.ts
+++ b/components/gitpod-protocol/src/util/timeutil.ts
@@ -77,6 +77,10 @@ export function rightBefore(date: string): string {
     return new Date(new Date(date).getTime() - 1).toISOString();
 }
 
+export function durationLongerThanSeconds(time: number, durationSeconds: number, now: number = Date.now()): boolean {
+    return (now - time) / 1000 > durationSeconds;
+}
+
 export function millisecondsToHours(milliseconds: number): number {
     return milliseconds / 1000 / 60 / 60;
 }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -133,6 +133,7 @@ import { GitpodTokenService } from "./user/gitpod-token-service";
 import { EnvVarService } from "./user/env-var-service";
 import { ScmService } from "./projects/scm-service";
 import { RelationshipUpdateJob } from "./authorization/relationship-updater-job";
+import { WorkspaceStartController } from "./workspace/workspace-start-controller";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -170,6 +171,7 @@ export const productionContainerModule = new ContainerModule(
         bind(WorkspaceService).toSelf().inSingletonScope();
         bind(WorkspaceFactory).toSelf().inSingletonScope();
         bind(WorkspaceStarter).toSelf().inSingletonScope();
+        bind(WorkspaceStartController).toSelf().inSingletonScope();
         bind(ImageSourceProvider).toSelf().inSingletonScope();
 
         bind(ServerFactory).toAutoFactory(GitpodServerImpl);

--- a/components/server/src/redis/mutex.ts
+++ b/components/server/src/redis/mutex.ts
@@ -6,7 +6,7 @@
 
 import { inject, injectable } from "inversify";
 import { Redis } from "ioredis";
-import Redlock, { RedlockAbortSignal } from "redlock";
+import Redlock, { RedlockAbortSignal, ResourceLockedError, ExecutionError, Settings } from "redlock";
 
 @injectable()
 export class RedisMutex {
@@ -40,7 +40,12 @@ export class RedisMutex {
         resources: string[],
         duration: number,
         routine: (signal: RedlockAbortSignal) => Promise<T>,
+        settings: Partial<Settings> = {},
     ): Promise<T> {
-        return this.client().using(resources, duration, routine);
+        return this.client().using(resources, duration, settings, routine);
+    }
+
+    public static isLockError(err: any): boolean {
+        return err instanceof ResourceLockedError || err instanceof ExecutionError;
     }
 }

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -122,7 +122,7 @@ describe("WorkspaceService", async () => {
         const workspace = await createTestWorkspace(workspaceService, org, owner, project);
 
         const result = await workspaceService.startWorkspace({}, owner, workspace.id);
-        expect(result.workspaceURL).to.equal(`https://${workspace.id}.ws.gitpod.io`);
+        expect(result.instanceID).to.not.be.undefined;
     });
 
     it("owner can start own workspace - shared", async () => {
@@ -131,7 +131,7 @@ describe("WorkspaceService", async () => {
         await workspaceService.controlAdmission(owner.id, workspace.id, "everyone");
 
         const result = await workspaceService.startWorkspace({}, owner, workspace.id);
-        expect(result.workspaceURL).to.equal(`https://${workspace.id}.ws.gitpod.io`);
+        expect(result.instanceID).to.not.be.undefined;
     });
 
     it("stanger cannot start owner workspace", async () => {
@@ -164,7 +164,7 @@ describe("WorkspaceService", async () => {
         const workspaceService = container.get(WorkspaceService);
         const workspace = await createTestWorkspace(workspaceService, org, member, project);
         const result = await workspaceService.startWorkspace({}, member, workspace.id);
-        expect(result.workspaceURL).to.equal(`https://${workspace.id}.ws.gitpod.io`);
+        expect(result.instanceID).to.not.be.undefined;
     });
 
     it("stanger cannot start org member workspace", async () => {

--- a/components/server/src/workspace/workspace-start-controller.ts
+++ b/components/server/src/workspace/workspace-start-controller.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable } from "inversify";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { Job } from "../jobs/runner";
+import { DBWithTracing, TracedWorkspaceDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/timeutil";
+import { WorkspaceStarter } from "./workspace-starter";
+
+@injectable()
+export class WorkspaceStartController implements Job {
+    public readonly name: string = "workspace-start-controller";
+    public readonly frequencyMs: number = 1000 * 10; // 10s
+
+    constructor(
+        @inject(TracedWorkspaceDB) private readonly workspaceDB: DBWithTracing<WorkspaceDB>,
+        @inject(UserDB) private readonly userDB: UserDB,
+        @inject(WorkspaceStarter) private readonly workspaceStarter: WorkspaceStarter,
+    ) {}
+
+    public async run(): Promise<void> {
+        const span = TraceContext.startSpan("controlStartingWorkspaces");
+        const ctx = { span };
+
+        try {
+            const instances = await this.workspaceDB.trace(ctx).findInstancesByPhase(WorkspaceStarter.STARTING_PHASES);
+            for (const instance of instances) {
+                const phase = instance.status.phase;
+                if (
+                    phase === "preparing" ||
+                    phase === "building" ||
+                    // !!! Note: during pending, the handover between app-cluster and ws-manager happens. !!!
+                    // This means:
+                    //  - there is a control loop on ws-manager-bridge that checks for an upper limit a instance may be in pending phase
+                    //  - it will take some time after calling ws-manager to see the first status update
+                    // In 99.9% this is due to timing, so we need to be a bit cautious here not to spam ourselves.
+                    (phase === "pending" && durationLongerThanSeconds(Date.parse(instance.creationTime), 30))
+                ) {
+                    // this.reconcileWorkspaceStart(ctx, instance.id);
+                    const workspace = await this.workspaceDB.trace(ctx).findById(instance.workspaceId);
+                    if (!workspace) {
+                        throw new Error("cannot find workspace for instance");
+                    }
+                    const user = await this.userDB.findUserById(workspace.ownerId);
+                    if (!user) {
+                        throw new Error("cannot find owner for workspace");
+                    }
+                    this.workspaceStarter.reconcileWorkspaceStart(ctx, instance.id, user, workspace);
+                }
+            }
+        } catch (err) {
+            TraceContext.setError(ctx, err);
+        } finally {
+            span.finish();
+        }
+    }
+}

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -56,6 +56,7 @@ import {
     WorkspaceImageSourceReference,
     WorkspaceInstance,
     WorkspaceInstanceConfiguration,
+    WorkspaceInstancePhase,
     WorkspaceInstanceStatus,
     WorkspaceTimeoutDuration,
 } from "@gitpod/gitpod-protocol";
@@ -63,8 +64,7 @@ import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { LogContext, log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
-import { TraceContext, TraceContextWithSpan } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import * as IdeServiceApi from "@gitpod/ide-service-api/lib/ide.pb";
 import {
@@ -101,6 +101,7 @@ import {
     PortProtocol,
     StopWorkspacePolicy,
     StopWorkspaceRequest,
+    DescribeWorkspaceRequest,
 } from "@gitpod/ws-manager/lib/core_pb";
 import * as grpc from "@grpc/grpc-js";
 import * as crypto from "crypto";
@@ -127,7 +128,8 @@ import { UserAuthentication } from "../user/user-authentication";
 import { ImageSourceProvider } from "./image-source-provider";
 import { WorkspaceClassesConfig } from "./workspace-classes";
 import { SYSTEM_USER } from "../authorization/authorizer";
-import { ResolvedEnvVars } from "../user/env-var-service";
+import { EnvVarService, ResolvedEnvVars } from "../user/env-var-service";
+import { RedlockAbortSignal } from "redlock";
 
 export interface StartWorkspaceOptions extends GitpodServer.StartWorkspaceOptions {
     excludeFeatureFlags?: NamedWorkspaceFeatureFlag[];
@@ -173,7 +175,10 @@ export async function getWorkspaceClassForInstance(
 }
 
 class StartInstanceError extends Error {
-    constructor(public readonly reason: FailedInstanceStartReason, public readonly cause: Error) {
+    constructor(
+        public readonly reason: FailedInstanceStartReason,
+        public readonly cause: Error,
+    ) {
         super("Starting workspace instance failed: " + cause.message);
     }
 }
@@ -193,6 +198,8 @@ export function isClusterMaintenanceError(err: any): boolean {
 
 @injectable()
 export class WorkspaceStarter {
+    static readonly STARTING_PHASES: WorkspaceInstancePhase[] = ["preparing", "building", "pending"];
+
     constructor(
         @inject(WorkspaceManagerClientProvider) private readonly clientProvider: WorkspaceManagerClientProvider,
         @inject(Config) private readonly config: Config,
@@ -212,13 +219,14 @@ export class WorkspaceStarter {
         @inject(EntitlementService) private readonly entitlementService: EntitlementService,
         @inject(RedisMutex) private readonly redisMutex: RedisMutex,
         @inject(RedisPublisher) private readonly publisher: RedisPublisher,
+        @inject(EnvVarService) private readonly envVarService: EnvVarService,
     ) {}
+
     public async startWorkspace(
         ctx: TraceContext,
         workspace: Workspace,
         user: User,
         project: Project | undefined,
-        envVars: ResolvedEnvVars,
         options?: StartWorkspaceOptions,
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("WorkspaceStarter.startWorkspace", ctx);
@@ -322,8 +330,10 @@ export class WorkspaceStarter {
             span.log({ newInstance: instance.id });
             instanceId = instance.id;
 
-            const result = await this.buildImageAndStartWorkspace({ span }, user, workspace, instance, envVars);
-            return result;
+            // start the instance
+            this.reconcileWorkspaceStart({ span }, instance.id, user, workspace);
+
+            return { instanceID: instance.id };
         } catch (e) {
             this.logAndTraceStartWorkspaceError({ span }, { userId: user.id, instanceId }, e);
             throw e;
@@ -332,46 +342,84 @@ export class WorkspaceStarter {
         }
     }
 
-    private async buildImageAndStartWorkspace(
-        ctx: TraceContextWithSpan,
-        user: User,
-        workspace: Workspace,
-        instance: WorkspaceInstance,
-        envVars: ResolvedEnvVars,
-    ): Promise<StartWorkspaceResult> {
-        const { span } = ctx;
+    public reconcileWorkspaceStart(_ctx: TraceContext, instanceId: string, user: User, workspace: Workspace) {
+        const ctx = TraceContext.childContext("reconcileWorkspaceStart", _ctx);
 
-        const forceRebuild = !!workspace.context.forceImageBuild;
-        let needsImageBuild: boolean;
-        try {
-            // if we need to build the workspace image we must not wait for actuallyStartWorkspace to return as that would block the
-            // frontend until the image is built.
-            const additionalAuth = await this.getAdditionalImageAuth(envVars);
-            needsImageBuild =
-                forceRebuild || (await this.needsImageBuild(ctx, user, workspace, instance, additionalAuth));
-            if (needsImageBuild) {
-                instance.status.conditions = {
-                    neededImageBuild: true,
-                };
-            }
-            span.setTag("needsImageBuild", needsImageBuild);
-        } catch (err) {
-            // if we fail to check if the workspace needs an image build (e.g. becuase the image builder is unavailable),
-            // we must properly fail the workspace instance, i.e. set its status to stopped, deal with prebuilds etc.
-            //
-            // Once we've reached actuallyStartWorkspace that function will take care of failing the instance.
-            await this.failInstanceStart(ctx, err, workspace, instance);
-            throw err;
-        }
+        // We try to acquire a mutex here, which we intend to hold until the workspace start request is sent to ws-manager.
+        // In case this container dies for whatever reason, the mutex is eventually released, and the instance can be picked up
+        // by another server process (cmp. WorkspaceStartController).
+        this.redisMutex
+            .using(
+                ["workspace-instance-start-" + instanceId],
+                5000, // After 5s without extension the lock is released
+                async (abortSignal) => {
+                    // Fetch a fresh instance to check it's phase
+                    const instance = await this.workspaceDb.trace({}).findInstanceById(instanceId);
+                    if (!instance) {
+                        ctx.span.finish();
+                        throw new Error("cannot find workspace for instance");
+                    }
+                    if (!WorkspaceStarter.STARTING_PHASES.includes(instance.status.phase)) {
+                        log.debug(
+                            { instanceId, workspaceId: instance.workspaceId, userId: user.id },
+                            "can't start workspace instance in this phase",
+                            { phase: instance.status.phase },
+                        );
+                        return;
+                    }
 
-        if (needsImageBuild) {
-            this.actuallyStartWorkspace({ span }, instance, workspace, user, envVars, forceRebuild).catch((err) =>
-                log.error("actuallyStartWorkspace", err),
-            );
-            return { instanceID: instance.id };
-        }
+                    const envVars = await this.envVarService.resolveEnvVariables(
+                        user.id,
+                        workspace.projectId,
+                        workspace.type,
+                        workspace.context,
+                    );
 
-        return await this.actuallyStartWorkspace({ span }, instance, workspace, user, envVars, forceRebuild);
+                    const forceRebuild = !!workspace.context.forceImageBuild;
+                    try {
+                        // if we need to build the workspace image we must not wait for actuallyStartWorkspace to return as that would block the
+                        // frontend until the image is built.
+                        const additionalAuth = await this.getAdditionalImageAuth(envVars);
+                        const needsImageBuild =
+                            forceRebuild ||
+                            (await this.needsImageBuild(ctx, user, workspace, instance, additionalAuth));
+                        if (needsImageBuild) {
+                            instance.status.conditions = {
+                                neededImageBuild: true,
+                            };
+                        }
+                        ctx.span?.setTag("needsImageBuild", needsImageBuild);
+                    } catch (err) {
+                        // if we fail to check if the workspace needs an image build (e.g. becuase the image builder is unavailable),
+                        // we must properly fail the workspace instance, i.e. set its status to stopped, deal with prebuilds etc.
+                        //
+                        // Once we've reached actuallyStartWorkspace that function will take care of failing the instance.
+                        await this.failInstanceStart(ctx, err, workspace, instance);
+                        throw err;
+                    }
+
+                    await this.actuallyStartWorkspace(
+                        ctx,
+                        instance,
+                        workspace,
+                        user,
+                        envVars,
+                        abortSignal,
+                        forceRebuild,
+                    );
+                },
+                { retryCount: 4, retryDelay: 500 }, // We wait at most 2s until we give up, and conclude that someone else is already starting this instance
+            )
+            .catch((err) => {
+                if (RedisMutex.isLockError(err)) {
+                    log.debug({ instanceId }, "unable to acquire lock for workspace instance start");
+                    return;
+                }
+                log.error({ instanceId }, "error in reconcileWorkspaceStart", err);
+            })
+            .finally(() => {
+                ctx.span.finish();
+            });
     }
 
     private async resolveIDEConfiguration(
@@ -479,8 +527,9 @@ export class WorkspaceStarter {
         workspace: Workspace,
         user: User,
         envVars: ResolvedEnvVars,
+        abortSignal: RedlockAbortSignal,
         forceRebuild?: boolean,
-    ): Promise<StartWorkspaceResult> {
+    ): Promise<void> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
         const region = instance.configuration.regionPreference;
         span.setTag("region_preference", region);
@@ -525,103 +574,78 @@ export class WorkspaceStarter {
             startRequest.setSpec(spec);
             startRequest.setServicePrefix(workspace.id);
 
-            const ideUrlPromise = new Deferred<string>();
-            const before = Date.now();
-            const logSuccess = (fromWsManager: boolean) => {
-                log.info(logCtx, "Received ideURL", {
-                    tookMs: Date.now() - before,
-                    fromWsManager,
-                });
-            };
-
-            const doStartWorkspace = async () => {
-                // choose a cluster and start the instance
-                let resp: StartWorkspaceResponse.AsObject | undefined = undefined;
-                let retries = 0;
-                try {
-                    for (; retries < MAX_INSTANCE_START_RETRIES; retries++) {
-                        resp = await this.tryStartOnCluster({ span }, startRequest, user, workspace, instance, region);
-                        if (resp) {
-                            break;
-                        }
-                        await new Promise((resolve) =>
-                            setTimeout(resolve, INSTANCE_START_RETRY_INTERVAL_SECONDS * 1000),
-                        );
-                    }
-                } catch (err) {
-                    let reason: FailedInstanceStartReason = "startOnClusterFailed";
-                    if (isResourceExhaustedError(err)) {
-                        reason = "resourceExhausted";
-                    }
-                    if (isClusterMaintenanceError(err)) {
-                        reason = "workspaceClusterMaintenance";
-                        err = new Error(
-                            "Cannot start a workspace because the workspace cluster is temporarily unavailable due to maintenance. Please try again in a few minutes",
-                        );
-                    }
-                    await this.failInstanceStart({ span }, err, workspace, instance);
-                    throw new StartInstanceError(reason, err);
+            if (instance.status.phase === "pending") {
+                // due to the reconciliation loop we might have already started the workspace, especially in the "pending" phase
+                const workspaceAlreadyExists = await this.existsWithWsManager(ctx, instance);
+                if (workspaceAlreadyExists) {
+                    log.warn(
+                        { instanceId: instance.id, workspaceId: instance.workspaceId },
+                        "workspace already exists, not starting again",
+                    );
+                    return;
                 }
+            }
 
-                if (!resp) {
-                    const err = new Error("cannot start a workspace because no workspace clusters are available");
-                    await this.failInstanceStart({ span }, err, workspace, instance);
-                    throw new StartInstanceError("clusterSelectionFailed", err);
-                }
-                increaseSuccessfulInstanceStartCounter(retries);
-
-                if (!ideUrlPromise.isResolved) {
-                    span.log({ resp: resp });
-                    logSuccess(true);
-                    ideUrlPromise.resolve(resp.url);
-                }
-            };
-            doStartWorkspace().catch((err) => ideUrlPromise.reject(err));
-
-            const intervalHandle = repeat(async () => {
-                const inst = await this.workspaceDb.trace(ctx).findInstanceById(instance.id);
-                if (inst?.ideUrl && !ideUrlPromise.isResolved) {
-                    logSuccess(false);
-                    ideUrlPromise.resolve(inst?.ideUrl);
-                }
-            }, 50);
-
+            // choose a cluster and start the instance
+            let resp: StartWorkspaceResponse.AsObject | undefined = undefined;
+            let retries = 0;
             try {
-                const url = await ideUrlPromise.promise;
-
-                this.analytics.track({
-                    userId: user.id,
-                    event: "workspace_started",
-                    properties: {
-                        workspaceId: workspace.id,
-                        instanceId: instance.id,
-                        projectId: workspace.projectId,
-                        contextURL: workspace.contextURL,
-                        type: workspace.type,
-                        class: instance.workspaceClass,
-                        ideConfig: instance.configuration?.ideConfig,
-                        usesPrebuild: spec.getInitializer()?.hasPrebuild(),
-                    },
-                    timestamp: new Date(instance.creationTime),
-                });
-
-                {
-                    if (type === WorkspaceType.PREBUILD) {
-                        // do not await
-                        this.notifyOnPrebuildQueued(ctx, workspace.id).catch((err) => {
-                            log.error("failed to notify on prebuild queued", err);
-                        });
+                for (; retries < MAX_INSTANCE_START_RETRIES; retries++) {
+                    if (abortSignal.aborted) {
+                        return;
                     }
+                    resp = await this.tryStartOnCluster({ span }, startRequest, user, workspace, instance, region);
+                    if (resp) {
+                        break;
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, INSTANCE_START_RETRY_INTERVAL_SECONDS * 1000));
                 }
+            } catch (err) {
+                let reason: FailedInstanceStartReason = "startOnClusterFailed";
+                if (isResourceExhaustedError(err)) {
+                    reason = "resourceExhausted";
+                }
+                if (isClusterMaintenanceError(err)) {
+                    reason = "workspaceClusterMaintenance";
+                    err = new Error(
+                        "Cannot start a workspace because the workspace cluster is temporarily unavailable due to maintenance. Please try again in a few minutes",
+                    );
+                }
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                throw new StartInstanceError(reason, err);
+            }
 
-                return { instanceID: instance.id, workspaceURL: url };
-            } finally {
-                intervalHandle.dispose();
+            if (!resp) {
+                const err = new Error("cannot start a workspace because no workspace clusters are available");
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                throw new StartInstanceError("clusterSelectionFailed", err);
+            }
+            increaseSuccessfulInstanceStartCounter(retries);
+
+            this.analytics.track({
+                userId: user.id,
+                event: "workspace_started",
+                properties: {
+                    workspaceId: workspace.id,
+                    instanceId: instance.id,
+                    projectId: workspace.projectId,
+                    contextURL: workspace.contextURL,
+                    type: workspace.type,
+                    class: instance.workspaceClass,
+                    ideConfig: instance.configuration?.ideConfig,
+                    usesPrebuild: spec.getInitializer()?.hasPrebuild(),
+                },
+                timestamp: new Date(instance.creationTime),
+            });
+
+            if (type === WorkspaceType.PREBUILD) {
+                // do not await
+                this.notifyOnPrebuildQueued(ctx, workspace.id).catch((err) => {
+                    log.error("failed to notify on prebuild queued", err);
+                });
             }
         } catch (err) {
             this.logAndTraceStartWorkspaceError({ span }, logCtx, err);
-
-            return { instanceID: instance.id };
         } finally {
             span.finish();
         }
@@ -832,7 +856,7 @@ export class WorkspaceStarter {
                     ideTasks = JSON.parse(ideConfig.tasks);
                 }
             } catch (e) {
-                log.info("failed parse tasks from ide config:", e, {
+                log.info({ workspaceId: workspace.id }, "failed parse tasks from ide config:", e, {
                     tasks: ideConfig.tasks,
                 });
             }
@@ -1893,6 +1917,19 @@ export class WorkspaceStarter {
         region?: WorkspaceRegion,
     ) {
         return this.imagebuilderClientProvider.getClient(user, workspace, instance, region);
+    }
+
+    private async existsWithWsManager(ctx: TraceContext, instance: WorkspaceInstance): Promise<boolean> {
+        try {
+            const req = new DescribeWorkspaceRequest();
+            req.setId(instance.id);
+
+            const client = await this.clientProvider.get(instance.region);
+            await client.describeWorkspace(ctx, req);
+            return true;
+        } catch (err) {
+            return false;
+        }
     }
 }
 

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -19,6 +19,7 @@ import { ClientProvider } from "./wsman-subscriber";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
 import { PrebuildUpdater } from "./prebuild-updater";
 import { RedisPublisher } from "@gitpod/gitpod-db/lib";
+import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 
 export const WorkspaceInstanceController = Symbol("WorkspaceInstanceController");
 
@@ -306,7 +307,3 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         }
     }
 }
-
-const durationLongerThanSeconds = (time: number, durationSeconds: number, now: number = Date.now()) => {
-    return (now - time) / 1000 > durationSeconds;
-};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef971c9</samp>

This pull request refactors the workspace start logic to use a reconciliation loop instead of a one-time request, which improves reliability and scalability. It also simplifies the workspace database layer and updates the TypeScript code for the `Timestamp` class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- open a workspace on this branch: https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/18673
 - join my org: https://gpl-interrd912ea6571.preview.gitpod-dev.com/orgs/join?inviteId=f3a899d3-a8c6-4044-bd24-ebddd73a37e1
 - start a workspace from [here](https://gpl-interrd912ea6571.preview.gitpod-dev.com/projects/gitpod-test-repo-548310c4-294f-46b4-8a09-4442ed1d2346) on the branch `gpl/docker-build-2mins`
   - if you don't see an image build, bump the `TRIGGER_REBUILD` # [here](https://github.com/geropl/gitpod-test-repo/blob/gpl/docker-build-2mins/.gitpod/Dockerfile)
 - wait until you see the image build logs streaming in
 - run `kubectl rollout restart deployment/server`
 - notice how:
   - the build keep running
   - once it's done, there workspace is started as expected :heavy_check_mark: 
   - :information_source: you might notice that a) upon re-trigger, a 2nd image build is started and b), the image build logs seem to start again (because we re-attach to the newest image build). This is due to a bug in image-builder-mk3, which is currently investigated [here](https://linear.app/gitpod/issue/EXP-570/imagebuildermk3buildworkspaceimage-is-not-idempotent)
     - (this leads also to the inverse situation: you still stream from the old image build and see the `exit.`, but under the hood we are waiting for the 2nd to emit the status updates :roll_eyes: )

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-interrd912ea6571</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-interrd912ea6571.preview.gitpod-dev.com/workspaces" target="_blank">gpl-interrd912ea6571.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-interruptable-start-reconcile-gha.16545</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-interrd912ea6571%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
