### PR TITLE
[cli] Support gp idp login aws --duration-seconds ENG-815

### DIFF
--- a/components/gitpod-cli/cmd/idp-login-aws.go
+++ b/components/gitpod-cli/cmd/idp-login-aws.go
@@ -21,17 +21,22 @@ const (
 )
 
 var idpLoginAwsOpts struct {
-	RoleARN string
-	Profile string
+	RoleARN         string
+	Profile         string
+	DurationSeconds int
 }
 
 var idpLoginAwsCmd = &cobra.Command{
 	Use:   "aws",
 	Short: "Login to AWS",
+	Long:  "Obtains credentials to access AWS. The command delegates to `aws sts assume-role-with-web-identity`, see https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html for more details.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		if idpLoginAwsOpts.RoleARN == "" {
 			return fmt.Errorf("missing --role-arn or IDP_AWS_ROLE_ARN env var")
+		}
+		if idpLoginAwsOpts.DurationSeconds <= 0 {
+			return fmt.Errorf("invalid --duration-seconds: %d, must be a positive integer", idpLoginAwsOpts.DurationSeconds)
 		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
@@ -47,7 +52,12 @@ var idpLoginAwsCmd = &cobra.Command{
 			return err
 		}
 
-		awsCmd := exec.Command("aws", "sts", "assume-role-with-web-identity", "--role-arn", idpLoginAwsOpts.RoleARN, "--role-session-name", fmt.Sprintf("%s-%d", wsInfo.WorkspaceId, time.Now().Unix()), "--web-identity-token", tkn)
+		awsCmd := exec.Command("aws", "sts", "assume-role-with-web-identity",
+			"--role-arn", idpLoginAwsOpts.RoleARN,
+			"--role-session-name", fmt.Sprintf("%s-%d", wsInfo.WorkspaceId, time.Now().Unix()),
+			"--web-identity-token", tkn,
+			"--duration-seconds", fmt.Sprintf("%d", idpLoginAwsOpts.DurationSeconds),
+		)
 		out, err := awsCmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%w: %s", err, string(out))
@@ -87,5 +97,6 @@ func init() {
 
 	idpLoginAwsCmd.Flags().StringVar(&idpLoginAwsOpts.RoleARN, "role-arn", os.Getenv("IDP_AWS_ROLE_ARN"), "AWS role to assume (defaults to IDP_AWS_ROLE_ARN env var)")
 	idpLoginAwsCmd.Flags().StringVarP(&idpLoginAwsOpts.Profile, "profile", "p", "default", "AWS profile to configure")
+	idpLoginAwsCmd.Flags().IntVarP(&idpLoginAwsOpts.DurationSeconds, "duration-seconds", "d", 3600, "Duration in seconds for which the credentials will be valid (defaults to 3600), upper bound is controlled by the AWS maximum session duration. See https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html")
 	_ = idpLoginAwsCmd.MarkFlagFilename("profile")
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes it possible to customize the AWS Token timeout

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7caf05</samp>

Added a new flag to customize the AWS credentials duration for the `idp-login-aws` command. This improves the user experience and flexibility of the `gitpod-cli` tool.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
