### PR TITLE
[jb] Update JetBrains stable image PR template

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -33,7 +33,9 @@ jobs:
 
                       ## How to test
 
-                      Merge if tests are green, if something breaks then add tests for regressions.
+                      Merge if:
+                      - [ ] Tests are green, if something breaks then add tests for regressions.
+                      - [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample
 
                       <details>
                       <summary>if you want to test manually for some reasons</summary>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update JetBrains stable image PR template

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c2baea</samp>

Add a checklist item for testing the warmup feature with IntelliJ and spring-petclinic. The warmup feature improves the startup time of workspaces with JetBrains IDEs.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://linear.app/gitpod/issue/EXP-99

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
