### PR TITLE
[dashboard] Add global timeout for Public APIs and better error message

### DIFF
--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -73,6 +73,7 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
     const orgs = useOrganizations();
     const user = useCurrentUser();
 
+    console.log("======useCurrentOrg", orgs.isLoading, user);
     if (orgs.isLoading || !orgs.data || !user) {
         return { data: undefined, isLoading: true };
     }
@@ -81,6 +82,7 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
     if (orgIdParam) {
         orgId = orgIdParam;
     }
+    console.log("======useCurrentOrg.2", orgId);
     let org = orgs.data.find((org) => org.id === orgId);
     if (!org) {
         org = orgs.data[0];

--- a/components/dashboard/src/data/organizations/orgs-query.ts
+++ b/components/dashboard/src/data/organizations/orgs-query.ts
@@ -73,7 +73,6 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
     const orgs = useOrganizations();
     const user = useCurrentUser();
 
-    console.log("======useCurrentOrg", orgs.isLoading, user);
     if (orgs.isLoading || !orgs.data || !user) {
         return { data: undefined, isLoading: true };
     }
@@ -82,7 +81,6 @@ export function useCurrentOrg(): { data?: OrganizationInfo; isLoading: boolean }
     if (orgIdParam) {
         orgId = orgIdParam;
     }
-    console.log("======useCurrentOrg.2", orgId);
     let org = orgs.data.find((org) => org.id === orgId);
     if (!org) {
         org = orgs.data[0];

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -58,7 +58,7 @@ export const workspacesService = wrapServiceError(createPromiseClient(Workspaces
 export const oidcService = wrapServiceError(createPromiseClient(OIDCService, transport));
 
 // We use Proxy here instead of add interceptor to transport
-// that's because AbortError is out of interceptor, connect-es will be force convert to deadline_exceeded
+// that's because AbortError is out of interceptor, connect-es will force convert error to deadline_exceeded
 // @see https://github.com/connectrpc/connect-es/blob/e0bffbab4e75e19fd7eeb9eadabe050941d39e5f/packages/connect/src/protocol/run-call.ts#L174-L181
 function wrapServiceError<T extends object>(service: T): T {
     return new Proxy(service, {
@@ -68,7 +68,7 @@ function wrapServiceError<T extends object>(service: T): T {
                     // @ts-ignore
                     return await target[prop](...args);
                 } catch (e) {
-                    throw new WrapError(`failed to call papi: ${String(prop)}`, e);
+                    throw new WrapError(`failed to call API [${String(prop)}]`, e);
                 }
             };
         },

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -22,7 +22,7 @@ import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_
 const transport = createConnectTransport({
     baseUrl: `${window.location.protocol}//${window.location.host}/public-api`,
     interceptors: [getMetricsInterceptor()],
-    // defaultTimeoutMs: 4000,
+    defaultTimeoutMs: 4000,
 });
 
 export const helloService = createPromiseClient(HelloService, transport);

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -22,6 +22,7 @@ import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_
 const transport = createConnectTransport({
     baseUrl: `${window.location.protocol}//${window.location.host}/public-api`,
     interceptors: [getMetricsInterceptor()],
+    // defaultTimeoutMs: 4000,
 });
 
 export const helloService = createPromiseClient(HelloService, transport);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2197,6 +2197,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkUser("getOrganizations");
         const orgs = await this.organizationService.listOrganizationsByMember(user.id, user.id);
 
+        const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        await sleep(5000);
+
         const filterOrg = async (org: Organization): Promise<Organization | undefined> => {
             const members = await this.organizationService.listMembers(user.id, org.id);
             if (!(await this.resourceAccessGuard.canAccess({ kind: "team", subject: org, members }, "get"))) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Add default `4s` timeout to public api
- Wrap public api errors to add method name

On dashboard, we will see changes (If listTeams API hang)

|Before|After Add Timeout 👍 | After Wrap Errors 👍|
|:-:|:-:|:-:|
|Show hanging page until server respond (never timeout), and never log errors |Timeout for 4s, and after useQueryRetry, log errors and goes to Error page| Same with `After Add Timeout` + better error message wrap | 
|<img width="1512" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/8e8b948f-20b1-4f1b-b937-05007df4a5bb">|<img width="1512" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/454f08aa-141f-4426-bd35-bfb334668735">|<img width="1512" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/100656dc-cc48-440b-8bb4-cc0892db36d9">|


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5990704</samp>

This pull request improves the error handling of the public API calls and adds a temporary delay for testing the dashboard UI. It introduces a `WrapError` class and a `wrapServiceError` function in `public-api.ts`, and a `WIP` delay in `gitpod-server-impl.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related EXP-775

## How to test
<!-- Provide steps to test this PR -->
- Debug commit has added, it mocked listTeams API hanging situation
- Go to preview env, it should stuck on /workspaces page and lead to Error page like below


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-papi-hang</li>
	<li><b>🔗 URL</b> - <a href="https://hw-papi-hang.preview.gitpod-dev.com/workspaces" target="_blank">hw-papi-hang.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-papi-hang-gha.18331</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-papi-hang%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
