### PR TITLE
Allow customize aws and vault audience

### DIFF
--- a/components/gitpod-cli/cmd/idp-login-aws.go
+++ b/components/gitpod-cli/cmd/idp-login-aws.go
@@ -24,6 +24,7 @@ var idpLoginAwsOpts struct {
 	RoleARN         string
 	Profile         string
 	DurationSeconds int
+	Audience        []string
 }
 
 var idpLoginAwsCmd = &cobra.Command{
@@ -42,7 +43,7 @@ var idpLoginAwsCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
-		tkn, err := idpToken(ctx, []string{idpAudienceAWS})
+		tkn, err := idpToken(ctx, idpLoginAwsOpts.Audience)
 		if err != nil {
 			return err
 		}
@@ -96,6 +97,7 @@ func init() {
 	idpLoginCmd.AddCommand(idpLoginAwsCmd)
 
 	idpLoginAwsCmd.Flags().StringVar(&idpLoginAwsOpts.RoleARN, "role-arn", os.Getenv("IDP_AWS_ROLE_ARN"), "AWS role to assume (defaults to IDP_AWS_ROLE_ARN env var)")
+	idpLoginAwsCmd.Flags().StringArrayVar(&idpLoginAwsOpts.Audience, "audience", []string{idpAudienceAWS}, "audience of the ID token")
 	idpLoginAwsCmd.Flags().StringVarP(&idpLoginAwsOpts.Profile, "profile", "p", "default", "AWS profile to configure")
 	idpLoginAwsCmd.Flags().IntVarP(&idpLoginAwsOpts.DurationSeconds, "duration-seconds", "d", 3600, "Duration in seconds for which the credentials will be valid (defaults to 3600), upper bound is controlled by the AWS maximum session duration. See https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html")
 	_ = idpLoginAwsCmd.MarkFlagFilename("profile")

--- a/components/gitpod-cli/cmd/idp-login-vault.go
+++ b/components/gitpod-cli/cmd/idp-login-vault.go
@@ -20,7 +20,8 @@ const (
 )
 
 var idpLoginVaultOpts struct {
-	Role string
+	Role     string
+	Audience []string
 }
 
 var idpLoginVaultCmd = &cobra.Command{
@@ -32,7 +33,7 @@ var idpLoginVaultCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
-		tkn, err := idpToken(ctx, []string{idpAudienceVault})
+		tkn, err := idpToken(ctx, idpLoginVaultOpts.Audience)
 		if err != nil {
 			return err
 		}
@@ -63,5 +64,6 @@ var idpLoginVaultCmd = &cobra.Command{
 func init() {
 	idpLoginCmd.AddCommand(idpLoginVaultCmd)
 
+	idpLoginVaultCmd.Flags().StringArrayVar(&idpLoginVaultOpts.Audience, "audience", []string{idpAudienceVault}, "audience of the ID token")
 	idpLoginVaultCmd.Flags().StringVar(&idpLoginVaultOpts.Role, "role", os.Getenv("IDP_VAULT_ROLE"), "Vault role to assume (defaults to IDP_VAULT_ROLE env var)")
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allow customize aws and vault audience

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4dc8663</samp>

Add `--audience` flag to `idp-login-aws` and `idp-login-vault` commands. This allows users to customize the audience of the ID token for different identity providers.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-725

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
