### PR TITLE
Add maintenance metric

### DIFF
--- a/components/ws-manager-mk2/controllers/maintenance_controller.go
+++ b/components/ws-manager-mk2/controllers/maintenance_controller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,11 +34,16 @@ var (
 	lookupOnce sync.Once
 )
 
-func NewMaintenanceReconciler(c client.Client) (*MaintenanceReconciler, error) {
-	return &MaintenanceReconciler{
+func NewMaintenanceReconciler(c client.Client, reg prometheus.Registerer) (*MaintenanceReconciler, error) {
+	r := &MaintenanceReconciler{
 		Client:       c,
 		enabledUntil: nil,
-	}, nil
+	}
+
+	gauge := newMaintenanceEnabledGauge(r)
+	reg.MustRegister(gauge)
+
+	return r, nil
 }
 
 type MaintenanceReconciler struct {

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	mgrCtx := ctrl.SetupSignalHandler()
 
-	maintenanceReconciler, err := controllers.NewMaintenanceReconciler(mgr.GetClient())
+	maintenanceReconciler, err := controllers.NewMaintenanceReconciler(mgr.GetClient(), metrics.Registry)
 	if err != nil {
 		setupLog.Error(err, "unable to create maintenance controller", "controller", "Maintenance")
 		os.Exit(1)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add metric in ws-manager-mk2 emitting whether maintenance mode is enabled or not

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bdd87f</samp>

Add a prometheus metric for cluster maintenance mode in ws-manager-mk2. The metric `ws_manager_mk2_maintenance_enabled` reports whether the cluster is in maintenance mode or not, based on the `maintenance_controller.go`, `metrics.go`, and `main.go` files.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env by enabling/disabling maintenance mode, and having `enabledUntil` time out

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
