### PR TITLE
[fga] check workspace relationships

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -416,21 +416,54 @@ export class Authorizer {
         if (!(await isFgaWritesEnabled(userID))) {
             return;
         }
-        return this.bulkAddWorkspaceToOrg([{ orgID, userID, workspaceID, shared }]);
-    }
-
-    async bulkAddWorkspaceToOrg(
-        ids: { orgID: string; userID: string; workspaceID: string; shared: boolean }[],
-    ): Promise<void> {
         const rels: v1.RelationshipUpdate[] = [];
-        for (const { orgID, userID, workspaceID, shared } of ids) {
-            rels.push(set(rel.workspace(workspaceID).org.organization(orgID)));
-            rels.push(set(rel.workspace(workspaceID).owner.user(userID)));
-            if (shared) {
-                rels.push(set(rel.workspace(workspaceID).shared.anyUser));
-            }
+        rels.push(set(rel.workspace(workspaceID).org.organization(orgID)));
+        rels.push(set(rel.workspace(workspaceID).owner.user(userID)));
+        if (shared) {
+            rels.push(set(rel.workspace(workspaceID).shared.anyUser));
         }
         await this.authorizer.writeRelationships(...rels);
+
+        //TODO(se) remove this double checking once we're confident that the above works
+        // check if the relationships were written
+        try {
+            const wsToOrgRel = this.find(rel.workspace(workspaceID).org.organization(orgID));
+            const wsToOwnerRel = this.find(rel.workspace(workspaceID).owner.user(userID));
+            const wsSharedRel = shared ? this.find(rel.workspace(workspaceID).shared.anyUser) : Promise.resolve(true);
+            if (!(await wsToOrgRel)) {
+                log.error("Failed to write workspace to org relationship", {
+                    orgID,
+                    userID,
+                    workspaceID,
+
+                    shared,
+                });
+            }
+            if (!(await wsToOwnerRel)) {
+                log.error("Failed to write workspace to owner relationship", {
+                    orgID,
+                    userID,
+                    workspaceID,
+                    shared,
+                });
+            }
+            if (!(await wsSharedRel)) {
+                log.error("Failed to write workspace shared relationship", {
+                    orgID,
+                    userID,
+                    workspaceID,
+                    shared,
+                });
+            }
+        } catch (error) {
+            log.error("Failed to check workspace relationships", {
+                orgID,
+                userID,
+                workspaceID,
+                shared,
+                error,
+            });
+        }
     }
 
     async removeWorkspaceFromOrg(orgID: string, userID: string, workspaceID: string): Promise<void> {

--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -286,7 +286,7 @@ describe("RelationshipUpdater", async () => {
     it("should create relationships for all user workspaces", async function () {
         const user = await userDB.newUser();
         const org = await orgDB.createTeam(user.id, "MyOrg");
-        const totalWorkspaces = 20;
+        const totalWorkspaces = 50;
         const expectedWorkspaces: Workspace[] = [];
         for (let i = 0; i < totalWorkspaces; i++) {
             const workspace = await workspaceDB.store({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We have identified that sometimes workspace relationships are missing without any error from spicedb. 

We used to write them in large chunks. This changes them taht and writes the workspace rleationship per workspace. In addition it checks if the rleationships have actually been written successfully.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 002c934</samp>

This pull request updates the authorization database migration logic and adds a temporary verification check. The changes aim to improve the robustness and consistency of the new authorization model for workspaces, organizations, and users.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
