### PR TITLE
Fix repo selector loading state and client cache bug

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -25,7 +25,6 @@
     "js-cookie": "^3.0.1",
     "lodash.debounce": "^4.0.8",
     "monaco-editor": "^0.25.2",
-    "p-throttle": "^5.1.0",
     "pretty-bytes": "^6.1.0",
     "process": "^0.11.10",
     "query-string": "^7.1.1",

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -25,7 +25,6 @@ interface RepositoryFinderProps {
     setSelection: (repoUrl: string, projectID?: string) => void;
     onError?: (error: string) => void;
     disabled?: boolean;
-    loading?: boolean;
 }
 
 export default function RepositoryFinder(props: RepositoryFinderProps) {
@@ -152,7 +151,8 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             expanded={!props.selectedContextURL}
             onSelectionChange={handleSelectionChange}
             disabled={props.disabled}
-            loading={props.loading || isLoading}
+            // Only consider the isLoading prop if we're including projects in list
+            loading={isLoading && includeProjectsOnCreateWorkspace}
             searchPlaceholder="Paste repository URL or type to find suggestions"
         >
             <DropDown2SelectedElement
@@ -173,7 +173,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                         ? displayContextUrl(selectedSuggestion?.url)
                         : undefined
                 }
-                loading={props.loading || isLoading}
+                loading={isLoading && includeProjectsOnCreateWorkspace}
             />
         </DropDown2>
     );

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -14,7 +14,7 @@ import {
 import { QueryCache, QueryClient, QueryKey } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { FunctionComponent } from "react";
-import pThrottle from "p-throttle";
+import debounce from "lodash.debounce";
 
 // This is used to version the cache
 // If data we cache changes in a non-backwards compatible way, increment this version
@@ -78,15 +78,22 @@ function createIDBPersister(idbValidKey: IDBValidKey = "gitpodQueryClient"): Per
     // If we get an error performing an operation, we'll disable persistance and assume it's not supported
     let persistanceActive = true;
 
-    const throttle = pThrottle({
-        interval: 500,
-        limit: 1,
-        strict: true,
-    });
-
-    const throttledSet = throttle(async (client: PersistedClient) => {
-        await set(idbValidKey, client);
-    });
+    // Ensure we don't persist the client too frequently
+    // Important to debounce (not throttle) this so we aren't queuing up a bunch of writes
+    // but instead, only persist the latest state
+    const throttledSet = debounce(
+        async (client: PersistedClient) => {
+            await set(idbValidKey, client);
+        },
+        500,
+        {
+            leading: true,
+            // important so we always persist the latest state when debouncing calls
+            trailing: true,
+            // ensure
+            maxWait: 1000,
+        },
+    );
 
     return {
         persistClient: async (client: PersistedClient) => {
@@ -94,10 +101,12 @@ function createIDBPersister(idbValidKey: IDBValidKey = "gitpodQueryClient"): Per
                 return;
             }
 
-            throttledSet(client).catch((e) => {
+            try {
+                await throttledSet(client);
+            } catch (e) {
                 console.error("unable to persist query client");
                 persistanceActive = false;
-            });
+            }
         },
         restoreClient: async () => {
             try {

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -81,7 +81,7 @@ function createIDBPersister(idbValidKey: IDBValidKey = "gitpodQueryClient"): Per
     // Ensure we don't persist the client too frequently
     // Important to debounce (not throttle) this so we aren't queuing up a bunch of writes
     // but instead, only persist the latest state
-    const throttledSet = debounce(
+    const debouncedSet = debounce(
         async (client: PersistedClient) => {
             await set(idbValidKey, client);
         },
@@ -102,7 +102,7 @@ function createIDBPersister(idbValidKey: IDBValidKey = "gitpodQueryClient"): Per
             }
 
             try {
-                await throttledSet(client);
+                await debouncedSet(client);
             } catch (e) {
                 console.error("unable to persist query client");
                 persistanceActive = false;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes 2 problems related to the new workspace repo selector loading state:

* When `includeProjectsOnCreateWorkspace` flag is off we don't want to consider repositories list in a "loading" state while the new `getSuggetedRepositories` call is happening (since we're not using it yet).
* Fixed issue with react query client persistence. Sometimes cache wouldn't seem to persist on page reloads. This was due to using a throttle on the persistance vs. debouncing. Throttling queues each call to persist, which can build up a long queue when we only persist 1 per interval. Debouncing (as configured here) will persist the latest cache per interval while still avoiding too many calls to persist without building up a queue that delays persistance.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3649b7f</samp>

Improved loading and error handling logic in dashboard components. Removed unused dependency `p-throttle` and replaced it with `lodash.debounce` for debouncing queries.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-707

## How to test
<!-- Provide steps to test this PR -->
## Testing with Projects included in list
* Load the [new workspace page](https://brad-fix-r42df37efb3.preview.gitpod-dev.com/new) and try reloading the page a few times. Ensure the repo selector doesn't have a loading state on subsequent reloads.

## Testing without projects in list
* Use [this invite link](https://brad-fix-r42df37efb3.preview.gitpod-dev.com/orgs/join?inviteId=c8d44f2b-fbbf-48dd-b091-667e2e56b85c) to join an org where I've disabled the `includeProjectsOnCreateWorkspace` flag.
* Load the new workspace page - there should be no loading state on the repo selector but it may take a second to populate the dropdown with entries. Try to reload a few times and ensure it doesn't have a loading state on subsequent reloads either.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-fix-r42df37efb3</li>
	<li><b>🔗 URL</b> - <a href="https://brad-fix-r42df37efb3.preview.gitpod-dev.com/workspaces" target="_blank">brad-fix-r42df37efb3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-fix-repo-finder-loading-state-gha.17731</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-fix-r42df37efb3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
