### PR TITLE
Fix compatibility issues with db-migration

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1695733993909-CodeSyncDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695733993909-CodeSyncDropDeleted.ts
@@ -10,22 +10,22 @@ import { columnExists } from "./helper/helper";
 export class CodeSyncDropDeleted1695733993909 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, "d_b_code_sync_resource", "deleted")) {
-            await queryRunner.query("ALTER TABLE `d_b_code_sync_resource` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+            await queryRunner.query("ALTER TABLE `d_b_code_sync_resource` DROP COLUMN `deleted`");
         }
         if (await columnExists(queryRunner, "d_b_code_sync_collection", "deleted")) {
-            await queryRunner.query("ALTER TABLE `d_b_code_sync_collection` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+            await queryRunner.query("ALTER TABLE `d_b_code_sync_collection` DROP COLUMN `deleted`");
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, "d_b_code_sync_collection", "deleted"))) {
             await queryRunner.query(
-                "ALTER TABLE `d_b_code_sync_collection` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+                "ALTER TABLE `d_b_code_sync_collection` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0'",
             );
         }
         if (!(await columnExists(queryRunner, "d_b_code_sync_resource", "deleted"))) {
             await queryRunner.query(
-                "ALTER TABLE `d_b_code_sync_resource` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+                "ALTER TABLE `d_b_code_sync_resource` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0'",
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695735203768-CostCenterDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695735203768-CostCenterDropDeleted.ts
@@ -10,14 +10,14 @@ import { columnExists } from "./helper/helper";
 export class CostCenterDropDeleted1695735203768 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, "d_b_cost_center", "deleted")) {
-            await queryRunner.query("ALTER TABLE `d_b_cost_center` DROP COLUMN `deleted`, ALGORITHM=INSTANT");
+            await queryRunner.query("ALTER TABLE `d_b_cost_center` DROP COLUMN `deleted`");
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, "d_b_cost_center", "deleted"))) {
             await queryRunner.query(
-                "ALTER TABLE `d_b_cost_center` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT",
+                "ALTER TABLE `d_b_cost_center` ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0'",
             );
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix compatibility issues with db-migration by removing `ALGORITHM=INSTANT`

- For MySQL 8.0, this is the default option. Adding it will cause DML statements that don't support instant updates to fail immediately.

- For MySQL 5.7, it doesn't support this, so removing is safe.

<details>
<summary>Summary generated by Copilot</summary>

copilot: summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fix-migration</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fix-migration.preview.gitpod-dev.com/workspaces" target="_blank">pd-fix-migration.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-fix-migration-gha.17853</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-fix-migration%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
