### PR TITLE
[server] (re)move deprecated properties

### DIFF
--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -19,45 +19,6 @@ export interface ProjectSettings {
      */
     prebuilds?: PrebuildSettings;
 
-    /** @deprecated see `Project.settings.prebuilds.enabled` instead. */
-    enablePrebuilds?: boolean;
-    /**
-     * Wether prebuilds (if enabled) should only be started on the default branch.
-     * Defaults to `true` on project creation.
-     *
-     * @deprecated see `Project.settings.prebuilds.branchStrategy` instead.
-     */
-    prebuildDefaultBranchOnly?: boolean;
-    /**
-     * Use this pattern to match branch names to run prebuilds on.
-     * The pattern matching will only be applied if prebuilds are enabled and
-     * they are not limited to the default branch.
-     *
-     * @deprecated see `Project.settings.prebuilds.branchMatchingPattern` instead.
-     */
-    prebuildBranchPattern?: string;
-    /**
-     * how many commits in the commit history a prebuild is good (undefined and 0 means every commit is prebuilt)
-     *
-     * @deprecated see `Project.settings.prebuilds.intervall` instead.
-     */
-    prebuildEveryNthCommit?: number;
-
-    /**
-     * @deprecated always false
-     */
-    useIncrementalPrebuilds?: boolean;
-
-    /**
-     * @deprecated always true (we should kill dangling prebuilds)
-     */
-    keepOutdatedPrebuildsRunning?: boolean;
-    // whether new workspaces can start on older prebuilds and incrementally update
-    /**
-     * @deprecated always true
-     */
-    allowUsingPreviousPrebuilds?: boolean;
-
     // preferred workspace classes
     workspaceClasses?: WorkspaceClasses;
 }

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -15,7 +15,7 @@ import "mocha";
 import { OrganizationService } from "../orgs/organization-service";
 import { expectError } from "../test/expect-utils";
 import { createTestContainer } from "../test/service-testing-container-module";
-import { ProjectsService } from "./projects-service";
+import { OldProjectSettings, ProjectsService } from "./projects-service";
 import { daysBefore } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 
 const expect = chai.expect;
@@ -200,7 +200,7 @@ describe("ProjectsService", async () => {
             name: "my-project",
             cloneUrl,
             creationTime: daysBefore(new Date().toISOString(), 20),
-            settings: {
+            settings: <OldProjectSettings>{
                 enablePrebuilds: true,
                 prebuildEveryNthCommit: 3,
                 workspaceClasses: { prebuild: "ultra" },
@@ -225,7 +225,7 @@ describe("ProjectsService", async () => {
             name: "my-project",
             cloneUrl,
             creationTime: daysBefore(new Date().toISOString(), 1),
-            settings: {
+            settings: <OldProjectSettings>{
                 enablePrebuilds: true,
                 prebuildEveryNthCommit: 3,
                 workspaceClasses: { prebuild: "ultra" },
@@ -250,7 +250,7 @@ describe("ProjectsService", async () => {
             name: "my-project",
             cloneUrl,
             creationTime: daysBefore(new Date().toISOString(), 1),
-            settings: {
+            settings: <OldProjectSettings>{
                 enablePrebuilds: true,
                 prebuildEveryNthCommit: 13,
                 workspaceClasses: { prebuild: "ultra" },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ab954e</samp>

This pull request refactors the prebuild settings logic for projects and migrates the old settings to the new format. It updates the `ProjectSettings` interface, the `ProjectsService` class, and the related tests. It also removes the deprecated fields from the interface.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
