### PR TITLE
support jb plugins from image

### DIFF
--- a/components/ide/jetbrains/launcher/rebuild.sh
+++ b/components/ide/jetbrains/launcher/rebuild.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+DIR="$(dirname "$(realpath "$0")")"
+COMPONENT="$(basename "$DIR")"
+cd "$DIR"
+
+# build
+go build .
+echo "$COMPONENT built"
+
+DIST_COMPONENT="jb-launcher"
+mv "$COMPONENT" "$DIST_COMPONENT"
+echo "rename $COMPONENT to $DIST_COMPONENT"
+COMPONENT="$DIST_COMPONENT"
+
+DEST="/ide-desktop"
+sudo rm -rf "$DEST/$COMPONENT" && true
+sudo mv ./"$COMPONENT" "$DEST"
+echo "$COMPONENT in $DEST replaced"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It allows to distribute JB plugins (similarly how we do it for options) as part of the image instead of using JB marketplace or custom repositories. It is helpful in case of proprietary plugins which should be distributed org wide.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ba9460</samp>

This pull request enhances the JetBrains IDE integration by enabling plugin synchronization. It extracts common logic for syncing files from the workspace context to the IDE and applies it to both options and plugins. It also handles the necessary steps for unpacking plugin archives and updating the system path.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix EXP-626

## How to test
<!-- Provide steps to test this PR -->


- Start a workspace on https://ak-jb-initd0c281dd69.preview.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo/tree/jb-proxy-test with IntelliJ (2023.2.2)
- Check local proxy settings are configured
- Check that JPAB plugin is installed

<img width="1039" alt="Screenshot 2023-09-18 at 14 07 23" src="https://github.com/gitpod-io/gitpod/assets/3082655/672417e9-02d3-4ad5-8440-096de6fa6d6b">
<img width="1058" alt="Screenshot 2023-09-18 at 14 07 17" src="https://github.com/gitpod-io/gitpod/assets/3082655/a4dc8289-5295-4c0e-89d2-e0c5baab6329">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-jb-initd0c281dd69</li>
	<li><b>🔗 URL</b> - <a href="https://ak-jb-initd0c281dd69.preview.gitpod-dev.com/workspaces" target="_blank">ak-jb-initd0c281dd69.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-jb_initial_image_plugins-gha.17082</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-jb-initd0c281dd69%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
