### PR TITLE
[fga] trying to understand the sharing issue

### DIFF
--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -54,8 +54,9 @@ export class SpiceDBAuthorizer {
         experimentsFields: {
             userId: string;
         },
+        forceEnablement?: boolean,
     ): Promise<boolean> {
-        const featureEnabled = await isFgaChecksEnabled(experimentsFields.userId);
+        const featureEnabled = !!forceEnablement || (await isFgaChecksEnabled(experimentsFields.userId));
         const timer = spicedbClientLatency.startTimer();
         let error: Error | undefined;
         try {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -176,6 +176,8 @@ import {
     suggestionFromRecentWorkspace,
     suggestionFromUserRepo,
 } from "./suggested-repos-sorter";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
+import { rel } from "../authorization/definitions";
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi); // userId is already taken care of in WebsocketConnectionManager
@@ -563,6 +565,23 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 ErrorCodes.PERMISSION_DENIED,
                 `operation not permitted: missing ${op} permission on ${resource.kind}`,
             );
+        }
+        if (resource.kind === "workspace" && op === "get") {
+            // access to workspaces is granted. Let's verify that this is also thecase with FGA
+            const result = await this.auth.hasPermissionOnWorkspace(
+                this.userID!,
+                "read_info",
+                resource.subject.id,
+                true,
+            );
+            if (!result) {
+                const isShared = await this.auth.find(rel.workspace(resource.subject.id).shared.anyUser);
+                log.error("user has access to workspace, but not through FGA", {
+                    userId: this.userID,
+                    workspace: new TrustedValue(resource.subject),
+                    sharedRelationship: isShared && new TrustedValue(isShared),
+                });
+            }
         }
     }
 
@@ -3794,7 +3813,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!parsedAttributionId) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unable to parse attributionId");
         }
-        await this.auth.checkPermissionOnOrganization(admin.id, "read_billing", attributionId);
+        await this.auth.checkPermissionOnOrganization(admin.id, "read_billing", parsedAttributionId.teamId);
         return this.billingModes.getBillingMode(admin.id, parsedAttributionId.teamId);
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adding logs to the situation where the old system grants workspace get but the new one doesn't.
So hopefully we can better understand what could be the reason.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f62db8e</samp>

This pull request implements fine-grained access control (FGA) checks for workspace access and organization membership, and fixes some related bugs. It adds a `forceEnablement` parameter to the `SpiceDBAuthorizer` class and the `authorizer.ts` module to enable FGA checks for debugging. It also updates the `gitpod-server-impl.ts` file to use the new parameter and correct some errors.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
