### PR TITLE
[dashboard] unify error reporting

### DIFF
--- a/components/dashboard/src/components/error-boundaries/ReloadPageErrorBoundary.tsx
+++ b/components/dashboard/src/components/error-boundaries/ReloadPageErrorBoundary.tsx
@@ -5,10 +5,10 @@
  */
 
 import { FC, useCallback } from "react";
-import { ErrorBoundary, FallbackProps, ErrorBoundaryProps } from "react-error-boundary";
+import { ErrorBoundary, ErrorBoundaryProps, FallbackProps } from "react-error-boundary";
 import gitpodIcon from "../../icons/gitpod.svg";
-import { getGitpodService } from "../../service/service";
 import { Heading1, Subheading } from "../typography/headings";
+import { reportError } from "../../service/metrics";
 
 export type CaughtError = Error & { code?: number };
 
@@ -64,11 +64,4 @@ export const ReloadPageErrorFallback: FC<Pick<FallbackProps, "error">> = ({ erro
     );
 };
 
-export const handleError: ErrorBoundaryProps["onError"] = async (error, info) => {
-    const url = window.location.toString();
-    try {
-        await getGitpodService().server.reportErrorBoundary(url, error.message || "Unknown Error");
-    } catch (e) {
-        console.error(e);
-    }
-};
+export const handleError: ErrorBoundaryProps["onError"] = (error, info) => reportError("Error boundary", error, info);

--- a/components/dashboard/src/service/metrics.ts
+++ b/components/dashboard/src/service/metrics.ts
@@ -40,6 +40,11 @@ console.error = function (...args) {
     reportError(...args);
 };
 
+let commonDetails = {};
+export function updateCommonErrorDetails(update: { [key: string]: string | undefined }) {
+    Object.assign(commonDetails, update);
+}
+
 export function reportError(...args: any[]) {
     let err = undefined;
     let details = undefined;
@@ -61,22 +66,26 @@ export function reportError(...args: any[]) {
         }
     }
 
-    let data = undefined;
+    let data = {};
     if (details && typeof details === "object") {
-        data = Object.fromEntries(
-            Object.entries(details)
-                .filter(([key, value]) => {
-                    return (
-                        typeof value === "string" ||
-                        typeof value === "number" ||
-                        typeof value === "boolean" ||
-                        value === null ||
-                        typeof value === "undefined"
-                    );
-                })
-                .map(([key, value]) => [key, String(value)]),
+        data = Object.assign(
+            data,
+            Object.fromEntries(
+                Object.entries(details)
+                    .filter(([key, value]) => {
+                        return (
+                            typeof value === "string" ||
+                            typeof value === "number" ||
+                            typeof value === "boolean" ||
+                            value === null ||
+                            typeof value === "undefined"
+                        );
+                    })
+                    .map(([key, value]) => [key, String(value)]),
+            ),
         );
     }
+    data = Object.assign(data, commonDetails);
 
     if (err) {
         metricsReporter.reportError(err, data);

--- a/components/dashboard/src/service/metrics.ts
+++ b/components/dashboard/src/service/metrics.ts
@@ -40,7 +40,7 @@ console.error = function (...args) {
     reportError(...args);
 };
 
-function reportError(...args: any[]) {
+export function reportError(...args: any[]) {
     let err = undefined;
     let details = undefined;
     if (args[0] instanceof Error) {

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -7,6 +7,7 @@
 import { User } from "@gitpod/gitpod-protocol";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { createContext, useState, useContext, useMemo, useCallback } from "react";
+import { updateCommonErrorDetails } from "./service/metrics";
 
 const UserContext = createContext<{
     user?: User;
@@ -18,10 +19,16 @@ const UserContext = createContext<{
 const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
 
+    const updateErrorUserDetails = (user?: User) => {
+        updateCommonErrorDetails({ userId: user?.id });
+    };
+    updateErrorUserDetails(user);
+
     const client = useQueryClient();
 
     const doSetUser = useCallback(
         (updatedUser: User) => {
+            updateErrorUserDetails(updatedUser);
             if (user?.id !== updatedUser.id) {
                 client.clear();
             }

--- a/components/public-api/typescript/src/metrics.ts
+++ b/components/public-api/typescript/src/metrics.ts
@@ -373,6 +373,10 @@ export class MetricsReporter {
         properties["error_name"] = error.name;
         properties["error_message"] = error.message;
 
+        const workspaceId = properties["workspaceId"];
+        const instanceId = properties["instanceId"];
+        const userId = properties["userId"];
+
         delete properties["workspaceId"];
         delete properties["instanceId"];
         delete properties["userId"];
@@ -381,9 +385,9 @@ export class MetricsReporter {
             component: this.options.clientName,
             errorStack: error.stack ?? String(error),
             version: this.options.clientVersion,
-            workspaceId: properties["workspaceId"] ?? "",
-            instanceId: properties["instanceId"] ?? "",
-            userId: properties["userId"] ?? "",
+            workspaceId: workspaceId ?? "",
+            instanceId: instanceId ?? "",
+            userId: userId ?? "",
             properties,
         });
     }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -22,7 +22,6 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(imageBuildsStartedTotal);
     registry.registerMetric(imageBuildsCompletedTotal);
     registry.registerMetric(spicedbClientLatency);
-    registry.registerMetric(dashboardErrorBoundary);
     registry.registerMetric(jwtCookieIssued);
     registry.registerMetric(jobStartedTotal);
     registry.registerMetric(jobsCompletedTotal);
@@ -262,15 +261,6 @@ export function observeSpicedbClientLatency(operation: string, outcome: Error | 
         { operation, outcome: outcome === undefined ? "success" : "error" },
         durationInSeconds,
     );
-}
-
-export const dashboardErrorBoundary = new prometheusClient.Counter({
-    name: "gitpod_dashboard_error_boundary_total",
-    help: "Total number of errors caught by an error boundary in the dashboard",
-});
-
-export function increaseDashboardErrorBoundaryCounter() {
-    dashboardErrorBoundary.inc();
 }
 
 export const jobStartedTotal = new prometheusClient.Counter({

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -144,7 +144,6 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { CostCenterJSON } from "@gitpod/gitpod-protocol/lib/usage";
 import { createCookielessId, maskIp } from "../analytics";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { increaseDashboardErrorBoundaryCounter } from "../prometheus-metrics";
 import { LinkedInService } from "../linkedin-service";
 import { SnapshotService, WaitForSnapshotOptions } from "./snapshot-service";
 import { IncrementalPrebuildsService } from "../prebuilds/incremental-prebuilds-service";
@@ -3464,14 +3463,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     //
     //#endregion
 
+    /**
+     * TODO(ak)
+     * @deprecated remove it after dashboard is deployed. It was replaced with error reporting in GCP.
+     */
     async reportErrorBoundary(ctx: TraceContextWithSpan, url: string, message: string): Promise<void> {
-        // Cap message and url length so the entries aren't of unbounded length
-        log.warn("dashboard error boundary", {
-            message: (message || "").substring(0, 200),
-            url: (url || "").substring(0, 200),
-            userId: this.userID,
-        });
-        increaseDashboardErrorBoundaryCounter();
+        // no-op
     }
 
     async getIDToken(): Promise<void> {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In https://github.com/gitpod-io/gitpod/pull/18691 we moved to dashboard to use metrics endpoint used already by other clients to collect client observability metrics and errors. This PR is a follow up to clean up other places where custom code was used.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a59a371</samp>

Improved error reporting for dashboard error boundaries and deprecated server-side method. Refactored `reportError` function and fixed a bug in `metrics.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Run `new Promise((_,reject) => reject(new Error("foobar")))` in devtool
- And check out that `reportError` is called with all necessary info including user id from network tab.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-dashboac8578745bf</li>
	<li><b>🔗 URL</b> - <a href="https://ak-dashboac8578745bf.preview.gitpod-dev.com/workspaces" target="_blank">ak-dashboac8578745bf.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-dashboard_unify_error_reporting-gha.17001</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-dashboac8578745bf%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
