### PR TITLE
Ensure containers inherit stdio

### DIFF
--- a/components/docker-up/runc-facade/main.go
+++ b/components/docker-up/runc-facade/main.go
@@ -90,7 +90,12 @@ func createAndRunc(runcPath string, log *logrus.Logger) error {
 	// See here for more details on why retries are necessary.
 	// https://github.com/gitpod-io/gitpod/issues/12365
 	for i := 0; i <= RETRY; i++ {
-		err = exec.Command(runcPath, os.Args[1:]...).Run()
+
+		cmd := exec.Command(runcPath, os.Args[1:]...)
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		err = cmd.Run()
 
 		if err != nil {
 			log.WithError(err).Warn("runc failed")


### PR DESCRIPTION
## Description
Ensure that containers started through runc-facade inherit the stdio file descriptors of the calling process. 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a1a5c0</samp>

Forward runc output to runc-facade in `components/docker-up/runc-facade/main.go`. This helps with troubleshooting and error handling for workspace container creation.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-900
Fixes https://github.com/gitpod-io/gitpod/issues/18814

## How to test
- Start docker container without these changes `docker run alpine echo hello`. There should be no output.
- Start docker container with the fix. Output should be `hello`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
