### PR TITLE
[spicedb] Grant all org members project "editor" role

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -77,9 +77,10 @@ export type OrganizationPermission =
 
 export type ProjectResourceType = "project";
 
-export type ProjectRelation = "org" | "editor" | "viewer";
+export type ProjectRelation = "org" | "viewer";
 
 export type ProjectPermission =
+    | "editor"
     | "read_info"
     | "write_info"
     | "delete"
@@ -333,26 +334,6 @@ export const rel = {
                             subject: {
                                 object: {
                                     objectType: "organization",
-                                    objectId: objectId,
-                                },
-                            },
-                        } as v1.Relationship;
-                    },
-                };
-            },
-
-            get editor() {
-                const result2 = {
-                    ...result,
-                    relation: "editor",
-                };
-                return {
-                    user(objectId: string) {
-                        return {
-                            ...result2,
-                            subject: {
-                                object: {
-                                    objectType: "user",
                                     objectId: objectId,
                                 },
                             },

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -223,7 +223,7 @@ describe("EnvVarService", async () => {
         expect(emptyEnvVars.length).to.equal(0);
     });
 
-    it("should not let members create, delete but allow get project env vars", async () => {
+    it("let members create, delete and get project env vars", async () => {
         await es.addProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR", censored: false });
 
         const envVars = await es.listProjectEnvVars(member.id, project.id);
@@ -232,12 +232,9 @@ describe("EnvVarService", async () => {
         const envVarById = await es.getProjectEnvVarById(member.id, envVars[0].id);
         expect(envVarById?.name).to.equal("FOO");
 
-        await expectError(ErrorCodes.PERMISSION_DENIED, es.deleteProjectEnvVar(member.id, envVars[0].id));
+        await es.deleteProjectEnvVar(member.id, envVars[0].id);
 
-        await expectError(
-            ErrorCodes.PERMISSION_DENIED,
-            es.addProjectEnvVar(member.id, project.id, { name: "FOO", value: "BAR", censored: false }),
-        );
+        await es.addProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR", censored: false });
     });
 
     it("should not let strangers create, delete and get project env vars", async () => {

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -91,13 +91,15 @@ schema: |-
   definition project {
     relation org: organization
 
-    relation editor: user
-
     // A subject is a viewer, if:
     //  * the users with access are directly assigned as a viewer
     //  * the project has granted access to all members in an organization
     //  * the project has granted access to _any_ user on this installation
     relation viewer: user | organization#member | user:*
+
+    // All org members are editors for now, to model the existing behavior.
+    permission editor = org->member
+
     permission read_info = viewer + editor + org->owner + org->installation_admin
     permission write_info = editor + org->owner + org->installation_admin
     permission delete = editor + org->owner + org->installation_admin
@@ -209,10 +211,14 @@ assertions:
     - organization:org_1#delete@user:user_0
     # Org owner can delete projects
     - project:project_1#delete@user:user_0
+    # org members can delete project
+    - project:project_1#delete@user:user_1
     # Org member can view projects
     - project:project_1#read_info@user:user_1
     # Org member can create projects
     - organization:org_1#create_project@user:user_1
+    # user 10 can access project_2
+    - project:project_2#write_info@user:user_10
     # installation user can create orgs
     - installation:installation_0#create_organization@user:user_0
     # Installation admin can do what org owners can
@@ -230,7 +236,6 @@ assertions:
   assertFalse:
     # user 10 cannot access project_1
     - project:project_1#read_info@user:user_10
-    - project:project_2#write_info@user:user_10
     # non-member/owner cannot access organization
     - organization:org_1#read_info@user:user_3
     - organization:org_1#write_info@user:user_3
@@ -244,7 +249,5 @@ assertions:
     - organization:org_1#write_git_provider@user:user_1
     # org member can not delete org
     - organization:org_1#delete@user:user_1
-    # org members can not delete project
-    - project:project_1#delete@user:user_1
     # stranger can't access other's non-shared workspace
     - workspace:workspace_1#access@user:user_2


### PR DESCRIPTION
## Description



<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a1555d</samp>

This pull request refactors the project authorization logic to use SpiceDB and permissions instead of relations. It removes the `editor` relation from the `ProjectRelation` type and adds it to the `ProjectPermission` type. It also updates the project settings and tests to reflect the new logic and allow more actions for project members. It modifies the files `components/server/src/authorization/definitions.ts`, `components/server/src/projects/projects-service.spec.db.ts`, `components/server/src/user/env-var-service.spec.db.ts`, and `components/spicedb/schema/schema.yaml`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-608

## How to test
 - user 1: create an org
 - user 2: join with that org (as member)
 - user 2: create a project
 - user 2: change settings on that project :heavy_check_mark: 
 - user 2: add/modify/remove env vars on that project :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-rm-prob4e288aa8b</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-rm-prob4e288aa8b.preview.gitpod-dev.com/workspaces" target="_blank">gpl-rm-prob4e288aa8b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-rm-project-editor-gha.17094</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-rm-prob4e288aa8b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
