### PR TITLE
[db] DBPrebuiltWorkspace: Add index ind_creationTime

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -53,6 +53,7 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
         default: () => "CURRENT_TIMESTAMP(6)",
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
     })
+    @Index("ind_creationTime")
     creationTime: string;
 
     @Column(TypeORM.WORKSPACE_ID_COLUMN_TYPE)

--- a/components/gitpod-db/src/typeorm/migration/1695797972732-PrebuildAddIndexCreationTime.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695797972732-PrebuildAddIndexCreationTime.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_prebuilt_workspace";
+const INDEX_NAME = "ind_creationTime";
+
+export class PrebuildAddIndexCreationTime1695797972732 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD INDEX \`${INDEX_NAME}\` (creationTime), ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await indexExists(queryRunner, TABLE_NAME, INDEX_NAME)) {
+            await queryRunner.query(`DROP INDEX ${INDEX_NAME} ON ${TABLE_NAME}`);
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a35e53</samp>

This pull request adds an index on the `creationTime` column of the `DBPrebuiltWorkspace` table to improve the performance of prebuild queries. It also adds a migration file to create or drop the index in the database schema.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-710

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-710-count-pws</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-710-count-pws.preview.gitpod-dev.com/workspaces" target="_blank">gpl-710-count-pws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-710-count-pws-gha.17779</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-710-count-pws%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
