### PR TITLE
[fga] further debug sharing issue

### DIFF
--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -428,51 +428,6 @@ export class Authorizer {
             rels.push(set(rel.workspace(workspaceID).shared.anyUser));
         }
         await this.authorizer.writeRelationships(...rels);
-
-        (async () => {
-            //TODO(se) remove this double checking once we're confident that the above works
-            // check if the relationships were written
-            try {
-                const wsToOrgRel = await this.find(rel.workspace(workspaceID).org.organization(orgID));
-                if (!wsToOrgRel) {
-                    log.error("Failed to write workspace to org relationship", {
-                        orgID,
-                        userID,
-                        workspaceID,
-
-                        shared,
-                    });
-                }
-                const wsToOwnerRel = await this.find(rel.workspace(workspaceID).owner.user(userID));
-                if (!wsToOwnerRel) {
-                    log.error("Failed to write workspace to owner relationship", {
-                        orgID,
-                        userID,
-                        workspaceID,
-                        shared,
-                    });
-                }
-                if (shared) {
-                    const wsSharedRel = await this.find(rel.workspace(workspaceID).shared.anyUser);
-                    if (!wsSharedRel) {
-                        log.error("Failed to write workspace shared relationship", {
-                            orgID,
-                            userID,
-                            workspaceID,
-                            shared,
-                        });
-                    }
-                }
-            } catch (error) {
-                log.error("Failed to check workspace relationships", {
-                    orgID,
-                    userID,
-                    workspaceID,
-                    shared,
-                    error,
-                });
-            }
-        })().catch((error) => log.error({ userId: userID }, "Failed to check workspace relationships", { error }));
     }
 
     async removeWorkspaceFromOrg(orgID: string, userID: string, workspaceID: string): Promise<void> {
@@ -490,8 +445,19 @@ export class Authorizer {
         if (!(await isFgaWritesEnabled(userID))) {
             return;
         }
-        const op = shared ? set : remove;
-        await this.authorizer.writeRelationships(op(rel.workspace(workspaceID).shared.anyUser));
+        if (shared) {
+            await this.authorizer.writeRelationships(set(rel.workspace(workspaceID).shared.anyUser));
+
+            // verify the relationship is there
+            const rs = await this.find(rel.workspace(workspaceID).shared.anyUser);
+            if (!rs) {
+                log.error("Failed to set workspace as shared", { workspaceID, userID });
+            } else {
+                log.info("Successfully set workspace as shared", { workspaceID, userID });
+            }
+        } else {
+            await this.authorizer.writeRelationships(remove(rel.workspace(workspaceID).shared.anyUser));
+        }
     }
 
     public async find(relation: v1.Relationship): Promise<v1.Relationship | undefined> {

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -130,7 +130,10 @@ export class SpiceDBAuthorizerImpl implements SpiceDBAuthorizer {
                     this.callOptions,
                 ),
             );
-            log.info("[spicedb] Successfully wrote relationships.", { response, updates });
+            log.info("[spicedb] Successfully wrote relationships.", {
+                response: new TrustedValue(response),
+                updates: new TrustedValue(updates),
+            });
 
             return response;
         } finally {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 328709e</samp>

This pull request refactors and enhances the authorizer module for workspace sharing. It removes redundant code, adds verification and logging, and wraps SpiceDB objects in `TrustedValue` instances.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
