### PR TITLE
Add deprecation note to `github` node in .gitpod.yml – EXP-682

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -178,34 +178,41 @@
         },
         "github": {
             "type": "object",
-            "description": "Configures Gitpod's GitHub app",
+            "description": "Configures Gitpod's GitHub app (deprecated)",
+            "deprecationMessage": "Deprecated. Please use the Project Settings to configure prebuilds.",
             "properties": {
                 "prebuilds": {
                     "type": [
                         "boolean",
                         "object"
                     ],
-                    "description": "Set to true to enable workspace prebuilds, false to disable them. Defaults to true.",
+                    "description": "Set to true to enable workspace prebuilds, false to disable them. Defaults to true. (deprecated)",
+                    "deprecationMessage": "Deprecated. Please use the Project Settings to configure prebuilds.",
                     "properties": {
                         "master": {
                             "type": "boolean",
-                            "description": "Enable prebuilds for the default branch (typically master). Defaults to true."
+                            "description": "Enable prebuilds for the default branch (typically master). Defaults to true.",
+                            "deprecationMessage": "Deprecated. Please use the Project Settings to configure prebuilds."
                         },
                         "branches": {
                             "type": "boolean",
-                            "description": "Enable prebuilds for all branches. Defaults to false."
+                            "description": "Enable prebuilds for all branches. Defaults to false.",
+                            "deprecationMessage": "Deprecated. Please use the Project Settings to configure prebuilds."
                         },
                         "pullRequests": {
                             "type": "boolean",
-                            "description": "Enable prebuilds for pull-requests from the original repo. Defaults to true."
+                            "description": "Enable prebuilds for pull-requests from the original repo. Defaults to true.",
+                            "deprecationMessage": "Deprecated. Please use the Project Settings to configure prebuilds."
                         },
                         "pullRequestsFromForks": {
                             "type": "boolean",
-                            "description": "Enable prebuilds for pull-requests from any repo (e.g. from forks). Defaults to false."
+                            "description": "Enable prebuilds for pull-requests from any repo (e.g. from forks). Defaults to false.",
+                            "deprecationMessage": "Deprecated. This feature is about to be removed."
                         },
                         "addBadge": {
                             "type": "boolean",
-                            "description": "Add a Review in Gitpod badge to pull requests. Defaults to true."
+                            "description": "Add a Review in Gitpod badge to pull requests. Defaults to true.",
+                            "deprecationMessage": "Deprecated. This feature is about to be removed."
                         },
                         "addCheck": {
                             "type": [
@@ -217,14 +224,16 @@
                                 false,
                                 "prevent-merge-on-error"
                             ],
-                            "description": "Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true."
+                            "description": "Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true.",
+                            "deprecationMessage": "Deprecated. This feature is about to be removed."
                         },
                         "addLabel": {
                             "type": [
                                 "boolean",
                                 "string"
                             ],
-                            "description": "Add a label to a PR when it's prebuilt. Set to true to use the default label (prebuilt-in-gitpod) or set to a string to use a different label name. This is a beta feature and may be unreliable. Defaults to false."
+                            "description": "Add a label to a PR when it's prebuilt. Set to true to use the default label (prebuilt-in-gitpod) or set to a string to use a different label name. This is a beta feature and may be unreliable. Defaults to false.",
+                            "deprecationMessage": "Deprecated. This feature is about to be removed."
                         }
                     }
                 }

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -31,10 +31,10 @@ type CoreDump struct {
 type Env struct {
 }
 
-// Github Configures Gitpod's GitHub app
+// Github Configures Gitpod's GitHub app (deprecated)
 type Github struct {
 
-	// Set to true to enable workspace prebuilds, false to disable them. Defaults to true.
+	// Set to true to enable workspace prebuilds, false to disable them. Defaults to true. (deprecated)
 	Prebuilds interface{} `yaml:"prebuilds,omitempty" json:"prebuilds,omitempty"`
 }
 
@@ -56,7 +56,7 @@ type GitpodConfig struct {
 	// Git config values should be provided in pairs. E.g. `core.autocrlf: input`. See https://git-scm.com/docs/git-config#_values.
 	GitConfig map[string]string `yaml:"gitConfig,omitempty" json:"gitConfig,omitempty"`
 
-	// Configures Gitpod's GitHub app
+	// Configures Gitpod's GitHub app (deprecated)
 	Github *Github `yaml:"github,omitempty" json:"github,omitempty"`
 
 	// The Docker image to run your workspace in.
@@ -164,7 +164,7 @@ type Prebuilds struct {
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
-// Prebuilds_object Set to true to enable workspace prebuilds, false to disable them. Defaults to true.
+// Prebuilds_object Set to true to enable workspace prebuilds, false to disable them. Defaults to true. (deprecated)
 type Prebuilds_object struct {
 
 	// Add a Review in Gitpod badge to pull requests. Defaults to true.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6d8eda</samp>

Deprecated some unused or redundant properties of the `github` field in the Gitpod schema file, to streamline the prebuild settings and UX.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-682

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-depreca21c83f1c9b</li>
	<li><b>🔗 URL</b> - <a href="https://at-depreca21c83f1c9b.preview.gitpod-dev.com/workspaces" target="_blank">at-depreca21c83f1c9b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-deprecate-github-in-config-gha.17568</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-depreca21c83f1c9b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
