### PR TITLE
[wip] mayStartTimeout: make organizationId mandatory

### DIFF
--- a/components/dashboard/src/data/current-user/may-set-timeout-query.ts
+++ b/components/dashboard/src/data/current-user/may-set-timeout-query.ts
@@ -7,21 +7,26 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentUser } from "../../user-context";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
-export const useUserMaySetTimeout = () => {
+export const useMaySetTimeout = () => {
     const user = useCurrentUser();
+    const org = useCurrentOrg();
 
     return useQuery<boolean>({
-        queryKey: getUserMaySetTimeoutQueryKey(user?.id ?? ""),
+        queryKey: getMaySetTimeoutQueryKey(user?.id ?? "", org.data?.id ?? ""),
         queryFn: async () => {
             if (!user) {
                 throw new Error("No current user");
             }
+            if (!org.data) {
+                throw new Error("No current org");
+            }
 
-            return !!(await getGitpodService().server.maySetTimeout());
+            return !!(await getGitpodService().server.maySetTimeout({ organizationId: org.data.id }));
         },
-        enabled: !!user,
+        enabled: !!user && !!org.data,
     });
 };
 
-export const getUserMaySetTimeoutQueryKey = (userId: string) => ["may-set-timeout", { userId }];
+export const getMaySetTimeoutQueryKey = (userId: string, orgId: string) => ["may-set-timeout", { userId }, { orgId }];

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -12,7 +12,7 @@ import { ThemeSelector } from "../components/ThemeSelector";
 import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
 import { Heading2, Heading3, Subheading } from "../components/typography/headings";
-import { useUserMaySetTimeout } from "../data/current-user/may-set-timeout-query";
+import { useMaySetTimeout } from "../data/current-user/may-set-timeout-query";
 import { Button } from "../components/Button";
 import SelectIDE from "./SelectIDE";
 import { InputField } from "../components/forms/InputField";
@@ -26,7 +26,7 @@ export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "pr
 export default function Preferences() {
     const { toast } = useToast();
     const { user, setUser } = useContext(UserContext);
-    const maySetTimeout = useUserMaySetTimeout();
+    const maySetTimeout = useMaySetTimeout();
     const updateDotfileRepo = useUpdateCurrentUserDotfileRepoMutation();
 
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
@@ -57,7 +57,9 @@ export default function Preferences() {
                 const updatedUser = await getGitpodService().server.getLoggedInUser();
                 setUser(updatedUser);
 
-                toast("Your default workspace timeout was updated.");
+                toast(
+                    "Your default workspace timeout was updated. Note that this will only affect workspaces in paid organizations.",
+                );
             } catch (e) {
                 // TODO: Convert this to an error style toast
                 alert("Cannot set custom workspace timeout: " + e.message);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -259,7 +259,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     reportErrorBoundary(url: string, message: string): Promise<void>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
-    maySetTimeout(): Promise<boolean>;
+    maySetTimeout(opts?: { organizationId?: string }): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
 
     /**

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -259,7 +259,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     reportErrorBoundary(url: string, message: string): Promise<void>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
-    maySetTimeout(opts?: { organizationId?: string }): Promise<boolean>;
+    maySetTimeout(opts: { organizationId: string }): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
 
     /**

--- a/components/server/src/billing/entitlement-service-ubp.ts
+++ b/components/server/src/billing/entitlement-service-ubp.ts
@@ -121,7 +121,7 @@ export class EntitlementServiceUBP implements EntitlementService {
             }
         }
 
-        // TODO(gpl) Remove everything below once organizations are fully rolled out
+        // TODO(gpl) Remove everything below once organizationId is always passed
         // This is the old behavior, stemming from our transition to PAYF, where our API did-/doesn't pass organizationId, yet
         // Member of paid team?
         const teams = await this.teamDB.findTeamsByUser(userId);

--- a/components/server/src/billing/entitlement-service-ubp.ts
+++ b/components/server/src/billing/entitlement-service-ubp.ts
@@ -4,7 +4,6 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { TeamDB } from "@gitpod/gitpod-db/lib";
 import {
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
@@ -14,7 +13,6 @@ import {
     WORKSPACE_LIFETIME_SHORT,
     User,
     BillingTier,
-    Team,
 } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { inject, injectable } from "inversify";
@@ -31,10 +29,7 @@ const MAX_PARALLEL_WORKSPACES_PAID = 16;
  */
 @injectable()
 export class EntitlementServiceUBP implements EntitlementService {
-    constructor(
-        @inject(UsageService) private readonly usageService: UsageService,
-        @inject(TeamDB) private readonly teamDB: TeamDB,
-    ) {}
+    constructor(@inject(UsageService) private readonly usageService: UsageService) {}
 
     async mayStartWorkspace(
         user: User,
@@ -79,7 +74,7 @@ export class EntitlementServiceUBP implements EntitlementService {
         }
     }
 
-    async maySetTimeout(userId: string, organizationId?: string): Promise<boolean> {
+    async maySetTimeout(userId: string, organizationId: string): Promise<boolean> {
         return this.hasPaidSubscription(userId, organizationId);
     }
 
@@ -109,48 +104,15 @@ export class EntitlementServiceUBP implements EntitlementService {
         return true;
     }
 
-    private async hasPaidSubscription(userId: string, organizationId?: string): Promise<boolean> {
-        if (organizationId) {
-            try {
-                // This is the "stricter", more correct version: We only allow privileges on the Organization that is paying for it
-                const { billingStrategy } = await this.usageService.getCostCenter(userId, organizationId);
-                return billingStrategy === CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
-            } catch (err) {
-                log.warn({ userId, organizationId }, "Error checking if user is subscribed to organization", err);
-                return false;
-            }
-        }
-
-        // TODO(gpl) Remove everything below once organizationId is always passed
-        // This is the old behavior, stemming from our transition to PAYF, where our API did-/doesn't pass organizationId, yet
-        // Member of paid team?
-        const teams = await this.teamDB.findTeamsByUser(userId);
-        const isTeamSubscribedPromises = teams.map(async (team: Team) => {
-            const { billingStrategy } = await this.usageService.getCostCenter(userId, team.id);
+    private async hasPaidSubscription(userId: string, organizationId: string): Promise<boolean> {
+        try {
+            // This is the "stricter", more correct version: We only allow privileges on the Organization that is paying for it
+            const { billingStrategy } = await this.usageService.getCostCenter(userId, organizationId);
             return billingStrategy === CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
-        });
-        // Return the first truthy promise, or false if all the promises were falsy.
-        // Source: https://gist.github.com/jbreckmckye/66364021ebaa0785e426deec0410a235
-        return new Promise((resolve, reject) => {
-            // If any promise returns true, immediately resolve with true
-            isTeamSubscribedPromises.forEach(async (isTeamSubscribedPromise: Promise<boolean>) => {
-                try {
-                    const isTeamSubscribed = await isTeamSubscribedPromise;
-                    if (isTeamSubscribed) resolve(true);
-                } catch (err) {
-                    log.warn({ userId, organizationId }, "Error checking if user is subscribed to organization", err);
-                    resolve(false);
-                }
-            });
-
-            // If neither of the above fires, resolve with false
-            // Check truthiness just in case callbacks fire out-of-band
-            Promise.all(isTeamSubscribedPromises)
-                .then((areTeamsSubscribed) => {
-                    resolve(!!areTeamsSubscribed.find((isTeamSubscribed: boolean) => !!isTeamSubscribed));
-                })
-                .catch(reject);
-        });
+        } catch (err) {
+            log.warn({ userId, organizationId }, "Error checking if user is subscribed to organization", err);
+            return false;
+        }
     }
 
     async getBillingTier(userId: string, organizationId: string): Promise<BillingTier> {

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -54,7 +54,7 @@ export interface EntitlementService {
      * @param userId
      * @param organizationId
      */
-    maySetTimeout(userId: string, organizationId?: string): Promise<boolean>;
+    maySetTimeout(userId: string, organizationId: string): Promise<boolean>;
 
     /**
      * Returns the default workspace timeout for the given user at a given point in time
@@ -127,7 +127,7 @@ export class EntitlementServiceImpl implements EntitlementService {
         }
     }
 
-    async maySetTimeout(userId: string, organizationId?: string): Promise<boolean> {
+    async maySetTimeout(userId: string, organizationId: string): Promise<boolean> {
         try {
             // TODO(gpl): We need to replace this with ".getBillingMode(user.id, organizationId);" once all callers forward organizationId
             const billingMode = await this.billingModes.getBillingModeForUser();

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -23,7 +23,6 @@ import { CreateUserParams } from "./user-authentication";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { TransactionalContext } from "@gitpod/gitpod-db/lib/typeorm/transactional-db-impl";
 import { RelationshipUpdater } from "../authorization/relationship-updater";
-import { EntitlementService } from "../billing/entitlement-service";
 
 @injectable()
 export class UserService {
@@ -33,7 +32,6 @@ export class UserService {
         @inject(Authorizer) private readonly authorizer: Authorizer,
         @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
         @inject(RelationshipUpdater) private readonly relationshipUpdater: RelationshipUpdater,
-        @inject(EntitlementService) private readonly entitlementService: EntitlementService,
     ) {}
 
     public async createUser(
@@ -142,13 +140,6 @@ export class UserService {
             } catch (err) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, err.message);
             }
-        }
-
-        if (!(await this.entitlementService.maySetTimeout(targetUserId))) {
-            throw new ApplicationError(
-                ErrorCodes.PERMISSION_DENIED,
-                "Configure workspace timeout only available for paid user.",
-            );
         }
 
         const user = await this.findUserById(userId, targetUserId);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -642,12 +642,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return updatedUser;
     }
 
-    public async maySetTimeout(ctx: TraceContext): Promise<boolean> {
-        const user = await this.checkUser("maySetTimeout");
+    public async maySetTimeout(ctx: TraceContext, opts?: { organizationId?: string }): Promise<boolean> {
+        const user = await this.checkUser("maySetTimeout", opts);
         await this.guardAccess({ kind: "user", subject: user }, "get");
+        // TODO(gpl) Remove once organizationId is mandatory
         await this.auth.checkPermissionOnUser(user.id, "read_info", user.id);
+        if (opts?.organizationId) {
+            await this.auth.checkPermissionOnOrganization(user.id, "read_info", opts.organizationId);
+        }
 
-        return await this.entitlementService.maySetTimeout(user.id);
+        return await this.entitlementService.maySetTimeout(user.id, opts?.organizationId);
     }
 
     public async updateWorkspaceTimeoutSetting(


### PR DESCRIPTION
## Description
Depends on: 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2eac6b</samp>

Updated the UI and the server logic for the workspace timeout configuration feature. This feature allows users to set a custom timeout for their workspaces, but only if they belong to a paid organization. The changes involved passing the organization id as a parameter to various methods and hooks, and checking the user and the organization permissions before applying the configuration.

</details>

## Related Issue(s)
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
