### PR TITLE
Solidify runc create retries

### DIFF
--- a/components/docker-up/runc-facade/main.go
+++ b/components/docker-up/runc-facade/main.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 )
 
-const RETRY = 3
+const RETRY = 10
 
 var (
 	defaultOOMScoreAdj = 1000
@@ -81,22 +82,28 @@ func createAndRunc(runcPath string, log *logrus.Logger) error {
 	if err != nil {
 		return xerrors.Errorf("cannot encode config.json: %w", err)
 	}
-	for _, fn := range []string{"config.json", "/tmp/debug.json"} {
-		err = os.WriteFile(fn, fc, 0644)
-		if err != nil {
-			return xerrors.Errorf("cannot encode config.json: %w", err)
-		}
+	err = os.WriteFile("config.json", fc, 0644)
+	if err != nil {
+		return xerrors.Errorf("cannot encode config.json: %w", err)
 	}
 
 	// See here for more details on why retries are necessary.
 	// https://github.com/gitpod-io/gitpod/issues/12365
 	for i := 0; i <= RETRY; i++ {
-		err = syscall.Exec(runcPath, os.Args, os.Environ())
-		if err == nil {
-			return err
-		} else {
+		err = exec.Command(runcPath, os.Args[1:]...).Run()
+
+		if err != nil {
 			log.WithError(err).Warn("runc failed")
+
+			// runc creation failures can be caused by timing issues with workspacekit/seccomp notify under load.
+			// Easing of on the pressure here lowers the likelihood of that error.
+			// NOTE(cw): glossing over races with delays is bad style, but also pragmatic.
+			//
+			// Context: https://linear.app/gitpod/issue/ENG-797/docker-containers-sometimes-fail-to-start
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
+		return nil
 	}
 	return xerrors.Errorf("exec %s: %w", runcPath, err)
 }


### PR DESCRIPTION
## Description
Retry more often and slow down if need be. Greatly reduces the likelihood of proc mount issues.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2a4e71</samp>

Improved runc-facade component by simplifying and enhancing runc execution.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Contributes to ENG-797

## How to test
See test description in the issue

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
