### PR TITLE
Fix UI Overflow Issue for Long Organization Names

### DIFF
--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -152,7 +152,7 @@ export default function OrganizationSelector() {
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
-                <div className="py-1 pr-1 flex font-medium whitespace-nowrap max-w-xs overflow-hidden">
+                <div className="py-1 pr-1 flex font-medium truncate max-w-xs">
                     <OrgIcon
                         id={currentOrg?.data?.id || user?.id || "empty"}
                         name={selectedTitle}
@@ -193,7 +193,7 @@ type OrgEntryProps = {
 };
 export const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle, iconSize }) => {
     return (
-        <div className="w-full text-gray-400 flex items-center">
+        <div className="w-full text-gray-400 flex items-center truncate">
             <OrgIcon id={id} name={title} className="mr-4" size={iconSize} />
             <div className="flex flex-col">
                 <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
@@ -209,7 +209,7 @@ type CurrentOrgEntryProps = {
 };
 const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ title, subtitle }) => {
     return (
-        <div className="w-full text-gray-400 flex items-center justify-between">
+        <div className="w-full text-gray-400 flex items-center justify-between truncate">
             <div className="flex flex-col">
                 <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
                 <span>{subtitle}</span>

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -152,7 +152,7 @@ export default function OrganizationSelector() {
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
-                <div className="py-1 pr-1 flex font-medium truncate max-w-xs">
+                <div className="py-1 pr-1 flex font-medium max-w-xs">
                     <OrgIcon
                         id={currentOrg?.data?.id || user?.id || "empty"}
                         name={selectedTitle}
@@ -193,10 +193,10 @@ type OrgEntryProps = {
 };
 export const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle, iconSize }) => {
     return (
-        <div className="w-full text-gray-400 flex items-center truncate">
+        <div className="w-full text-gray-400 flex items-center">
             <OrgIcon id={id} name={title} className="mr-4" size={iconSize} />
             <div className="flex flex-col">
-                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
+                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold truncate w-40">{title}</span>
                 <span>{subtitle}</span>
             </div>
         </div>
@@ -209,9 +209,9 @@ type CurrentOrgEntryProps = {
 };
 const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ title, subtitle }) => {
     return (
-        <div className="w-full text-gray-400 flex items-center justify-between truncate">
+        <div className="w-full text-gray-400 flex items-center justify-between">
             <div className="flex flex-col">
-                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
+                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold truncate w-40">{title}</span>
                 <span>{subtitle}</span>
             </div>
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR addresses a UI overflow bug that occurs when organization names exceed a certain length. Users were experiencing a visual glitch where long organization names would overflow their container, leading to a disrupted user interface and degraded user experience.


| Before | After |
|--------|--------|
|<img width="846" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/9470df99-96af-4660-bf0d-350d15981dd5"> |<img width="512" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/19dd3731-cd7b-421b-be82-6aa362b267bd"> |
|![image](https://github.com/gitpod-io/gitpod/assets/55068936/2016937c-52cf-42c4-8021-b67c161f951b)|<img width="421" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/dfd57dfd-776a-4866-863c-dc4e426bc902">|

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7f1578</samp>

This pull request improves the UI of the dashboard by truncating long organization names and icons in the organization selector component. It applies the `truncate` class to several divs in `OrganizationSelector.tsx`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [EXP-708](https://linear.app/gitpod/issue/EXP-708/ui-overflow-on-large-organization-names)

## How to test
<!-- Provide steps to test this PR -->

- Open preview
- Create organization of 60 chracters (FYI: max. limit is 64 characters)
- And, see the Top left Org dropdown :eyes:

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e845ef0a504</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e845ef0a504.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e845ef0a504.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-708-ui-overflow-on-large-organization-names-gha.17761</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e845ef0a504%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
