### PR TITLE
[server] SpiceDB: Add metric for consistency usage

### DIFF
--- a/components/server/src/authorization/caching-spicedb-authorizer.ts
+++ b/components/server/src/authorization/caching-spicedb-authorizer.ts
@@ -139,7 +139,7 @@ export class RequestLocalZedTokenCache implements ZedTokenCache {
             if (!prev || prev.timestamp < curr.timestamp) {
                 return curr;
             }
-            return curr;
+            return prev;
         }, undefined);
     }
 }

--- a/components/server/src/authorization/caching-spicedb-authorizer.ts
+++ b/components/server/src/authorization/caching-spicedb-authorizer.ts
@@ -11,6 +11,7 @@ import { inject, injectable } from "inversify";
 import { clearZedTokenOnContext, getZedTokenFromContext, setZedTokenToContext } from "../util/log-context";
 import { base64decode } from "@jmondi/oauth2-server";
 import { DecodedZedToken } from "@gitpod/spicedb-impl/lib/impl/v1/impl.pb";
+import { incSpiceDBRequestsCheckTotal } from "../prometheus-metrics";
 
 export type ZedTokenCacheKV = [objectRef: v1.ObjectReference | undefined, token: string | undefined];
 export const ZedTokenCache = Symbol("ZedTokenCache");
@@ -36,6 +37,8 @@ export class CachingSpiceDBAuthorizer implements SpiceDBAuthorizer {
         forceEnablement?: boolean | undefined,
     ): Promise<CheckResult> {
         req.consistency = await this.tokenCache.consistency(req.resource);
+        incSpiceDBRequestsCheckTotal(req.consistency?.requirement?.oneofKind || "undefined");
+
         const result = await this.impl.check(req, experimentsFields, forceEnablement);
         if (result.checkedAt) {
             await this.tokenCache.set([req.resource, result.checkedAt]);

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -352,3 +352,19 @@ export type GuardAccessCheckType = "fga" | "resource-access";
 export function reportGuardAccessCheck(type: GuardAccessCheckType) {
     guardAccessChecksTotal.labels(type).inc();
 }
+
+export const spicedbCheckRequestsTotal = new prometheusClient.Counter({
+    name: "gitpod_spicedb_requests_check_total",
+    help: "Counter for the number of check requests against SpiceDB",
+    labelNames: ["consistency"],
+});
+
+export type SpiceDBCheckConsistency =
+    | "minimizeLatency"
+    | "atLeastAsFresh"
+    | "atExactSnapshot"
+    | "fullyConsistent"
+    | "undefined";
+export function incSpiceDBRequestsCheckTotal(consistency: SpiceDBCheckConsistency) {
+    spicedbCheckRequestsTotal.labels(consistency).inc();
+}


### PR DESCRIPTION
## Description
1. adds test (and actually fixes ordering of! :see_no_evil: ) ZedTokens. This should not affect prod, though, because of our short token live span
2. introduced `incSpiceDBRequestsCheckTotal` to understand how many of our check requests are actually performed with `fullyConsistent` vs `atLeastAsFresh`

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f77ae12</samp>

This pull request adds a new class and test suite for caching Zed tokens per request, improves the performance and reliability of authorization checks with SpiceDB, adds Prometheus metrics for SpiceDB check requests, and fixes a cache bug in the `CachingSpiceDBAuthorizer` class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
