### PR TITLE
[fga] try any spicedb operation 3 times

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -828,9 +828,13 @@ export class WorkspaceStarter {
         try {
             let ideTasks: TaskConfig[] = [];
             try {
-                ideTasks = JSON.parse(ideConfig.tasks);
+                if (ideConfig.tasks && ideConfig.tasks.trim() !== "") {
+                    ideTasks = JSON.parse(ideConfig.tasks);
+                }
             } catch (e) {
-                console.error("failed get tasks from ide config:", e);
+                log.info("failed parse tasks from ide config:", e, {
+                    tasks: ideConfig.tasks,
+                });
             }
 
             const configuration: WorkspaceInstanceConfiguration = {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We still see error responses from spicedb such as the one in [the logs](https://cloudlogging.app.goo.gl/C9G3YJrnERZyLmJm7)

Becuase this can happen on any request to spicedb I'm expanding the retries to all operations for now.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 610d92d</samp>

This pull request enhances the server component's authorization system by adding retry logic to the SpiceDB client calls. This helps to avoid failures and inconsistencies due to transient network errors or SpiceDB unavailability. The retry logic is implemented in a new helper function `tryThree` in `spicedb-authorizer.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
