### PR TITLE
[installer] Remove redundant `len` and `nil` check

### DIFF
--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -271,23 +271,21 @@ func getGenericImages(k8sObj string) []string {
 	re := regexp.MustCompile(fmt.Sprintf("%s(.*)|%s(.*)", "docker.io", common.GitpodContainerRegistry))
 	img := re.FindAllString(k8sObj, -1)
 
-	if len(img) > 0 {
-		for _, i := range img {
-			// Remove whitespace
-			i = strings.TrimSpace(i)
-			// Remove end commas
-			i = strings.TrimRight(i, ",")
-			// Remove wrapping quotes
-			i = strings.Trim(i, "\"")
-			// Validate the image - assumes images are already fully qualified names
-			_, err := reference.ParseNamed(i)
-			if err != nil {
-				// Invalid - ignore
-				continue
-			}
-
-			images = append(images, i)
+	for _, i := range img {
+		// Remove whitespace
+		i = strings.TrimSpace(i)
+		// Remove end commas
+		i = strings.TrimRight(i, ",")
+		// Remove wrapping quotes
+		i = strings.Trim(i, "\"")
+		// Validate the image - assumes images are already fully qualified names
+		_, err := reference.ParseNamed(i)
+		if err != nil {
+			// Invalid - ignore
+			continue
 		}
+
+		images = append(images, i)
 	}
 
 	return images
@@ -301,17 +299,15 @@ func getPodImages(k8sObj string) []string {
 	re := regexp.MustCompile("image:(.*)")
 	img := re.FindAllString(k8sObj, -1)
 
-	if len(img) > 0 {
-		for _, i := range img {
-			// Remove "image":
-			i = re.ReplaceAllString(i, "$1")
-			// Remove whitespace
-			i = strings.TrimSpace(i)
-			// Remove wrapping quotes
-			i = strings.Trim(i, "\"")
+	for _, i := range img {
+		// Remove "image":
+		i = re.ReplaceAllString(i, "$1")
+		// Remove whitespace
+		i = strings.TrimSpace(i)
+		// Remove wrapping quotes
+		i = strings.Trim(i, "\"")
 
-			images = append(images, i)
-		}
+		images = append(images, i)
 	}
 
 	return images

--- a/install/installer/pkg/common/objects.go
+++ b/install/installer/pkg/common/objects.go
@@ -16,12 +16,10 @@ func DefaultServiceAccount(component string) RenderFunc {
 	return func(cfg *RenderContext) ([]runtime.Object, error) {
 		pullSecrets := make([]corev1.LocalObjectReference, 0)
 
-		if len(cfg.Config.ImagePullSecrets) > 0 {
-			for _, i := range cfg.Config.ImagePullSecrets {
-				pullSecrets = append(pullSecrets, corev1.LocalObjectReference{
-					Name: i.Name,
-				})
-			}
+		for _, i := range cfg.Config.ImagePullSecrets {
+			pullSecrets = append(pullSecrets, corev1.LocalObjectReference{
+				Name: i.Name,
+			})
 		}
 
 		return []runtime.Object{

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -143,24 +143,22 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	volumes := make([]corev1.Volume, 0)
 	volumeMounts := make([]corev1.VolumeMount, 0)
 
-	if len(ctx.Config.AuthProviders) > 0 {
-		for i, provider := range ctx.Config.AuthProviders {
-			volumeName := fmt.Sprintf("auth-provider-%d", i)
-			volumes = append(volumes, corev1.Volume{
-				Name: volumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: provider.Name,
-					},
+	for i, provider := range ctx.Config.AuthProviders {
+		volumeName := fmt.Sprintf("auth-provider-%d", i)
+		volumes = append(volumes, corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: provider.Name,
 				},
-			})
+			},
+		})
 
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      volumeName,
-				MountPath: fmt.Sprintf("%s/%s", authProviderFilePath, provider.Name),
-				ReadOnly:  true,
-			})
-		}
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: fmt.Sprintf("%s/%s", authProviderFilePath, provider.Name),
+			ReadOnly:  true,
+		})
 	}
 
 	// mount the optional twilio secret

--- a/install/installer/pkg/helm/helm.go
+++ b/install/installer/pkg/helm/helm.go
@@ -237,12 +237,10 @@ func ImportTemplate(chart *charts.Chart, templateCfg TemplateConfig, pkgConfig P
 // CustomizeAnnotation check for customized annotations and output in Helm format
 func CustomizeAnnotation(registryValues []string, prefix string, ctx *common.RenderContext, component string, typeMeta metav1.TypeMeta, existingAnnotations ...func() map[string]string) []string {
 	annotations := common.CustomizeAnnotation(ctx, component, typeMeta, existingAnnotations...)
-	if len(annotations) > 0 {
-		for k, v := range annotations {
-			// Escape any dots in the keys so they're not expanded
-			key := strings.Replace(k, ".", "\\.", -1)
-			registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s.%s", prefix, key), v))
-		}
+	for k, v := range annotations {
+		// Escape any dots in the keys so they're not expanded
+		key := strings.Replace(k, ".", "\\.", -1)
+		registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s.%s", prefix, key), v))
 	}
 
 	return registryValues
@@ -257,12 +255,10 @@ func CustomizeLabel(registryValues []string, prefix string, ctx *common.RenderCo
 		delete(labels, k)
 	}
 
-	if len(labels) > 0 {
-		for k, v := range labels {
-			// Escape any dots in the keys so they're not expanded
-			key := strings.Replace(k, ".", "\\.", -1)
-			registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s.%s", prefix, key), v))
-		}
+	for k, v := range labels {
+		// Escape any dots in the keys so they're not expanded
+		key := strings.Replace(k, ".", "\\.", -1)
+		registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s.%s", prefix, key), v))
 	}
 
 	return registryValues
@@ -281,11 +277,9 @@ func CustomizeEnvvar(registryValues []string, prefix string, ctx *common.RenderC
 		return envs
 	}())
 
-	if len(envvars) > 0 {
-		for k, v := range envvars {
-			registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s[%d].name", prefix, k), v.Name))
-			registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s[%d].value", prefix, k), v.Value))
-		}
+	for k, v := range envvars {
+		registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s[%d].name", prefix, k), v.Name))
+		registryValues = append(registryValues, KeyValue(fmt.Sprintf("%s[%d].value", prefix, k), v.Value))
 	}
 
 	return registryValues


### PR DESCRIPTION
## Description

This pull request is a minor code cleanup.

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the slice or map is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6848a1e</samp>

Simplify code in various functions by removing redundant checks for empty slices and maps. This affects the files `mirror_list.go`, `helm.go`, `objects.go`, `deployment.go`, and `validation.go` in the installer package.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
