### PR TITLE
Implement searchRepos for Bitbucket

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -62,6 +62,7 @@
     "@octokit/rest": "18.6.1",
     "@probot/get-private-key": "^1.1.1",
     "@types/jaeger-client": "^3.18.3",
+    "async-batch": "^1.1.2",
     "base-64": "^1.0.0",
     "bitbucket": "^2.7.0",
     "body-parser": "^1.19.2",

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -188,8 +188,21 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
         return commits.map((c) => c.id);
     }
 
-    // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        return [];
+        // Only load 1 page of 10 results for our searchString
+        const results = await this.api.getRepos(user, { maxPages: 1, limit: 10, searchString });
+
+        const repos: RepositoryInfo[] = [];
+        results.forEach((r) => {
+            const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;
+            if (cloneUrl) {
+                repos.push({
+                    url: cloneUrl.replace("http://", "https://"),
+                    name: r.name,
+                });
+            }
+        });
+
+        return repos;
     }
 }

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -166,7 +166,7 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
         const api = await this.apiFactory.create(user);
 
-        const workspaces = await api.workspaces.getWorkspaces({ fields: "workspace.slug" });
+        const workspaces = await api.workspaces.getWorkspaces({});
 
         const workspaceSlugs: string[] = (
             workspaces.data.values?.map((w) => {
@@ -181,8 +181,6 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
         // Array of promises searching for repos in each workspace
         const workspaceSearches = workspaceSlugs.map((workspaceSlug) => {
             return api.repositories.list({
-                // limit to just the fields we need
-                fields: "name,links.html.href",
                 workspace: workspaceSlug,
                 // name includes searchString
                 q: `name ~ "${searchString}"`,

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -166,7 +166,7 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
         const api = await this.apiFactory.create(user);
 
-        const workspaces = await api.workspaces.getWorkspaces({});
+        const workspaces = await api.workspaces.getWorkspaces({ fields: "workspace.slug" });
 
         const workspaceSlugs: string[] = (
             workspaces.data.values?.map((w) => {
@@ -181,8 +181,12 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
         // Array of promises searching for repos in each workspace
         const workspaceSearches = workspaceSlugs.map((workspaceSlug) => {
             return api.repositories.list({
+                // limit to just the fields we need
+                fields: "name,links.html.href",
                 workspace: workspaceSlug,
+                // name includes searchString
                 q: `name ~ "${searchString}"`,
+                // sort by most recently updatd first
                 sort: "-updated_on",
                 // limit to the first 10 results per workspace
                 pagelen: 10,

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -142,23 +142,6 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        const projects = await this.gitlab.run<GitLab.Project[]>(user, async (g) => {
-            return g.Projects.search(searchString, {
-                orderBy: "last_activity_at",
-                sort: "desc",
-            });
-        });
-        if (GitLab.ApiError.is(projects)) {
-            throw projects;
-        }
-
-        const repos: RepositoryInfo[] = projects.map((project) => {
-            return {
-                name: project.name,
-                url: project.http_url_to_repo,
-            };
-        });
-
-        return repos;
+        return [];
     }
 }

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -142,6 +142,23 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
 
     // TODO: implement repo search
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        return [];
+        const projects = await this.gitlab.run<GitLab.Project[]>(user, async (g) => {
+            return g.Projects.search(searchString, {
+                orderBy: "last_activity_at",
+                sort: "desc",
+            });
+        });
+        if (GitLab.ApiError.is(projects)) {
+            throw projects;
+        }
+
+        const repos: RepositoryInfo[] = projects.map((project) => {
+            return {
+                name: project.name,
+                url: project.http_url_to_repo,
+            };
+        });
+
+        return repos;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,6 +4424,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+async-batch@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/async-batch/-/async-batch-1.1.2.tgz#ecac7dee0f02a1a3a846438ba7d3f96746239d79"
+  integrity sha512-tBR4YIKi7s1cCtNHuguyXVBdRSkS6N8OhM1czrpE0W2j2yovj/IAxXD187cNX0d+kGxBbZLPwW5ASonYuZJprA==
+
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Implements the `searchRepos` function for our Bitbucket & Bitbucket Server repository providers. This is used on the create workspace page as you search for repositories. Gitlab will be added in a followup PR.

You can see results from bitbucket cloud/server & github in this screenshot
![image](https://github.com/gitpod-io/gitpod/assets/367275/973e4fed-f988-421b-a26b-0cc65d6c867b)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e13f258</samp>

Implemented repository search for Bitbucket integration. Added `searchRepos` method to `BitbucketRepositoryProvider` class in `bitbucket-repository-provider.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-749 & EXP-751

## How to test
<!-- Provide steps to test this PR -->
* You'll need to connect your account with Bitbucket cloud, and then with Bitbucket Server.
* I've setup an org w/ our test Bitbucket Server instance and you can use [this invite](https://brad-exp-7faffdc08ac.preview.gitpod-dev.com/orgs/join?inviteId=a927242e-0ef9-4939-895c-2137f62d87cf) to join.
* Go to your User Settings => Git Providers and connect both of the Bitbucket providers (cloud and server).
* Go to the New Workspace page and search for repositories.
* You may need to create a few test repositories if you don't have any already.
* **_Bitbucket Server search is limited to prefix-search only, so keep that in mind when searching for repositories there._**

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-7faffdc08ac</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-7faffdc08ac.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-7faffdc08ac.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-749-implement-searchrepositories-for-bitbucket-cloud-gha.18041</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-exp-7faffdc08ac%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
