### PR TITLE
[wip] maySetTimeout: introduce ogranizationId as argument

### DIFF
--- a/components/dashboard/src/data/current-user/may-set-timeout-query.ts
+++ b/components/dashboard/src/data/current-user/may-set-timeout-query.ts
@@ -7,21 +7,26 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentUser } from "../../user-context";
+import { useCurrentOrg } from "../organizations/orgs-query";
 
-export const useUserMaySetTimeout = () => {
+export const useMaySetTimeout = () => {
     const user = useCurrentUser();
+    const org = useCurrentOrg();
 
     return useQuery<boolean>({
-        queryKey: getUserMaySetTimeoutQueryKey(user?.id ?? ""),
+        queryKey: getMaySetTimeoutQueryKey(user?.id ?? "", org.data?.id ?? ""),
         queryFn: async () => {
             if (!user) {
                 throw new Error("No current user");
             }
+            if (!org.data) {
+                throw new Error("No current org");
+            }
 
-            return !!(await getGitpodService().server.maySetTimeout());
+            return !!(await getGitpodService().server.maySetTimeout({ organizationId: org.data.id }));
         },
-        enabled: !!user,
+        enabled: !!user && !!org.data,
     });
 };
 
-export const getUserMaySetTimeoutQueryKey = (userId: string) => ["may-set-timeout", { userId }];
+export const getMaySetTimeoutQueryKey = (userId: string, orgId: string) => ["may-set-timeout", { userId }, { orgId }];

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -12,7 +12,7 @@ import { ThemeSelector } from "../components/ThemeSelector";
 import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
 import { Heading2, Heading3, Subheading } from "../components/typography/headings";
-import { useUserMaySetTimeout } from "../data/current-user/may-set-timeout-query";
+import { useMaySetTimeout } from "../data/current-user/may-set-timeout-query";
 import { Button } from "../components/Button";
 import SelectIDE from "./SelectIDE";
 import { InputField } from "../components/forms/InputField";
@@ -26,7 +26,7 @@ export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "pr
 export default function Preferences() {
     const { toast } = useToast();
     const { user, setUser } = useContext(UserContext);
-    const maySetTimeout = useUserMaySetTimeout();
+    const maySetTimeout = useMaySetTimeout();
     const updateDotfileRepo = useUpdateCurrentUserDotfileRepoMutation();
 
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
@@ -57,7 +57,9 @@ export default function Preferences() {
                 const updatedUser = await getGitpodService().server.getLoggedInUser();
                 setUser(updatedUser);
 
-                toast("Your default workspace timeout was updated.");
+                toast(
+                    "Your default workspace timeout was updated. Note that this will only affect workspaces in paid organizations.",
+                );
             } catch (e) {
                 // TODO: Convert this to an error style toast
                 alert("Cannot set custom workspace timeout: " + e.message);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -259,7 +259,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     reportErrorBoundary(url: string, message: string): Promise<void>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
-    maySetTimeout(): Promise<boolean>;
+    maySetTimeout(opts?: { organizationId?: string }): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
 
     /**

--- a/components/server/src/billing/entitlement-service-ubp.ts
+++ b/components/server/src/billing/entitlement-service-ubp.ts
@@ -121,7 +121,7 @@ export class EntitlementServiceUBP implements EntitlementService {
             }
         }
 
-        // TODO(gpl) Remove everything below once organizations are fully rolled out
+        // TODO(gpl) Remove everything below once organizationId is always passed
         // This is the old behavior, stemming from our transition to PAYF, where our API did-/doesn't pass organizationId, yet
         // Member of paid team?
         const teams = await this.teamDB.findTeamsByUser(userId);

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -23,7 +23,6 @@ import { CreateUserParams } from "./user-authentication";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { TransactionalContext } from "@gitpod/gitpod-db/lib/typeorm/transactional-db-impl";
 import { RelationshipUpdater } from "../authorization/relationship-updater";
-import { EntitlementService } from "../billing/entitlement-service";
 
 @injectable()
 export class UserService {
@@ -33,7 +32,6 @@ export class UserService {
         @inject(Authorizer) private readonly authorizer: Authorizer,
         @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
         @inject(RelationshipUpdater) private readonly relationshipUpdater: RelationshipUpdater,
-        @inject(EntitlementService) private readonly entitlementService: EntitlementService,
     ) {}
 
     public async createUser(
@@ -142,13 +140,6 @@ export class UserService {
             } catch (err) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, err.message);
             }
-        }
-
-        if (!(await this.entitlementService.maySetTimeout(targetUserId))) {
-            throw new ApplicationError(
-                ErrorCodes.PERMISSION_DENIED,
-                "Configure workspace timeout only available for paid user.",
-            );
         }
 
         const user = await this.findUserById(userId, targetUserId);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -650,12 +650,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return updatedUser;
     }
 
-    public async maySetTimeout(ctx: TraceContext): Promise<boolean> {
-        const user = await this.checkUser("maySetTimeout");
+    public async maySetTimeout(ctx: TraceContext, opts?: { organizationId?: string }): Promise<boolean> {
+        const user = await this.checkUser("maySetTimeout", opts);
         await this.guardAccess({ kind: "user", subject: user }, "get");
+        // TODO(gpl) Remove once organizationId is mandatory
         await this.auth.checkPermissionOnUser(user.id, "read_info", user.id);
+        if (opts?.organizationId) {
+            await this.auth.checkPermissionOnOrganization(user.id, "read_info", opts.organizationId);
+        }
 
-        return await this.entitlementService.maySetTimeout(user.id);
+        return await this.entitlementService.maySetTimeout(user.id, opts?.organizationId);
     }
 
     public async updateWorkspaceTimeoutSetting(


### PR DESCRIPTION
## Description
This is refactoring a bit of tech-debt: We made "default workspace timeout" a user setting. But since UBP the decision whether it gets applied or not depends on the organization. So far, maySetTimeout did not take the organizationId, but had a fallback case which was introduced for compatibility during UBP rollout.

This PR allows to always passes the current organizationId, as well as prepares us to remove the old compatibility code.

In order to do that, it allows _all users_ to set their "default workspace timeout", but hints them that it only affects workspaces started in paid organizations.

Follow-up PR: https://github.com/gitpod-io/gitpod/pull/18744

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9caad95</samp>

This pull request updates the frontend and backend logic of setting the workspace timeout based on the user's subscription and entitlements. It introduces a new hook `useMaySetTimeout` and a new parameter `opts` to the `maySetTimeout` method, which allow passing the organization ID to the server. It also simplifies and improves the code of some related components and services.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
