### PR TITLE
[db] Move towards sync deletion (away from PeriodicDeleter) - step I/II

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -39,16 +39,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: "deleted",
         },
         {
-            name: "d_b_oauth_auth_code_entry",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_installation_admin",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_volume_snapshot",
             primaryKeys: ["id"],
             timeColumn: "_lastModified",
@@ -80,42 +70,9 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             dependencies: ["d_b_user"],
         },
         {
-            name: "d_b_workspace_instance_user",
-            primaryKeys: ["instanceId", "userId"],
-            timeColumn: "_lastModified",
-            dependencies: ["d_b_user"],
-        },
-        {
-            name: "d_b_workspace_report_entry",
-            primaryKeys: ["uid"],
-            timeColumn: "time",
-            dependencies: [],
-        },
-        {
-            name: "d_b_snapshot",
-            primaryKeys: ["id"],
-            timeColumn: "creationTime",
-            dependencies: [],
-        },
-        {
-            name: "d_b_email_domain_filter",
-            primaryKeys: ["domain"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_app_installation",
-            primaryKeys: ["platform", "installationID", "state"],
-            timeColumn: "creationTime",
-        },
-        {
             name: "d_b_token_entry",
             primaryKeys: ["uid"],
             deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_user_env_var",
-            primaryKeys: ["id", "userId"],
             timeColumn: "_lastModified",
         },
         {
@@ -136,17 +93,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             primaryKeys: ["id"],
             deletionColumn: "deleted",
             timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_code_sync_collection",
-            primaryKeys: ["userId", "collection"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_code_sync_resource",
-            primaryKeys: ["userId", "kind", "rev", "collection"],
-            timeColumn: "created",
-            dependencies: ["d_b_code_sync_collection"],
         },
         {
             name: "d_b_team",
@@ -197,16 +143,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_cost_center",
-            primaryKeys: ["id", "creationTime"],
-            timeColumn: "_lastModified",
-        },
-        {
-            name: "d_b_usage",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_stripe_customer",
             primaryKeys: ["stripeCustomerId"],
             timeColumn: "_lastModified",
@@ -217,11 +153,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             primaryKeys: ["id"],
             timeColumn: "_lastModified",
             deletionColumn: "deleted",
-        },
-        {
-            name: "d_b_linked_in_profile",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
         },
     ];
 

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -63,13 +63,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_user_storage_resource",
-            primaryKeys: ["userId", "uri"],
-            timeColumn: "_lastModified",
-            deletionColumn: "deleted",
-            dependencies: ["d_b_user"],
-        },
-        {
             name: "d_b_token_entry",
             primaryKeys: ["uid"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
@@ -48,7 +48,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
 
         // 2. then mark as deleted
         const repo = await this.getAuthProviderRepo();
-        await repo.update({ id }, { deleted: true });
+        await repo.delete({ id });
     }
 
     async findAll(exceptOAuthRevisions: string[] = []): Promise<AuthProviderEntry[]> {

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -118,10 +118,7 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
             await projectInfoRepo.update(projectId, { deleted: true });
         }
         const projectUsageRepo = await this.getProjectUsageRepo();
-        const usage = await projectUsageRepo.findOne({ projectId, deleted: false });
-        if (usage) {
-            await projectUsageRepo.update(projectId, { deleted: true });
-        }
+        await projectUsageRepo.delete({ projectId });
     }
 
     public async findProjectEnvironmentVariable(

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -328,8 +328,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
                 "The given user is not currently a member of this organization or does not exist.",
             );
         }
-        membership.deleted = true;
-        await membershipRepo.save(membership);
+        await membershipRepo.delete(membership);
     }
 
     public async findTeamMembershipInviteById(inviteId: string): Promise<TeamMembershipInvite> {

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -29,7 +29,7 @@ import {
     OAuthUser,
 } from "@jmondi/oauth2-server";
 import { inject, injectable, optional } from "inversify";
-import { EntityManager, Equal, Not, Repository } from "typeorm";
+import { EntityManager, Equal, FindOperator, Not, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
 import {
     BUILTIN_WORKSPACE_PROBE_USER_ID,
@@ -256,27 +256,12 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
 
     public async deleteGitpodToken(tokenHash: string): Promise<void> {
         const repo = await this.getGitpodTokenRepo();
-        await repo.query(
-            `
-                UPDATE d_b_gitpod_token AS gt
-                SET gt.deleted = TRUE
-                WHERE tokenHash = ?;
-            `,
-            [tokenHash],
-        );
+        await repo.delete({ tokenHash });
     }
 
     public async deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void> {
         const repo = await this.getGitpodTokenRepo();
-        await repo.query(
-            `
-            UPDATE d_b_gitpod_token AS gt
-            SET gt.deleted = TRUE
-            WHERE userId = ?
-              AND name LIKE ?
-        `,
-            [userId, namePattern],
-        );
+        await repo.delete({ userId, name: new FindOperator("like", namePattern) });
     }
 
     public async storeSingleToken(identity: Identity, token: Token): Promise<TokenEntry> {

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -463,7 +463,7 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
 
     public async deleteSSHPublicKey(userId: string, id: string): Promise<void> {
         const repo = await this.getSSHPublicKeyRepo();
-        await repo.update({ userId, id }, { deleted: true });
+        await repo.delete({ userId, id });
     }
 
     public async findAllUsers(


### PR DESCRIPTION
## Description

PeriodicDeleter is a leftover of the time we had multiple databases + db-sync, which forced us to have an async deletion mechanism. Since this is no longer true, we should move away from this pattern as it started to rot really badly.

It's step I/II, and defensively only switches to sync deletion for the entities that don't do that already. Column deletion is done in a 2nd step (https://github.com/gitpod-io/gitpod/pull/18826).

For details see the [commits overview](https://github.com/gitpod-io/gitpod/pull/18825/commits).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7d19e6</samp>

This pull request refactors the database layer of the `gitpod-io/gitpod` repository to use hard deletion instead of soft deletion for several tables and entities. This simplifies the code, improves performance and maintainability, and avoids unnecessary data retention. It also removes the unused `deleted` columns and properties from the `d_b_team`, `d_b_project`, `Project`, and `Organization` tables and interfaces. It includes the corresponding migration files to apply the schema changes to the existing database.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-718

## How to test
 - check server logs, and verify that there are no errors (from garbage collectors or PeriodicDeleter)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-716-deleted-1</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-716-deleted-1.preview.gitpod-dev.com/workspaces" target="_blank">gpl-716-deleted-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-716-deleted-1-gha.17868</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-716-deleted-1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
