### PR TITLE
Include regular not active alerts in Dedicated

### DIFF
--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -14,6 +14,8 @@ spec:
   - name: workspace-rules
     rules:
     - record: gitpod_workspace_regular_not_active_percentage_mk2
+      labels:
+        dedicated: included
       expr: |
         sum(gitpod_ws_manager_mk2_workspace_activity_total{active="false"}) by (cluster) / sum(gitpod_ws_manager_mk2_workspace_activity_total) by (cluster)
 
@@ -22,8 +24,7 @@ spec:
     - alert: GitpodWorkspaceTooManyRegularNotActiveMk2
       labels:
         severity: critical
-        # TODO: uncomment after recording rule import is working in Grafana Cloud
-        # dedicated: included
+        dedicated: included
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceRegularNotActive.md
@@ -37,8 +38,7 @@ spec:
     - alert: GitpodWorkspacesNotStartingMk2
       labels:
         severity: critical
-        # TODO: uncomment after recording rule import is working in Grafana Cloud
-        # dedicated: included
+        dedicated: included
       for: 10m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceRegularNotActive.md


### PR DESCRIPTION
## Description
Include regular not active alerts in Dedicated now that we can [import ](https://github.com/gitpod-io/gitpod-dedicated/pull/1998)recording rules.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ee97c5</samp>

Enable `dedicated: included` label for workspace startup and stop alerts in `workspaces.yaml`. This improves observability of dedicated workspaces in Gitpod.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-504



## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
