### PR TITLE
[supervisor] fix panic with runGP option

### DIFF
--- a/components/supervisor/pkg/serverapi/publicapi.go
+++ b/components/supervisor/pkg/serverapi/publicapi.go
@@ -198,14 +198,14 @@ func (s *Service) usePublicAPI(ctx context.Context) bool {
 }
 
 func (s *Service) GetToken(ctx context.Context, query *gitpod.GetTokenSearchOptions) (res *gitpod.Token, err error) {
+	if s == nil {
+		return nil, errNotConnected
+	}
 	startTime := time.Now()
 	usePublicApi := s.usePublicAPI(ctx)
 	defer func() {
 		s.apiMetrics.ProcessMetrics(usePublicApi, "GetToken", err, startTime)
 	}()
-	if s == nil {
-		return nil, errNotConnected
-	}
 	if !usePublicApi {
 		return s.gitpodService.GetToken(ctx, query)
 	}
@@ -230,14 +230,14 @@ func (s *Service) GetToken(ctx context.Context, query *gitpod.GetTokenSearchOpti
 }
 
 func (s *Service) UpdateGitStatus(ctx context.Context, status *gitpod.WorkspaceInstanceRepoStatus) (err error) {
+	if s == nil {
+		return errNotConnected
+	}
 	startTime := time.Now()
 	usePublicApi := s.usePublicAPI(ctx)
 	defer func() {
 		s.apiMetrics.ProcessMetrics(usePublicApi, "UpdateGitStatus", err, startTime)
 	}()
-	if s == nil {
-		return errNotConnected
-	}
 	workspaceID := s.cfg.WorkspaceID
 	if !usePublicApi {
 		return s.gitpodService.UpdateGitStatus(ctx, workspaceID, status)
@@ -263,14 +263,14 @@ func (s *Service) UpdateGitStatus(ctx context.Context, status *gitpod.WorkspaceI
 }
 
 func (s *Service) OpenPort(ctx context.Context, port *gitpod.WorkspaceInstancePort) (res *gitpod.WorkspaceInstancePort, err error) {
+	if s == nil {
+		return nil, errNotConnected
+	}
 	startTime := time.Now()
 	usePublicApi := s.usePublicAPI(ctx)
 	defer func() {
 		s.apiMetrics.ProcessMetrics(usePublicApi, "OpenPort", err, startTime)
 	}()
-	if s == nil {
-		return nil, errNotConnected
-	}
 	workspaceID := s.cfg.WorkspaceID
 	if !usePublicApi {
 		return s.gitpodService.OpenPort(ctx, workspaceID, port)
@@ -304,14 +304,14 @@ func (s *Service) OpenPort(ctx context.Context, port *gitpod.WorkspaceInstancePo
 }
 
 func (s *Service) GetDefaultWorkspaceImage(ctx context.Context) (image string, err error) {
+	if s == nil {
+		return "", errNotConnected
+	}
 	startTime := time.Now()
 	usePublicApi := s.usePublicAPI(ctx)
 	defer func() {
 		s.apiMetrics.ProcessMetrics(usePublicApi, "GetDefaultWorkspaceImage", nil, startTime)
 	}()
-	if s == nil {
-		return "", errNotConnected
-	}
 	workspaceID := s.cfg.WorkspaceID
 	if !usePublicApi {
 		resp, err := s.gitpodService.GetDefaultWorkspaceImage(ctx, &gitpod.GetDefaultWorkspaceImageParams{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b1950f</samp>

Refactor and improve default workspace image logic in `services.go`. Fix a possible nil pointer error and make the code more testable.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [[internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1695384891095829)]

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-supc9dec79fa4</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-supc9dec79fa4.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-supc9dec79fa4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-supervisor-panic-gha.17497</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-supc9dec79fa4%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
