### PR TITLE
[db] Optimize WorkspaceDB.findWorkspacesForGarbageCollection to avoid full table scan

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -214,6 +214,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                 "ws.id = wsiRunning.workspaceId",
             )
             .where("ws.ownerId = :userId", { userId: options.userId })
+            .andWhere("ws.softDeletedTime = ''") // enables usage of: ind_softDeletion
             .andWhere("ws.softDeleted IS NULL")
             .andWhere("ws.deleted != TRUE")
             .orderBy("wsiRunning.workspaceId", "DESC")
@@ -517,6 +518,8 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
 
     public async findWorkspacesForGarbageCollection(minAgeInDays: number, limit: number): Promise<WorkspaceAndOwner[]> {
         const workspaceRepo = await this.getWorkspaceRepo();
+
+        // AND ws.softDeletedTime = ''    // enables usage of: ind_softDeletion
         const dbResults = await workspaceRepo.query(
             `
                 SELECT ws.id AS id,
@@ -525,6 +528,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                     LEFT OUTER JOIN d_b_workspace_instance AS wsi ON ws.id=wsi.workspaceid
                     WHERE	ws.deleted = 0
                         AND ws.type='regular'
+                        AND ws.softDeletedTime = ''
                         AND ws.softDeleted IS NULL
                         AND ws.pinned = 0
                         AND ws.creationTime < NOW() - INTERVAL ? DAY


### PR DESCRIPTION
## Description

Before, we would scan the workspace table every 30s... :see_no_evil: 

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
