### PR TITLE
[server, usage, db] Drop CostCenter.deleted (not used)

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -201,7 +201,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
         {
             name: "d_b_cost_center",
             primaryKeys: ["id", "creationTime"],
-            deletionColumn: "deleted",
             timeColumn: "_lastModified",
         },
         {

--- a/components/gitpod-db/src/typeorm/migration/1695735203768-CostCenterDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695735203768-CostCenterDropDeleted.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class CostCenterDropDeleted1695735203768 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, "d_b_cost_center", "deleted")) {
+            await queryRunner.query("ALTER TABLE `d_b_cost_center` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, "d_b_cost_center", "deleted"))) {
+            await queryRunner.query(
+                "ALTER TABLE `d_b_cost_center` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description
Drop CostCenter.deleted because it was not used and caused expensive queries.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e454607</samp>

This pull request removes the `deleted` column from the `d_b_cost_center` table and the corresponding `deletionColumn` property from the `GitpodTableDescriptionProvider` class. It also adds a new migration file to drop the column from the database schema. These changes are part of the migration to hard-delete cost centers.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-705

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
