### PR TITLE
[UX] Redirect to newly created org after creation

### DIFF
--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -27,7 +27,8 @@ export default function NewTeamPage() {
             const team = publicApiTeamToProtocol((await teamsService.createTeam({ name })).team!);
 
             invalidateOrgs();
-            history.push(`/?org=${team.id}`);
+            // Redirects to the new Org's dashboard
+            history.push(`/workspaces/?org=${team.id}`);
         } catch (error) {
             console.error(error);
             if (error instanceof ConnectError) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See [internal conversation](https://gitpod.slack.com/archives/C01KPEPNBD0/p1695701635705849)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58b4bac</samp>

Refactor dashboard routing to use new workspaces page. Update `history.push` in `NewTeam.tsx` to redirect to `/workspaces/` after creating a new organization.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [EXP-698](https://linear.app/gitpod/issue/EXP-698/[ux]-post-creation-of-create-org-leads-to-some-different-organization)

fixes #16875

## How to test
<!-- Provide steps to test this PR -->

- Open preview
- Create a new organization (create two different organizations to see the difference of prod. vs preview)
- After the creation of Org. it would redirect you to the new org's dashboard instead of some random org's dashboard (current behavior in prod.)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-ec13de4268d</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-ec13de4268d.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-ec13de4268d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-698-ux-post-creation-of-create-org-leads-to-some-different-gha.17656</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-ec13de4268d%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
