### PR TITLE
Update Platform Version of JetBrains Backend Plugin (EAP) to 233.8264-EAP-CANDIDATE-SNAPSHOT

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -82,3 +82,6 @@ vscode:
         - esbenp.prettier-vscode
         - akosyakov.gitpod-monitor
         - hbenl.vscode-mocha-test-adapter
+jetbrains:
+  intellij:
+    vmoptions: -Xmx4g

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
-    id("org.jetbrains.kotlin.jvm") version "1.7.20"
+    id("org.jetbrains.kotlin.jvm") version "1.9.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "1.10.1"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=232.9921
-pluginUntilBuild=232.*
+pluginSinceBuild=233.8264
+pluginUntilBuild=233.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2023.2
+pluginVerifierIdeVersions=2023.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=232.9921-EAP-CANDIDATE-SNAPSHOT
+platformVersion=233.8264-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
@@ -7,6 +7,7 @@ package io.gitpod.jetbrains.remote
 import com.intellij.codeWithMe.ClientId
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.CommandLineProcessor
+import com.intellij.openapi.client.ClientKind
 import com.intellij.openapi.client.ClientSession
 import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.components.service
@@ -124,10 +125,10 @@ class GitpodCLIService : RestService() {
         var session: ClientSession? = null
         while (session == null) {
             if (project != null) {
-                session = ClientSessionsManager.getProjectSessions(project, false).firstOrNull()
+                session = ClientSessionsManager.getProjectSessions(project, ClientKind.REMOTE).firstOrNull()
             }
             if (session == null) {
-                session = ClientSessionsManager.getAppSessions(false).firstOrNull()
+                session = ClientSessionsManager.getAppSessions(ClientKind.REMOTE).firstOrNull()
             }
             if (session == null) {
                 delay(1000L)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

a fix for https://github.com/gitpod-io/gitpod/pull/18775
<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f73354</samp>

This pull request adds support for JetBrains IDEs in Gitpod workspaces, by updating the backend-plugin module and the `.gitpod.yml` file. It also updates the Kotlin plugin version and the IntelliJ Platform compatibility ranges for the plugin.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-fix-jb</li>
	<li><b>🔗 URL</b> - <a href="https://ak-fix-jb.preview.gitpod-dev.com/workspaces" target="_blank">ak-fix-jb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-fix_jb-gha.18188</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-fix-jb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
