### PR TITLE
Load recent repos and not all repos for BBS

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -429,6 +429,19 @@ export class BitbucketServerApi {
         }
     }
 
+    async getRecentRepos(userOrToken: User | string, options: { limit: number }) {
+        const params = new URLSearchParams({
+            limit: `${options.limit}`,
+        });
+
+        const { values } = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.Repository>>(
+            userOrToken,
+            `/profile/recent/repos?${params.toString()}`,
+        );
+
+        return values || [];
+    }
+
     async getPullRequest(
         user: User,
         params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string; nr: number },

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -147,7 +147,8 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
     async getUserRepos(user: User): Promise<RepositoryInfo[]> {
         try {
             // TODO: implement incremental search
-            const repos = await this.api.getRepos(user, { maxPages: 10, permission: "REPO_READ" });
+            const repos = await this.api.getRecentRepos(user, { limit: 25 });
+
             const result: RepositoryInfo[] = [];
             repos.forEach((r) => {
                 const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -146,7 +146,6 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
 
     async getUserRepos(user: User): Promise<RepositoryInfo[]> {
         try {
-            // TODO: implement incremental search
             const repos = await this.api.getRecentRepos(user, { limit: 25 });
 
             const result: RepositoryInfo[] = [];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This updates the repos we load for getSuggestedRepositories for Bitbucket Server to load the user's recent repositories instead of trying to grab up to 10k repos. With repository searching integrated we no longer need to load so many up front, and this should dramatically increase performance for BBS customers with a large number of repositories.

I've place this logic behind the `repositoryFinderSearch` flag since it depends on that functionality to be useful.

Initial repo results including a mix of most recent entries, but not ALL of the BBS test repos like it used to)
![image](https://github.com/gitpod-io/gitpod/assets/367275/f46a7a78-6b5a-4636-b9be-92b2ad174eb1)


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84b26a0</samp>

This pull request adds a new method to the `BitbucketServerApi` class to query the Bitbucket Server API for recent repositories, and modifies the `BitbucketServerRepositoryProvider` class to use this method instead of querying all repositories. This is part of a feature to improve the repository selection experience for Bitbucket Server users in Gitpod.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-750

## How to test
<!-- Provide steps to test this PR -->
* Join an org I’ve setup with our test Bitbucket Server git provider with [this invite link](https://brad-recent-repos.preview.gitpod-dev.com/orgs/join?inviteId=c7af5abb-a657-46d9-9c4b-4da069229744).
* Navigate to the Create Workspace page
* Before you’ve searched in the repository selector, scroll down and ensure you don’t see any of the `repo-n-nnn` test repos (unless you've used one of them recently, then it should show up). These used to get loaded in the initial suggestions, they shouldn’t anymore.
* Start typing `repo-` and you should see it search, and then pull back results matching those test repos.
* This validates we’re no longer pulling back all of the repos for the initial suggestions, but that we can still find them with search.
* You can also create a new repository on the test BBS server and you should see it show up in the initial results if you scroll through before searching.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-recent-repos</li>
	<li><b>🔗 URL</b> - <a href="https://brad-recent-repos.preview.gitpod-dev.com/workspaces" target="_blank">brad-recent-repos.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-recent-repos-gha.18082</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-recent-repos%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
