### PR TITLE
[server] Tone down log messages on startWorkspace

### DIFF
--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -108,7 +108,7 @@ export class JobRunner {
                 });
             });
         } catch (err) {
-            if (RedisMutex.isLockError(err)) {
+            if (RedisMutex.isLockedError(err)) {
                 log.debug(
                     `Failed to acquire lock for job ${job.name}. Likely another instance already holds the lock.`,
                     err,

--- a/components/server/src/redis/mutex.ts
+++ b/components/server/src/redis/mutex.ts
@@ -45,7 +45,12 @@ export class RedisMutex {
         return this.client().using(resources, duration, settings, routine);
     }
 
-    public static isLockError(err: any): boolean {
-        return err instanceof ResourceLockedError || err instanceof ExecutionError;
+    public static isLockedError(err: any): boolean {
+        return (
+            err instanceof ResourceLockedError ||
+            // Should be a ResourceLockedError as well, but is ExecutionError in v5.x: https://github.com/mike-marcacci/node-redlock/issues/168
+            (err instanceof ExecutionError &&
+                err.message.includes("unable to achieve a quorum during its retry window"))
+        );
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5afea4a</samp>

Improve logging of workspace instance start operations in `workspace-starter.ts`. Use a new type to mark safe values and provide more details on errors.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-605

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-605-tone-down</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-605-tone-down.preview.gitpod-dev.com/workspaces" target="_blank">gpl-605-tone-down.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-605-tone-down-gha.16961</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-605-tone-down%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
