### PR TITLE
[fga] enable all writes by feature flag

### DIFF
--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -22,7 +22,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { UnauthorizedError } from "../errors";
 import { RepoURL } from "../repohost";
 import { HostContextProvider } from "./host-context-provider";
-import { isFgaAuthorizerEnabled } from "../authorization/authorizer";
+import { isFgaChecksEnabled } from "../authorization/authorizer";
 import { reportGuardAccessCheck } from "../prometheus-metrics";
 
 declare let resourceInstance: GuardedResource;
@@ -161,7 +161,7 @@ export class FGAResourceAccessGuard implements ResourceAccessGuard {
     constructor(private readonly userId: string, private readonly delegate: ResourceAccessGuard) {}
 
     async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
-        const authorizerEnabled = await isFgaAuthorizerEnabled(this.userId);
+        const authorizerEnabled = await isFgaChecksEnabled(this.userId);
         if (authorizerEnabled) {
             // Authorizer takes over, so we should not check.
             reportGuardAccessCheck("fga");

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -8,11 +8,11 @@ import { v1 } from "@authzed/authzed-node";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { inject, injectable } from "inversify";
 import { observeSpicedbClientLatency, spicedbClientLatency } from "../prometheus-metrics";
 import { SpiceDBClientProvider } from "./spicedb";
 import * as grpc from "@grpc/grpc-js";
+import { isFgaChecksEnabled } from "./authorizer";
 
 @injectable()
 export class SpiceDBAuthorizer {
@@ -31,11 +31,7 @@ export class SpiceDBAuthorizer {
             userId: string;
         },
     ): Promise<boolean> {
-        const featureEnabled = await getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
-            user: {
-                id: experimentsFields.userId,
-            },
-        });
+        const featureEnabled = await isFgaChecksEnabled(experimentsFields.userId);
         if (!featureEnabled) {
             return true;
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need to enable/disable all writes for spicedb not only the initial migration, because the relationships would run out of sync if we don't continue to update the relationships as a user uses the product.


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 236dc7c</samp>

Refactor and simplify FGA-related code in the server component. Use consistent and clear function names for FGA checks and writes. Reduce feature flag calls and imports.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-featured2b5cae174</li>
	<li><b>🔗 URL</b> - <a href="https://se-featured2b5cae174.preview.gitpod-dev.com/workspaces" target="_blank">se-featured2b5cae174.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-feature-flag-writes-gha.16576</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-featured2b5cae174%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
