### PR TITLE
[prebuilds] install and uninstall webhooks

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -45,6 +45,8 @@ import { LinkedInProfileDB } from "./linked-in-profile-db";
 import { DataCache, DataCacheNoop } from "./data-cache";
 import { TracingManager } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { EncryptionService, GlobalEncryptionService } from "@gitpod/gitpod-protocol/lib/encryption/encryption-service";
+import { WebhookInstallationDBImpl } from "./typeorm/webhook-installation-db-impl";
+import { WebhookInstallationDB } from "./webhook-installation-db";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = (cacheClass = DataCacheNoop) =>
@@ -108,6 +110,8 @@ export const dbContainerModule = (cacheClass = DataCacheNoop) =>
         bind(ProjectDB).toService(ProjectDBImpl);
         bind(WebhookEventDBImpl).toSelf().inSingletonScope();
         bind(WebhookEventDB).toService(WebhookEventDBImpl);
+        bind(WebhookInstallationDBImpl).toSelf().inSingletonScope();
+        bind(WebhookInstallationDB).toService(WebhookInstallationDBImpl);
 
         bind(PersonalAccessTokenDBImpl).toSelf().inSingletonScope();
         bind(PersonalAccessTokenDB).toService(PersonalAccessTokenDBImpl);

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -28,6 +28,7 @@ export * from "./email-domain-filter-db";
 export * from "./project-db";
 export * from "./team-db";
 export * from "./webhook-event-db";
+export * from "./webhook-installation-db";
 export * from "./typeorm/metrics";
 export * from "./personal-access-token-db";
 export * from "./typeorm/entity/db-personal-access-token";

--- a/components/gitpod-db/src/typeorm/entity/db-webhook-installation.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-webhook-installation.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Entity, Column, PrimaryColumn, Index } from "typeorm";
+import { TypeORM } from "../typeorm";
+
+@Entity()
+export class DBWebhookInstallation {
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    id: string;
+
+    @Column(TypeORM.UUID_COLUMN_TYPE)
+    @Index()
+    projectId: string;
+
+    @Column(TypeORM.UUID_COLUMN_TYPE)
+    installerUserId: string;
+}

--- a/components/gitpod-db/src/typeorm/migration/1695201864588-AddWebhookInstallation.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695201864588-AddWebhookInstallation.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddWebhookInstallation1695201864588 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `
+                CREATE TABLE IF NOT EXISTS d_b_webhook_installation
+                    ( id char(36) NOT NULL, projectId char(36) NOT NULL, installerUserId char(36) NOT NULL, _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (id), UNIQUE INDEX (projectId))
+                ENGINE=InnoDB
+            `,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/webhook-installation-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-installation-db-impl.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { injectable, inject, optional } from "inversify";
+import { EntityManager, Repository } from "typeorm";
+
+import { TypeORM } from "./typeorm";
+import { WebhookInstallationDB } from "../webhook-installation-db";
+import { TransactionalDBImpl } from "./transactional-db-impl";
+import { DBWebhookInstallation } from "./entity/db-webhook-installation";
+
+@injectable()
+export class WebhookInstallationDBImpl
+    extends TransactionalDBImpl<WebhookInstallationDBImpl>
+    implements WebhookInstallationDB
+{
+    constructor(@inject(TypeORM) private readonly typeORM: TypeORM, @optional() transactionalEM?: EntityManager) {
+        super(typeORM, transactionalEM);
+    }
+
+    protected async getEntityManager() {
+        return (await this.typeORM.getConnection()).manager;
+    }
+
+    protected async getRepo(): Promise<Repository<DBWebhookInstallation>> {
+        return (await this.getEntityManager()).getRepository(DBWebhookInstallation);
+    }
+
+    protected createTransactionalDB(transactionalEM: EntityManager): WebhookInstallationDBImpl {
+        return new WebhookInstallationDBImpl(this.typeorm, transactionalEM);
+    }
+
+    async createInstallation(installation: DBWebhookInstallation): Promise<void> {
+        const repo = await this.getRepo();
+        await repo.save(installation);
+    }
+    async deleteInstallation(id: string): Promise<DBWebhookInstallation | undefined> {
+        const repo = await this.getRepo();
+        const before = await repo.findOne(id);
+        await repo.delete(id);
+        return before;
+    }
+    async findByProjectId(projectId: string): Promise<DBWebhookInstallation | undefined> {
+        const repo = await this.getRepo();
+        return repo.findOne({ projectId });
+    }
+}

--- a/components/gitpod-db/src/webhook-installation-db.ts
+++ b/components/gitpod-db/src/webhook-installation-db.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { DBWebhookInstallation } from "./typeorm/entity/db-webhook-installation";
+
+export const WebhookInstallationDB = Symbol("WebhookInstallationDB");
+export interface WebhookInstallationDB {
+    createInstallation(installation: DBWebhookInstallation): Promise<void>;
+    deleteInstallation(id: string): Promise<DBWebhookInstallation | undefined>;
+    findByProjectId(projectId: string): Promise<DBWebhookInstallation | undefined>;
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -311,13 +311,26 @@ export class BitbucketServerApi {
         user: User,
         params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
         webhook: BitbucketServer.WebhookParams,
-    ) {
+    ): Promise<BitbucketServer.Webhook> {
         const body = JSON.stringify(webhook);
-        return this.runQuery<any>(
+        const result = await this.runQuery<BitbucketServer.Webhook>(
             user,
             `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/webhooks`,
             "POST",
             body,
+        );
+        return result;
+    }
+
+    async deleteWebhook(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
+        webhookId: string,
+    ): Promise<void> {
+        await this.runQuery<void>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/webhooks/${webhookId}`,
+            "DELETE",
         );
     }
 

--- a/components/server/src/repohost/repo-service.ts
+++ b/components/server/src/repohost/repo-service.ts
@@ -21,7 +21,11 @@ export class RepositoryService {
         return false;
     }
 
-    async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {
+    async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<string> {
+        throw new Error("unsupported");
+    }
+
+    async uninstallAutomatedPrebuilds(user: User, cloneUrl: string, webhookId: string): Promise<void> {
         throw new Error("unsupported");
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86f432d</samp>

This pull request adds a new database service and entity for storing webhook installation records, and modifies the existing services and interfaces for managing webhooks for automated prebuilds on different SCM providers. It also simplifies and improves the error handling and logging of the webhook operations. The purpose is to enable more robust and consistent webhook management for projects that use automated prebuilds.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
