### PR TITLE
Retrieve & Copy Org Id in Org settings

### DIFF
--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -207,7 +207,7 @@ function OrgSettingsForm(props: { org?: OrganizationInfo }) {
         >
             {props.org && (
                 <InputField label="Organization ID">
-                    <InputWithCopy value={props.org.id} tip="Copy Org ID" />
+                    <InputWithCopy value={props.org.id} tip="Copy Organization ID" />
                 </InputField>
             )}
 

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -24,6 +24,7 @@ import { OrgSettingsPage } from "./OrgSettingsPage";
 import { useDefaultWorkspaceImageQuery } from "../data/workspaces/default-workspace-image-query";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { InputField } from "../components/forms/InputField";
+import { InputWithCopy } from "../components/InputWithCopy";
 import { ReactComponent as Stack } from "../icons/Stack.svg";
 
 export default function TeamSettingsPage() {
@@ -204,6 +205,12 @@ function OrgSettingsForm(props: { org?: OrganizationInfo }) {
                 // handleUpdateTeamSettings({ defaultWorkspaceImage });
             }}
         >
+            {props.org && (
+                <InputField label="Organization ID">
+                    <InputWithCopy value={props.org.id} tip="Copy Org ID" />
+                </InputField>
+            )}
+
             <Heading2 className="pt-12">Collaboration & Sharing</Heading2>
 
             {updateTeamSettings.isError && (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It aims to retrieve and copy Organization Id in Organization settings which can be used in enabling Org level feature flags & in user's integrations of Gitpod APIs (such as [this experimental project](https://github.com/Siddhant-K-code/Gitpod-GitHub-Repo-Importer))

See this [internal discussion]()

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15dbabd</samp>

Added a feature to display and copy the organization ID in the team settings page. Modified `TeamSettings.tsx` to use the `InputWithCopy` component.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open preview URL
- Login & Go to `/settings`
- See `Organization Id` section 👀

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - org-settin6099290239</li>
	<li><b>🔗 URL</b> - <a href="https://org-settin6099290239.preview.gitpod-dev.com/workspaces" target="_blank">org-settin6099290239.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - Org-settings-get-org-id-gha.17550</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-org-settin6099290239%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
