### PR TITLE
[code] Cleanup unused replace rules

### DIFF
--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -21,21 +21,6 @@ import (
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	// todo(sje): find this value
-	hasOpenVSXProxy := true
-
-	// todo(sje): find this value
-	//nolint:typecheck
-	openVSXProxyUrl := "vsx-proxy-host"
-	if hasOpenVSXProxy {
-		openVSXProxyUrl = fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain)
-	}
-
-	// Check also link below before change values
-	// https://github.com/gitpod-io/gitpod/blob/2cba7bd1d8a2accd294ab7733f6da4532e48984c/components/ide/code/startup.sh#L37
-	extensionsGalleryItemUrl := "https://open-vsx.org/vscode/item"
-	trustedDomain := "https://open-vsx.org"
-
 	bscfg := blobserve_config.Config{
 		BlobServe: blobserve_config.BlobServe{
 			Port:    ContainerPort,
@@ -44,38 +29,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				ctx.RepoName(ctx.Config.Repository, ide.CodeIDEImage): {
 					PrePull: []string{},
 					Workdir: "/ide",
-					Replacements: []blobserve_config.StringReplacement{{
-						Search:      "vscode-cdn.net",
-						Replacement: ctx.Config.Domain,
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "https://open-vsx.org",
-						Replacement: openVSXProxyUrl,
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "{{extensionsGalleryItemUrl}}",
-						Replacement: extensionsGalleryItemUrl,
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "{{trustedDomain}}",
-						Replacement: trustedDomain,
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "ide.gitpod.io/code/markeplace.json",
-						Replacement: fmt.Sprintf("ide.%s/code/marketplace.json", ctx.Config.Domain),
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}},
 					// TODO consider to provide it as a part of image label or rather inline ${ide} and ${supervisor} in index.html
 					// to decouple blobserve and code image
 					InlineStatic: []blobserve_config.InlineReplacement{{
 						Search:      "{{WORKBENCH_WEB_BASE_URL}}",
 						Replacement: "${ide}",
-					}, {
-						Search:      "window.location.origin;",
-						Replacement: "'${ide}';",
-					}, {
-						Search:      "./out",
-						Replacement: "${ide}/out",
 					}, {
 						Search:      "/_supervisor/frontend",
 						Replacement: "${supervisor}",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc09d2c</samp>

This pull request simplifies the code and configuration of the `codehelper` and `blobserve` components, which are responsible for serving the VS Code web server to the IDE. It removes some unnecessary logic and variables that were used to customize the Open VSX registry URL, which is now handled by `blobserve` alone.

</details>

## How to test
<!-- Provide steps to test this PR -->
- Check vscode web works, webviews, web extension, gp validate, etc

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-managing-skunk</li>
	<li><b>🔗 URL</b> - <a href="https://jp-managing-skunk.preview.gitpod-dev.com/workspaces" target="_blank">jp-managing-skunk.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-managing-skunk-gha.18268</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-managing-skunk%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
