### PR TITLE
[server] Remove feature flag workspace_start_controller

### DIFF
--- a/components/server/src/workspace/workspace-start-controller.ts
+++ b/components/server/src/workspace/workspace-start-controller.ts
@@ -10,7 +10,6 @@ import { Job } from "../jobs/runner";
 import { DBWithTracing, TracedWorkspaceDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { WorkspaceStarter } from "./workspace-starter";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
@@ -51,18 +50,6 @@ export class WorkspaceStartController implements Job {
                         const user = await this.userDB.findUserById(workspace.ownerId);
                         if (!user) {
                             throw new Error("cannot find owner for workspace");
-                        }
-
-                        const isEnabled = await getExperimentsClientForBackend().getValueAsync(
-                            "workspace_start_controller",
-                            false,
-                            {
-                                user,
-                                projectId: workspace.projectId,
-                            },
-                        );
-                        if (!isEnabled) {
-                            continue;
                         }
 
                         await this.workspaceStarter.reconcileWorkspaceStart(ctx, instance.id, user, workspace);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -129,7 +129,6 @@ import { WorkspaceClassesConfig } from "./workspace-classes";
 import { SYSTEM_USER } from "../authorization/authorizer";
 import { EnvVarService, ResolvedEnvVars } from "../user/env-var-service";
 import { RedlockAbortSignal } from "redlock";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { ConfigProvider } from "./config-provider";
 import { isGrpcError } from "@gitpod/gitpod-protocol/lib/util/grpc";
 
@@ -381,17 +380,6 @@ export class WorkspaceStarter {
                 ctx.span.finish();
             }
         };
-
-        const runWithMutex = await getExperimentsClientForBackend().getValueAsync("workspace_start_controller", false, {
-            user,
-            projectId: workspace.projectId,
-        });
-        ctx.span.setTag("runWithMutex", runWithMutex);
-        if (!runWithMutex) {
-            const abortController = new AbortController();
-            await doReconcileWorkspaceStart(abortController.signal);
-            return;
-        }
 
         // We try to acquire a mutex here, which we intend to hold until the workspace start request is sent to ws-manager.
         // In case this container dies for whatever reason, the mutex is eventually released, and the instance can be picked up


### PR DESCRIPTION
## Description
Let's merge this after we completely rolled this out

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b0239c</samp>

This pull request removes the legacy code for the workspace start controller and starter, and fully adopts the new implementation. This improves the code quality and consistency of the workspace launch process on Kubernetes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-636

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
