### PR TITLE
Adding getSuggestedRepositories method

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -4,10 +4,12 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { DropDown2, DropDown2Element, DropDown2SelectedElement } from "./DropDown2";
 import Repository from "../icons/Repository.svg";
+import { useSuggestedRepositories } from "../data/git-providers/suggested-repositories-query";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 const LOCAL_STORAGE_KEY = "open-in-gitpod-search-data";
 
@@ -28,7 +30,20 @@ function stripOffProtocol(url: string): string {
 }
 
 export default function RepositoryFinder(props: RepositoryFinderProps) {
+    const includeProjectsOnCreateWorkspace = useFeatureFlag("includeProjectsOnCreateWorkspace");
+
     const [suggestedContextURLs, setSuggestedContextURLs] = useState<string[]>(loadSearchData());
+    const { data: suggestedRepos } = useSuggestedRepositories();
+
+    const suggestedRepoURLs = useMemo(() => {
+        // If the flag is disabled continue to use suggestedContextURLs
+        if (!includeProjectsOnCreateWorkspace) {
+            return suggestedContextURLs;
+        }
+
+        return suggestedRepos?.map((repo) => repo.url) || [];
+    }, [suggestedContextURLs, suggestedRepos, includeProjectsOnCreateWorkspace]);
+
     useEffect(() => {
         getGitpodService()
             .server.getSuggestedContextURLs()
@@ -43,7 +58,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             let result: string[];
             searchString = searchString.trim();
             if (searchString.length > 1) {
-                result = suggestedContextURLs.filter((e) => e.toLowerCase().indexOf(searchString.toLowerCase()) !== -1);
+                result = suggestedRepoURLs.filter((e) => e.toLowerCase().indexOf(searchString.toLowerCase()) !== -1);
                 if (result.length > 200) {
                     result = result.slice(0, 200);
                 }
@@ -51,13 +66,13 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                     try {
                         // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
                         new URL(searchString);
-                        if (!suggestedContextURLs.includes(searchString)) {
+                        if (!suggestedRepoURLs.includes(searchString)) {
                             result.push(searchString);
                         }
                     } catch {}
                 }
             } else {
-                result = suggestedContextURLs.slice(0, 200);
+                result = suggestedRepoURLs.slice(0, 200);
             }
 
             return result.map(
@@ -79,7 +94,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                     } as DropDown2Element),
             );
         },
-        [suggestedContextURLs],
+        [suggestedRepoURLs],
     );
 
     const element = (

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -41,6 +41,8 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             return suggestedContextURLs;
         }
 
+        // For now, convert the suggestedRepos to a list of URLs
+        // We'll follow up with updating the UI with the new data
         return suggestedRepos?.map((repo) => repo.url) || [];
     }, [suggestedContextURLs, suggestedRepos, includeProjectsOnCreateWorkspace]);
 

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -27,6 +27,7 @@ const featureFlags = {
     supervisor_live_git_status: false,
     enabledOrbitalDiscoveries: "",
     newProjectIncrementalRepoSearchBBS: false,
+    includeProjectsOnCreateWorkspace: false,
 };
 
 type FeatureFlags = typeof featureFlags;

--- a/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
+import { getGitpodService } from "../../service/service";
+
+export const useSuggestedRepositories = () => {
+    const { data: org } = useCurrentOrg();
+
+    return useQuery(["suggested-repositories", { orgId: org?.id }], async () => {
+        if (!org) {
+            throw new Error("No org selected");
+        }
+
+        return await getGitpodService().server.getSuggestedRepositories(org.id);
+    });
+};

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -30,6 +30,7 @@ import {
     WorkspaceTimeoutSetting,
     WorkspaceContext,
     LinkedInProfile,
+    SuggestedRepository,
 } from "./protocol";
 import {
     Team,
@@ -98,6 +99,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getWorkspaceUsers(workspaceId: string): Promise<WorkspaceInstanceUser[]>;
     getFeaturedRepositories(): Promise<WhitelistedRepository[]>;
     getSuggestedContextURLs(): Promise<string[]>;
+    getSuggestedRepositories(organizationId: string): Promise<SuggestedRepository[]>;
     /**
      * **Security:**
      * Sensitive information like an owner token is erased, since it allows access for all team members.

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1620,5 +1620,4 @@ export type SuggestedRepository = {
     url: string;
     projectId?: string;
     projectName?: string;
-    repositoryName?: string;
 };

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1615,3 +1615,10 @@ export interface LinkedInProfile {
     profilePicture: string;
     emailAddress: string;
 }
+
+export type SuggestedRepository = {
+    url: string;
+    projectId?: string;
+    projectName?: string;
+    repositoryName?: string;
+};

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -65,6 +65,7 @@ const defaultFunctions: FunctionsConfig = {
     getWorkspaceUsers: { group: "default", points: 1 },
     getFeaturedRepositories: { group: "default", points: 1 },
     getSuggestedContextURLs: { group: "default", points: 1 },
+    getSuggestedRepositories: { group: "default", points: 1 },
     getWorkspace: { group: "default", points: 1 },
     isWorkspaceOwner: { group: "default", points: 1 },
     getOwnerToken: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1750,7 +1750,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const repos = await this.getFeaturedRepositories(ctx);
 
             return repos.map((repo) => ({
-                repositoryName: repo.name,
                 url: repo.url,
                 priority: 0,
             }));
@@ -1760,11 +1759,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const projects = await this.projectsService.getProjects(user.id, organizationId);
 
             return projects.map((project) => ({
-                // TODO: determine if we can parse this name out of the cloneUrl
-                // repositoryName: project.id,
-                projectName: project.name,
-                projectId: project.id,
                 url: project.cloneUrl.replace(/\.git$/, ""),
+                projectId: project.id,
+                projectName: project.name,
                 priority: 1,
             }));
         };
@@ -1785,7 +1782,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                         const userRepos = await services.repositoryProvider.getUserRepos(user);
 
                         return userRepos.map((r) => ({
-                            // repositoryName: "",
                             url: r.replace(/\.git$/, ""),
                             priority: 5,
                         }));
@@ -1818,9 +1814,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                     recentRepos.push({
                         url: repoUrl,
                         projectId: ws.workspace.projectId,
-                        // TODO: get project name
-                        lastUse,
                         priority: 10,
+                        lastUse,
                     });
                 }
             }
@@ -1836,14 +1831,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         ]);
 
         const uniqueRepositories = new Map<string, SuggestedRepositoryWithSorting>();
-
-        if (projects.status === "fulfilled") {
-            for (const repo of projects.value) {
-                uniqueRepositories.set(repo.url, repo);
-            }
-        } else {
-            log.error(logCtx, "Could not fetch projects", projects.reason);
-        }
 
         const remainingRepos = [
             // Add projects first so we have projectId/projectName set

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1873,8 +1873,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 url: repo.url,
                 projectId: repo.projectId,
                 projectName: repo.projectName,
-                // TODO: determine if we want to include this
-                repositoryName: repo.repositoryName,
             }),
         );
     }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1738,7 +1738,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     public async getSuggestedRepositories(ctx: TraceContext, organizationId: string): Promise<SuggestedRepository[]> {
-        const user = await this.checkAndBlockUser("getSuggestedProjects");
+        const user = await this.checkAndBlockUser("getSuggestedRepositories");
+        await this.guardWithFeatureFlag("includeProjectsOnCreateWorkspace", user, organizationId);
+
+        if (!uuidValidate(organizationId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId must be a valid UUID");
+        }
+
         const logCtx: LogContext = { userId: user.id };
 
         type SuggestedRepositoryWithSorting = SuggestedRepository & {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1068,7 +1068,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     public async getWorkspaces(
         ctx: TraceContext,
-        options: GitpodServer.GetWorkspacesOptions = {},
+        options: GitpodServer.GetWorkspacesOptions,
     ): Promise<WorkspaceInfo[]> {
         traceAPIParams(ctx, { options });
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is part of work to include projects on the create workspace page. Functionality is gated behind the `includeProjectsOnCreateWorkspace` feature flag and is only on in non-prod. When it is on, it will data from the new api, and incorporate it into the existing UI. Otherwise it will continue to use `getSuggestedContextUrls`

Adding a new `getSuggestedRepositories` method to server that returns similar items to `getSuggestedContextUrls`, except in the form of structured data to include project details (if there is a project).

```ts
export type SuggestedRepository = {
    url: string;
    projectId?: string;
    projectName?: string;
};
```

Followup work will update the UI based on the new designs to incorporate projects information.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a124119</samp>

This pull request adds a new feature to suggest repositories for the user based on their organization and projects when creating a workspace. It also adds a new feature flag to toggle between the server-based and the local storage-based suggestions. It modifies the `RepositoryFinder` component, the `GitpodServer` interface, and the `GitpodService` class to implement this feature. It also adds new types, hooks, and queries to handle the suggested repositories data.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-583

## How to test
<!-- Provide steps to test this PR -->
* Visit the Create Workspace page
* Everything should look like normal, even though it's using the new `getSuggestedRepositories` api

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-5b845f19347</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-5b845f19347.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-5b845f19347.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-583-add-new-getsuggestedprojects-api-gha.16635</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-exp-5b845f19347%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
