### PR TITLE
[usage] FindRunningWorkspaceInstances: Make sure we use an index

### DIFF
--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -80,10 +80,12 @@ func FindRunningWorkspaceInstances(ctx context.Context, conn *gorm.DB) ([]Worksp
 	var instancesInBatch []WorkspaceInstanceForUsage
 
 	tx := queryWorkspaceInstanceForUsage(ctx, conn).
-		Where("wsi.stoppingTime = ?", "").
-		Where("wsi.usageAttributionId != ?", "").
+		Where("wsi.phasePersisted = ?", "running").
 		// We are only interested in instances that have been started within the last 10 days.
 		Where("wsi.startedTime > ?", TimeToISO8601(time.Now().Add(-10*24*time.Hour))).
+		// All other selectors are there to ensure data quality
+		Where("wsi.stoppingTime = ?", "").
+		Where("wsi.usageAttributionId != ?", "").
 		FindInBatches(&instancesInBatch, 1000, func(_ *gorm.DB, _ int) error {
 			instances = append(instances, instancesInBatch...)
 			return nil

--- a/components/gitpod-db/go/workspace_instance_test.go
+++ b/components/gitpod-db/go/workspace_instance_test.go
@@ -138,19 +138,22 @@ func TestFindRunningWorkspace(t *testing.T) {
 		}),
 		// one unstopped before 10 days ago
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(moreThan10DaysAgo),
+			WorkspaceID:    workspace.ID,
+			StartedTime:    db.NewVarCharTime(moreThan10DaysAgo),
+			PhasePersisted: "running",
 		}),
 		// Two running instances
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			ID:          uuid.New(),
-			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(tenMinAgo),
+			ID:             uuid.New(),
+			WorkspaceID:    workspace.ID,
+			StartedTime:    db.NewVarCharTime(tenMinAgo),
+			PhasePersisted: "running",
 		}),
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			ID:          uuid.New(),
-			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarCharTime(tenMinAgo),
+			ID:             uuid.New(),
+			WorkspaceID:    workspace.ID,
+			StartedTime:    db.NewVarCharTime(tenMinAgo),
+			PhasePersisted: "running",
 		}),
 	}
 

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -355,13 +355,13 @@ func reconcileUsage(instances []db.WorkspaceInstanceForUsage, drafts []db.Usage,
 
 	instancesByID := dedupeWorkspaceInstancesForUsage(instances)
 
-	draftsByWorkspaceID := map[uuid.UUID]db.Usage{}
+	draftsByInstanceID := map[uuid.UUID]db.Usage{}
 	for _, draft := range drafts {
-		draftsByWorkspaceID[*draft.WorkspaceInstanceID] = draft
+		draftsByInstanceID[*draft.WorkspaceInstanceID] = draft
 	}
 
 	for instanceID, instance := range instancesByID {
-		if usage, exists := draftsByWorkspaceID[instanceID]; exists {
+		if usage, exists := draftsByInstanceID[instanceID]; exists {
 			updatedUsage, err := updateUsageFromInstance(instance, usage, pricer, now)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to construct updated usage record: %w", err)


### PR DESCRIPTION
## Description
Before the query took minutes, now it takes <2s.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6061942</samp>

This pull request fixes a bug in the usage tracking query and refactors some variable names in the usage tracking code. The bug fix improves the accuracy of usage data and billing, while the refactoring improves the readability and maintainability of the code. The changes affect the files `workspace_instance.go` and `usage.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-702

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
