### PR TITLE
[server] whitelist cursor

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -36,6 +36,7 @@ packages:
       - components/gitpod-db:docker
       - components/ide/code-desktop:docker
       - components/ide/code-desktop:docker-insiders
+      - components/ide/code-desktop:docker-cursor
       - components/ide/code:docker
       - components/ide/code/codehelper:docker
       - components/ide/jetbrains/launcher:docker

--- a/components/ide/code-desktop/BUILD.yaml
+++ b/components/ide/code-desktop/BUILD.yaml
@@ -35,3 +35,21 @@ packages:
       image:
         - ${imageRepoBase}/ide/code-desktop-insiders:${version}
         - ${imageRepoBase}/ide/code-desktop-insiders:commit-${__git_commit}
+  - name: docker-cursor
+    type: docker
+    srcs:
+      - "startup.sh"
+      - "supervisor-ide-config_cursor.json"
+    deps:
+      - components/ide/code-desktop/status:app
+    argdeps:
+      - imageRepoBase
+    config:
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: workspace.desktopIdeImages.cursor
+      buildArgs:
+        SUPERVISOR_IDE_CONFIG: supervisor-ide-config_cursor.json
+      image:
+        - ${imageRepoBase}/ide/cursor:${version}
+        - ${imageRepoBase}/ide/cursor:commit-${__git_commit}

--- a/components/ide/code-desktop/supervisor-ide-config_cursor.json
+++ b/components/ide/code-desktop/supervisor-ide-config_cursor.json
@@ -1,0 +1,10 @@
+{
+    "entrypoint": "/ide-desktop/status",
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in Cursor", "cursor" ],
+    "readinessProbe": {
+        "type": "http",
+        "http": {
+            "path": "/status"
+        }
+      }
+}

--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -57,12 +57,18 @@ const jetBrainsGateway: OAuthClient = {
     ],
 };
 
-function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium"): OAuthClient {
+function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium" | "cursor"): OAuthClient {
+    let name = "VS Code";
+    if (protocol === "vscode-insiders") {
+        name = "VS Code Insiders";
+    } else if (protocol === "vscodium") {
+        name = "VS Codium";
+    } else if (protocol === "cursor") {
+        name = "Cursor";
+    }
     return {
         id: protocol + "-" + "gitpod",
-        name: `VS${protocol === "vscodium" ? "Codium" : " Code"}${
-            protocol === "vscode-insiders" ? " Insiders" : ""
-        }: Gitpod extension`,
+        name: `${name}: Gitpod extension`,
         redirectUris: [protocol + "://gitpod.gitpod-desktop/complete-gitpod-auth"],
         allowedGrants: ["authorization_code"],
         scopes: [
@@ -113,6 +119,7 @@ const desktopClient: OAuthClient = {
 const vscode = createVSCodeClient("vscode");
 const vscodeInsiders = createVSCodeClient("vscode-insiders");
 const vscodium = createVSCodeClient("vscodium");
+const cursor = createVSCodeClient("cursor");
 
 export const inMemoryDatabase: InMemory = {
     clients: {
@@ -121,6 +128,7 @@ export const inMemoryDatabase: InMemory = {
         [vscode.id]: vscode,
         [vscodeInsiders.id]: vscodeInsiders,
         [vscodium.id]: vscodium,
+        [cursor.id]: cursor,
         [desktopClient.id]: desktopClient,
     },
     tokens: {},

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -25,6 +25,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	codeDesktop := "code-desktop"
+	cursor := "cursor"
 
 	/*
 		Upgrading previous JB Version:
@@ -96,6 +97,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					DesktopIDEs:       []string{intellij, goland, pycharm, phpstorm, rubymine, webstorm, rider, clion},
 					InstallationSteps: []string{
 						"If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+					},
+				},
+				"cursor": {
+					DefaultDesktopIDE: cursor,
+					DesktopIDEs:       []string{cursor},
+					InstallationSteps: []string{
+						"If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://www.cursor.so'>Cursor</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
 					},
 				},
 			},
@@ -236,6 +244,13 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Image:              ctx.ImageName(ctx.Config.Repository, ide.XtermIDEImage, "latest"),
 					LatestImage:        ctx.ImageName(ctx.Config.Repository, ide.XtermIDEImage, "latest"),
 					ResolveImageDigest: true,
+				},
+				cursor: {
+					OrderKey: "13",
+					Title:    "Cursor",
+					Type:     ide_config.IDETypeDesktop,
+					Logo:     getIdeLogoPath("vscode"),
+					Image:    ctx.ImageName(ctx.Config.Repository, ide.CursorIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.Cursor.Version),
 				},
 			},
 			DefaultIde:        "code",

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -12,6 +12,7 @@ const (
 	CodeWebExtensionVersion     = "commit-1de61b5711089287b7f27bc1223c57d6d9bb3144" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
+	CursorIDEImage              = "ide/cursor"
 	XtermIDEImage               = "ide/xterm-web"
 	IntelliJDesktopIDEImage     = "ide/intellij"
 	GoLandDesktopIdeImage       = "ide/goland"

--- a/install/installer/pkg/config/versions/versions.go
+++ b/install/installer/pkg/config/versions/versions.go
@@ -49,6 +49,7 @@ type Components struct {
 		DesktopIdeImages struct {
 			CodeDesktopImage                  Versioned `json:"codeDesktop"`
 			CodeDesktopImageInsiders          Versioned `json:"codeDesktopInsiders"`
+			Cursor                            Versioned `json:"cursor"`
 			IntelliJImage                     Versioned `json:"intellij"`
 			IntelliJLatestImage               Versioned `json:"intellijLatest"`
 			GoLandImage                       Versioned `json:"goland"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6dca7f</samp>

Add cursor protocol support to OAuth server. Create a new OAuth client for `cursor` and update test database in `db.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-cursor</li>
	<li><b>🔗 URL</b> - <a href="https://ak-cursor.preview.gitpod-dev.com/workspaces" target="_blank">ak-cursor.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-cursor-gha.16591</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-cursor%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
