### PR TITLE
[content-service] log ready file metrics

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -571,6 +571,8 @@ func PlaceWorkspaceReadyFile(ctx context.Context, wspath string, initsrc csapi.W
 		return xerrors.Errorf("cannot rename workspace ready file: %w", err)
 	}
 
+	log.WithField("content", string(fc)).WithField("destination", wspath).Info("ready file metrics")
+
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
These can be useful when exploring individual workspace start performance.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de5a41a</samp>

Add logging to content initialization. This change adds a log statement to the `PlaceWorkspaceReadyFile` function in `initializer.go` to help monitor and debug the content service metrics.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
1. inspect the ready file
```
gitpod@kylos101-dotfiles-psyi99aslbf:/workspace/dotfiles$ cat /workspace/.gitpod/ready
{"source":"from-other","metrics":[{"type":"git","duration":1339992994,"size":294912}]}
```
2. [Check logs](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-09-22T22:03:58.613613003Z;duration=P1D;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-l33d0810420%22%0A%0A--%20Filter%20on%20service:%0A%22ready%20file%20metrics%22%0Atimestamp%3D%222023-09-22T22:03:58.613613003Z%22%0AinsertId%3D%221d405hef2ohap4%22?project=gitpod-core-dev)

cc: @lucasvaltl per your request

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-l33d0810420</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-l33d0810420.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-l33d0810420.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-log-init-stats-gha.17524</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-l33d0810420%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview 
- [x] /werft with-large-vm  
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
