### PR TITLE
[log] log requestId

### DIFF
--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -20,7 +20,17 @@ export interface LogContext {
     workspaceId?: string;
     instanceId?: string;
 }
+
+/**
+ * allows to globally augment the log context, default is an identity function
+ */
+let logContextAugmenter: LogContext.Augmenter = (context) => context;
+
 export namespace LogContext {
+    export type Augmenter = (context: LogContext | undefined) => LogContext | undefined;
+    export function setAugmenter(augmenter: Augmenter): void {
+        logContextAugmenter = augmenter;
+    }
     export function from(params: { userId?: string; user?: any; request?: any }) {
         return <LogContext>{
             sessionId: params.request?.requestID,
@@ -306,6 +316,7 @@ function makeLogItem(
     if (context !== undefined && Object.keys(context).length == 0) {
         context = undefined;
     }
+    context = logContextAugmenter(context);
     context = scrubPayload(context, plainLogging);
 
     let reportedErrorEvent: {} = {};

--- a/components/server/src/util/log-context.ts
+++ b/components/server/src/util/log-context.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { v4 } from "uuid";
+
+// we are installing a special augmenter that enhances the log context if executed within `runWithContext`
+// with a contextId and a contextTimeMs, which denotes the amount of milliseconds since the context was created.
+type EnhancedLogContext = LogContext & {
+    contextId?: string;
+    contextTimeMs: number;
+};
+const asyncLocalStorage = new AsyncLocalStorage<EnhancedLogContext>();
+const augmenter: LogContext.Augmenter = (ctx) => {
+    const globalContext = asyncLocalStorage.getStore();
+    const contextTime = globalContext?.contextTimeMs ? Date.now() - globalContext.contextTimeMs : undefined;
+    return {
+        ...globalContext,
+        contextTime,
+        ...ctx,
+    };
+};
+LogContext.setAugmenter(augmenter);
+
+export async function runWithContext<T>(context: LogContext, fun: () => T): Promise<T> {
+    return asyncLocalStorage.run(
+        {
+            ...context,
+            contextId: v4(),
+            contextTimeMs: Date.now(),
+        },
+        fun,
+    );
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change will automatically add a requstId as well as the userID to any requets done through the websocket.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 604eea2</samp>

This pull request improves the logging of JSON-RPC requests from the websocket clients by adding request IDs and user IDs to the log context. It also introduces a new file `log-context.ts` that implements a global context augmenter and a helper function for running functions with the context.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-590

## How to test
<!-- Provide steps to test this PR -->
Check the logs of server when doing requests and verify that the same unique requestId is used in all log messages per request.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-log-context</li>
        <li><b>🔗 URL</b> - <a href="https://se-log-context.preview.gitpod-dev.com/workspaces" target="_blank">se-log-context.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-log-context%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] with-monitoring
</details>

/hold
