### PR TITLE
Add private registry support for Dockerfile image build

### DIFF
--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -59,6 +59,7 @@ var proxyCmd = &cobra.Command{
 		}
 
 		auth := func() docker.Authorizer { return docker.NewDockerAuthorizer(docker.WithAuthCreds(authP.Authorize)) }
+		mirrorAuth := func() docker.Authorizer { return docker.NewDockerAuthorizer(docker.WithAuthCreds(authA.Authorize)) }
 		prx, err := proxy.NewProxy(&url.URL{Host: "localhost:8080", Scheme: "http"}, map[string]proxy.Repo{
 			"base": {
 				Host: reference.Domain(baseref),
@@ -72,7 +73,7 @@ var proxyCmd = &cobra.Command{
 				Tag:  targettag,
 				Auth: auth,
 			},
-		})
+		}, mirrorAuth)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.2-gitpod
+FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.2-gitpod.1
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM moby/buildkit:v0.12.2
+FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.2-gitpod
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/components/image-builder-bob/pkg/proxy/proxy.go
+++ b/components/image-builder-bob/pkg/proxy/proxy.go
@@ -20,7 +20,7 @@ import (
 
 const authKey = "authKey"
 
-func NewProxy(host *url.URL, aliases map[string]Repo) (*Proxy, error) {
+func NewProxy(host *url.URL, aliases map[string]Repo, mirrorAuth func() docker.Authorizer) (*Proxy, error) {
 	if host.Host == "" || host.Scheme == "" {
 		return nil, fmt.Errorf("host Host or Scheme are missing")
 	}
@@ -41,8 +41,9 @@ type Proxy struct {
 	Host    url.URL
 	Aliases map[string]Repo
 
-	mu      sync.Mutex
-	proxies map[string]*httputil.ReverseProxy
+	mu         sync.Mutex
+	proxies    map[string]*httputil.ReverseProxy
+	mirrorAuth func() docker.Authorizer
 }
 
 type Repo struct {
@@ -126,6 +127,23 @@ func (proxy *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
+
+	// get mirror host
+	if host := r.URL.Query().Get("ns"); host != "" && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		if host == "docker.io" {
+			host = "registry-1.docker.io"
+		}
+		r.URL.Host = host
+		r.Host = host
+
+		auth := proxy.mirrorAuth
+		r = r.WithContext(context.WithValue(ctx, authKey, auth))
+
+		r.RequestURI = ""
+		proxy.mirror(host).ServeHTTP(w, r)
+		return
+	}
+
 	if repo == nil {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
@@ -271,5 +289,98 @@ func (proxy *Proxy) reverse(alias string) *httputil.ReverseProxy {
 		return nil
 	}
 	proxy.proxies[alias] = rp
+	return rp
+}
+
+// mirror produces an authentication-adding reverse proxy for given host
+func (proxy *Proxy) mirror(host string) *httputil.ReverseProxy {
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+
+	if rp, ok := proxy.proxies[host]; ok {
+		return rp
+	}
+
+	rp := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "https", Host: host})
+
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if err != nil {
+			log.WithError(err).Warn("saw error during CheckRetry")
+			return false, err
+		}
+		auth, ok := ctx.Value(authKey).(docker.Authorizer)
+		if !ok || auth == nil {
+			return false, nil
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			// the docker authorizer only refreshes OAuth tokens after two
+			// successive 401 errors for the same URL. Rather than issue the same
+			// request multiple times to tickle the token-refreshing logic, just
+			// provide the same response twice to trick it into refreshing the
+			// cached OAuth token. Call AddResponses() twice, first to invalidate
+			// the existing token (with two responses), second to fetch a new one
+			// (with one response).
+			// TODO: fix after one of these two PRs are merged and available:
+			//     https://github.com/containerd/containerd/pull/8735
+			//     https://github.com/containerd/containerd/pull/8388
+			err := auth.AddResponses(ctx, []*http.Response{resp, resp})
+			if err != nil {
+				log.WithError(err).WithField("URL", resp.Request.URL.String()).Warn("cannot add responses although response was Unauthorized")
+				return false, nil
+			}
+
+			err = auth.AddResponses(ctx, []*http.Response{resp})
+			if err != nil {
+				log.WithError(err).WithField("URL", resp.Request.URL.String()).Warn("cannot add responses although response was Unauthorized")
+				return false, nil
+			}
+			return true, nil
+		}
+		if resp.StatusCode == http.StatusBadRequest {
+			log.WithField("URL", resp.Request.URL.String()).Warn("bad request")
+			return true, nil
+		}
+
+		return false, nil
+	}
+	client.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, i int) {
+		// Total hack: we need a place to modify the request before retrying, and this log
+		//             hook seems to be the only place. We need to modify the request, because
+		//             maybe we just added the host authorizer in the previous CheckRetry call.
+		//
+		//			   The ReverseProxy sets the X-Forwarded-For header with the host machine
+		//			   address. If on a cluster with IPV6 enabled, this will be "::1" (IPV6 equivalent
+		//			   of "127.0.0.1"). This can have the knock-on effect of receiving an IPV6
+		//			   URL, e.g. auth.ipv6.docker.com instead of auth.docker.com which may not
+		//			   exist. By forcing the value to be "127.0.0.1", we ensure consistency
+		//			   across clusters.
+		//
+		// 			   @link https://golang.org/src/net/http/httputil/reverseproxy.go
+		r.Header.Set("X-Forwarded-For", "127.0.0.1")
+
+		auth, ok := r.Context().Value(authKey).(docker.Authorizer)
+		if !ok || auth == nil {
+			return
+		}
+		_ = auth.Authorize(r.Context(), r)
+	}
+	client.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {}
+
+	rp.Transport = &retryablehttp.RoundTripper{
+		Client: client,
+	}
+	rp.ModifyResponse = func(r *http.Response) error {
+		if r.StatusCode == http.StatusBadGateway {
+			// BadGateway makes containerd retry - we don't want that because we retry the upstream
+			// requests internally.
+			r.StatusCode = http.StatusInternalServerError
+			r.Status = http.StatusText(http.StatusInternalServerError)
+		}
+
+		return nil
+	}
+	proxy.proxies[host] = rp
 	return rp
 }

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -220,6 +220,8 @@ func (a *Authentication) Empty() bool {
 
 var ecrRegistryRegexp = regexp.MustCompile(`\d{12}.dkr.ecr.\w+-\w+-\w+.amazonaws.com`)
 
+const DummyECRRegistryDomain = "000000000000.dkr.ecr.dummy-host-zone.amazonaws.com"
+
 // isECRRegistry returns true if the registry domain is an ECR registry
 func isECRRegistry(domain string) bool {
 	return ecrRegistryRegexp.MatchString(domain)

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -336,7 +336,7 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 	wsref, err := reference.ParseNamed(wsrefstr)
 	var additionalAuth []byte
 	if err == nil {
-		ath := reqauth.GetImageBuildAuthFor(ctx, o.Auth, []string{reference.Domain(pbaseref)}, []string{
+		ath := reqauth.GetImageBuildAuthFor(ctx, o.Auth, []string{reference.Domain(pbaseref), auth.DummyECRRegistryDomain}, []string{
 			reference.Domain(wsref),
 		})
 		additionalAuth, err = json.Marshal(ath)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add private registry support for Dockerfile image build

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1bfd46</samp>

This pull request adds support for ECR registries as mirrors for image building, by introducing changes to the `proxy`, `auth`, and `orchestrator` packages, and by using a custom buildkit image with a patched containerd. This feature allows users to specify ECR registries as sources for their workspace images, and improves the performance and reliability of image building.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes PRD-111

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-private0a4bb2d004</li>
	<li><b>🔗 URL</b> - <a href="https://pd-private0a4bb2d004.preview.gitpod-dev.com/workspaces" target="_blank">pd-private0a4bb2d004.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-private-docker-mirror-gha.17323</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-private0a4bb2d004%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
