### PR TITLE
enable hmr for dashboard

### DIFF
--- a/components/dashboard/craco.config.js
+++ b/components/dashboard/craco.config.js
@@ -47,6 +47,15 @@ module.exports = {
             ],
         },
     },
+    devServer: {
+        client: {
+            webSocketURL: {
+                hostname: process.env.HMR_HOST ? new URL(process.env.HMR_HOST).hostname : "localhost",
+                port: process.env.HMR_HOST ? 443 : 3000,
+                protocol: "wss",
+            },
+        },
+    },
     ...when(process.env.GP_DEV_HOST && process.env.GP_DEV_COOKIE, () => ({
         devServer: {
             proxy: {

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -83,7 +83,7 @@
     "web-vitals": "^1.1.1"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "BROWSER=none HMR_HOST=`gp url 3000` craco start",
     "build": "craco build --verbose",
     "lint": "eslint --max-warnings=0 --ext=.jsx,.js,.tsx,.ts ./src",
     "test": "yarn test:unit",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updating the webpack config so hot module reloading works for development. This stopped working after our webpack upgrade, so I'm guessing something changed w/ that that causes us to need this now.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 400e349</samp>

This pull request enables hot module replacement for the dashboard component in both local and Gitpod development environments. It adds a `devServer` configuration to `craco.config.js` and two environment variables to the `start` script in `package.json`.

</details>


## How to test
<!-- Provide steps to test this PR -->
* Start a workspace on this branch
* `cd components/dashboard`
* `yarn start`
* Then make port 3000 public and grab that url.
* Load https://gitpod-staging.com and setup the `x-frontend-dev-url` header w/ a browser extension to use that url.
* Ensure that app loads, you should see an icon in the bottom right if it's using your dev server.
* Make a change and you should see it reflected w/o a page reload

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
