### PR TITLE
add ws client metrics

### DIFF
--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -8,6 +8,7 @@ packages:
       - "src/**/*.svg"
       - "src/**/*.png"
       - "src/**/*.webp"
+      - "src/**/*.json"
       - "typings/**"
       - package.json
       - tailwind.config.js
@@ -21,7 +22,10 @@ packages:
       - components/public-api/typescript:lib
     config:
       commands:
-        build: ["yarn", "build"]
+        build:
+         - sh
+         - -c
+         - yq w -i src/service/config.json commit commit-${__git_commit} -j && yarn build
         test: ["yarn", "test:unit"]
       yarnLock: ${coreYarnLockBase}/yarn.lock
       dontTest: false

--- a/components/dashboard/src/service/config.json
+++ b/components/dashboard/src/service/config.json
@@ -1,0 +1,3 @@
+{
+  "commit": "<this value will insert by leeway before running tsc/webpack>"
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -54,8 +54,6 @@ import {
     WorkspaceInstanceRepoStatus,
 } from "./workspace-instance";
 import { AdminServer } from "./admin-protocol";
-import { GitpodHostUrl } from "./util/gitpod-host-url";
-import { WebSocketConnectionProvider } from "./messaging/browser/connection";
 import { Emitter } from "./util/event";
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from "./analytics";
 import { IDEServer } from "./ide-protocol";
@@ -698,27 +696,4 @@ export class GitpodServiceImpl<Client extends GitpodClient, Server extends Gitpo
             await this.options.onReconnect();
         }
     }
-}
-
-export function createGitpodService<C extends GitpodClient, S extends GitpodServer>(
-    serverUrl: string | Promise<string>,
-) {
-    const toWsUrl = (serverUrl: string) => {
-        return new GitpodHostUrl(serverUrl).asWebsocket().withApi({ pathname: GitpodServerPath }).toString();
-    };
-    let url: string | Promise<string>;
-    if (typeof serverUrl === "string") {
-        url = toWsUrl(serverUrl);
-    } else {
-        url = serverUrl.then((url) => toWsUrl(url));
-    }
-
-    const connectionProvider = new WebSocketConnectionProvider();
-    let onReconnect = () => {};
-    const gitpodServer = connectionProvider.createProxy<S>(url, undefined, {
-        onListening: (socket) => {
-            onReconnect = () => socket.reconnect();
-        },
-    });
-    return new GitpodServiceImpl<C, S>(gitpodServer, { onReconnect });
 }

--- a/components/gitpod-protocol/src/messaging/browser/connection.ts
+++ b/components/gitpod-protocol/src/messaging/browser/connection.ts
@@ -87,14 +87,14 @@ export class WebSocketConnectionProvider {
     /**
      * Creates a web socket for the given url
      */
-    createWebSocket(url: string): WebSocket {
+    createWebSocket(url: string, WebSocketConstructor = WebSocket): WebSocket {
         return new ReconnectingWebSocket(url, undefined, {
             maxReconnectionDelay: 10000,
             minReconnectionDelay: 1000,
             reconnectionDelayGrowFactor: 1.3,
             maxRetries: Infinity,
             debug: false,
-            WebSocket: WebSocket,
+            WebSocket: WebSocketConstructor,
         }) as any;
     }
 }

--- a/components/public-api/typescript/src/metrics.ts
+++ b/components/public-api/typescript/src/metrics.ts
@@ -52,6 +52,8 @@ class PrometheusClientCallMetrics {
     readonly handledCounter: PromCounter<string>;
     readonly handledSecondsHistogram: PromHistorgram<string>;
 
+    readonly webSocketCounter: PromCounter<string>;
+
     constructor() {
         this.startedCounter = new Counter({
             name: "grpc_client_started_total",
@@ -82,6 +84,13 @@ class PrometheusClientCallMetrics {
             help: "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
             labelNames: ["grpc_service", "grpc_method", "grpc_type", "grpc_code"],
             buckets: [0.1, 0.2, 0.5, 1, 2, 5, 10], // it should be aligned with https://github.com/gitpod-io/gitpod/blob/84ed1a0672d91446ba33cb7b504cfada769271a8/install/installer/pkg/components/ide-metrics/configmap.go#L315
+            registers: [register],
+        });
+
+        this.webSocketCounter = new Counter({
+            name: "websocket_client_total",
+            help: "Total number of WebSocket connections by the client",
+            labelNames: ["origin", "instance_phase", "status", "code", "was_clean"],
             registers: [register],
         });
     }
@@ -140,7 +149,7 @@ class PrometheusClientCallMetrics {
     }
 }
 
-const GRPCMetrics = new PrometheusClientCallMetrics();
+const metrics = new PrometheusClientCallMetrics();
 
 export function getMetricsInterceptor(): Interceptor {
     const getLabels = (req: UnaryRequest | StreamRequest): IGrpcCallMetricsLabels => {
@@ -185,14 +194,14 @@ export function getMetricsInterceptor(): Interceptor {
             } finally {
                 if (handleMetrics && !settled) {
                     stopTimer({ grpc_code: status ? Code[status] : "OK" });
-                    GRPCMetrics.handled({ ...labels, code: status ? Code[status] : "OK" });
+                    metrics.handled({ ...labels, code: status ? Code[status] : "OK" });
                 }
             }
         }
 
         const labels = getLabels(req);
-        GRPCMetrics.started(labels);
-        const stopTimer = GRPCMetrics.startHandleTimer(labels);
+        metrics.started(labels);
+        const stopTimer = metrics.startHandleTimer(labels);
 
         let settled = false;
         let status: Code | undefined;
@@ -203,11 +212,7 @@ export function getMetricsInterceptor(): Interceptor {
             } else {
                 request = {
                     ...req,
-                    message: incrementStreamMessagesCounter(
-                        req.message,
-                        GRPCMetrics.sent.bind(GRPCMetrics, labels),
-                        false,
-                    ),
+                    message: incrementStreamMessagesCounter(req.message, metrics.sent.bind(metrics, labels), false),
                 };
             }
 
@@ -220,11 +225,7 @@ export function getMetricsInterceptor(): Interceptor {
             } else {
                 response = {
                     ...res,
-                    message: incrementStreamMessagesCounter(
-                        res.message,
-                        GRPCMetrics.received.bind(GRPCMetrics, labels),
-                        true,
-                    ),
+                    message: incrementStreamMessagesCounter(res.message, metrics.received.bind(metrics, labels), true),
                 };
             }
 
@@ -237,11 +238,13 @@ export function getMetricsInterceptor(): Interceptor {
         } finally {
             if (settled) {
                 stopTimer({ grpc_code: status ? Code[status] : "OK" });
-                GRPCMetrics.handled({ ...labels, code: status ? Code[status] : "OK" });
+                metrics.handled({ ...labels, code: status ? Code[status] : "OK" });
             }
         }
     };
 }
+
+export type MetricsRequest = RequestInit & { url: string };
 
 export class MetricsReporter {
     private static readonly REPORT_INTERVAL = 10000;
@@ -250,16 +253,28 @@ export class MetricsReporter {
 
     private readonly metricsHost: string;
 
+    private sendQueue = Promise.resolve();
+
+    private readonly pendingRequests: MetricsRequest[] = [];
+
     constructor(
         private readonly options: {
             gitpodUrl: string;
             clientName: string;
             clientVersion: string;
-            logError: typeof console.error;
-            isEnabled: () => Promise<boolean>;
+            log: {
+                error: typeof console.error;
+                debug: typeof console.debug;
+            };
+            isEnabled?: () => Promise<boolean>;
+            commonErrorDetails: { [key: string]: string | undefined };
         },
     ) {
         this.metricsHost = `ide.${new URL(options.gitpodUrl).hostname}`;
+    }
+
+    updateCommonErrorDetails(update: { [key: string]: string | undefined }) {
+        Object.assign(this.options.commonErrorDetails, update);
     }
 
     startReporting() {
@@ -267,7 +282,7 @@ export class MetricsReporter {
             return;
         }
         this.intervalHandler = setInterval(
-            () => this.report().catch((e) => this.options.logError("metrics: error while reporting", e)),
+            () => this.report().catch((e) => this.options.log.error("metrics: error while reporting", e)),
             MetricsReporter.REPORT_INTERVAL,
         );
     }
@@ -278,11 +293,19 @@ export class MetricsReporter {
         }
     }
 
+    private async isEnabled(): Promise<boolean> {
+        if (!this.options.isEnabled) {
+            return true;
+        }
+        return this.options.isEnabled();
+    }
+
     private async report() {
-        const enabled = await this.options.isEnabled();
+        const enabled = await this.isEnabled();
         if (!enabled) {
             return;
         }
+
         const metrics = await register.getMetricsAsJSON();
         register.resetMetrics();
         for (const m of metrics) {
@@ -298,16 +321,25 @@ export class MetricsReporter {
                 this.syncReportHistogram(m);
             }
         }
+
+        while (this.pendingRequests.length) {
+            const request = this.pendingRequests.shift();
+            if (request) {
+                this.send(request);
+            }
+        }
     }
 
     private syncReportCounter(metric: MetricObjectWithValues<MetricValue<string>>) {
         for (const { value, labels } of metric.values) {
             if (value > 0) {
-                this.post("metrics/counter/add/" + metric.name, {
-                    name: metric.name,
-                    labels,
-                    value,
-                });
+                this.push(
+                    this.create("metrics/counter/add/" + metric.name, {
+                        name: metric.name,
+                        labels,
+                        value,
+                    }),
+                );
             }
         }
     }
@@ -330,13 +362,15 @@ export class MetricsReporter {
                 sum = value;
             } else if (metricName.endsWith("_count")) {
                 if (value > 0) {
-                    this.post("metrics/histogram/add/" + metric.name, {
-                        name: metric.name,
-                        labels,
-                        count: value,
-                        sum,
-                        buckets,
-                    });
+                    this.push(
+                        this.create("metrics/histogram/add/" + metric.name, {
+                            name: metric.name,
+                            labels,
+                            count: value,
+                            sum,
+                            buckets,
+                        }),
+                    );
                 }
                 sum = 0;
                 buckets = [];
@@ -365,11 +399,11 @@ export class MetricsReporter {
             [key: string]: string | undefined;
         },
     ): Promise<void> {
-        const enabled = await this.options.isEnabled();
+        const enabled = await this.isEnabled();
         if (!enabled) {
             return;
         }
-        const properties = { ...data };
+        const properties = { ...data, ...this.options.commonErrorDetails };
         properties["error_name"] = error.name;
         properties["error_message"] = error.message;
 
@@ -381,20 +415,23 @@ export class MetricsReporter {
         delete properties["instanceId"];
         delete properties["userId"];
 
-        await this.post("reportError", {
-            component: this.options.clientName,
-            errorStack: error.stack ?? String(error),
-            version: this.options.clientVersion,
-            workspaceId: workspaceId ?? "",
-            instanceId: instanceId ?? "",
-            userId: userId ?? "",
-            properties,
-        });
+        await this.send(
+            this.create("reportError", {
+                component: this.options.clientName,
+                errorStack: error.stack ?? String(error),
+                version: this.options.clientVersion,
+                workspaceId: workspaceId ?? "",
+                instanceId: instanceId ?? "",
+                userId: userId ?? "",
+                properties,
+            }),
+        );
     }
 
-    private async post(endpoint: string, data: any): Promise<void> {
+    private create(endpoint: string, data: any): MetricsRequest | undefined {
         try {
-            const response = await fetch(`https://${this.metricsHost}/metrics-api/` + endpoint, {
+            return <MetricsRequest>{
+                url: `https://${this.metricsHost}/metrics-api/` + endpoint,
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -403,13 +440,66 @@ export class MetricsReporter {
                 },
                 body: JSON.stringify(data),
                 credentials: "omit",
-            });
-
-            if (!response.ok) {
-                this.options.logError(`metrics: endpoint responded with ${response.status} ${response.statusText}`);
-            }
+            };
         } catch (e) {
-            this.options.logError("metrics: failed to post", e);
+            this.options.log.error("metrics: failed to create request", e);
+            return undefined;
         }
+    }
+
+    private push(request: MetricsRequest | undefined): void {
+        if (!request) {
+            return;
+        }
+        this.pendingRequests.push(request);
+    }
+
+    private async send(request: MetricsRequest | undefined): Promise<void> {
+        if (!request) {
+            return request;
+        }
+        this.sendQueue = this.sendQueue.then(async () => {
+            try {
+                const response = await fetch(request.url, request);
+                if (!response.ok) {
+                    this.options.log.error(
+                        `metrics: endpoint responded with ${response.status} ${response.statusText}`,
+                    );
+                }
+            } catch (e) {
+                this.options.log.debug("metrics: failed to post, trying again next time", e);
+                this.push(request);
+            }
+        });
+        await this.sendQueue;
+    }
+
+    instrumentWebSocket(ws: WebSocket, origin: string) {
+        const inc = (status: string, code?: number, wasClean?: boolean) => {
+            metrics.webSocketCounter
+                .labels({
+                    origin,
+                    instance_phase: this.options.commonErrorDetails["instancePhase"],
+                    status,
+                    code: code !== undefined ? String(code) : undefined,
+                    was_clean: wasClean !== undefined ? String(Number(wasClean)) : undefined,
+                })
+                .inc();
+        };
+        inc("new");
+        ws.addEventListener("open", () => inc("open"));
+        ws.addEventListener("error", (event) => {
+            inc("error");
+            this.reportError(new Error(`WebSocket failed: ${String(event)}`));
+        });
+        ws.addEventListener("close", (event) => {
+            inc("close", event.code, event.wasClean);
+            if (!event.wasClean) {
+                this.reportError(new Error("WebSocket was not closed cleanly"), {
+                    code: String(event.code),
+                    reason: event.reason,
+                });
+            }
+        });
     }
 }

--- a/components/supervisor/frontend/BUILD.yaml
+++ b/components/supervisor/frontend/BUILD.yaml
@@ -12,6 +12,7 @@ packages:
       - components/gitpod-protocol:lib
       - components/supervisor-api/typescript-grpc:lib
       - components/ide-metrics-api/typescript-grpcweb:lib
+      - components/public-api/typescript:lib
     config:
       dontTest: true
       yarnLock: ${coreYarnLockBase}/../yarn.lock

--- a/components/supervisor/frontend/package.json
+++ b/components/supervisor/frontend/package.json
@@ -5,17 +5,20 @@
   "version": "0.0.0",
   "dependencies": {
     "@gitpod/gitpod-protocol": "0.1.5",
+    "@gitpod/public-api": "0.1.5",
     "@gitpod/supervisor-api-grpc": "0.1.5",
+    "buffer": "^4.3.0",
     "crypto-browserify": "3.12.0",
+    "process": "^0.11.10",
     "stream-browserify": "^2.0.1",
     "url": "^0.11.1",
     "util": "^0.11.1",
-    "buffer": "^4.3.0",
-    "process": "^0.11.10"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.29",
     "@types/trusted-types": "^2.0.0",
+    "@types/uuid": "8.3.1",
     "concurrently": "^6.2.1",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",

--- a/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
+++ b/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
@@ -4,17 +4,33 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FrontendDashboardServiceClient } from "../shared/frontend-dashboard-service";
 import { serverUrl, workspaceUrl } from "../shared/urls";
 const commit = require("../../config.json").commit;
+import { v4 } from "uuid";
+
+import { MetricsReporter } from "@gitpod/public-api/lib/metrics";
+
+export const metricsReporter = new MetricsReporter({
+    gitpodUrl: serverUrl.toString(),
+    clientName: "supervisor-frontend",
+    clientVersion: commit,
+    log: console,
+    commonErrorDetails: {
+        sessionId: v4(),
+    },
+});
+metricsReporter.startReporting();
+
+import { FrontendDashboardServiceClient } from "../shared/frontend-dashboard-service";
+
+// TODO(ak) migrate to MetricsReporter
+const MetricsUrl = serverUrl.asIDEMetrics().toString();
 
 export enum MetricsName {
     SupervisorFrontendClientTotal = "gitpod_supervisor_frontend_client_total",
     SupervisorFrontendErrorTotal = "gitpod_supervisor_frontend_error_total",
     SupervisorFrontendLoadTotal = "gitpod_vscode_web_load_total",
 }
-
-const MetricsUrl = serverUrl.asIDEMetrics().toString();
 
 interface AddCounterParam {
     value?: number;

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -256,7 +256,7 @@ LoadingFrame.load().then(async (loading) => {
         }
         if (!isWorkspaceInstancePhase("running")) {
             if (debugWorkspace && frontendDashboardServiceClient.latestInfo) {
-                window.open('', '_self')?.close()
+                window.open("", "_self")?.close();
             }
             await new Promise<void>((resolve) => {
                 frontendDashboardServiceClient.onInfoUpdate((status) => {
@@ -269,8 +269,8 @@ LoadingFrame.load().then(async (loading) => {
         const supervisorServiceClient = SupervisorServiceClient.get();
         if (debugWorkspace) {
             supervisorServiceClient.supervisorWillShutdown.then(() => {
-                window.open('', '_self')?.close()
-            })
+                window.open("", "_self")?.close();
+            });
         }
         const [ideStatus] = await Promise.all([
             supervisorServiceClient.ideReady,

--- a/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
+++ b/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
@@ -9,6 +9,7 @@ import { IDEFrontendDashboardService } from "@gitpod/gitpod-protocol/lib/fronten
 import { RemoteTrackMessage } from "@gitpod/gitpod-protocol/lib/analytics";
 import { Emitter } from "@gitpod/gitpod-protocol/lib/util/event";
 import { workspaceUrl, serverUrl } from "./urls";
+import { metricsReporter } from "../ide/ide-metrics-service-client";
 
 export class FrontendDashboardServiceClient implements IDEFrontendDashboardService.IClient {
     public latestInfo!: IDEFrontendDashboardService.Info;
@@ -31,6 +32,13 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
                 return;
             }
             if (IDEFrontendDashboardService.isInfoUpdateEventData(event.data)) {
+                metricsReporter.updateCommonErrorDetails({
+                    userId: event.data.info.loggedUserId,
+                    ownerId: event.data.info.ownerId,
+                    workspaceId: event.data.info.workspaceID,
+                    instanceId: event.data.info.instanceId,
+                    instancePhase: event.data.info.statusPhase,
+                });
                 this.version = event.data.version;
                 this.latestInfo = event.data.info;
                 if (event.data.info.credentialsToken?.length > 0) {

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -305,6 +305,37 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				DefaultValue: "unknown",
 			},
 		},
+		{
+			Name: "websocket_client_total",
+			Help: "Total number of WebSocket connections by the client",
+			Labels: []config.LabelAllowList{
+				{
+					Name:         "origin",
+					AllowValues:  []string{"unknown", "workspace", "gitpod", "localhost"},
+					DefaultValue: "unknown",
+				},
+				{
+					Name:         "instance_phase",
+					AllowValues:  []string{"undefined", "unknown", "preparing", "building", "pending", "creating", "initializing", "running", "interrupted", "stopping", "stopped"},
+					DefaultValue: "undefined",
+				},
+				{
+					Name:         "status",
+					AllowValues:  []string{"unknown", "new", "open", "error", "close"},
+					DefaultValue: "unknown",
+				},
+				{
+					Name:         "code",
+					AllowValues:  []string{"*"},
+					DefaultValue: "unknown",
+				},
+				{
+					Name:         "was_clean",
+					AllowValues:  []string{"unknown", "0", "1"},
+					DefaultValue: "unknown",
+				},
+			},
+		},
 	}
 
 	histogramMetrics := []config.HistogramMetricsConfiguration{

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,7 +3477,7 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
-"@types/uuid@^8.3.1":
+"@types/uuid@8.3.1", "@types/uuid@^8.3.1":
   version "8.3.1"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz"
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
@@ -14009,7 +14009,7 @@ utils-merge@1.0.1, utils-merge@1.x.x:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^8.3.2:
+uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR:
- adds a metrics to monitor state of ws from client perspective
- it adds as well client error reporting if ws errored or closed unexpectedly
- since ws can fail because of issues with a network this PR adds a retry to report metrics and errors
- it also improves generally error reporting for dashboard by putting commit in the bundle and quieting unknown errors for Public API streaming test

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c27efb6</samp>

This pull request adds metrics reporting for WebSocket connections to the public API endpoint and improves the error reporting mechanism in the dashboard and IDE components. It also introduces a new way to display the client version in the UI using the commit hash from the `config.json` file, which is generated during the build process with `yq`. It modifies several files in the `components` directory, such as `dashboard/BUILD.yaml`, `gitpod-protocol/src/gitpod-service.ts`, `supervisor/frontend/src/ide/ide-web-socket.ts`, and `public-api/typescript/src/metrics.ts`. It also updates the dependencies and configuration for the `supervisor-frontend` and `ide-metrics` components.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open a dashboard, toggle your wifi and wait a bit to break web socket connections.
- Start a workspace, toggle your wifi and wait a bit to break web socket connections.
- Inspect new metrics
```
kubectl port-forward <ide-metrics-pod> 9500:9500
curl localhost:9500/metrics | grep websocket_client
```

You should see something like
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 50399    0 50399    0     0  75408      0 --:--:-- --:--:-- --:--:-- 75447
# HELP websocket_client_total Total number of WebSocket connections by the client
# TYPE websocket_client_total counter
websocket_client_total{code="1000",origin="gitpod",status="close",was_clean="1"} 1
websocket_client_total{code="1000",origin="workspace",status="close",was_clean="1"} 5
websocket_client_total{code="1006",origin="gitpod",status="close",was_clean="0"} 2
websocket_client_total{code="unknown",origin="gitpod",status="new",was_clean="unknown"} 10
websocket_client_total{code="unknown",origin="gitpod",status="open",was_clean="unknown"} 9
websocket_client_total{code="unknown",origin="workspace",status="error",was_clean="unknown"} 5
websocket_client_total{code="unknown",origin="workspace",status="new",was_clean="unknown"} 7
websocket_client_total{code="unknown",origin="workspace",status="open",was_clean="unknown"} 2
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-ws-client-total</li>
	<li><b>🔗 URL</b> - <a href="https://ak-ws-client-total.preview.gitpod-dev.com/workspaces" target="_blank">ak-ws-client-total.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-ws_client_total-gha.17468</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-ws-client-total%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] with-monitoring
</details>

/hold
