### PR TITLE
[WorkspaceStarter] Fail instance on all errors

### DIFF
--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -105,3 +105,7 @@ export function createClientCallMetricsInterceptor(metrics: IClientCallMetrics):
         return new grpc.InterceptingCall(nextCall(options), requester);
     };
 }
+
+export function isGrpcError(err: any): err is grpc.StatusObject {
+    return err.code && err.details;
+}

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -122,7 +122,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     throw new Error("Unsupported billing mode: " + (billingMode as any).mode); // safety net
             }
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementService error: mayStartWorkspace", err);
+            log.warn({ userId: user.id }, "EntitlementService error: mayStartWorkspace", err);
             return {}; // When there is an EntitlementService error, we never want to break workspace starts
         }
     }
@@ -139,7 +139,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     return this.ubp.maySetTimeout(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId }, "EntitlementService error: maySetTimeout", err);
+            log.warn({ userId }, "EntitlementService error: maySetTimeout", err);
             return true;
         }
     }
@@ -154,7 +154,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     return this.ubp.getDefaultWorkspaceTimeout(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId }, "EntitlementService error: getDefaultWorkspaceTimeout", err);
+            log.warn({ userId }, "EntitlementService error: getDefaultWorkspaceTimeout", err);
             return WORKSPACE_TIMEOUT_DEFAULT_LONG;
         }
     }
@@ -169,7 +169,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     return this.ubp.getDefaultWorkspaceLifetime(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId }, "EntitlementService error: getDefaultWorkspaceLifetime", err);
+            log.warn({ userId }, "EntitlementService error: getDefaultWorkspaceLifetime", err);
             return WORKSPACE_LIFETIME_LONG;
         }
     }
@@ -188,7 +188,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     return this.ubp.limitNetworkConnections(userId, organizationId);
             }
         } catch (err) {
-            log.error({ userId }, "EntitlementService error: limitNetworkConnections", err);
+            log.warn({ userId }, "EntitlementService error: limitNetworkConnections", err);
             return false;
         }
     }
@@ -208,7 +208,7 @@ export class EntitlementServiceImpl implements EntitlementService {
                     return billingMode.paid ? "paid" : "free";
             }
         } catch (err) {
-            log.error({ userId }, "EntitlementService error: getBillingTier", err);
+            log.warn({ userId }, "EntitlementService error: getBillingTier", err);
             return "paid";
         }
     }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -200,6 +200,7 @@ export type FailedInstanceStartReason =
     | "clusterSelectionFailed"
     | "startOnClusterFailed"
     | "imageBuildFailed"
+    | "imageBuildFailedUser"
     | "resourceExhausted"
     | "workspaceClusterMaintenance"
     | "other";

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -60,6 +60,7 @@ import { goDurationToHumanReadable } from "@gitpod/gitpod-protocol/lib/util/time
 import { HeadlessLogEndpoint, HeadlessLogService } from "./headless-log-service";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { OrganizationService } from "../orgs/organization-service";
+import { isGrpcError } from "@gitpod/gitpod-protocol/lib/util/grpc";
 
 export interface StartWorkspaceOptions extends StarterStartWorkspaceOptions {
     /**
@@ -901,10 +902,6 @@ export class WorkspaceService {
 
 // TODO(gpl) Make private after FGA rollout
 export function mapGrpcError(err: Error): Error {
-    function isGrpcError(err: any): err is grpc.StatusObject {
-        return err.code && err.details;
-    }
-
     if (!isGrpcError(err)) {
         return err;
     }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -559,6 +559,7 @@ export class WorkspaceStarter {
                 additionalAuth,
                 forceRebuild,
                 forceRebuild,
+                abortSignal,
                 region,
             );
 
@@ -579,23 +580,23 @@ export class WorkspaceStarter {
             startRequest.setSpec(spec);
             startRequest.setServicePrefix(workspace.id);
 
-            if (instance.status.phase === "pending") {
-                // due to the reconciliation loop we might have already started the workspace, especially in the "pending" phase
-                const workspaceAlreadyExists = await this.existsWithWsManager(ctx, instance);
-                if (workspaceAlreadyExists) {
-                    log.debug(
-                        { instanceId: instance.id, workspaceId: instance.workspaceId },
-                        "workspace already exists, not starting again",
-                        { phase: instance.status.phase },
-                    );
-                    return;
-                }
-            }
-
             // choose a cluster and start the instance
             let resp: StartWorkspaceResponse.AsObject | undefined = undefined;
             let retries = 0;
             try {
+                if (instance.status.phase === "pending") {
+                    // due to the reconciliation loop we might have already started the workspace, especially in the "pending" phase
+                    const workspaceAlreadyExists = await this.existsWithWsManager(ctx, instance);
+                    if (workspaceAlreadyExists) {
+                        log.debug(
+                            { instanceId: instance.id, workspaceId: instance.workspaceId },
+                            "workspace already exists, not starting again",
+                            { phase: instance.status.phase },
+                        );
+                        return;
+                    }
+                }
+
                 for (; retries < MAX_INSTANCE_START_RETRIES; retries++) {
                     if (abortSignal.aborted) {
                         return;
@@ -659,6 +660,12 @@ export class WorkspaceStarter {
                 });
             }
         } catch (err) {
+            if (!(err instanceof StartInstanceError)) {
+                // fallback in case we did not already handle this error
+                await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
+                err = new StartInstanceError("other", err); // don't throw because there's nobody catching it. We just want to log/trace it.
+            }
+
             this.logAndTraceStartWorkspaceError({ span }, logCtx, err);
         } finally {
             if (abortSignal.aborted) {
@@ -811,8 +818,9 @@ export class WorkspaceStarter {
             // We may have never actually started the workspace which means that ws-manager-bridge never set a workspace status.
             // We have to set that status ourselves.
             instance.status.phase = "stopped";
-            instance.stoppingTime = new Date().toISOString();
-            instance.stoppedTime = new Date().toISOString();
+            const now = new Date().toISOString();
+            instance.stoppingTime = now;
+            instance.stoppedTime = now;
 
             instance.status.conditions.failed = err.toString();
             instance.status.message = `Workspace cannot be started: ${err}`;
@@ -1201,6 +1209,7 @@ export class WorkspaceStarter {
         additionalAuth: Map<string, string>,
         ignoreBaseImageresolvedAndRebuildBase: boolean = false,
         forceRebuild: boolean = false,
+        abortSignal: RedlockAbortSignal,
         region?: WorkspaceRegion,
     ): Promise<WorkspaceInstance> {
         const span = TraceContext.startSpan("buildWorkspaceImage", ctx);
@@ -1302,6 +1311,7 @@ export class WorkspaceStarter {
                         additionalAuth,
                         true,
                         forceRebuild,
+                        abortSignal,
                         region,
                     );
                 } else {
@@ -1338,24 +1348,8 @@ export class WorkspaceStarter {
             }
 
             // This instance's image build "failed" as well, so mark it as such.
-            const now = new Date().toISOString();
-            instance = await this.workspaceDb.trace({ span }).updateInstancePartial(instance.id, {
-                status: { ...instance.status, phase: "stopped", conditions: { failed: message }, message },
-                stoppedTime: now,
-                stoppingTime: now,
-            });
+            await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
 
-            // Mark the PrebuildWorkspace as failed
-            await this.failPrebuildWorkspace({ span }, err, workspace);
-
-            // Publish updated workspace instance
-            await this.publisher.publishInstanceUpdate({
-                workspaceID: workspace.ownerId,
-                instanceID: instance.id,
-                ownerID: workspace.ownerId,
-            });
-
-            TraceContext.setError({ span }, err);
             const looksLikeUserError = (msg: string): boolean => {
                 return msg.startsWith("build failed:") || msg.includes("headless task failed:");
             };
@@ -1365,6 +1359,8 @@ export class WorkspaceStarter {
                     `workspace image build failed: ${message}`,
                     { looksLikeUserError: true },
                 );
+                err = new StartInstanceError("imageBuildFailedUser", err);
+                // Don't report this as "failed" to our metrics as it would trigger an alert
             } else {
                 log.error(
                     { instanceId: instance.id, userId: user.id, workspaceId: workspace.id },
@@ -1963,6 +1959,9 @@ export class WorkspaceStarter {
             await client.describeWorkspace(ctx, req);
             return true;
         } catch (err) {
+            if (isClusterMaintenanceError(err)) {
+                throw err;
+            }
             return false;
         }
     }


### PR DESCRIPTION
## Description
Until now some errors were just logged, but did not fail a workspace (instance) start. This got more prominent with FGA and the associated refactorings, as we tend to throw more errors (NOT_FOUND, PERMISSIONS_DENIED) in more places.

[This is the core change](https://github.com/gitpod-io/gitpod/compare/gpl/make-startworkspace-convergent?expand=1#diff-b1c591e18af598ccba93b570ce7c97dece0988c9109a6d3be82bbe0df1fbd619R661-R666), everything else is just about a) re-use of `failInstanceStart` and b) making sure errors get propagated up properly.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fa2acc</samp>

This pull request improves the logging, error handling, and cancellation logic for workspace start requests, and adds a new metric value for image build failures caused by user errors.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-647

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-make-s2972ac667f</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-make-s2972ac667f.preview.gitpod-dev.com/workspaces" target="_blank">gpl-make-s2972ac667f.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-make-startworkspace-convergent-gha.17210</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-make-s2972ac667f%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
