### PR TITLE
[db] inCluster: remove mysql version flag

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -483,11 +483,6 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.enforce 
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.connectionsPerMinute "3000"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.networkLimits.bucketSize "3000"
 
-#
-# Configure DB
-#
-yq w -i "${INSTALLER_CONFIG_PATH}" database.inClusterMySql_8_0 "true"
-
 log_success "Generated config at $INSTALLER_CONFIG_PATH"
 
 # ========

--- a/install/installer/pkg/components/database/incluster/helm.go
+++ b/install/installer/pkg/components/database/incluster/helm.go
@@ -33,15 +33,11 @@ var Helm = common.CompositeHelmFunc(
 			Value string `json:"value,omitempty"`
 		}
 		extraEnvVars := []EnvVar{}
-		// MySQL 5.7: We switched to specific tags because we got subtle broken versions with just specifying major versions
-		mysqlBitnamiImageTag := "5.7.34-debian-10-r55"
-		if cfg.Config.Database.InClusterMysSQL_8_0 {
-			mysqlBitnamiImageTag = "8.0.33-debian-11-r24"
-			extraEnvVars = append(extraEnvVars, EnvVar{
-				Name:  "MYSQL_AUTHENTICATION_PLUGIN",
-				Value: "mysql_native_password",
-			})
-		}
+		mysqlBitnamiImageTag := "8.0.33-debian-11-r24"
+		extraEnvVars = append(extraEnvVars, EnvVar{
+			Name:  "MYSQL_AUTHENTICATION_PLUGIN",
+			Value: "mysql_native_password",
+		})
 		extraEnvVarsBytes, err := yaml.Marshal(extraEnvVars)
 		if err != nil {
 			return nil, err

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -195,8 +195,6 @@ type Database struct {
 	External  *DatabaseExternal `json:"external,omitempty"`
 	CloudSQL  *DatabaseCloudSQL `json:"cloudSQL,omitempty"`
 	SSL       *SSLOptions       `json:"ssl,omitempty"`
-	// A temporary flag to help debug for the migration to MySQL 8.0
-	InClusterMysSQL_8_0 bool `json:"inClusterMySql_8_0,omitempty"`
 }
 
 type DatabaseExternal struct {


### PR DESCRIPTION
## Description
This caused a problem with installer: if it was not set, we render a malformed mysql chart. As we don't need it anymore we can drop it anyway.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d16cd4</samp>

Remove MySQL 5.7 support from cluster installation. This change simplifies the installation script, the helm chart, and the configuration struct for the database component.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-644

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
