### PR TITLE
[ws-manager-mk2] log image pull time from pod events

### DIFF
--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -317,7 +317,7 @@ func (r *WorkspaceReconciler) logImagePullDuration(ctx context.Context, pod *cor
 	log := log.FromContext(ctx)
 
 	eventList := &corev1.EventList{}
-	eventListOpts := client.MatchingFields{"involvedObject.uid": string(pod.UID)}
+	eventListOpts := client.MatchingFields{"involvedObject.name": string(pod.Name)}
 	err := r.Client.List(ctx, eventList, eventListOpts)
 	if err != nil {
 		log.Error(err, "cannot list events for workspace pod", "pod", pod.Name)

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -135,6 +135,7 @@ var leaderElectionRules = []rbacv1.PolicyRule{
 		Verbs: []string{
 			"create",
 			"patch",
+			// necessary to inspect pod events for image pull times
 			"list",
 			"get",
 		},

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -135,6 +135,8 @@ var leaderElectionRules = []rbacv1.PolicyRule{
 		Verbs: []string{
 			"create",
 			"patch",
+			"list",
+			"get",
 		},
 	},
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14849d6</samp>

Add image pull duration logging for workspace pods. This change modifies the `workspace_controller.go` file to record and log the time it takes to pull the workspace image from the registry.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-w0zuznvivoy</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-w0zuznvivoy.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-w0zuznvivoy.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-W0ZUzNvIvOY-gha.17350</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-w0zuznvivoy%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
