### PR TITLE
[stripe] reconcile missing invoices

### DIFF
--- a/components/public-api-server/pkg/webhooks/stripe.go
+++ b/components/public-api-server/pkg/webhooks/stripe.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/billingservice"
+	"github.com/sirupsen/logrus"
 	"github.com/stripe/stripe-go/v72/webhook"
 )
 
@@ -56,57 +57,61 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// https://stripe.com/docs/webhooks/signatures#verify-official-libraries
-	event, err := webhook.ConstructEvent(payload, req.Header.Get("Stripe-Signature"), h.stripeWebhookSignature)
+	event, err := webhook.ConstructEvent(payload, stripeSignature, h.stripeWebhookSignature)
 	if err != nil {
 		log.WithError(err).Error("Failed to verify webhook signature.")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
+	logger := log.WithFields(logrus.Fields{"event": event.ID})
+
 	switch event.Type {
 	case InvoiceFinalizedEventType:
+		logger.Info("Handling invoice finalization")
 		invoiceID, ok := event.Data.Object["id"].(string)
 		if !ok {
-			log.Error("failed to find invoice id in Stripe event payload")
+			logger.Error("failed to find invoice id in Stripe event payload")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		err = h.billingService.FinalizeInvoice(req.Context(), invoiceID)
 		if err != nil {
-			log.WithError(err).Error("Failed to finalize invoice")
+			logger.WithError(err).Error("Failed to finalize invoice")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	case CustomerSubscriptionDeletedEventType:
+		logger.Info("Handling subscription cancellation")
 		subscriptionID, ok := event.Data.Object["id"].(string)
 		if !ok {
-			log.Error("failed to find subscriptionId id in Stripe event payload")
+			logger.Error("failed to find subscriptionId id in Stripe event payload")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		err = h.billingService.CancelSubscription(req.Context(), subscriptionID)
 		if err != nil {
-			log.WithError(err).Error("Failed to cancel subscription")
+			logger.WithError(err).Error("Failed to cancel subscription")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	case ChargeDisputeCreatedEventType:
-		log.Info("Handling charge dispute")
+		logger.Info("Handling charge dispute")
 		disputeID, ok := event.Data.Object["id"].(string)
 		if !ok {
-			log.Error("Failed to identify dispute ID from Stripe webhook.")
+			logger.Error("Failed to identify dispute ID from Stripe webhook.")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		if err := h.billingService.OnChargeDispute(req.Context(), disputeID); err != nil {
-			log.WithError(err).Errorf("Failed to handle charge dispute event for dispute ID: %s", disputeID)
+			logger.WithError(err).Errorf("Failed to handle charge dispute event for dispute ID: %s", disputeID)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	default:
-		log.Errorf("Unexpected Stripe event type: %s", event.Type)
+		logger.Errorf("Unexpected Stripe event type: %s", event.Type)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -326,12 +326,76 @@ func (s *BillingService) ReconcileInvoices(ctx context.Context, in *v1.Reconcile
 		log.WithError(err).Errorf("Failed to udpate usage in stripe.")
 		return nil, status.Errorf(codes.Internal, "Failed to update usage in stripe")
 	}
+	err = s.ReconcileStripeCustomers(ctx)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to reconcile stripe customers.")
+	}
 
 	return &v1.ReconcileInvoicesResponse{}, nil
 }
 
+func (s *BillingService) ReconcileStripeCustomers(ctx context.Context) error {
+	log.Info("Reconciling stripe customers")
+	var costCenters []db.CostCenter
+	result := s.conn.Raw("SELECT * from d_b_cost_center where creationTime in (SELECT max(creationTime) from d_b_cost_center group by id) and nextBillingTime < creationTime and billingStrategy='stripe'").Scan(&costCenters)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	log.Infof("Found %d cost centers to reconcile", len(costCenters))
+
+	for _, costCenter := range costCenters {
+		log.Infof("Reconciling stripe invoices for cost center %s", costCenter.ID)
+		err := s.reconcileStripeInvoices(ctx, costCenter.ID)
+		if err != nil {
+			return err
+		}
+		_, err = s.ccManager.IncrementBillingCycle(ctx, costCenter.ID)
+		if err != nil {
+			// we are just logging at this point, so that we don't see the event again as the usage has been recorded.
+			log.WithError(err).Errorf("Failed to increment billing cycle.")
+		}
+	}
+	return nil
+}
+
+func (s *BillingService) reconcileStripeInvoices(ctx context.Context, id db.AttributionID) error {
+	cust, err := s.stripeClient.GetCustomerByAttributionID(ctx, string(id))
+	if err != nil {
+		return err
+	}
+	invoices, err := s.stripeClient.ListInvoices(ctx, cust.ID)
+	if err != nil {
+		return err
+	}
+	for _, invoice := range invoices {
+		if invoice.Status == "paid" {
+			usage, err := InternalComputeInvoiceUsage(ctx, invoice, invoice.Customer)
+			if err != nil {
+				return err
+			}
+			// check if a usage entry exists for this invoice
+			var existingUsage db.Usage
+			result := s.conn.First(existingUsage, "description = ?", usage.Description)
+			if result.Error != nil {
+				if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+					log.Infof("No usage entry found for invoice %s. Inserting one now.", invoice.ID)
+					err = db.InsertUsage(ctx, s.conn, usage)
+					if err != nil {
+						return err
+					}
+				} else {
+					return result.Error
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInvoiceRequest) (*v1.FinalizeInvoiceResponse, error) {
 	logger := log.WithField("invoice_id", in.GetInvoiceId())
+	logger.Info("Invoice finalized. Recording usage.")
 
 	if in.GetInvoiceId() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Missing InvoiceID")
@@ -342,7 +406,7 @@ func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInv
 		logger.WithError(err).Error("Failed to retrieve invoice from Stripe.")
 		return nil, status.Errorf(codes.NotFound, "Failed to get invoice with ID %s: %s", in.GetInvoiceId(), err.Error())
 	}
-	usage, err := InternalComputeInvoiceUsage(ctx, invoice)
+	usage, err := InternalComputeInvoiceUsage(ctx, invoice, invoice.Customer)
 	if err != nil {
 		return nil, err
 	}
@@ -376,9 +440,9 @@ func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInv
 	return &v1.FinalizeInvoiceResponse{}, nil
 }
 
-func InternalComputeInvoiceUsage(ctx context.Context, invoice *stripe_api.Invoice) (db.Usage, error) {
+func InternalComputeInvoiceUsage(ctx context.Context, invoice *stripe_api.Invoice, customer *stripe_api.Customer) (db.Usage, error) {
 	logger := log.WithField("invoice_id", invoice.ID)
-	attributionID, err := stripe.GetAttributionID(ctx, invoice.Customer)
+	attributionID, err := stripe.GetAttributionID(ctx, customer)
 	if err != nil {
 		return db.Usage{}, err
 	}

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -55,7 +55,7 @@ func NewStripeRecorder(t *testing.T, name string) *recorder.Recorder {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		r.Stop()
+		err = r.Stop()
 	})
 
 	// Add a hook which removes Authorization headers from all requests
@@ -191,7 +191,7 @@ func TestBalancesForStripeCostCenters(t *testing.T) {
 func TestFinalizeInvoiceForIndividual(t *testing.T) {
 	invoice := stripe_api.Invoice{}
 	require.NoError(t, json.Unmarshal([]byte(IndiInvoiceTestData), &invoice))
-	usage, err := InternalComputeInvoiceUsage(context.Background(), &invoice)
+	usage, err := InternalComputeInvoiceUsage(context.Background(), &invoice, invoice.Customer)
 	require.NoError(t, err)
 	require.Equal(t, usage.CreditCents, db.CreditCents(-103100))
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We have seen sporadic misses of invoice.finalized events from Stripe. Although they were received (we can tell from proxy logs) and responded with 200 OK, there is no sign of them in the logs or the DB. As a result some customers lack credits they have paid for and hand on an old billingcycle.

This PR introduces the following improvements:
 - check stripe invoices and reinsert if they are missing
 - When bumping the billing cycle ensure it is set around now, i.e. the start is in the past and the end is in the future.
 - more logging to the webhook


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e1758f</samp>

This pull request improves various aspects of the billing system, such as simplifying the billing cycle handling, enhancing the webhook handler for stripe events, increasing the reliability and performance of the billing tests, and adding a new function to list invoices for a customer. The changes affect the files `cost_center.go`, `stripe.go`, `billing_test.go`, `billing.go`, and `stripe.go` in different components.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-602, EXP-703, EXP-699

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
