### PR TITLE
Enable CRI plugin in dockerd

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gitpod-io/gitpod/common-go/cgroups"
 	"github.com/rootless-containers/rootlesskit/pkg/sigproxy"
 	sigproxysignal "github.com/rootless-containers/rootlesskit/pkg/sigproxy/signal"
 	"github.com/sirupsen/logrus"
@@ -104,18 +103,7 @@ func runWithinNetns() (err error) {
 
 	args := []string{
 		"--data-root=/workspace/.docker-root",
-	}
-
-	unified, err := cgroups.IsUnifiedCgroupSetup()
-	if err != nil {
-		return xerrors.Errorf("could not determine cgroup setup: %w", err)
-	}
-	if !unified {
-		// Enable rootless mode only in cgroup v1 because docker requires systemd when using it in cgroup v2
-		args = append(args,
-			"--experimental",
-			"--rootless",
-		)
+		"--cri-containerd",
 	}
 
 	if opts.Verbose {


### PR DESCRIPTION
## Description

By default CRI is disabled. This prevents us to run `ctr image mount`
Also, remove code referencing cgroups v1

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3721fe</samp>

Simplified and optimized `docker-up` component by removing rootless docker code and using containerd runtime.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Run `sudo more /var/run/docker/containerd/containerd.toml` in a workspace and check `disabled_plugins` is empty`

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-docker-cri</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-docker-cri.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-docker-cri.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-docker-cri-gha.17366</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-docker-cri%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
