### PR TITLE
[public-api] improve error handling

### DIFF
--- a/components/dashboard/resolver.js
+++ b/components/dashboard/resolver.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+//@ts-check
+const path = require('path');
+const fetch = require('node-fetch').default;
+const { SourceMapConsumer } = require('source-map');
+
+const sourceMapCache = {};
+
+function extractJsUrlFromLine(line) {
+    const match = line.match(/https?:\/\/[^\s]+\.js/);
+    return match ? match[0] : null;
+}
+
+async function fetchSourceMap(jsUrl) {
+    // Use cached source map if available
+    if (sourceMapCache[jsUrl]) {
+        return sourceMapCache[jsUrl];
+    }
+
+    const jsResponse = await fetch(jsUrl);
+    const jsContent = await jsResponse.text();
+
+    // Extract source map URL from the JS file
+    const mapUrlMatch = jsContent.match(/\/\/#\s*sourceMappingURL=(.+)/);
+    if (!mapUrlMatch) {
+        throw new Error('Source map URL not found');
+    }
+
+    const mapUrl = new URL(mapUrlMatch[1], jsUrl).href;  // Resolve relative URL
+    const mapResponse = await fetch(mapUrl);
+    const mapData = await mapResponse.json();
+
+    // Cache the fetched source map
+    sourceMapCache[jsUrl] = mapData;
+
+    return mapData;
+}
+
+const BASE_PATH = '/workspace/gitpod/components';
+
+async function resolveLine(line) {
+    const jsUrl = extractJsUrlFromLine(line);
+    if (!jsUrl) return line;
+
+    const rawSourceMap = await fetchSourceMap(jsUrl);
+    const matches = line.match(/at (?:([\S]+) )?\(?(https?:\/\/[^\s]+\.js):(\d+):(\d+)\)?/);
+
+    if (!matches) {
+        return line;
+    }
+
+    const functionName = matches[1] || '';
+    const lineNum = Number(matches[3]);
+    const colNum = Number(matches[4]);
+
+    const consumer = new SourceMapConsumer(rawSourceMap);
+    const originalPosition = consumer.originalPositionFor({ line: lineNum, column: colNum });
+
+    if (originalPosition && originalPosition.source) {
+        const fullPath = path.join(BASE_PATH, originalPosition.source);
+        const originalFunctionName = originalPosition.name || functionName;
+        return `    at ${originalFunctionName} (${fullPath}:${originalPosition.line}:${originalPosition.column})`;
+    }
+
+    return line;
+}
+
+
+let obfuscatedTrace = '';
+
+process.stdin.on('data', function(data) {
+    obfuscatedTrace += data;
+});
+
+process.stdin.on('end', async function() {
+    const lines = obfuscatedTrace.split('\n');
+    const resolvedLines = await Promise.all(lines.map(resolveLine));
+    const resolvedTrace = resolvedLines.join('\n');
+    console.log('\nResolved Stack Trace:\n');
+    console.log(resolvedTrace);
+});
+
+if (process.stdin.isTTY) {
+    console.error("Please provide the obfuscated stack trace either as a multi-line input or from a file.");
+    process.exit(1);
+}

--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -4,11 +4,31 @@
   "license": "AGPL-3.0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "module": "./lib/esm/index.js",
   "files": [
     "lib"
   ],
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/index.js"
+    },
+    "./lib/*": {
+      "types": "./lib/*.d.ts",
+      "import": "./lib/esm/*.js",
+      "require": "./lib/*.js"
+    },
+    "./lib/gitpod/experimental/v1": {
+      "types": "./lib/gitpod/experimental/v1/index.d.ts",
+      "import": "./lib/esm/gitpod/experimental/v1/index.js",
+      "require": "./lib/gitpod/experimental/v1/index.js"
+    }
+  },
   "scripts": {
-    "build": "mkdir -p lib; tsc",
+    "build": "yarn run build:cjs && yarn run build:esm",
+    "build:cjs": "tsc",
+    "build:esm": "tsc --module es2015 --outDir ./lib/esm",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "test:brk": "yarn test --inspect-brk"
@@ -16,11 +36,11 @@
   "dependencies": {
     "@bufbuild/connect": "^0.13.0",
     "@bufbuild/protobuf": "^0.1.1",
-    "@bufbuild/protoc-gen-connect-web": "^0.2.1",
-    "@bufbuild/protoc-gen-es": "^0.1.1",
     "prom-client": "^14.2.0"
   },
   "devDependencies": {
+    "@bufbuild/protoc-gen-connect-web": "^0.2.1",
+    "@bufbuild/protoc-gen-es": "^0.1.1",
     "@testdeck/mocha": "0.1.2",
     "@types/chai": "^4.1.2",
     "@types/node": "^16.11.0",

--- a/components/public-api/typescript/tsconfig.json
+++ b/components/public-api/typescript/tsconfig.json
@@ -3,6 +3,7 @@
         "rootDir": "src",
         "experimentalDecorators": true,
         "outDir": "lib",
+        "declarationDir": "lib",
         "lib": [
             "es6",
             "esnext.asynciterable",
@@ -14,7 +15,7 @@
         "emitDecoratorMetadata": true,
         "strictPropertyInitialization": false,
         "downlevelIteration": true,
-        "module": "ES6",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "target": "es6",
         "jsx": "react",

--- a/components/public-api/typescript/tsconfig.json
+++ b/components/public-api/typescript/tsconfig.json
@@ -14,7 +14,7 @@
         "emitDecoratorMetadata": true,
         "strictPropertyInitialization": false,
         "downlevelIteration": true,
-        "module": "commonjs",
+        "module": "ES6",
         "moduleResolution": "node",
         "target": "es6",
         "jsx": "react",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR:
- fix the bug with parsing cookie in public api middleware
- turn unexpected errors in internal, log them on server and communicate properly to the client, i.e. will be measured as internal error code + don't leak server logs to clients
- get rid of duplicate module loading for @bufbuild modules in dashboard like commonjs and es6 (it was breaking instanceof for ConnectError) by generating esm exports in public-api
- makes streaming test less chatty with the exponential backoff to avoid spamming ourself

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a22b88</samp>

Improve public API retry logic in dashboard service. Use exponential backoff with jitter in `service.tsx` to handle network errors and rate limits.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open preview envs but don't login.
- In the inspector you should see retries of LotsOfReplies (which should not happen very often).
- Close inspecting of response body should surface unauthenticated error, not unknown as before.
- Check that grpc client metrics are reported with unauthenticated code as well not unknown as before.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-grpc-clc8e082e080</li>
	<li><b>🔗 URL</b> - <a href="https://ak-grpc-clc8e082e080.preview.gitpod-dev.com/workspaces" target="_blank">ak-grpc-clc8e082e080.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-grpc_client_errors-gha.17176</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-grpc-clc8e082e080%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
