### PR TITLE
Adding searchRepositories jsonrpc method

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -17,6 +17,7 @@ import React, {
 } from "react";
 import Arrow from "./Arrow";
 import classNames from "classnames";
+import { SpinnerLoader } from "./Loader";
 
 export interface DropDown2Element {
     id: string;
@@ -171,6 +172,9 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
         [setShowDropDown],
     );
 
+    const showInputLoadingIndicator = filteredOptions.length > 0 && loading;
+    const showResultsLoadingIndicator = filteredOptions.length === 0 && loading;
+
     return (
         <div
             onKeyDown={onKeyDown}
@@ -213,16 +217,21 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                                 value={search}
                                 onChange={(e) => updateSearch(e.target.value)}
                             />
+                            {showInputLoadingIndicator && (
+                                <div className="absolute top-0 right-0 h-full flex items-center pr-2">
+                                    <SpinnerLoader />
+                                </div>
+                            )}
                         </div>
                     )}
                     <ul className="max-h-60 overflow-auto">
-                        {loading && (
+                        {showResultsLoadingIndicator && (
                             <div className="flex-col space-y-2 animate-pulse">
                                 <div className="bg-gray-300 dark:bg-gray-500 h-4 rounded" />
                                 <div className="bg-gray-300 dark:bg-gray-500 h-4 rounded" />
                             </div>
                         )}
-                        {!loading && filteredOptions.length > 0 ? (
+                        {!showResultsLoadingIndicator && filteredOptions.length > 0 ? (
                             filteredOptions.map((element) => {
                                 let selectionClasses = `dark:bg-gray-800 cursor-pointer`;
                                 if (element.id === selectedElementTemp) {
@@ -250,7 +259,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                                     </li>
                                 );
                             })
-                        ) : !loading ? (
+                        ) : !showResultsLoadingIndicator ? (
                             <li key="no-elements" className={"rounded-md "}>
                                 <div className="h-12 pl-8 py-3 text-gray-800 dark:text-gray-200">No results</div>
                             </li>

--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -32,6 +32,8 @@ export interface DropDown2Props {
     disableSearch?: boolean;
     expanded?: boolean;
     onSelectionChange: (id: string) => void;
+    // Meant to allow consumers to react to search changes even though state is managed internally
+    onSearchChange?: (searchString: string) => void;
     allOptions?: string;
 }
 
@@ -45,6 +47,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
     disableSearch,
     children,
     onSelectionChange,
+    onSearchChange,
 }) => {
     const [showDropDown, setShowDropDown] = useState<boolean>(!disabled && !!expanded);
     const nodeRef: RefObject<HTMLDivElement> = useRef(null);
@@ -61,7 +64,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
 
     // reset search when the drop down is expanded or closed
     useEffect(() => {
-        setSearch("");
+        updateSearch("");
         if (allOptions) {
             setSelectedElementTemp(allOptions);
         }
@@ -71,6 +74,16 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
         // we only want this behavior when showDropDown changes to true.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [showDropDown]);
+
+    const updateSearch = useCallback(
+        (value: string) => {
+            setSearch(value);
+            if (onSearchChange) {
+                onSearchChange(value);
+            }
+        },
+        [onSearchChange],
+    );
 
     const toggleDropDown = useCallback(() => {
         if (disabled) {
@@ -198,7 +211,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                                 className={"w-full focus rounded-lg"}
                                 placeholder={searchPlaceholder}
                                 value={search}
-                                onChange={(e) => setSearch(e.target.value)}
+                                onChange={(e) => updateSearch(e.target.value)}
                             />
                         </div>
                     )}

--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -17,7 +17,7 @@ import React, {
 } from "react";
 import Arrow from "./Arrow";
 import classNames from "classnames";
-import { SpinnerLoader } from "./Loader";
+import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 
 export interface DropDown2Element {
     id: string;
@@ -208,7 +208,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
             {showDropDown && (
                 <div className="absolute w-full top-12 bg-gray-100 dark:bg-gray-800 rounded-b-lg mt-3 z-50 p-2 filter drop-shadow-xl">
                     {!disableSearch && (
-                        <div className="h-12">
+                        <div className="relative mb-2">
                             <input
                                 type="text"
                                 autoFocus
@@ -219,7 +219,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                             />
                             {showInputLoadingIndicator && (
                                 <div className="absolute top-0 right-0 h-full flex items-center pr-2">
-                                    <SpinnerLoader />
+                                    <Spinner className="h-4 w-4 opacity-25 animate-spin" />
                                 </div>
                             )}
                         </div>

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -9,10 +9,10 @@ import { getGitpodService } from "../service/service";
 import { DropDown2, DropDown2Element, DropDown2SelectedElement } from "./DropDown2";
 import RepositorySVG from "../icons/Repository.svg";
 import { ReactComponent as RepositoryIcon } from "../icons/RepositoryWithColor.svg";
-import { useSuggestedRepositories } from "../data/git-providers/suggested-repositories-query";
 import { useFeatureFlag } from "../data/featureflag-query";
 import { SuggestedRepository } from "@gitpod/gitpod-protocol";
 import { MiddleDot } from "./typography/MiddleDot";
+import { useUnifiedRepositorySearch } from "../data/git-providers/unified-repositories-search-query";
 
 // TODO: Remove this once we've fully enabled `includeProjectsOnCreateWorkspace`
 // flag (caches w/ react-query instead of local storage)
@@ -31,10 +31,12 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
     const includeProjectsOnCreateWorkspace = useFeatureFlag("includeProjectsOnCreateWorkspace");
 
     const [suggestedContextURLs, setSuggestedContextURLs] = useState<string[]>(loadSearchData());
-    const { data: suggestedRepos, isLoading } = useSuggestedRepositories();
+
+    const [searchString, setSearchString] = useState("");
+    const { data: repos, isLoading, isSearching } = useUnifiedRepositorySearch({ searchString });
 
     // TODO: remove this once includeProjectsOnCreateWorkspace is fully enabled
-    const suggestedRepoURLs = useMemo(() => {
+    const normalizedRepos = useMemo(() => {
         // If the flag is disabled continue to use suggestedContextURLs, but convert into SuggestedRepository objects
         if (!includeProjectsOnCreateWorkspace) {
             return suggestedContextURLs.map(
@@ -44,8 +46,9 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             );
         }
 
-        return suggestedRepos || [];
-    }, [suggestedContextURLs, suggestedRepos, includeProjectsOnCreateWorkspace]);
+        // return suggestedRepos || [];
+        return repos;
+    }, [includeProjectsOnCreateWorkspace, repos, suggestedContextURLs]);
 
     // TODO: remove this once includeProjectsOnCreateWorkspace is fully enabled
     useEffect(() => {
@@ -60,7 +63,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
     const handleSelectionChange = useCallback(
         (selectedID: string) => {
             // selectedId is either projectId or repo url
-            const matchingSuggestion = suggestedRepos?.find((repo) => {
+            const matchingSuggestion = normalizedRepos?.find((repo) => {
                 if (repo.projectId) {
                     return repo.projectId === selectedID;
                 }
@@ -75,12 +78,12 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             // If we have no matching suggestion, it's a context URL they typed/pasted in, so just use that as the url
             props.setSelection(selectedID);
         },
-        [props, suggestedRepos],
+        [props, normalizedRepos],
     );
 
     // Resolve the selected context url & project id props to a suggestion entry
     const selectedSuggestion = useMemo(() => {
-        let match = suggestedRepos?.find((repo) => {
+        let match = normalizedRepos?.find((repo) => {
             if (props.selectedProjectID) {
                 return repo.projectId === props.selectedProjectID;
             }
@@ -105,36 +108,37 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
         }
 
         return match;
-    }, [props.selectedProjectID, props.selectedContextURL, suggestedRepos]);
+    }, [normalizedRepos, props.selectedContextURL, props.selectedProjectID]);
 
     const getElements = useCallback(
         (searchString: string) => {
-            const results = filterRepos(searchString, suggestedRepoURLs);
-
+            // TODO: remove once includeProjectsOnCreateWorkspace is fully enabled
             // With the flag off, we only want to show the suggestedContextURLs
             if (!includeProjectsOnCreateWorkspace) {
-                return results.map(
+                // w/o the flag on we still need to filter the repo as the search string changes
+                const filteredResults = filterRepos(searchString, normalizedRepos);
+                return filteredResults.map(
                     (repo) =>
-                        ({
-                            id: repo.url,
-                            element: (
-                                <div className="flex-col ml-1 mt-1 flex-grow">
-                                    <div className="flex">
-                                        <div className="text-gray-700 dark:text-gray-300 font-semibold">
-                                            {stripOffProtocol(repo.url)}
-                                        </div>
-                                        <div className="ml-1 text-gray-400">{}</div>
+                    ({
+                        id: repo.url,
+                        element: (
+                            <div className="flex-col ml-1 mt-1 flex-grow">
+                                <div className="flex">
+                                    <div className="text-gray-700 dark:text-gray-300 font-semibold">
+                                        {stripOffProtocol(repo.url)}
                                     </div>
-                                    <div className="flex text-xs text-gray-400">{}</div>
+                                    <div className="ml-1 text-gray-400">{ }</div>
                                 </div>
-                            ),
-                            isSelectable: true,
-                        } as DropDown2Element),
+                                <div className="flex text-xs text-gray-400">{ }</div>
+                            </div>
+                        ),
+                        isSelectable: true,
+                    } as DropDown2Element),
                 );
             }
 
-            // Otherwise we show the suggestedRepos
-            return results.map((repo) => {
+            // Otherwise we show the suggestedRepos (already filtered)
+            return normalizedRepos.map((repo) => {
                 return {
                     id: repo.projectId || repo.url,
                     element: <SuggestedRepositoryOption repo={repo} />,
@@ -142,19 +146,22 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                 } as DropDown2Element;
             });
         },
-        [includeProjectsOnCreateWorkspace, suggestedRepoURLs],
+        [includeProjectsOnCreateWorkspace, normalizedRepos],
     );
 
     return (
         <DropDown2
             getElements={getElements}
             expanded={!props.selectedContextURL}
+            // we use this to track the search string so we can search for repos via the api
             onSelectionChange={handleSelectionChange}
             disabled={props.disabled}
             // Only consider the isLoading prop if we're including projects in list
             loading={isLoading && includeProjectsOnCreateWorkspace}
             searchPlaceholder="Paste repository URL or type to find suggestions"
+            onSearchChange={setSearchString}
         >
+            {/* TODO: add a subtle indicator for the isSearching state */}
             <DropDown2SelectedElement
                 icon={RepositorySVG}
                 htmlTitle={displayContextUrl(props.selectedContextURL) || "Repository"}
@@ -162,8 +169,8 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                     <div className="truncate w-80">
                         {displayContextUrl(
                             selectedSuggestion?.projectName ||
-                                selectedSuggestion?.repositoryName ||
-                                selectedSuggestion?.url,
+                            selectedSuggestion?.repositoryName ||
+                            selectedSuggestion?.url,
                         ) || "Select a repository"}
                     </div>
                 }
@@ -238,6 +245,7 @@ function saveSearchData(searchData: string[]): void {
     }
 }
 
+// TODO: remove this and import from unified-repositories-search-query
 function filterRepos(searchString: string, suggestedRepos: SuggestedRepository[]) {
     let results = suggestedRepos;
     const normalizedSearchString = searchString.trim().toLowerCase();
@@ -252,7 +260,7 @@ function filterRepos(searchString: string, suggestedRepos: SuggestedRepository[]
                 // If the normalizedSearchString is a URL, and it's not present in the proposed results, "artificially" add it here.
                 new URL(normalizedSearchString);
                 results.push({ url: normalizedSearchString });
-            } catch {}
+            } catch { }
         }
     }
 

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -119,21 +119,21 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                 const filteredResults = filterRepos(searchString, normalizedRepos);
                 return filteredResults.map(
                     (repo) =>
-                    ({
-                        id: repo.url,
-                        element: (
-                            <div className="flex-col ml-1 mt-1 flex-grow">
-                                <div className="flex">
-                                    <div className="text-gray-700 dark:text-gray-300 font-semibold">
-                                        {stripOffProtocol(repo.url)}
+                        ({
+                            id: repo.url,
+                            element: (
+                                <div className="flex-col ml-1 mt-1 flex-grow">
+                                    <div className="flex">
+                                        <div className="text-gray-700 dark:text-gray-300 font-semibold">
+                                            {stripOffProtocol(repo.url)}
+                                        </div>
+                                        <div className="ml-1 text-gray-400">{}</div>
                                     </div>
-                                    <div className="ml-1 text-gray-400">{ }</div>
+                                    <div className="flex text-xs text-gray-400">{}</div>
                                 </div>
-                                <div className="flex text-xs text-gray-400">{ }</div>
-                            </div>
-                        ),
-                        isSelectable: true,
-                    } as DropDown2Element),
+                            ),
+                            isSelectable: true,
+                        } as DropDown2Element),
                 );
             }
 
@@ -157,11 +157,10 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             onSelectionChange={handleSelectionChange}
             disabled={props.disabled}
             // Only consider the isLoading prop if we're including projects in list
-            loading={isLoading && includeProjectsOnCreateWorkspace}
+            loading={includeProjectsOnCreateWorkspace && (isLoading || isSearching)}
             searchPlaceholder="Paste repository URL or type to find suggestions"
             onSearchChange={setSearchString}
         >
-            {/* TODO: add a subtle indicator for the isSearching state */}
             <DropDown2SelectedElement
                 icon={RepositorySVG}
                 htmlTitle={displayContextUrl(props.selectedContextURL) || "Repository"}
@@ -169,8 +168,8 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                     <div className="truncate w-80">
                         {displayContextUrl(
                             selectedSuggestion?.projectName ||
-                            selectedSuggestion?.repositoryName ||
-                            selectedSuggestion?.url,
+                                selectedSuggestion?.repositoryName ||
+                                selectedSuggestion?.url,
                         ) || "Select a repository"}
                     </div>
                 }
@@ -180,7 +179,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                         ? displayContextUrl(selectedSuggestion?.url)
                         : undefined
                 }
-                loading={isLoading && includeProjectsOnCreateWorkspace}
+                loading={includeProjectsOnCreateWorkspace && isLoading}
             />
         </DropDown2>
     );
@@ -260,7 +259,7 @@ function filterRepos(searchString: string, suggestedRepos: SuggestedRepository[]
                 // If the normalizedSearchString is a URL, and it's not present in the proposed results, "artificially" add it here.
                 new URL(normalizedSearchString);
                 results.push({ url: normalizedSearchString });
-            } catch { }
+            } catch {}
         }
     }
 

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -28,6 +28,7 @@ const featureFlags = {
     enabledOrbitalDiscoveries: "",
     newProjectIncrementalRepoSearchBBS: false,
     includeProjectsOnCreateWorkspace: false,
+    repositoryFinderSearch: false,
 };
 
 type FeatureFlags = typeof featureFlags;

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -8,8 +8,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { useDebounce } from "../../hooks/use-debounce";
+import { useFeatureFlag } from "../featureflag-query";
 
 export const useSearchRepositories = ({ searchString }: { searchString: string }) => {
+    // This disables the search behavior when flag is disabled
+    const repositoryFinderSearchEnabled = useFeatureFlag("repositoryFinderSearch");
     const { data: org } = useCurrentOrg();
     const debouncedSearchString = useDebounce(searchString);
 
@@ -22,7 +25,7 @@ export const useSearchRepositories = ({ searchString }: { searchString: string }
             });
         },
         {
-            enabled: !!org && searchString.length >= 3,
+            enabled: repositoryFinderSearchEnabled && !!org && searchString.length >= 3,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
             // We intentionally don't want to trigger refetches here to avoid a loading state side effect of focusing

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -25,7 +25,7 @@ export const useSearchRepositories = ({ searchString }: { searchString: string }
             });
         },
         {
-            enabled: repositoryFinderSearchEnabled && !!org && searchString.length >= 3,
+            enabled: repositoryFinderSearchEnabled && !!org && debouncedSearchString.length >= 3,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
             // We intentionally don't want to trigger refetches here to avoid a loading state side effect of focusing

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentOrg } from "../organizations/orgs-query";
+import { useDebounce } from "../../hooks/use-debounce";
+
+export const useSearchRepositories = ({ searchString }: { searchString: string }) => {
+    const { data: org } = useCurrentOrg();
+    const debouncedSearchString = useDebounce(searchString);
+
+    return useQuery(
+        ["searchRepositories", { organizationId: org?.id || "", searchString: debouncedSearchString }],
+        async () => {
+            const result = await getGitpodService().server.searchRepositories({
+                searchString,
+                organizationId: org?.id ?? "",
+            });
+            return result;
+        },
+        {
+            enabled: searchString.length >= 3 && !!org,
+            // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
+            keepPreviousData: true,
+        },
+    );
+};

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -14,19 +14,18 @@ export const useSearchRepositories = ({ searchString }: { searchString: string }
     const debouncedSearchString = useDebounce(searchString);
 
     return useQuery(
-        ["searchRepositories", { organizationId: org?.id || "", searchString: debouncedSearchString }],
+        ["search-repositories", { organizationId: org?.id || "", searchString: debouncedSearchString }],
         async () => {
-            const result = await getGitpodService().server.searchRepositories({
+            return await getGitpodService().server.searchRepositories({
                 searchString,
                 organizationId: org?.id ?? "",
             });
-            return result;
         },
         {
-            enabled: searchString.length >= 3 && !!org,
+            enabled: !!org && searchString.length >= 3,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
-            // We intentionally don't want to trigger refetches here
+            // We intentionally don't want to trigger refetches here to avoid a loading state side effect of focusing
             refetchOnWindowFocus: false,
             refetchOnReconnect: false,
         },

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -26,6 +26,9 @@ export const useSearchRepositories = ({ searchString }: { searchString: string }
             enabled: searchString.length >= 3 && !!org,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
+            // We intentionally don't want to trigger refetches here
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
         },
     );
 };

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -9,6 +9,7 @@ import { useSearchRepositories } from "./search-repositories-query";
 import { useSuggestedRepositories } from "./suggested-repositories-query";
 import { useMemo } from "react";
 
+// Combines the suggested repositories and the search repositories query into one hook
 export const useUnifiedRepositorySearch = ({ searchString }: { searchString: string }) => {
     const suggestedQuery = useSuggestedRepositories();
     const searchQuery = useSearchRepositories({ searchString });
@@ -35,7 +36,7 @@ export const useUnifiedRepositorySearch = ({ searchString }: { searchString: str
     };
 };
 
-const filterRepos = (searchString: string, suggestedRepos: SuggestedRepository[]) => {
+export const filterRepos = (searchString: string, suggestedRepos: SuggestedRepository[]) => {
     let results = suggestedRepos;
     const normalizedSearchString = searchString.trim().toLowerCase();
 

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { SuggestedRepository } from "@gitpod/gitpod-protocol";
+import { useSearchRepositories } from "./search-repositories-query";
+import { useSuggestedRepositories } from "./suggested-repositories-query";
+import { useMemo } from "react";
+
+export const useUnifiedRepositorySearch = ({ searchString }: { searchString: string }) => {
+    const suggestedQuery = useSuggestedRepositories();
+    const searchQuery = useSearchRepositories({ searchString });
+
+    const filteredRepos = useMemo(() => {
+        const repoMap = new Map<string, SuggestedRepository>((suggestedQuery.data || []).map((r) => [r.url, r]));
+
+        // Merge the search results into the suggested results
+        for (const repo of searchQuery.data || []) {
+            if (!repoMap.has(repo.url)) {
+                repoMap.set(repo.url, repo);
+            }
+        }
+
+        return filterRepos(searchString, Array.from(repoMap.values()));
+    }, [searchQuery.data, searchString, suggestedQuery.data]);
+
+    return {
+        data: filteredRepos,
+        isLoading: suggestedQuery.isLoading,
+        isSearching: searchQuery.isFetching,
+        isError: suggestedQuery.isError || searchQuery.isError,
+        error: suggestedQuery.error || searchQuery.error,
+    };
+};
+
+const filterRepos = (searchString: string, suggestedRepos: SuggestedRepository[]) => {
+    let results = suggestedRepos;
+    const normalizedSearchString = searchString.trim().toLowerCase();
+
+    if (normalizedSearchString.length > 1) {
+        results = suggestedRepos.filter((r) => {
+            return `${r.url}${r.projectName || ""}`.toLowerCase().includes(normalizedSearchString);
+        });
+
+        if (results.length === 0) {
+            try {
+                // If the normalizedSearchString is a URL, and it's not present in the proposed results, "artificially" add it here.
+                new URL(normalizedSearchString);
+                results.push({ url: normalizedSearchString });
+            } catch {}
+        }
+    }
+
+    // Limit what we show to 200 results
+    return results.length > 200 ? results.slice(0, 200) : results;
+};

--- a/components/dashboard/src/hooks/use-debounce.ts
+++ b/components/dashboard/src/hooks/use-debounce.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import debounce from "lodash.debounce";
+
+export const useDebounce = <T>(value: T, delay = 500): T => {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    const debouncedSetValue = useMemo(() => {
+        return debounce(setDebouncedValue, delay);
+    }, [delay]);
+
+    useEffect(() => {
+        debouncedSetValue(value);
+    }, [value, debouncedSetValue]);
+
+    return debouncedValue;
+};

--- a/components/dashboard/src/hooks/use-debounce.ts
+++ b/components/dashboard/src/hooks/use-debounce.ts
@@ -7,12 +7,22 @@
 import { useEffect, useMemo, useState } from "react";
 import debounce from "lodash.debounce";
 
-export const useDebounce = <T>(value: T, delay = 500): T => {
+type DebounceOptions = {
+    leading?: boolean;
+    trailing?: boolean;
+    maxWait?: number;
+};
+
+export const useDebounce = <T>(value: T, delay = 500, options?: DebounceOptions): T => {
     const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
     const debouncedSetValue = useMemo(() => {
-        return debounce(setDebouncedValue, delay);
-    }, [delay]);
+        return debounce(setDebouncedValue, delay, {
+            leading: options?.leading || false,
+            trailing: options?.trailing || true,
+            maxWait: options?.maxWait ?? undefined,
+        });
+    }, [delay, options?.leading, options?.maxWait, options?.trailing]);
 
     useEffect(() => {
         debouncedSetValue(value);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -98,6 +98,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getFeaturedRepositories(): Promise<WhitelistedRepository[]>;
     getSuggestedContextURLs(): Promise<string[]>;
     getSuggestedRepositories(organizationId: string): Promise<SuggestedRepository[]>;
+    searchRepositories(params: SearchRepositoriesParams): Promise<SuggestedRepository[]>;
     /**
      * **Security:**
      * Sensitive information like an owner token is erased, since it allows access for all team members.
@@ -313,6 +314,10 @@ export interface GetProviderRepositoriesParams {
     searchString?: string;
     limit?: number;
     maxPages?: number;
+}
+export interface SearchRepositoriesParams {
+    organizationId: string;
+    searchString: string;
 }
 export interface ProviderRepository {
     name: string;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -66,6 +66,7 @@ const defaultFunctions: FunctionsConfig = {
     getFeaturedRepositories: { group: "default", points: 1 },
     getSuggestedContextURLs: { group: "default", points: 1 },
     getSuggestedRepositories: { group: "default", points: 1 },
+    searchRepositories: { group: "default", points: 1 },
     getWorkspace: { group: "default", points: 1 },
     isWorkspaceOwner: { group: "default", points: 1 },
     getOwnerToken: { group: "default", points: 1 },

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -187,4 +187,9 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
         const commits = commitsResult.values || [];
         return commits.map((c) => c.id);
     }
+
+    // TODO: implement repo search
+    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+        return [];
+    }
 }

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -190,6 +190,19 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        return [];
+        const repos = await this.api.getRepos(user, { searchString, maxPages: 1, limit: 10 });
+
+        const result: RepositoryInfo[] = [];
+        repos.forEach((r) => {
+            const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;
+            if (cloneUrl) {
+                result.push({
+                    url: cloneUrl.replace("http://", "https://"),
+                    name: r.name,
+                });
+            }
+        });
+
+        return result;
     }
 }

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -190,19 +190,6 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        const repos = await this.api.getRepos(user, { searchString, maxPages: 1, limit: 10 });
-
-        const result: RepositoryInfo[] = [];
-        repos.forEach((r) => {
-            const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;
-            if (cloneUrl) {
-                result.push({
-                    url: cloneUrl.replace("http://", "https://"),
-                    name: r.name,
-                });
-            }
-        });
-
-        return result;
+        return [];
     }
 }

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -156,4 +156,9 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
         }
         return commits.map((v: Schema.Commit) => v.hash!);
     }
+
+    // TODO: implement repo search
+    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+        return [];
+    }
 }

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -159,16 +159,6 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        // const api = await this.apiFactory.create(user);
-
-        // const workspaces = await api.workspaces.getWorkspaces({ pagelen: 5, sort: "-updated_on" });
-
-        // const workspaceSlugs = workspaces.data.values?.map(workspace => {
-        //     return workspace.slug
-        // })
-
-        // const response = await api.repositories.list({ q: searchString, pagelen: 10, sort: "-updated_on", workspace: });
-
         return [];
     }
 }

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -159,6 +159,16 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+        // const api = await this.apiFactory.create(user);
+
+        // const workspaces = await api.workspaces.getWorkspaces({ pagelen: 5, sort: "-updated_on" });
+
+        // const workspaceSlugs = workspaces.data.values?.map(workspace => {
+        //     return workspace.slug
+        // })
+
+        // const response = await api.repositories.list({ q: searchString, pagelen: 10, sort: "-updated_on", workspace: });
+
         return [];
     }
 }

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -242,7 +242,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
 
         // TODO: determine if there's a maximum # of orgs we can include in a single query and split into multiple calls if necessary
         // A string of org query filters, i.e. "org:org1 org:org2 org:org3"
-        const orgFilters = orgs?.data.map((org) => `org:${org}`).join(" ");
+        const orgFilters = orgs?.data.map((org) => `org:${org.organization.login}`).join(" ");
 
         const repoSearchQuery = `
             query SearchRepos($search: String!, $orgs: String! ) {

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -244,10 +244,10 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         // A string of org query filters, i.e. "org:org1 org:org2 org:org3"
         const orgFilters = orgs?.data.map((org) => `org:${org.organization.login}`).join(" ");
 
-        const query = `${searchString} in:name user:@me ${orgFilters}`;
+        const query = JSON.stringify(`${searchString} in:name user:@me ${orgFilters}`);
         const repoSearchQuery = `
             query SearchRepos {
-                search (type:REPOSITORY, first:10, query:"${query}"){
+                search (type: REPOSITORY, first: 10, query: ${query}){
                     edges {
                         node {
                             ... on Repository {

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -244,9 +244,10 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         // A string of org query filters, i.e. "org:org1 org:org2 org:org3"
         const orgFilters = orgs?.data.map((org) => `org:${org.organization.login}`).join(" ");
 
+        const query = `${searchString} in:name user:@me ${orgFilters}`;
         const repoSearchQuery = `
-            query SearchRepos($search: String!, $orgs: String! ) {
-                search (type:REPOSITORY, first:10, query:"$search in:name user:@me $orgs"){
+            query SearchRepos {
+                search (type:REPOSITORY, first:10, query:"${query}"){
                     edges {
                         node {
                             ... on Repository {
@@ -259,10 +260,6 @@ export class GithubRepositoryProvider implements RepositoryProvider {
                         }
                     }
                 }
-            }
-            variables {
-                "search": "${searchString}",
-                "orgs": "${orgFilters}"
             }`;
 
         let repos: RepositoryInfo[] = [];

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -243,24 +243,6 @@ export class GithubRepositoryProvider implements RepositoryProvider {
             });
         });
 
-        // const queryString = `"${searchString}" in:name user:@me sort:updated`;
-        // const userSearch2 = this.githubQueryApi.runQuery(
-        //     user,
-        //     `query {
-        //         search(query: ${queryString}, type: REPOSITORY, first: 10) {
-        //             repos: edges {
-        //                 repo: node {
-        //                     ... on Repository {
-        //                         url
-        //                         name
-        //                         updatedAt
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }`,
-        // );
-
         // Attach an error handler to log error and not throw
         userSearch.catch((err) => {
             log.warn(logCtx, "Error searching user repos", err);
@@ -273,8 +255,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
             .run(user, async (api) => {
                 return api.orgs.listMembershipsForAuthenticatedUser({
                     state: "active",
-                    // limit to 5 orgs
-                    per_page: 10,
+                    per_page: 5,
                 });
             })
             .catch((err) => {
@@ -282,9 +263,6 @@ export class GithubRepositoryProvider implements RepositoryProvider {
             });
 
         const orgLogins = orgs?.data.map((org) => org.organization.login) ?? [];
-
-        // TODO: remove this
-        log.debug(logCtx, "Searching org repos", { orgs: orgLogins.join(",") });
 
         const orgSearches = orgLogins.map((org) => {
             const orgSearch = this.github.run(user, async (api) => {

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -139,4 +139,9 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
         }
         return result.slice(1).map((c: GitLab.Commit) => c.id);
     }
+
+    // TODO: implement repo search
+    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+        return [];
+    }
 }

--- a/components/server/src/repohost/repository-provider.ts
+++ b/components/server/src/repohost/repository-provider.ts
@@ -15,4 +15,5 @@ export interface RepositoryProvider {
     getUserRepos(user: User): Promise<RepositoryInfo[]>;
     hasReadAccess(user: User, owner: string, repo: string): Promise<boolean>;
     getCommitHistory(user: User, owner: string, repo: string, ref: string, maxDepth: number): Promise<string[]>;
+    searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]>;
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1910,7 +1910,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                         }),
                     );
                 } catch (error) {
-                    log.debug(logCtx, "Could not search repositories from host " + p.host, error);
+                    log.warn(logCtx, "Could not search repositories from host " + p.host, error);
                 }
 
                 return [];

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1924,6 +1924,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             };
         });
 
+        // TODO: consider how we want to sort these results
+
         return repos;
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1884,7 +1884,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         ctx: TraceContext,
         params: SearchRepositoriesParams,
     ): Promise<SuggestedRepository[]> {
-        const user = await this.checkAndBlockUser("getProviderRepositoriesForUser");
+        const user = await this.checkAndBlockUser("searchRepositories");
 
         const logCtx: LogContext = { userId: user.id };
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1917,16 +1917,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             }),
         );
 
-        const repos: SuggestedRepository[] = providerRepos.flat().map((repo) => {
-            return {
+        const sortedRepos = sortSuggestedRepositories(providerRepos.flat());
+
+        return sortedRepos.map(
+            (repo): SuggestedRepository => ({
                 url: repo.url,
                 repositoryName: repo.repositoryName,
-            };
-        });
-
-        // TODO: consider how we want to sort these results
-
-        return repos;
+            }),
+        );
     }
 
     public async setWorkspaceTimeout(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a new `searchRepositories()` method to server to assist in enhancing the repo selector for creating new workspaces/projects that searches across scm providers. It then integrates that call into the `<RepositoryFinder/>` component used on the create workspace page.

The feature is behind a new flag, `repositoryFinderSearch`, which is only on in non-prod.

<img width="609" alt="image" src="https://github.com/gitpod-io/gitpod/assets/367275/65ac68c7-7831-4c7a-826e-28fa2fb520e2">

* GitHub implemented in this PR
* BBS, Bitbucket & Gitlab will be implemented in followup PRs to keep this scope from growing too large and make testing incrementally easier.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 558dbf7</samp>

Added a new API method `searchRepositories` to the `GitpodServer` interface and implemented it for the `GitpodServerImpl` class. Added stub or working implementations of the `searchRepos` method to the various `RepositoryProvider` classes for different repohosts. The purpose of these changes is to enable a repository search feature for workspace creation.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-729

## How to test
<!-- Provide steps to test this PR -->
* Try out the preview environment, and you should have repo searching enabled by default. Try searching for public and private repos both personal and in orgs you belong to in GitHub.
* Join [this org](https://brad-searcf262e91741.preview.gitpod-dev.com/orgs/join?inviteId=1c8a6847-756d-4972-96cc-f0b7052cd74e) (which has the feature flag disabled) and you shouldn't see any repo searching behavior.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-searcf262e91741</li>
	<li><b>🔗 URL</b> - <a href="https://brad-searcf262e91741.preview.gitpod-dev.com/workspaces" target="_blank">brad-searcf262e91741.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-searchRepositories-method-gha.17834</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-searcf262e91741%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
