### PR TITLE
[dashboard] add session id to error reporting

### DIFF
--- a/components/dashboard/resolver.js
+++ b/components/dashboard/resolver.js
@@ -3,10 +3,23 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
+
+/*
+ * Resolver allows to reconstruct stack traces from obfuscated stack traces for the dashboard.
+ * Usage:
+ *  node resolver.js < obfuscated-stack-trace.txt
+ *
+ * OR
+ *
+ *  node resolver.js <<EOF
+ *  obfuscated stack trace
+ *  EOF
+ */
+
 //@ts-check
-const path = require('path');
-const fetch = require('node-fetch').default;
-const { SourceMapConsumer } = require('source-map');
+const path = require("path");
+const fetch = require("node-fetch").default;
+const { SourceMapConsumer } = require("source-map");
 
 const sourceMapCache = {};
 
@@ -27,10 +40,10 @@ async function fetchSourceMap(jsUrl) {
     // Extract source map URL from the JS file
     const mapUrlMatch = jsContent.match(/\/\/#\s*sourceMappingURL=(.+)/);
     if (!mapUrlMatch) {
-        throw new Error('Source map URL not found');
+        throw new Error("Source map URL not found");
     }
 
-    const mapUrl = new URL(mapUrlMatch[1], jsUrl).href;  // Resolve relative URL
+    const mapUrl = new URL(mapUrlMatch[1], jsUrl).href; // Resolve relative URL
     const mapResponse = await fetch(mapUrl);
     const mapData = await mapResponse.json();
 
@@ -40,7 +53,7 @@ async function fetchSourceMap(jsUrl) {
     return mapData;
 }
 
-const BASE_PATH = '/workspace/gitpod/components';
+const BASE_PATH = "/workspace/gitpod/components";
 
 async function resolveLine(line) {
     const jsUrl = extractJsUrlFromLine(line);
@@ -53,7 +66,7 @@ async function resolveLine(line) {
         return line;
     }
 
-    const functionName = matches[1] || '';
+    const functionName = matches[1] || "";
     const lineNum = Number(matches[3]);
     const colNum = Number(matches[4]);
 
@@ -69,18 +82,17 @@ async function resolveLine(line) {
     return line;
 }
 
+let obfuscatedTrace = "";
 
-let obfuscatedTrace = '';
-
-process.stdin.on('data', function(data) {
+process.stdin.on("data", function (data) {
     obfuscatedTrace += data;
 });
 
-process.stdin.on('end', async function() {
-    const lines = obfuscatedTrace.split('\n');
+process.stdin.on("end", async function () {
+    const lines = obfuscatedTrace.split("\n");
     const resolvedLines = await Promise.all(lines.map(resolveLine));
-    const resolvedTrace = resolvedLines.join('\n');
-    console.log('\nResolved Stack Trace:\n');
+    const resolvedTrace = resolvedLines.join("\n");
+    console.log("\nResolved Stack Trace:\n");
     console.log(resolvedTrace);
 });
 

--- a/components/dashboard/src/service/metrics.ts
+++ b/components/dashboard/src/service/metrics.ts
@@ -7,6 +7,7 @@
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { MetricsReporter } from "@gitpod/public-api/lib/metrics";
 import { getExperimentsClient } from "../experiments/client";
+import { v4 } from "uuid";
 
 const originalConsoleError = console.error;
 
@@ -40,7 +41,9 @@ console.error = function (...args) {
     reportError(...args);
 };
 
-let commonDetails = {};
+const commonDetails = {
+    sessionId: v4(),
+};
 export function updateCommonErrorDetails(update: { [key: string]: string | undefined }) {
     Object.assign(commonDetails, update);
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
