### PR TITLE
[content-service] remove s5cmd integration

### DIFF
--- a/components/content-service/pkg/storage/s3.go
+++ b/components/content-service/pkg/storage/s3.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -290,39 +289,33 @@ func (s3st *s3Storage) DownloadSnapshot(ctx context.Context, destination string,
 	return s3st.download(ctx, destination, name, mappings)
 }
 
-// download object using s5cmd (prior to which we used aws sdk)
 func (s3st *s3Storage) download(ctx context.Context, destination string, obj string, mappings []archive.IDMapping) (found bool, err error) {
-	tempFile, err := os.CreateTemp("", "temporal-s3-file")
+	downloader := s3manager.NewDownloader(s3st.client, func(d *s3manager.Downloader) {
+		d.Concurrency = defaultCopyConcurrency
+		d.PartSize = defaultPartSize * megabytes
+		d.BufferProvider = s3manager.NewPooledBufferedWriterReadFromProvider(25 * megabytes)
+	})
+
+	s3File, err := os.CreateTemp("", "temporal-s3-file")
 	if err != nil {
 		return true, xerrors.Errorf("creating temporal file: %s", err.Error())
 	}
-	tempFile.Close()
+	defer os.Remove(s3File.Name())
 
-	args := []string{
-		"cp",
-		// # of file parts to download at once
-		"--concurrency", "20",
-		// size in MB of each part
-		"--part-size", "25",
-		destination,
-		tempFile.Name(),
-	}
-	cmd := exec.Command("s5cmd", args...)
-	out, err := cmd.CombinedOutput()
+	_, err = downloader.Download(ctx, s3File, &s3.GetObjectInput{
+		Bucket: aws.String(s3st.Config.Bucket),
+		Key:    aws.String(obj),
+	})
 	if err != nil {
-		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")
-		return true, xerrors.Errorf("unexpected error downloading file")
+		return false, err
 	}
 
-	tempFile, err = os.Open(tempFile.Name())
+	_, err = s3File.Seek(0, 0)
 	if err != nil {
-		return true, xerrors.Errorf("unexpected error opening downloaded file")
+		return false, err
 	}
 
-	defer os.Remove(tempFile.Name())
-	defer tempFile.Close()
-
-	err = archive.ExtractTarbal(ctx, tempFile, destination, archive.WithUIDMapping(mappings), archive.WithGIDMapping(mappings))
+	err = archive.ExtractTarbal(ctx, s3File, destination, archive.WithUIDMapping(mappings), archive.WithGIDMapping(mappings))
 	if err != nil {
 		return true, xerrors.Errorf("tar %s: %s", destination, err.Error())
 	}

--- a/components/content-service/pkg/storage/s3.go
+++ b/components/content-service/pkg/storage/s3.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
@@ -309,14 +308,11 @@ func (s3st *s3Storage) download(ctx context.Context, destination string, obj str
 		tempFile.Name(),
 	}
 	cmd := exec.Command("s5cmd", args...)
-	downloadStart := time.Now()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")
-		return false, xerrors.Errorf("unexpected error downloading file")
+		return true, xerrors.Errorf("unexpected error downloading file")
 	}
-	downloadDuration := time.Since(downloadStart)
-	log.WithField("downloadDuration", downloadDuration.String()).Info("S3 download duration")
 
 	tempFile, err = os.Open(tempFile.Name())
 	if err != nil {
@@ -326,13 +322,10 @@ func (s3st *s3Storage) download(ctx context.Context, destination string, obj str
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	extractStart := time.Now()
 	err = archive.ExtractTarbal(ctx, tempFile, destination, archive.WithUIDMapping(mappings), archive.WithGIDMapping(mappings))
 	if err != nil {
 		return true, xerrors.Errorf("tar %s: %s", destination, err.Error())
 	}
-	extractDuration := time.Since(extractStart)
-	log.WithField("extractdDuration", extractDuration.String()).Info("tarbar extraction duration")
 
 	return true, nil
 }

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -9,11 +9,6 @@ RUN apk add --no-cache curl file \
   && chmod +x runc.amd64 \
   && if ! file runc.amd64 | grep -iq "ELF 64-bit LSB pie executable"; then echo "runc.amd64 is not a binary file"; exit 1;fi
 
-RUN curl -OsSL https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_Linux-64bit.tar.gz \
- && tar -xzvf s5cmd_2.2.2_Linux-64bit.tar.gz s5cmd \
- && chmod +x s5cmd \
- && if ! file s5cmd | grep -iq "ELF 64-bit LSB executable"; then echo "s5cmd is not a binary file"; exit 1;fi
-
 FROM ubuntu:22.04
 
 # trigger manual rebuild increasing the value
@@ -51,7 +46,6 @@ RUN apt update \
     /var/tmp/*
 
 COPY --from=dl /dl/runc.amd64 /usr/bin/runc
-COPY --from=dl /dl/s5cmd /usr/bin/s5cmd
 
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)
 RUN groupadd -r -g 33333 gitpod \

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -406,12 +406,15 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 		"-o", tempFile.Name(),
 	}
 
+	downloadStart := time.Now()
 	cmd := exec.Command("aria2c", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithError(err).WithField("out", string(out)).Error("unexpected error downloading file")
 		return true, xerrors.Errorf("unexpected error downloading file")
 	}
+	downloadDuration := time.Since(downloadStart)
+	log.WithField("downloadDuration", downloadDuration.String()).Info("aria2c download duration")
 
 	tempFile, err = os.Open(tempFile.Name())
 	if err != nil {
@@ -421,10 +424,13 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
+	extractStart := time.Now()
 	err = archive.ExtractTarbal(ctx, tempFile, destination, archive.WithUIDMapping(mappings), archive.WithGIDMapping(mappings))
 	if err != nil {
 		return true, xerrors.Errorf("tar %s: %s", destination, err.Error())
 	}
+	extractDuration := time.Since(extractStart)
+	log.WithField("extractDuration", extractDuration.String()).Info("extract tarbal duration")
 
 	return true, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Revert s5cmd changes for content-service and ws-daemon, they weren't being used as part of content-initialization, we were still using aria2c.

Also, add logging to ws-daemon, so we can see duration for download and tarball extraction.

Additionally, we cannot use s5cmd as an alternative aria2c. This is because ws-daemon expects a presigned URL, and s5cmd works with S3 URI and AWS credential.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cab5c9</samp>

Replaced `s5cmd` with `s3manager` for S3 storage operations in `content-service` and `ws-daemon`. Added logging and timing metrics to the workspace content download function in `ws-daemon`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENG-884

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
