### PR TITLE
[db] DBCodeSyncResource/-Collection: Drop deleted column

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -140,13 +140,11 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
         {
             name: "d_b_code_sync_collection",
             primaryKeys: ["userId", "collection"],
-            deletionColumn: "deleted",
             timeColumn: "_lastModified",
         },
         {
             name: "d_b_code_sync_resource",
             primaryKeys: ["userId", "kind", "rev", "collection"],
-            deletionColumn: "deleted",
             timeColumn: "created",
             dependencies: ["d_b_code_sync_collection"],
         },

--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
@@ -32,7 +32,7 @@ export class CodeSyncResourceDB {
         const resourcesResult = await connection.manager
             .createQueryBuilder(DBCodeSyncResource, "resource")
             .where(
-                "resource.userId = :userId AND resource.kind != 'editSessions' AND resource.collection = :collection AND resource.deleted = 0",
+                "resource.userId = :userId AND resource.kind != 'editSessions' AND resource.collection = :collection",
                 {
                     userId,
                     collection: uuid.NIL,
@@ -46,7 +46,7 @@ export class CodeSyncResourceDB {
                     .addSelect("max(resource2.created)")
                     .from(DBCodeSyncResource, "resource2")
                     .where(
-                        "resource2.userId = :userId AND resource2.kind != 'editSessions' AND resource2.collection = :collection AND resource2.deleted = 0",
+                        "resource2.userId = :userId AND resource2.kind != 'editSessions' AND resource2.collection = :collection",
                         { userId, collection: uuid.NIL },
                     )
                     .groupBy("resource2.kind")
@@ -63,7 +63,7 @@ export class CodeSyncResourceDB {
         const collectionsResult = await connection.manager
             .createQueryBuilder(DBCodeSyncResource, "resource")
             .where(
-                "resource.userId = :userId AND resource.kind != 'editSessions' AND resource.collection != :collection AND resource.deleted = 0",
+                "resource.userId = :userId AND resource.kind != 'editSessions' AND resource.collection != :collection",
                 {
                     userId,
                     collection: uuid.NIL,
@@ -78,7 +78,7 @@ export class CodeSyncResourceDB {
                     .addSelect("max(resource2.created)")
                     .from(DBCodeSyncResource, "resource2")
                     .where(
-                        "resource2.userId = :userId AND resource2.kind != 'editSessions' AND resource2.collection != :collection AND resource2.deleted = 0",
+                        "resource2.userId = :userId AND resource2.kind != 'editSessions' AND resource2.collection != :collection",
                         { userId, collection: uuid.NIL },
                     )
                     .groupBy("resource2.kind")
@@ -236,19 +236,21 @@ export class CodeSyncResourceDB {
         if (rev === "latest") {
             return manager
                 .createQueryBuilder(DBCodeSyncResource, "resource")
-                .where(
-                    "resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection AND resource.deleted = 0",
-                    { userId, kind, collection: collection || uuid.NIL },
-                )
+                .where("resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection", {
+                    userId,
+                    kind,
+                    collection: collection || uuid.NIL,
+                })
                 .orderBy("resource.created", "DESC")
                 .getOne();
         } else {
             return manager
                 .createQueryBuilder(DBCodeSyncResource, "resource")
-                .where(
-                    "resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection AND resource.deleted = 0",
-                    { userId, kind, collection: collection || uuid.NIL },
-                )
+                .where("resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection", {
+                    userId,
+                    kind,
+                    collection: collection || uuid.NIL,
+                })
                 .andWhere("resource.rev = :rev", { rev })
                 .getOne();
         }
@@ -263,10 +265,11 @@ export class CodeSyncResourceDB {
         return manager
             .getRepository(DBCodeSyncResource)
             .createQueryBuilder("resource")
-            .where(
-                "resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection AND resource.deleted = 0",
-                { userId, kind, collection: collection || uuid.NIL },
-            )
+            .where("resource.userId = :userId AND resource.kind = :kind AND resource.collection = :collection", {
+                userId,
+                kind,
+                collection: collection || uuid.NIL,
+            })
             .orderBy("resource.created", "DESC")
             .getMany();
     }
@@ -275,7 +278,7 @@ export class CodeSyncResourceDB {
         const connection = await this.typeORM.getConnection();
         const result = await connection.manager
             .createQueryBuilder(DBCodeSyncCollection, "collection")
-            .where("collection.userId = :userId AND collection.deleted = 0", { userId })
+            .where("collection.userId = :userId", { userId })
             .getMany();
         return result.map((r) => ({ id: r.collection }));
     }
@@ -284,7 +287,7 @@ export class CodeSyncResourceDB {
         const connection = await this.typeORM.getConnection();
         const result = await connection.manager
             .createQueryBuilder(DBCodeSyncCollection, "collection")
-            .where("collection.userId = :userId AND collection.collection = :collection AND collection.deleted = 0", {
+            .where("collection.userId = :userId AND collection.collection = :collection", {
                 userId,
                 collection,
             })

--- a/components/gitpod-db/src/typeorm/entity/db-code-sync-collection.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-code-sync-collection.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Entity, PrimaryColumn } from "typeorm";
 import { TypeORM } from "../typeorm";
 
 @Entity()
@@ -15,7 +15,4 @@ export class DBCodeSyncCollection {
 
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
     collection: string;
-
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
@@ -86,7 +86,4 @@ export class DBCodeSyncResource {
         },
     })
     created: string;
-
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/migration/1695733993909-CodeSyncDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695733993909-CodeSyncDropDeleted.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class CodeSyncDropDeleted1695733993909 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, "d_b_code_sync_resource", "deleted")) {
+            await queryRunner.query("ALTER TABLE `d_b_code_sync_resource` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+        }
+        if (await columnExists(queryRunner, "d_b_code_sync_collection", "deleted")) {
+            await queryRunner.query("ALTER TABLE `d_b_code_sync_collection` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, "d_b_code_sync_collection", "deleted"))) {
+            await queryRunner.query(
+                "ALTER TABLE `d_b_code_sync_collection` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+            );
+        }
+        if (!(await columnExists(queryRunner, "d_b_code_sync_resource", "deleted"))) {
+            await queryRunner.query(
+                "ALTER TABLE `d_b_code_sync_resource` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

Remove the `deleted` fields in both entities as they are not used anywhere, and result in expensive queries that are executed regulary (by PeriodicDeleter, because they are listed in tables.ts with a deletionColumn).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d927be2</samp>

This pull request removes the `deleted` column from the code sync tables in the Gitpod database and updates the related entity classes, query methods, and migration file. This is part of the code sync feature that allows users to synchronize their code between different workspaces and devices.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-704

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
