### PR TITLE
[ws-daemon] use s5cmd to download from s3

### DIFF
--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -17,7 +17,7 @@ RUN curl -OsSL https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.
 FROM ubuntu:22.04
 
 # trigger manual rebuild increasing the value
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
 ARG CLOUD_SDK_VERSION=437.0.1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Download with `s5cmd` when the destination is from S3, otherwise use `aria2c`.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3265c0</samp>

Improved and refactored the workspace content download logic in `ws-daemon` by using `s5cmd` for S3 downloads and simplifying the error handling. Rebuilt the `ws-daemon` Docker image to apply the changes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-884

## How to test
<!-- Provide steps to test this PR -->
1. From a preview environment, we should use `aria2c`. ([log](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-10-02T22:57:28.074416637Z;duration=PT30M;lfeCustomFields=jsonPayload%252FserviceContext%252Fservice;query=--%20without%20protected_secrets%20enabled%0AjsonPayload.kubernetes.host%3D%22preview-kylos101-epofxcozhu%22%0A%22download%20duration%22%0Atimestamp%3D%222023-10-02T22:57:28.074416637Z%22%0AinsertId%3D%221rjrwlcfbllwcd%22;summaryFields=jsonPayload%252Fseverity,jsonPayload%252FserviceContext%252Fservice,jsonPayload%252FdownloadDuration:false:32:beginning?project=gitpod-core-dev))
2. From `dev-internal`, we should use `s5cmd`. (log, tbd)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
