### PR TITLE
[fga] retry write relationships

### DIFF
--- a/components/server/src/orgs/usage-service.ts
+++ b/components/server/src/orgs/usage-service.ts
@@ -17,6 +17,7 @@ import { inject, injectable } from "inversify";
 import { Authorizer } from "../authorization/authorizer";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { CostCenterJSON, ListUsageRequest, ListUsageResponse } from "@gitpod/gitpod-protocol/lib/usage";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
 @injectable()
 export class UsageService {
@@ -149,9 +150,9 @@ export class UsageService {
         const currentInvoiceCredits = creditBalance.usedCredits;
         const usageLimit = creditBalance.usageLimit;
         if (currentInvoiceCredits >= usageLimit) {
-            log.info({ userId }, "Usage limit reached", {
+            log.info({ userId, organizationId }, "Usage limit reached", {
                 attributionId,
-                currentInvoiceCredits,
+                currentInvoiceCredits: new TrustedValue(currentInvoiceCredits),
                 usageLimit,
             });
             return {
@@ -159,9 +160,9 @@ export class UsageService {
                 attributionId,
             };
         } else if (currentInvoiceCredits > usageLimit * 0.8) {
-            log.info({ userId }, "Usage limit almost reached", {
+            log.info({ userId, organizationId }, "Usage limit almost reached", {
                 attributionId,
-                currentInvoiceCredits,
+                currentInvoiceCredits: new TrustedValue(currentInvoiceCredits),
                 usageLimit,
             });
             return {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Occasionally we see errors when trying to write relkation ships in Gitpod Cloud ([logs](https://cloudlogging.app.goo.gl/GFtYW7bE4hp85DHC7)).

```
Error: 13 INTERNAL: Received RST_STREAM with code 2 (Internal server error)
    at callErrorFromStatus (/app/node_modules/@grpc/grpc-js/src/call.ts:82:17)
    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/src/client.ts:360:55)
    at /app/node_modules/@grpc/grpc-js/src/call-interface.ts:149:27
    at Object.onReceiveStatus (/app/node_modules/@gitpod/gitpod-protocol/src/util/grpc.ts:80:29)
    at InterceptingListenerImpl.onReceiveStatus (/app/node_modules/@grpc/grpc-js/src/call-interface.ts:145:19)
    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/src/client-interceptors.ts:458:34)
    at Object.onReceiveStatus (/app/node_modules/@grpc/grpc-js/src/client-interceptors.ts:419:48)
    at /app/node_modules/@grpc/grpc-js/src/resolving-call.ts:132:24
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
for call at
    at Proxy.makeUnaryRequest (/app/node_modules/@grpc/grpc-js/src/client.ts:325:42)
    at Proxy.writeRelationships (/app/node_modules/@authzed/authzed-node/src/authzedapi/authzed/api/v1/permission_service.grpc-client.ts:129:21)
    at node:internal/util:375:7
    at new Promise (<anonymous>)
    at Proxy.writeRelationships (node:internal/util:361:12)
    at SpiceDBAuthorizer.writeRelationships (/app/node_modules/@gitpod/server/src/authorization/spicedb-authorizer.ts:61:48)
    at Authorizer.addOrganization (/app/node_modules/@gitpod/server/src/authorization/authorizer.ts:362:31)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at RelationshipUpdater.updateOrganization (/app/node_modules/@gitpod/server/src/authorization/relationship-updater.ts:161:9)
    at /app/node_modules/@gitpod/server/src/authorization/relationship-updater.ts:76:21
    at Redlock.using (/app/node_modules/redlock/src/index.ts:742:14)
    at RelationshipUpdater.migrate (/app/node_modules/@gitpod/server/src/authorization/relationship-updater.ts:56:20)
    at UserService.findUserById (/app/node_modules/@gitpod/server/src/user/user-service.ts:88:20)
    at GithubApp.findInstallationOwner (/app/node_modules/@gitpod/server/src/prebuilds/github-app.ts:672:22)
    at GithubApp.findOwnerAndProject (/app/node_modules/@gitpod/server/src/prebuilds/github-app.ts:230:52)
    at GithubApp.handlePushEvent (/app/node_modules/@gitpod/server/src/prebuilds/github-app.ts:264:37)
```

This seems to. be a GRPC connection error and has been reported here as well without a solution:

https://github.com/grpc/grpc-node/issues/1747

Since it happens only rarely, I'll add retry logic, so at least we don't miss any relationships until we have understood and fixed the underlying issue.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8d82e9</samp>

Added logging for organization usage limits and improved retry logic for writing permissions to SpiceDB. These changes aim to enhance the visibility and reliability of the billing and authorization features of Gitpod.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-585

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-fga-retry</li>
	<li><b>🔗 URL</b> - <a href="https://se-fga-retry.preview.gitpod-dev.com/workspaces" target="_blank">se-fga-retry.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-fga-retry-gha.16660</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-fga-retry%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
