### PR TITLE
Fix react-query cache persistence

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -21,7 +21,6 @@ import { SSOLoginForm } from "./login/SSOLoginForm";
 import { useAuthProviders } from "./data/auth-providers/auth-provider-query";
 import { SetupPending } from "./login/SetupPending";
 import { useNeedsSetup } from "./dedicated-setup/use-needs-setup";
-import { useQueryClient } from "@tanstack/react-query";
 
 export function markLoggedIn() {
     document.cookie = GitpodCookie.generateCookie(window.location.hostname);
@@ -36,7 +35,6 @@ type LoginProps = {
 };
 export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
     const { setUser } = useContext(UserContext);
-    const client = useQueryClient();
 
     const urlHash = useMemo(() => getURLHash(), []);
 
@@ -68,11 +66,9 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
     const updateUser = useCallback(async () => {
         await getGitpodService().reconnect();
         const user = await getGitpodService().server.getLoggedInUser();
-        // Clear the query cache on login to reset it
-        client.clear();
         setUser(user);
         markLoggedIn();
-    }, [client, setUser]);
+    }, [setUser]);
 
     const authorizeSuccessful = useCallback(async () => {
         updateUser().catch(console.error);

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -170,7 +170,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                 subtitle={
                     // Only show the url if we have a project or repo name, otherwise it's redundant w/ the title
                     selectedSuggestion?.projectName || selectedSuggestion?.repositoryName
-                        ? selectedSuggestion?.url
+                        ? displayContextUrl(selectedSuggestion?.url)
                         : undefined
                 }
                 loading={props.loading || isLoading}

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -12,7 +12,6 @@ import { ReactComponent as RepositoryIcon } from "../icons/RepositoryWithColor.s
 import { useSuggestedRepositories } from "../data/git-providers/suggested-repositories-query";
 import { useFeatureFlag } from "../data/featureflag-query";
 import { SuggestedRepository } from "@gitpod/gitpod-protocol";
-import classNames from "classnames";
 import { MiddleDot } from "./typography/MiddleDot";
 
 // TODO: Remove this once we've fully enabled `includeProjectsOnCreateWorkspace`
@@ -157,14 +156,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             searchPlaceholder="Paste repository URL or type to find suggestions"
         >
             <DropDown2SelectedElement
-                // TODO: clean this up - have to use different icons to keep the right shade of gray when there's no project
-                icon={
-                    selectedSuggestion?.projectId ? (
-                        <RepositoryIcon className={classNames("w-8 h-8 text-orange-500")} />
-                    ) : (
-                        RepositorySVG
-                    )
-                }
+                icon={RepositorySVG}
                 htmlTitle={displayContextUrl(props.selectedContextURL) || "Repository"}
                 title={
                     <div className="truncate w-80">
@@ -199,9 +191,7 @@ const SuggestedRepositoryOption: FC<SuggestedRepositoryOptionProps> = ({ repo })
             aria-label={`${repo.projectId ? "Project" : "Repo"}: ${repo.url}`}
         >
             <span className={"pr-2"}>
-                <RepositoryIcon
-                    className={classNames("w-5 h-5 text-orange-500", !repo.projectId && "filter-grayscale")}
-                />
+                <RepositoryIcon className={"w-5 h-5 text-gray-400"} />
             </span>
 
             {name && (

--- a/components/dashboard/src/components/error-boundaries/QueryErrorBoundary.tsx
+++ b/components/dashboard/src/components/error-boundaries/QueryErrorBoundary.tsx
@@ -5,7 +5,7 @@
  */
 
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { QueryErrorResetBoundary, useQueryClient } from "@tanstack/react-query";
 import { FC } from "react";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
 import { hasLoggedInBefore, Login } from "../../Login";
@@ -28,11 +28,14 @@ export const QueryErrorBoundary: FC = ({ children }) => {
 
 // This handles any expected errors, i.e. errors w/ a code that an api call produced
 const ExpectedQueryErrorsFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+    const client = useQueryClient();
     // adjust typing, as we may have caught an api error here w/ a code property
     const caughtError = error as CaughtError;
 
     // User needs to Login
     if (caughtError.code === ErrorCodes.NOT_AUTHENTICATED) {
+        console.log("clearing query cache for unauthenticated user");
+        client.clear();
         // Before we show a Login screen, check to see if we need to redirect to www site
         // Redirects if it's the root, no user, and no gp cookie present (has logged in recently)
         if (isGitpodIo() && window.location.pathname === "/" && window.location.hash === "") {

--- a/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
@@ -11,11 +11,18 @@ import { getGitpodService } from "../../service/service";
 export const useSuggestedRepositories = () => {
     const { data: org } = useCurrentOrg();
 
-    return useQuery(["suggested-repositories", { orgId: org?.id }], async () => {
-        if (!org) {
-            throw new Error("No org selected");
-        }
+    return useQuery(
+        ["suggested-repositories", { orgId: org?.id }],
+        async () => {
+            if (!org) {
+                throw new Error("No org selected");
+            }
 
-        return await getGitpodService().server.getSuggestedRepositories(org.id);
-    });
+            return await getGitpodService().server.getSuggestedRepositories(org.id);
+        },
+        {
+            // Keeps data in cache for 24h - will still refresh though
+            cacheTime: 1000 * 60 * 60 * 24,
+        },
+    );
 };

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -30,6 +30,12 @@ export function isNoPersistence(queryKey: QueryKey): boolean {
 
 export const setupQueryClientProvider = () => {
     const client = new QueryClient({
+        defaultOptions: {
+            queries: {
+                // Default stale time to help avoid re-fetching data too frequently
+                staleTime: 1000 * 5, // 5 seconds
+            },
+        },
         queryCache: new QueryCache({
             // log any errors our queries throw
             onError: (error) => {

--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -20,7 +20,6 @@ import { isGitpodIo } from "../utils";
 import OrganizationSelector from "./OrganizationSelector";
 import { getAdminTabs } from "../admin/admin.routes";
 import classNames from "classnames";
-import { useQueryClient } from "@tanstack/react-query";
 
 interface Entry {
     title: string;
@@ -168,8 +167,6 @@ type UserMenuProps = {
     onFeedback?: () => void;
 };
 const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, withFeedbackLink, onFeedback }) => {
-    const client = useQueryClient();
-
     const extraSection = useMemo(() => {
         const items: ContextMenuEntry[] = [];
 
@@ -222,13 +219,9 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, withFeedb
             {
                 title: "Log out",
                 href: gitpodHostUrl.asApiLogout().toString(),
-                // Clear query cache on logout
-                onClick: () => {
-                    client.clear();
-                },
             },
         ];
-    }, [client, extraSection, user]);
+    }, [extraSection, user]);
 
     return (
         <div

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -32,7 +32,6 @@ const UserContextProvider: React.FC = ({ children }) => {
             // If user has changed clear cache
             // Ignore the case where user hasn't been set yet - initial load
             if (user && user?.id !== updatedUser.id) {
-                console.log("user changed, clearing query cache");
                 client.clear();
             }
             setUser(updatedUser);

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -29,7 +29,10 @@ const UserContextProvider: React.FC = ({ children }) => {
     const doSetUser = useCallback(
         (updatedUser: User) => {
             updateErrorUserDetails(updatedUser);
-            if (user?.id !== updatedUser.id) {
+            // If user has changed clear cache
+            // Ignore the case where user hasn't been set yet - initial load
+            if (user && user?.id !== updatedUser.id) {
+                console.log("user changed, clearing query cache");
                 client.clear();
             }
             setUser(updatedUser);
@@ -53,7 +56,7 @@ const UserContextProvider: React.FC = ({ children }) => {
                 }, frequencyMs);
             }
         },
-        [user?.id, setUser, client],
+        [user, client],
     );
 
     // Wrap value in useMemo to avoid unnecessary re-renders


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Found a bug where we end up always clearing the query cache on page load. This adjusts some of the logic with where/how we reset that cache so we benefit from loading up the cache from IDB. 

Instead of the logic that was there, which would clear the cache anytime the user id changes in `UserContext`, I've adjust it to only do that when we have a user in context already. This avoids clearing it on initial page load. I've also added explicit clearing of the cache on logout and login.

I've also updated the icons in the repository selector to remove the color distinction between projects non-project suggestions. We may revisit the iconography and colors later.

<img width="540" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/2935859f-00f1-4d2c-91e5-55a6de916352">

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e0af49</samp>

This pull request enhances the data fetching and caching logic for the login and user menu components, using React Query hooks and clearing the cache when appropriate. It also improves the user context management by syncing it with the query cache.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-655

## How to test
<!-- Provide steps to test this PR -->
* Visit the `/new` page for creating a new workspace.
* The first time you visit it, the repository selector should have a loading state until it finishes loading the suggestions.
* Do a hard refresh and it should show suggestions right away w/o a loading state.
* Verify projects are listed in the selector w/o any color indicator.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-queryfc19f41826</li>
	<li><b>🔗 URL</b> - <a href="https://brad-queryfc19f41826.preview.gitpod-dev.com/workspaces" target="_blank">brad-queryfc19f41826.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-query-cache-get-suggested-repos-gha.17339</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-queryfc19f41826%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
