### PR TITLE
Increase getSuggestedRepositories client cache to 7 days

### DIFF
--- a/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
@@ -21,8 +21,8 @@ export const useSuggestedRepositories = () => {
             return await getGitpodService().server.getSuggestedRepositories(org.id);
         },
         {
-            // Keeps data in cache for 24h - will still refresh though
-            cacheTime: 1000 * 60 * 60 * 24,
+            // Keeps data in cache for 7 days - will still refresh though
+            cacheTime: 1000 * 60 * 60 * 24 * 7,
         },
     );
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a change to help improve some of the usability around creating a workspace.

Increases the cacheTime for the `getSuggestedRepositories` call from 1 day to 7 days. This will keep the result in cache for up to a week which will help reduce the chance of not having any data after a weekend. New data will still get loaded when the user visits the create workspace page, but it won't get hung up waiting for an initial result from `getSuggestedRepositories` and will use the data in cache.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f96db25</samp>

Increased the cache time for the `suggested-repositories-query` to reduce API calls and improve dashboard performance. This was part of a pull request to optimize the dashboard loading time and user experience.

</details>

## How to test
<!-- Provide steps to test this PR -->
* Verify create workspace loads your suggested repositories on initial load.
* Refresh the page and it shouldn't block on loading them.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-sugge850d20b595</li>
	<li><b>🔗 URL</b> - <a href="https://brad-sugge850d20b595.preview.gitpod-dev.com/workspaces" target="_blank">brad-sugge850d20b595.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-suggested-repos-query-cache-bump-gha.18045</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-sugge850d20b595%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
