### PR TITLE
[content-service] log duration for s3 download and tar extract

### DIFF
--- a/components/content-service/pkg/storage/s3.go
+++ b/components/content-service/pkg/storage/s3.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
@@ -308,11 +309,14 @@ func (s3st *s3Storage) download(ctx context.Context, destination string, obj str
 		tempFile.Name(),
 	}
 	cmd := exec.Command("s5cmd", args...)
+	downloadStart := time.Now()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")
 		return true, xerrors.Errorf("unexpected error downloading file")
 	}
+	downloadDuration := time.Since(downloadStart)
+	log.WithField("downloadDuration", downloadDuration.String()).Info("S3 download duration")
 
 	tempFile, err = os.Open(tempFile.Name())
 	if err != nil {
@@ -322,10 +326,13 @@ func (s3st *s3Storage) download(ctx context.Context, destination string, obj str
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
+	extractStart := time.Now()
 	err = archive.ExtractTarbal(ctx, tempFile, destination, archive.WithUIDMapping(mappings), archive.WithGIDMapping(mappings))
 	if err != nil {
 		return true, xerrors.Errorf("tar %s: %s", destination, err.Error())
 	}
+	extractDuration := time.Since(extractStart)
+	log.WithField("extractdDuration", extractDuration.String()).Info("tarbar extraction duration")
 
 	return true, nil
 }

--- a/components/content-service/pkg/storage/s3.go
+++ b/components/content-service/pkg/storage/s3.go
@@ -313,7 +313,7 @@ func (s3st *s3Storage) download(ctx context.Context, destination string, obj str
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")
-		return true, xerrors.Errorf("unexpected error downloading file")
+		return false, xerrors.Errorf("unexpected error downloading file")
 	}
 	downloadDuration := time.Since(downloadStart)
 	log.WithField("downloadDuration", downloadDuration.String()).Info("S3 download duration")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add logging to help understand how long it takes to download and extract files. Also, fix a scenario where the download is not found, so we properly inform upstream consumers.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6beb51</samp>

Improved logging and error handling for S3 storage in `content-service`. Fixed a download retry bug in `s3.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-884

## How to test
<!-- Provide steps to test this PR -->
n/a

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
