### PR TITLE
Move towards sync deletion (away from PeriodicDeleter) - step II/II

### DIFF
--- a/components/gitpod-db/go/organization.go
+++ b/components/gitpod-db/go/organization.go
@@ -23,9 +23,6 @@ type Organization struct {
 	LastModified time.Time   `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
 
 	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"marked_deleted"`
-
-	// deleted is reserved for use by periodic deleter
-	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 
 // TableName sets the insert table name for this struct type
@@ -85,7 +82,6 @@ func GetSingleOrganizationWithActiveSSO(ctx context.Context, conn *gorm.DB) (Org
 		WithContext(ctx).
 		Table(fmt.Sprintf("%s as team", (&Organization{}).TableName())).
 		Joins(fmt.Sprintf("JOIN %s AS config ON team.id = config.organizationId", (&OIDCClientConfig{}).TableName())).
-		Where("team.deleted = ?", 0).
 		Where("config.deleted = ?", 0).
 		Where("config.active = ?", 1).
 		Find(&orgs)

--- a/components/gitpod-db/go/project.go
+++ b/components/gitpod-db/go/project.go
@@ -28,9 +28,6 @@ type Project struct {
 	UserID sql.NullString `gorm:"column:userId;type:char;size:36;" json:"userId"`
 
 	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"markedDeleted"`
-
-	// deleted is reserved for use by periodic deleter
-	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 
 // TableName sets the insert table name for this struct type

--- a/components/gitpod-db/go/project_test.go
+++ b/components/gitpod-db/go/project_test.go
@@ -23,7 +23,6 @@ var projectJSON = map[string]interface{}{
 	"teamId":            "0e433063-1358-4892-9ed2-68e273d17d07",
 	"appInstallationId": "20446411",
 	"creationTime":      "2021-11-01T19:36:07.532Z",
-	"deleted":           0,
 	"_lastModified":     "2021-11-02 10:49:12.473658",
 	"name":              "gptest1-repo1-private",
 	"markedDeleted":     1,
@@ -49,7 +48,7 @@ func TestProject_ReadExistingRecords(t *testing.T) {
 
 func insertRawProject(t *testing.T, conn *gorm.DB, obj map[string]interface{}) uuid.UUID {
 	columns := []string{
-		"id", "cloneUrl", "teamId", "appInstallationId", "creationTime", "deleted", "_lastModified", "name", "markedDeleted", "userId", "slug", "settings",
+		"id", "cloneUrl", "teamId", "appInstallationId", "creationTime", "_lastModified", "name", "markedDeleted", "userId", "slug", "settings",
 	}
 	statement := fmt.Sprintf(`INSERT INTO d_b_project (%s) VALUES ?;`, strings.Join(columns, ", "))
 	id := uuid.MustParse(obj["id"].(string))

--- a/components/gitpod-db/src/auth-provider-entry.spec.db.ts
+++ b/components/gitpod-db/src/auth-provider-entry.spec.db.ts
@@ -38,7 +38,6 @@ describe("AuthProviderEntryDBSpec", async () => {
             status: "verified",
             type: "GitHub",
             oauthRevision: undefined,
-            deleted: false,
             ...ap,
             oauth: {
                 callBackUrl: "example.org/some/callback",

--- a/components/gitpod-db/src/auth-provider-entry.spec.db.ts
+++ b/components/gitpod-db/src/auth-provider-entry.spec.db.ts
@@ -73,7 +73,7 @@ describe("AuthProviderEntryDBSpec", async () => {
         await db.storeAuthProvider(ap2, false);
 
         const all = await db.findAllHosts();
-        expect(all, "findAllHosts([])").to.deep.equal(["foo", "bar"]);
+        expect(all.sort(), "findAllHosts([])").to.deep.equal(["foo", "bar"].sort());
     });
 
     it("should oauthRevision", async () => {

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -63,13 +63,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_gitpod_token",
-            primaryKeys: ["tokenHash"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-            dependencies: ["d_b_user"],
-        },
-        {
             name: "d_b_one_time_secret",
             primaryKeys: ["id"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -88,12 +88,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_team",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_team_membership",
             primaryKeys: ["id"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -100,12 +100,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_project",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_project_env_var",
             primaryKeys: ["id", "projectId"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -87,12 +87,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_project_usage",
-            primaryKeys: ["projectId"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_user_ssh_public_key",
             primaryKeys: ["id"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -87,12 +87,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_user_ssh_public_key",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_stripe_customer",
             primaryKeys: ["stripeCustomerId"],
             timeColumn: "_lastModified",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -69,12 +69,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_team_membership",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_team_membership_invite",
             primaryKeys: ["id"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -63,12 +63,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_token_entry",
-            primaryKeys: ["uid"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_gitpod_token",
             primaryKeys: ["tokenHash"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -76,12 +76,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_auth_provider_entry",
-            primaryKeys: ["id"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_team_membership",
             primaryKeys: ["id"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
@@ -46,7 +46,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
             [id],
         );
 
-        // 2. then mark as deleted
+        // 2. then delete
         const repo = await this.getAuthProviderRepo();
         await repo.delete({ id });
     }
@@ -55,7 +55,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         exceptOAuthRevisions = exceptOAuthRevisions.filter((r) => r !== ""); // never filter out '' which means "undefined" in the DB
 
         const repo = await this.getAuthProviderRepo();
-        let query = repo.createQueryBuilder("auth_provider").where("auth_provider.deleted != true");
+        let query = repo.createQueryBuilder("auth_provider");
         if (exceptOAuthRevisions.length > 0) {
             query = query.andWhere("auth_provider.oauthRevision NOT IN (:...exceptOAuthRevisions)", {
                 exceptOAuthRevisions,
@@ -68,7 +68,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         const hostField: keyof DBAuthProviderEntry = "host";
 
         const repo = await this.getAuthProviderRepo();
-        const query = repo.createQueryBuilder("auth_provider").select(hostField).where("auth_provider.deleted != true");
+        const query = repo.createQueryBuilder("auth_provider").select(hostField);
         const result = (await query.execute()) as Pick<DBAuthProviderEntry, "host">[];
         // HINT: host is expected to be lower case
         return result.map((r) => r.host?.toLowerCase()).filter((h) => !!h);
@@ -76,10 +76,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
 
     async findByHost(host: string): Promise<AuthProviderEntry | undefined> {
         const repo = await this.getAuthProviderRepo();
-        const query = repo
-            .createQueryBuilder("auth_provider")
-            .where(`auth_provider.host = :host`, { host })
-            .andWhere("auth_provider.deleted != true");
+        const query = repo.createQueryBuilder("auth_provider").where(`auth_provider.host = :host`, { host });
         return query.getOne();
     }
 
@@ -93,8 +90,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         const query = repo
             .createQueryBuilder("auth_provider")
             .where(`auth_provider.ownerId = :ownerId`, { ownerId })
-            .andWhere("(auth_provider.organizationId IS NULL OR auth_provider.organizationId = '')")
-            .andWhere("auth_provider.deleted != true");
+            .andWhere("(auth_provider.organizationId IS NULL OR auth_provider.organizationId = '')");
         return query.getMany();
     }
 
@@ -102,8 +98,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         const repo = await this.getAuthProviderRepo();
         const query = repo
             .createQueryBuilder("auth_provider")
-            .where(`auth_provider.organizationId = :organizationId`, { organizationId })
-            .andWhere("auth_provider.deleted != true");
+            .where(`auth_provider.organizationId = :organizationId`, { organizationId });
         return query.getMany();
     }
 

--- a/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
@@ -45,7 +45,4 @@ export class DBAuthProviderEntry implements AuthProviderEntry {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     oauthRevision?: string;
-
-    @Column()
-    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-gitpod-token.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-gitpod-token.ts
@@ -32,7 +32,4 @@ export class DBGitpodToken implements GitpodToken {
 
     @Column()
     created: string;
-
-    @Column()
-    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
@@ -19,8 +19,4 @@ export class DBProjectUsage {
 
     @Column("varchar")
     lastWorkspaceStart: string;
-
-    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project.ts
@@ -6,12 +6,12 @@
 
 import { Entity, Column, PrimaryColumn, Index } from "typeorm";
 import { TypeORM } from "../typeorm";
-import { ProjectSettings } from "@gitpod/gitpod-protocol";
+import { Project, ProjectSettings } from "@gitpod/gitpod-protocol";
 import { Transformer } from "../transformer";
 
 @Entity()
 // on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
-export class DBProject {
+export class DBProject implements Project {
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
     id: string;
 
@@ -37,10 +37,6 @@ export class DBProject {
 
     @Column("varchar")
     creationTime: string;
-
-    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
-    @Column()
-    deleted: boolean;
 
     @Column()
     markedDeleted: boolean;

--- a/components/gitpod-db/src/typeorm/entity/db-team-membership.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-membership.ts
@@ -27,8 +27,4 @@ export class DBTeamMembership {
 
     @Column("varchar")
     creationTime: string;
-
-    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-team.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team.ts
@@ -25,8 +25,4 @@ export class DBTeam implements Team {
 
     @Column()
     markedDeleted?: boolean;
-
-    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-token-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-token-entry.ts
@@ -42,7 +42,4 @@ export class DBTokenEntry implements TokenEntry {
         ),
     })
     token: Token;
-
-    @Column()
-    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-user-ssh-public-key.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-user-ssh-public-key.ts
@@ -49,8 +49,4 @@ export class DBUserSshPublicKey implements UserSSHPublicKey {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     lastUsedTime?: string;
-
-    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
-    @Column()
-    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/migration/1695810605786-TeamDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695810605786-TeamDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_team";
+const COLUMN_NAME = "deleted";
+
+export class TeamDropDeleted1695810605786 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695810605786-TeamDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695810605786-TeamDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class TeamDropDeleted1695810605786 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695817445588-ProjectDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695817445588-ProjectDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class ProjectDropDeleted1695817445588 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695817445588-ProjectDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695817445588-ProjectDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_project";
+const COLUMN_NAME = "deleted";
+
+export class ProjectDropDeleted1695817445588 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695819413747-DropTableUserStorageResource.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695819413747-DropTableUserStorageResource.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropTableUserStorageResource1695819413747 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP TABLE IF EXISTS `d_b_user_storage_resource`");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/migration/1695820427730-TokenEntryDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695820427730-TokenEntryDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class TokenEntryDropDeleted1695820427730 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695820427730-TokenEntryDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695820427730-TokenEntryDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_token_entry";
+const COLUMN_NAME = "deleted";
+
+export class TokenEntryDropDeleted1695820427730 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695820658574-AuthProviderEntryDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695820658574-AuthProviderEntryDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_auth_provider_entry";
+const COLUMN_NAME = "deleted";
+
+export class AuthProviderEntryDropDeleted1695820658574 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695820658574-AuthProviderEntryDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695820658574-AuthProviderEntryDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class AuthProviderEntryDropDeleted1695820658574 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695821079717-GitpodTokenDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821079717-GitpodTokenDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class GitpodTokenDropDeleted1695821079717 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695821079717-GitpodTokenDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821079717-GitpodTokenDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_gitpod_token";
+const COLUMN_NAME = "deleted";
+
+export class GitpodTokenDropDeleted1695821079717 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695821464987-TeamMembershipDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821464987-TeamMembershipDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class TeamMembershipDropDeleted1695821464987 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695821464987-TeamMembershipDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821464987-TeamMembershipDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_team_membership";
+const COLUMN_NAME = "deleted";
+
+export class TeamMembershipDropDeleted1695821464987 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695821957148-ProjectUsageDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821957148-ProjectUsageDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_project_usage";
+const COLUMN_NAME = "deleted";
+
+export class ProjectUsageDropDeleted1695821957148 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1695821957148-ProjectUsageDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695821957148-ProjectUsageDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class ProjectUsageDropDeleted1695821957148 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695822248160-UserSshPublicKeyDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695822248160-UserSshPublicKeyDropDeleted.ts
@@ -13,14 +13,14 @@ const COLUMN_NAME = "deleted";
 export class UserSshPublicKeyDropDeleted1695822248160 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
-            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\``);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
-                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0'`,
             );
         }
     }

--- a/components/gitpod-db/src/typeorm/migration/1695822248160-UserSshPublicKeyDropDeleted.ts
+++ b/components/gitpod-db/src/typeorm/migration/1695822248160-UserSshPublicKeyDropDeleted.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_user_ssh_public_key";
+const COLUMN_NAME = "deleted";
+
+export class UserSshPublicKeyDropDeleted1695822248160 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE \`${TABLE_NAME}\` DROP COLUMN \`${COLUMN_NAME}\`, ALGORITHM=INSTANT`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INSTANT`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -84,7 +84,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
 
     public async findTeamByMembershipId(membershipId: string): Promise<Team | undefined> {
         const membershipRepo = await this.getMembershipRepo();
-        const membership = await membershipRepo.findOne({ id: membershipId, deleted: false });
+        const membership = await membershipRepo.findOne({ id: membershipId });
         if (!membership) {
             return;
         }
@@ -94,7 +94,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
     public async findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]> {
         const membershipRepo = await this.getMembershipRepo();
         const userRepo = await this.getUserRepo();
-        const memberships = await membershipRepo.find({ teamId, deleted: false });
+        const memberships = await membershipRepo.find({ teamId });
         const users = await userRepo.findByIds(memberships.map((m) => m.userId));
         const infos = users.map((u) => {
             const m = memberships.find((m) => m.userId === u.id)!;
@@ -113,13 +113,13 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
 
     public async findTeamMembership(userId: string, teamId: string): Promise<DBTeamMembership | undefined> {
         const membershipRepo = await this.getMembershipRepo();
-        return membershipRepo.findOne({ userId, teamId, deleted: false });
+        return membershipRepo.findOne({ userId, teamId });
     }
 
     public async findTeamsByUser(userId: string): Promise<Team[]> {
         const teamRepo = await this.getTeamRepo();
         const membershipRepo = await this.getMembershipRepo();
-        const memberships = await membershipRepo.find({ userId, deleted: false });
+        const memberships = await membershipRepo.find({ userId });
         const teams = await teamRepo.findByIds(memberships.map((m) => m.teamId));
         return teams.filter((t) => !t.markedDeleted);
     }
@@ -251,7 +251,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
 
     private async deleteOrgSettings(orgId: string): Promise<void> {
         const orgSettingsRepo = await this.getOrgSettingsRepo();
-        const orgSettings = await orgSettingsRepo.findOne({ where: { orgId, deleted: false } });
+        const orgSettings = await orgSettingsRepo.findOne({ where: { orgId } });
         if (orgSettings) {
             orgSettings.deleted = true;
             orgSettingsRepo.save(orgSettings);
@@ -265,7 +265,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
-        const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
+        const membership = await membershipRepo.findOne({ teamId, userId });
         if (!!membership) {
             // already a member, this is the desired outcome
             return "already_member";
@@ -292,7 +292,6 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
             const allOwners = await membershipRepo.find({
                 teamId,
                 role: "owner",
-                deleted: false,
             });
             const otherOwnerCount = allOwners.filter((m) => m.userId != userId).length;
             if (otherOwnerCount === 0) {
@@ -300,7 +299,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
             }
         }
 
-        const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
+        const membership = await membershipRepo.findOne({ teamId, userId });
         if (!membership) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this organization");
         }
@@ -315,7 +314,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
-        const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
+        const membership = await membershipRepo.findOne({ teamId, userId });
         if (!membership) {
             throw new ApplicationError(
                 ErrorCodes.BAD_REQUEST,

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -340,10 +340,10 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
         }
     }
 
-    public async findTokensForIdentity(identity: Identity, includeDeleted?: boolean): Promise<TokenEntry[]> {
+    public async findTokensForIdentity(identity: Identity): Promise<TokenEntry[]> {
         const repo = await this.getTokenRepo();
         const entry = await repo.find({ authProviderId: identity.authProviderId, authId: identity.authId });
-        return entry.filter((te) => includeDeleted || !te.deleted);
+        return entry;
     }
 
     private mapUserToDBUser(user: User): DBUser {

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -221,7 +221,6 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
         } else {
             qBuilder.where("gitpodToken.tokenHash = :tokenHash", { tokenHash });
         }
-        qBuilder.andWhere("gitpodToken.deleted <> TRUE");
         const token = await qBuilder.getOne();
         if (!token) {
             return;

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -425,18 +425,18 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
 
     public async hasSSHPublicKey(userId: string): Promise<boolean> {
         const repo = await this.getSSHPublicKeyRepo();
-        return !!(await repo.findOne({ where: { userId, deleted: false } }));
+        return !!(await repo.findOne({ where: { userId } }));
     }
 
     public async getSSHPublicKeys(userId: string): Promise<UserSSHPublicKey[]> {
         const repo = await this.getSSHPublicKeyRepo();
-        return repo.find({ where: { userId, deleted: false }, order: { creationTime: "ASC" } });
+        return repo.find({ where: { userId }, order: { creationTime: "ASC" } });
     }
 
     public async addSSHPublicKey(userId: string, value: SSHPublicKeyValue): Promise<UserSSHPublicKey> {
         const repo = await this.getSSHPublicKeyRepo();
         const fingerprint = SSHPublicKeyValue.getFingerprint(value);
-        const allKeys = await repo.find({ where: { userId, deleted: false } });
+        const allKeys = await repo.find({ where: { userId } });
         const prevOne = allKeys.find((e) => e.fingerprint === fingerprint);
         if (!!prevOne) {
             throw new Error(`Key already in use`);

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -680,9 +680,6 @@ export interface GitpodToken {
 
     /** Created timestamp */
     created: string;
-
-    // token is deleted on the database and about to be collected by periodic deleter
-    deleted?: boolean;
 }
 
 export enum GitpodTokenType {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -751,8 +751,6 @@ export interface TokenEntry {
     token: Token;
     expiryDate?: string;
     refreshable?: boolean;
-    /** This is a flag that triggers the HARD DELETION of this entity */
-    deleted?: boolean;
 }
 
 export interface EmailDomainFilterEntry {

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -199,8 +199,6 @@ export interface Organization {
     slug?: string;
     creationTime: string;
     markedDeleted?: boolean;
-    /** This is a flag that triggers the HARD DELETION of this entity */
-    deleted?: boolean;
 }
 
 export interface OrganizationSettings {

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -47,8 +47,6 @@ export interface Project {
     appInstallationId: string;
     settings?: ProjectSettings;
     creationTime: string;
-    /** This is a flag that triggers the HARD DELETION of this entity */
-    deleted?: boolean;
     markedDeleted?: boolean;
 }
 

--- a/components/server/src/user/gitpod-token-service.ts
+++ b/components/server/src/user/gitpod-token-service.ts
@@ -21,7 +21,7 @@ export class GitpodTokenService {
     async getGitpodTokens(requestorId: string, userId: string): Promise<GitpodToken[]> {
         await this.auth.checkPermissionOnUser(requestorId, "read_tokens", userId);
         const gitpodTokens = await this.userDB.findAllGitpodTokensOfUser(userId);
-        return gitpodTokens.filter((v) => !v.deleted);
+        return gitpodTokens;
     }
 
     async generateNewGitpodToken(
@@ -55,9 +55,6 @@ export class GitpodTokenService {
             token = await this.userDB.findGitpodTokensOfUser(userId, tokenHash);
         } catch (error) {
             log.error({ userId }, "failed to resolve gitpod token: ", error);
-        }
-        if (token?.deleted) {
-            token = undefined;
         }
         return token;
     }


### PR DESCRIPTION
## Description
Depends on - and follow-up to: https://github.com/gitpod-io/gitpod/pull/18833

Deletes all the columns that we are not using anymore.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66cbbe5</samp>

This pull request removes the `deleted` column from various tables and entities in the `components/gitpod-db` module and replaces it with the `markedDeleted` column where applicable. It also drops some unused tables from the database schema. It adds migration scripts to apply these changes to the database. The purpose of this pull request is to simplify and update the database schema and the code that interacts with it.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-719

## How to test
 - check server logs, and verify that `database-gc` does execute without errors
 - create an org, and successfully delete it right after

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-719-deleted-2</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-719-deleted-2.preview.gitpod-dev.com/workspaces" target="_blank">gpl-719-deleted-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-719-deleted-2-gha.18120</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-719-deleted-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
