### PR TITLE
ssh: Add options for port forwarding

### DIFF
--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -18,6 +18,11 @@ import (
 // todo(ft): distribute this common metadata from the root command to all subcommands to reduce latency
 var gitpodHost = os.Getenv("GITPOD_HOST")
 
+var sshCmdOpts struct {
+	Local bool
+	Remote bool
+}
+
 // sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
@@ -34,12 +39,22 @@ See %s/user/keys for a guide on setting them up.
 			return fmt.Errorf("cannot get workspace info: %w", err)
 		}
 
-		sshCommand := fmt.Sprintf("ssh '%s@%s.ssh.%s'", wsInfo.WorkspaceId, wsInfo.WorkspaceId, wsInfo.WorkspaceClusterHost)
+		var options := ""
+		if sshCmdOpts.Local {
+			options += "-L 3000:localhost:3000 "
+		}
+		if sshCmdOpts.Remote {
+			options += "-N -R 5000:localhost:5000 "
+		}
+
+		sshCommand := fmt.Sprintf("ssh '%s@%s.ssh.%s' %s", wsInfo.WorkspaceId, wsInfo.WorkspaceId, wsInfo.WorkspaceClusterHost, options)
 		fmt.Println(sshCommand)
 		return nil
 	},
 }
 
 func init() {
+	sshCmd.Flags().BoolVarP(&sshCmdOpts.Local, "local", "", false, "Add options for local port forwarding")
+	sshCmd.Flags().BoolVarP(&sshCmdOpts.Remote, "remote", "", false, "Add options for remote port forwarding")
 	rootCmd.AddCommand(sshCmd)
 }

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -19,7 +19,7 @@ import (
 var gitpodHost = os.Getenv("GITPOD_HOST")
 
 var sshCmdOpts struct {
-	Local bool
+	Local  bool
 	Remote bool
 }
 
@@ -39,7 +39,7 @@ See %s/user/keys for a guide on setting them up.
 			return fmt.Errorf("cannot get workspace info: %w", err)
 		}
 
-		var options := ""
+		var options = ""
 		if sshCmdOpts.Local {
 			options += "-L 3000:localhost:3000 "
 		}

--- a/components/gitpod-cli/cmd/ssh.go
+++ b/components/gitpod-cli/cmd/ssh.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
@@ -39,16 +40,16 @@ See %s/user/keys for a guide on setting them up.
 			return fmt.Errorf("cannot get workspace info: %w", err)
 		}
 
-		var options = ""
+		var cmdline = []string{"ssh"}
 		if sshCmdOpts.Local {
-			options += "-L 3000:localhost:3000 "
+			cmdline = append(cmdline, "-L 3000:localhost:3000")
 		}
 		if sshCmdOpts.Remote {
-			options += "-N -R 5000:localhost:5000 "
+			cmdline = append(cmdline, "-N -R 5000:localhost:5000")
 		}
 
-		sshCommand := fmt.Sprintf("ssh '%s@%s.ssh.%s' %s", wsInfo.WorkspaceId, wsInfo.WorkspaceId, wsInfo.WorkspaceClusterHost, options)
-		fmt.Println(sshCommand)
+		cmdline = append(cmdline, fmt.Sprintf("'%s@%s.ssh.%s'", wsInfo.WorkspaceId, wsInfo.WorkspaceId, wsInfo.WorkspaceClusterHost))
+		fmt.Println(strings.Join(cmdline, " "))
 		return nil
 	},
 }


### PR DESCRIPTION
## Description

Make `gp ssh --local` generate parameters for local port forwarding, and `--remote` for remote forwards.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d910feb</samp>

Add port forwarding options to `ssh` command in `gitpod-cli`. This enables users to access or expose services between their local machines and their workspaces.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
