### PR TITLE
[grafana] SpiceDB: add graph for request consistency

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/spicedb.json
+++ b/operations/observability/mixins/meta/dashboards/components/spicedb.json
@@ -623,7 +623,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "opm"
         },
         "overrides": [
           {
@@ -687,7 +688,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "rate (sum (spicedb_cache_hits_total[$__rate_interval]))",
+          "expr": "sum (increase (spicedb_cache_hits_total[$__rate_interval]))",
           "legendFormat": "Hit",
           "range": true,
           "refId": "A"
@@ -698,23 +699,11 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "rate (sum (spicedb_cache_misses_total[$__rate_interval]))",
+          "expr": "sum (increase (spicedb_cache_misses_total[$__rate_interval]))",
           "hide": false,
           "legendFormat": "Miss",
           "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P4169E866C3094E38"
-          },
-          "editorMode": "code",
-          "expr": "spicedb",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C"
         }
       ],
       "title": "Cache Hit & Miss Rates [1m]",
@@ -802,21 +791,106 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "rate (sum (spicedb_cache_hits_total[$__rate_interval])) / rate (sum (spicedb_cache_misses_total[$__rate_interval]))",
+          "expr": "sum (increase (spicedb_cache_hits_total[$__rate_interval])) / sum (increase (spicedb_cache_misses_total[$__rate_interval]))",
           "legendFormat": "Ratio",
           "range": true,
           "refId": "A"
+        }
+      ],
+      "title": "Cache Hit/Miss Ratio [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "opm"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "P4169E866C3094E38"
           },
-          "hide": false,
-          "refId": "C"
+          "editorMode": "code",
+          "expr": "sum(increase (gitpod_spicedb_requests_check_total[$__rate_interval])) by (consistency)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "title": "Cache Hit/Miss Ratio[1m]",
+      "title": "Check Request Consistency [1m] (client reported)",
       "type": "timeseries"
     }
   ],
@@ -846,6 +920,6 @@
   "timezone": "utc",
   "title": "Gitpod / Components / spicedb",
   "uid": "tw0BBk-Vz",
-  "version": 1,
+  "version": 2,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Description
Adds this new graph to the "Cache" row: 
![image](https://github.com/gitpod-io/gitpod/assets/32448529/f7162adc-2d35-4baa-a6c0-eb9e6fd2cf72)

Also, fixes some of the earlier queries.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0a8d2d</samp>

Improve spicedb dashboard with better cache metrics, check consistency panel, and formatting fixes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
