### PR TITLE
[public-api] add request context

### DIFF
--- a/components/dashboard/src/service/metrics.ts
+++ b/components/dashboard/src/service/metrics.ts
@@ -4,7 +4,6 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { MetricsReporter } from "@gitpod/public-api/lib/metrics";
 import { getExperimentsClient } from "../experiments/client";
 import { v4 } from "uuid";
@@ -13,7 +12,7 @@ const commit = require("./config.json").commit;
 const originalConsoleError = console.error;
 
 const metricsReporter = new MetricsReporter({
-    gitpodUrl: new GitpodHostUrl(window.location.href).withoutWorkspacePrefix().toString(),
+    gitpodUrl: window.location.href,
     clientName: "dashboard",
     clientVersion: commit,
     log: {

--- a/components/server/src/api/dummy.ts
+++ b/components/server/src/api/dummy.ts
@@ -24,7 +24,7 @@ export class APIHelloService implements ServiceImpl<typeof HelloService> {
     }
     async *lotsOfReplies(req: LotsOfRepliesRequest, context: HandlerContext): AsyncGenerator<LotsOfRepliesResponse> {
         let count = req.previousCount || 0;
-        while (true) {
+        while (!context.signal.aborted) {
             const response = new LotsOfRepliesResponse();
             response.reply = `Hello ${this.getSubject(context)} ${count}`;
             response.count = count;

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -144,7 +144,7 @@ export class Server {
         app.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 const userId = req.user ? req.user.id : undefined;
-                await runWithContext("http", { userId, requestPath: req.path }, () => next());
+                runWithContext("http", { userId, requestPath: req.path }, () => next());
             } catch (err) {
                 next(err);
             }

--- a/components/server/src/util/log-context.ts
+++ b/components/server/src/util/log-context.ts
@@ -6,20 +6,27 @@
 
 import { LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { performance } from "node:perf_hooks";
 import { v4 } from "uuid";
+
+export type LogContextOptions = LogContext & {
+    contextId?: string;
+    contextTimeMs?: number;
+    [p: string]: any;
+};
 
 // we are installing a special augmenter that enhances the log context if executed within `runWithContext`
 // with a contextId and a contextTimeMs, which denotes the amount of milliseconds since the context was created.
-type EnhancedLogContext = LogContext & {
-    contextId?: string;
-    contextTimeMs: number;
+type EnhancedLogContext = LogContextOptions & {
     contextKind: string;
+    contextId: string;
+    contextTimeMs: number;
 };
 
 const asyncLocalStorage = new AsyncLocalStorage<EnhancedLogContext>();
 const augmenter: LogContext.Augmenter = (ctx) => {
     const globalContext = asyncLocalStorage.getStore();
-    const contextTimeMs = globalContext?.contextTimeMs ? Date.now() - globalContext.contextTimeMs : undefined;
+    const contextTimeMs = globalContext?.contextTimeMs ? performance.now() - globalContext.contextTimeMs : undefined;
     const result = {
         ...globalContext,
         contextTimeMs,
@@ -30,18 +37,30 @@ const augmenter: LogContext.Augmenter = (ctx) => {
 };
 LogContext.setAugmenter(augmenter);
 
-export function runWithContext<T>(
-    contextKind: string,
-    context: LogContext & { contextId?: string } & any,
-    fun: () => T,
-): T {
+export function runWithContext<T>(contextKind: string, context: LogContextOptions, fun: () => T): T {
     return asyncLocalStorage.run(
         {
             ...context,
             contextKind,
             contextId: context.contextId || v4(),
-            contextTimeMs: Date.now(),
+            contextTimeMs: context.contextTimeMs || performance.now(),
         },
         fun,
     );
+}
+
+export type AsyncGeneratorDecorator<T> = (f: () => T) => T;
+export function wrapAsyncGenerator<T>(
+    generator: AsyncGenerator<T>,
+    decorator: AsyncGeneratorDecorator<any>,
+): AsyncGenerator<T> {
+    return <AsyncGenerator<T>>{
+        next: () => decorator(() => generator.next()),
+        return: (value?: any) => decorator(() => generator.return(value)),
+        throw: (e?: any) => decorator(() => generator.throw(e)),
+
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
 }

--- a/components/server/src/util/log-context.ts
+++ b/components/server/src/util/log-context.ts
@@ -30,11 +30,11 @@ const augmenter: LogContext.Augmenter = (ctx) => {
 };
 LogContext.setAugmenter(augmenter);
 
-export async function runWithContext<T>(
+export function runWithContext<T>(
     contextKind: string,
     context: LogContext & { contextId?: string } & any,
     fun: () => T,
-): Promise<T> {
+): T {
     return asyncLocalStorage.run(
         {
             ...context,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- This PR enhances the Public API on the server by adding log context support.
- It introduces warning logs for unary calls exceeding 100ms, using 'getLoggedInUser' in JSON-RPC as a benchmark.
- Additionally, it fixes a leak in server streams.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f9d889</samp>

This pull request refactors the server API and util modules to improve logging and error handling of gRPC calls. It adds request IDs and logging context to the server API, and removes unnecessary async and await keywords from the util module.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Enable debug log on server.
- Open a workspace and start a workspace.
- Inspect server logs for `public-api: done`.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-public-28f4cdcfb3</li>
	<li><b>🔗 URL</b> - <a href="https://ak-public-28f4cdcfb3.preview.gitpod-dev.com/workspaces" target="_blank">ak-public-28f4cdcfb3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-public_api_request_context-gha.18016</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-public-28f4cdcfb3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
