### PR TITLE
Implement name validation before server calls on Org creation

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -191,6 +191,7 @@ export default function ProjectSettingsView() {
                     value={projectName}
                     error={badProjectName}
                     onChange={setProjectName}
+                    placeholder="My Project"
                 />
 
                 <Button className="mt-4" htmlType="submit" disabled={project?.name === projectName || !!badProjectName}>

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -23,6 +23,22 @@ export default function NewTeamPage() {
     const createTeam = async (event: FormEvent) => {
         event.preventDefault();
 
+        /* Basic name validation before sending to the server to save time & API calls */
+
+        // The name is invalid if it is empty. Show an error message and don't send the request to the server.
+        if (!name) {
+            return setCreationError(new Error("Organization name is required"));
+        }
+
+        // The name is invalid if it is shorter than 3 characters or longer than 64 characters
+        if (name.length < 3) {
+            return setCreationError(new Error("Organization name must be at least 3 characters long"));
+        }
+
+        if (name.length > 64) {
+            return setCreationError(new Error("Organization name can not be longer than 64 characters"));
+        }
+
         try {
             const team = publicApiTeamToProtocol((await teamsService.createTeam({ name })).team!);
 
@@ -62,9 +78,10 @@ export default function NewTeamPage() {
                     <h4>Organization Name</h4>
                     <input
                         autoFocus
-                        className={`w-full${!!creationError ? " error" : ""}`}
+                        className={`w-full ${!!creationError ? "error" : ""}`}
                         type="text"
                         onChange={(event) => setName(event.target.value)}
+                        placeholder="My Organization"
                     />
                     {!!creationError && (
                         <p className="text-gitpod-red">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR addresses the need for adding a basic organization name validation before making server calls during the organization creation process.

### Impact

The goal is to optimize server load and elevate user experience by confirming that only valid organization names are processed. Currently, calls are made to the createTeam endpoint even when the name is empty. This approach allows users to promptly receive basic error messages for issues like empty fields and character limits, instead of sending a request to the server and then displaying the error on the UI, a process that typically takes approximately 1.2 seconds for updates.


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b21dc8e</samp>

Added placeholders and validation for team and project names. This enhances the usability and feedback of the dashboard UI.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

- Open preview
- Create a new organization
    - Hit `Create organization` when input box is empty & see error message 👀
    - Now, do same with Org name of characters less than 3 and more than 64

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - sid-name-va7d9ee39a0</li>
	<li><b>🔗 URL</b> - <a href="https://sid-name-va7d9ee39a0.preview.gitpod-dev.com/workspaces" target="_blank">sid-name-va7d9ee39a0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - sid-name-validation-org-creation-gha.17755</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-sid-name-va7d9ee39a0%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
