### PR TITLE
[ws-proxy] additional logging to better errors causing OTHER error_type

### DIFF
--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -6,9 +6,7 @@ package sshproxy
 
 import (
 	"context"
-	"crypto/md5"
 	"crypto/subtle"
-	"encoding/hex"
 	"net"
 	"regexp"
 	"strings"
@@ -251,12 +249,7 @@ func (s *Server) HandleConn(c net.Conn) {
 	wsInfo, err := s.GetWorkspaceInfo(workspaceId)
 	if err != nil {
 		ReportSSHAttemptMetrics(err)
-		workspaceIdBytes := []byte(workspaceId)
-		hash := md5.New()
-		hash.Write(workspaceIdBytes)
-		checksum := hash.Sum(nil)
-		derivedInstanceId := hex.EncodeToString(checksum)
-		log.WithField("derivedInstanceId", derivedInstanceId).WithError(err).Error("failed to get workspace info")
+		log.WithField("workspaceId", workspaceId).WithError(err).Error("failed to get workspace info")
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're recording ssh connect attempt failures in dogfood for the OTHER error_type.

But, we don't log the underlying errors for all scenarios when the error_type is OTHER. Let's log them, to better understand what's happening.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c14c2b5</samp>

Improved SSH proxy robustness by using a derived instance ID when workspace info is not available. Added logging and imports to `server.go` for this feature.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
