### PR TITLE
Fix account deletion modal

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -47,7 +47,12 @@ export const ConfirmationModal: FC<Props> = ({
     }, [onConfirm]);
 
     return (
-        <Modal visible={visible === undefined ? true : visible} onClose={onClose} onSubmit={handleSubmit}>
+        <Modal
+            visible={visible === undefined ? true : visible}
+            onClose={onClose}
+            onSubmit={handleSubmit}
+            disabled={buttonDisabled}
+        >
             <ModalHeader>{title}</ModalHeader>
             <ModalBody>
                 {warningText && (

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -28,6 +28,7 @@ type Props = {
     autoFocus?: boolean;
     disableFocusLock?: boolean;
     className?: string;
+    disabled?: boolean;
     onClose: () => void;
     onSubmit?: () => void | Promise<void>;
 };
@@ -42,6 +43,7 @@ export const Modal: FC<Props> = ({
     autoFocus = false,
     disableFocusLock = false,
     className,
+    disabled = false,
     onClose,
     onSubmit,
 }) => {
@@ -103,7 +105,7 @@ export const Modal: FC<Props> = ({
                             aria-labelledby="modal-header"
                             tabIndex={-1}
                         >
-                            <MaybeWithForm onSubmit={onSubmit}>
+                            <MaybeWithForm onSubmit={onSubmit} disabled={disabled}>
                                 {closeable && <ModalCloseIcon onClose={() => closeModal("x")} />}
                                 {title ? (
                                     <>
@@ -127,8 +129,9 @@ export default Modal;
 
 type MaybeWithFormProps = {
     onSubmit: Props["onSubmit"];
+    disabled: Props["disabled"];
 };
-const MaybeWithForm: FC<MaybeWithFormProps> = ({ onSubmit, children }) => {
+const MaybeWithForm: FC<MaybeWithFormProps> = ({ onSubmit, disabled, children }) => {
     const handleSubmit = useCallback(
         (e: FormEvent) => {
             e.preventDefault();
@@ -147,7 +150,7 @@ const MaybeWithForm: FC<MaybeWithFormProps> = ({ onSubmit, children }) => {
     return (
         <form onSubmit={handleSubmit}>
             {/* including a hidden submit button ensures submit on enter works despite a button w/ type="submit" existing or not */}
-            <input type="submit" className="hidden" hidden />
+            <input type="submit" className="hidden" hidden disabled={disabled} />
             {children}
         </form>
     );


### PR DESCRIPTION
## Description

Fixes accidental account deletions by preventing the modal submission via the keyboard. This essentially meant that the email didn't have to match for a user to delete their account, which, at that stage, might be unexpected.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f8c8e4</samp>

Add `disabled` prop to `Modal` and `ConfirmationModal` components to improve user feedback and prevent unwanted actions.

</details>

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-prevent6fc83b89fe</li>
	<li><b>🔗 URL</b> - <a href="https://ft-prevent6fc83b89fe.preview.gitpod-dev.com/workspaces" target="_blank">ft-prevent6fc83b89fe.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-prevent-accidental-account-deletions-gha.18281</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-prevent6fc83b89fe%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

