### PR TITLE
Add cursor as an OAuth client

### DIFF
--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -57,12 +57,10 @@ const jetBrainsGateway: OAuthClient = {
     ],
 };
 
-function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium"): OAuthClient {
+function createVSCodeClient(protocol: string, displayName: string): OAuthClient {
     return {
         id: protocol + "-" + "gitpod",
-        name: `VS${protocol === "vscodium" ? "Codium" : " Code"}${
-            protocol === "vscode-insiders" ? " Insiders" : ""
-        }: Gitpod extension`,
+        name: `${displayName}: Gitpod extension`,
         redirectUris: [protocol + "://gitpod.gitpod-desktop/complete-gitpod-auth"],
         allowedGrants: ["authorization_code"],
         scopes: [
@@ -110,9 +108,11 @@ const desktopClient: OAuthClient = {
     ],
 };
 
-const vscode = createVSCodeClient("vscode");
-const vscodeInsiders = createVSCodeClient("vscode-insiders");
-const vscodium = createVSCodeClient("vscodium");
+const vscode = createVSCodeClient("vscode", "VS Code");
+const vscodeInsiders = createVSCodeClient("vscode-insiders", "VS Code Insiders");
+
+const vscodium = createVSCodeClient("vscodium", "VSCodium");
+const cursor = createVSCodeClient("cursor", "Cursor");
 
 export const inMemoryDatabase: InMemory = {
     clients: {
@@ -121,6 +121,7 @@ export const inMemoryDatabase: InMemory = {
         [vscode.id]: vscode,
         [vscodeInsiders.id]: vscodeInsiders,
         [vscodium.id]: vscodium,
+        [cursor.id]: cursor,
         [desktopClient.id]: desktopClient,
     },
     tokens: {},


### PR DESCRIPTION
## Description

Adds support for the cursor editor

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
