### PR TITLE
Fix loading state bug when creating new workspace

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -15,12 +15,16 @@ export const useUnifiedRepositorySearch = ({ searchString }: { searchString: str
     const searchQuery = useSearchRepositories({ searchString });
 
     const filteredRepos = useMemo(() => {
-        const repoMap = new Map<string, SuggestedRepository>((suggestedQuery.data || []).map((r) => [r.url, r]));
+        const repoMap = new Map<string, SuggestedRepository>(
+            (suggestedQuery.data || []).map((r) => [`${r.url}:${r.projectId || ""}`, r]),
+        );
 
         // Merge the search results into the suggested results
         for (const repo of searchQuery.data || []) {
-            if (!repoMap.has(repo.url)) {
-                repoMap.set(repo.url, repo);
+            const key = `${repo.url}:${repo.projectId || ""}`;
+
+            if (!repoMap.has(key)) {
+                repoMap.set(key, repo);
             }
         }
 

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -398,7 +398,7 @@ export function CreateWorkspacePage() {
                             selectedIdeOption={selectedIde}
                             useLatest={useLatestIde}
                             disabled={createWorkspaceMutation.isStarting}
-                            loading={workspaceContext.isLoading || !optionsLoaded}
+                            loading={workspaceContext.isLoading}
                         />
                     </InputField>
 
@@ -408,7 +408,7 @@ export function CreateWorkspacePage() {
                             setError={setErrorWsClass}
                             selectedWorkspaceClass={selectedWsClass}
                             disabled={createWorkspaceMutation.isStarting}
-                            loading={workspaceContext.isLoading || !optionsLoaded}
+                            loading={workspaceContext.isLoading}
                         />
                     </InputField>
                 </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a bug where on create workspace the editor & ws class hung in a loading state until a repo was selected. I've left the `optionsLoaded` state as it's used for preventing an autostart before we've loaded any previously used options, but am just not considering it for the loading state anymore.

I also fixed a bug I noticed where multiple projects w/ same repo wouldn't show up correctly after you started searching.

| Before | After |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/aecb83f4-b7ed-4195-aa4b-6970f5ef66bb) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/3d2e9d48-cd38-4e7f-a578-9b87459479c8) | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 366cbf4</samp>

This pull request improves the user experience and performance of the `CreateWorkspacePage` component by simplifying the loading logic and avoiding repository conflicts. It affects the files `CreateWorkspacePage.tsx` and `unified-repositories-search-query.ts`.

</details>

## How to test
<!-- Provide steps to test this PR -->

Open Create Workspace and verify the editor and class selectors aren't disabled in a loading state even when you don't have a repo selected.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-creat93d718e069</li>
	<li><b>🔗 URL</b> - <a href="https://brad-creat93d718e069.preview.gitpod-dev.com/workspaces" target="_blank">brad-creat93d718e069.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-create-ws-option-loading-bug-gha.18161</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-creat93d718e069%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
