### PR TITLE
[ci] wait 5m on publish to yarn register before timing out

### DIFF
--- a/components/gitpod-protocol/scripts/publish.js
+++ b/components/gitpod-protocol/scripts/publish.js
@@ -36,6 +36,18 @@ fs.writeFileSync(path.join(pckDir, "package.json"), JSON.stringify(pck, undefine
 const tag = qualifier.substr(0, qualifier.lastIndexOf("."));
 
 child_process.execSync(
-    ["yarn", "--cwd", pckDir, "publish", "--tag", tag, "--access", "public", "--ignore-scripts", "--network-timeout", "100000"].join(" "),
+    [
+        "yarn",
+        "--cwd",
+        pckDir,
+        "publish",
+        "--tag",
+        tag,
+        "--access",
+        "public",
+        "--ignore-scripts",
+        "--network-timeout",
+        "300000",
+    ].join(" "),
     { stdio: "inherit" },
 );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This times out in 100 seconds, and is causing failures for builds in main.

Maybe it needs more time.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39b2e7e</samp>

Increased the network timeout for `yarn publish` in `publish.js` to prevent publishing failures. This was part of a pull request to improve the publishing process of gitpod-protocol and other packages.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to EXP-722

## How to test
<!-- Provide steps to test this PR -->
merge to main and build

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
