### PR TITLE
[code] Pass GITPOD_CODE_HOST when starting vscode server

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 5feb1e45248c023ec02cd29ca75a2f4ada60f211
+  codeCommit: 2c2a7627acd15897b643e7631c068600286693f5
   codeVersion: 1.83.0
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 7a889d86d94c160fa1a4cab832cdbcf45eac0f88
-  codeVersion: 1.82.2
+  codeCommit: 5feb1e45248c023ec02cd29ca75a2f4ada60f211
+  codeVersion: 1.83.0
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2023.2.2.tar.gz"

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 2c2a7627acd15897b643e7631c068600286693f5
+  codeCommit: 8bcdbe5e6e097191649984c8329af15a3e6b3066
   codeVersion: 1.83.0
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -55,9 +55,7 @@ RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     setNameShort="setpath([\"nameShort\"]; \"$nameShort\")" && \
     setNameLong="setpath([\"nameLong\"]; \"$nameLong\")" && \
     setSegmentKey="setpath([\"segmentKey\"]; \"untrusted-dummy-key\")" && \
-    setExtensionsGalleryItemUrl="setpath([\"extensionsGallery\", \"itemUrl\"]; \"{{extensionsGalleryItemUrl}}\")" && \
-    addTrustedDomain=".linkProtectionTrustedDomains += [\"{{trustedDomain}}\"]" && \
-    jqCommands="${setQuality} | ${setNameShort} | ${setNameLong} | ${setSegmentKey} | ${setExtensionsGalleryItemUrl} | ${addTrustedDomain}" && \
+    jqCommands="${setQuality} | ${setNameShort} | ${setNameLong} | ${setSegmentKey}" && \
     cat product.json | jq "${jqCommands}" > product.json.tmp && \
     mv product.json.tmp product.json && \
     jq '{quality,nameLong,nameShort}' product.json
@@ -69,15 +67,10 @@ RUN yarn gulp compile-build \
     && yarn gulp vscode-reh-linux-x64-min-ci
 
 # config for first layer needed by blobserve
-# we also remove `static/` from resource urls as that's needed by blobserve,
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
 RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
     && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
-    # TODO: remove next line when workbench.html changes are merged to gp-code/main
-    && sed -i -e 's#static/##g' /vscode-web/index.html \
-    && sed -i -e 's#baseUrl =.*;#baseUrl = window.location.origin;#g' /vscode-web/index.html \
-    && sed -i -e 's#{{WORKBENCH_WEB_BASE_URL}}#.#g' /vscode-web/index.html \
     && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
 
 # cli config: alises to gitpod-code

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -28,7 +28,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	//nolint:typecheck
 	openVSXProxyUrl := "vsx-proxy-host"
 	if hasOpenVSXProxy {
-		openVSXProxyUrl = fmt.Sprintf("open-vsx.%s", ctx.Config.Domain)
+		openVSXProxyUrl = fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain)
 	}
 
 	// Check also link below before change values
@@ -49,7 +49,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Replacement: ctx.Config.Domain,
 						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
 					}, {
-						Search:      "open-vsx.org",
+						Search:      "https://open-vsx.org",
 						Replacement: openVSXProxyUrl,
 						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
 					}, {
@@ -76,20 +76,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					// TODO consider to provide it as a part of image label or rather inline ${ide} and ${supervisor} in index.html
 					// to decouple blobserve and code image
 					InlineStatic: []blobserve_config.InlineReplacement{{
+						Search:      "{{WORKBENCH_WEB_BASE_URL}}",
+						Replacement: "${ide}",
+					}, {
 						Search:      "window.location.origin;",
 						Replacement: "'${ide}';",
 					}, {
-						Search:      "${window.location.origin}",
-						Replacement: ".",
-					}, {
-						Search:      "value.startsWith(window.location.origin)",
-						Replacement: "value.startsWith(window.location.origin) || value.startsWith('${ide}')",
-					}, {
 						Search:      "./out",
 						Replacement: "${ide}/out",
-					}, {
-						Search:      "./node_modules",
-						Replacement: "${ide}/node_modules",
 					}, {
 						Search:      "/_supervisor/frontend",
 						Replacement: "${supervisor}",

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -55,15 +55,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					}, {
 						Search:      "{{extensionsGalleryItemUrl}}",
 						Replacement: extensionsGalleryItemUrl,
-						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
-					}, {
-						Search:      "{{extensionsGalleryItemUrl}}",
-						Replacement: extensionsGalleryItemUrl,
 						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "{{trustedDomain}}",
-						Replacement: trustedDomain,
-						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
 					}, {
 						Search:      "{{trustedDomain}}",
 						Replacement: trustedDomain,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Related https://github.com/gitpod-io/openvscode-server/commit/8bcdbe5e6e097191649984c8329af15a3e6b3066

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a526592</samp>

Switched the code-server component to use the open-vsx proxy for extensions and refactored the codehelper package to support different domains. Simplified the code-server Dockerfile and updated the workspace configuration.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Check both vscode stable and insiders works:
- Extension gallery
- Settings sync
- Webviews
- Web extensions (vim)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-tempora4ddbe88d45</li>
	<li><b>🔗 URL</b> - <a href="https://jp-tempora4ddbe88d45.preview.gitpod-dev.com/workspaces" target="_blank">jp-tempora4ddbe88d45.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-temporary-seahorse-gha.17069</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-tempora4ddbe88d45%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
