### PR TITLE
[dashboard] set project wsClass

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -128,29 +128,6 @@ export function CreateWorkspacePage() {
         }
     }, [project, selectedProjectID]);
 
-    // Apply project ws class settings
-    useEffect(() => {
-        // If URL has a ws class set, we don't override it w/ project settings
-        if (props.workspaceClass) {
-            return;
-        }
-
-        if (!project) {
-            // If no project and user hasn't changed ws class, reset it to default value
-            // Empty value causes SelectWorkspaceClassComponent to use the default ws class
-            if (!selectedWsClassIsDirty) {
-                setSelectedWsClass(defaultWorkspaceClass, false);
-            }
-            return;
-        }
-        const wsClass = project.settings?.workspaceClasses;
-
-        // only set if user hasn't changed the value themselves, and project has a vaue
-        if (wsClass?.regular && !selectedWsClassIsDirty) {
-            setSelectedWsClass(wsClass?.regular, false);
-        }
-    }, [defaultWorkspaceClass, project, props.workspaceClass, selectedWsClassIsDirty, setSelectedWsClass]);
-
     // In addition to updating state, we want to update the url hash as well
     // This allows the contextURL to persist if user changes orgs, or copies/shares url
     const handleContextURLChange = useCallback(
@@ -276,6 +253,9 @@ export function CreateWorkspacePage() {
 
     // when workspaceContext is available, we look up if options are remembered
     useEffect(() => {
+        if (!workspaceContext.data || !user || !currentOrg) {
+            return;
+        }
         const cloneURL = CommitContext.is(workspaceContext.data) && workspaceContext.data.repository.cloneUrl;
         if (!cloneURL) {
             return undefined;
@@ -299,13 +279,14 @@ export function CreateWorkspacePage() {
                 setUseLatestIde(defaultLatestIde);
             }
             if (!selectedWsClassIsDirty) {
-                setSelectedWsClass(defaultWorkspaceClass, false);
+                const projectWsClass = project?.settings?.workspaceClasses?.regular;
+                setSelectedWsClass(projectWsClass || defaultWorkspaceClass, false);
             }
         }
         setOptionsLoaded(true);
         // we only update the remembered options when the workspaceContext changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [workspaceContext.data, setOptionsLoaded]);
+    }, [workspaceContext.data, setOptionsLoaded, project]);
 
     // Need a wrapper here so we call createWorkspace w/o any arguments
     const onClickCreate = useCallback(() => createWorkspace(), [createWorkspace]);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The recent change to createWorkspace would ignore the project-level wsclass in certain situations.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 298ab8d</samp>

Refactor and enhance the create workspace page. Simplify the logic, fix some bugs, and use the project settings for workspace class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Create a project and change the workspace class for it.
- open the create workspace page for that project and verify that the workspace class changes.
- change the repo and verify that the class changes back to default
- select the project again and manually change the workspace class, start a workspace.
- create another workspace on that project and verify that now the previously selected workspace class is selected again.


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-project-options</li>
	<li><b>🔗 URL</b> - <a href="https://se-project-options.preview.gitpod-dev.com/workspaces" target="_blank">se-project-options.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-project-options-gha.17896</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-project-options%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
