### PR TITLE
[spicedb] Fix application of migrations with ArgoCD

### DIFF
--- a/components/server/src/authorization/relationship-updater.ts
+++ b/components/server/src/authorization/relationship-updater.ts
@@ -16,7 +16,7 @@ import { RedisMutex } from "../redis/mutex";
 
 @injectable()
 export class RelationshipUpdater {
-    public static readonly version = 4;
+    public static readonly version = 5;
 
     constructor(
         @inject(UserDB) private readonly userDB: UserDB,

--- a/components/spicedb/buf.gen.yaml
+++ b/components/spicedb/buf.gen.yaml
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S buf generate --template buf.gen.yaml https://github.com/authzed/spicedb.git#tag=v1.22.2 --path proto/internal/impl/v1/impl.proto
+#!/usr/bin/env -S buf generate https://github.com/authzed/spicedb.git#tag=v1.25.0 --path=proto/internal/impl/v1/impl.proto --template
 # The version refers to the version of the SpiceDB image/binary that we are running
 version: v1
 plugins:

--- a/components/spicedb/typescript/src/impl/v1/impl.pb.ts
+++ b/components/spicedb/typescript/src/impl/v1/impl.pb.ts
@@ -57,6 +57,8 @@ export interface V1Cursor {
    * parameters, including limits and zedtoken, to ensure no inputs changed when using this cursor.
    */
   callAndParametersHash: string;
+  /** dispatch_version is the version of the dispatcher which created the cursor. */
+  dispatchVersion: number;
 }
 
 export interface DocComment {
@@ -662,7 +664,7 @@ export const DecodedCursor = {
 };
 
 function createBaseV1Cursor(): V1Cursor {
-  return { revision: "", sections: [], callAndParametersHash: "" };
+  return { revision: "", sections: [], callAndParametersHash: "", dispatchVersion: 0 };
 }
 
 export const V1Cursor = {
@@ -675,6 +677,9 @@ export const V1Cursor = {
     }
     if (message.callAndParametersHash !== "") {
       writer.uint32(26).string(message.callAndParametersHash);
+    }
+    if (message.dispatchVersion !== 0) {
+      writer.uint32(32).uint32(message.dispatchVersion);
     }
     return writer;
   },
@@ -707,6 +712,13 @@ export const V1Cursor = {
 
           message.callAndParametersHash = reader.string();
           continue;
+        case 4:
+          if (tag !== 32) {
+            break;
+          }
+
+          message.dispatchVersion = reader.uint32();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -721,6 +733,7 @@ export const V1Cursor = {
       revision: isSet(object.revision) ? String(object.revision) : "",
       sections: Array.isArray(object?.sections) ? object.sections.map((e: any) => String(e)) : [],
       callAndParametersHash: isSet(object.callAndParametersHash) ? String(object.callAndParametersHash) : "",
+      dispatchVersion: isSet(object.dispatchVersion) ? Number(object.dispatchVersion) : 0,
     };
   },
 
@@ -735,6 +748,9 @@ export const V1Cursor = {
     if (message.callAndParametersHash !== "") {
       obj.callAndParametersHash = message.callAndParametersHash;
     }
+    if (message.dispatchVersion !== 0) {
+      obj.dispatchVersion = Math.round(message.dispatchVersion);
+    }
     return obj;
   },
 
@@ -746,6 +762,7 @@ export const V1Cursor = {
     message.revision = object.revision ?? "";
     message.sections = object.sections?.map((e) => e) || [];
     message.callAndParametersHash = object.callAndParametersHash ?? "";
+    message.dispatchVersion = object.dispatchVersion ?? 0;
     return message;
   },
 };

--- a/install/installer/pkg/components/spicedb/migrations.go
+++ b/install/installer/pkg/components/spicedb/migrations.go
@@ -28,10 +28,20 @@ func migrations(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	objectMeta := metav1.ObjectMeta{
-		Name:        fmt.Sprintf("%s-migrations", Component),
-		Namespace:   ctx.Namespace,
-		Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaBatchJob),
-		Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaBatchJob),
+		Name:      fmt.Sprintf("%s-migrations", Component),
+		Namespace: ctx.Namespace,
+		Labels:    common.CustomizeLabel(ctx, Component, common.TypeMetaBatchJob),
+		Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaBatchJob, func() map[string]string {
+			// Because we are using ArgoCD to deploy, we need to add these annotations so:
+			// 1. it knows when to apply it (during the "Sync" hook, the same phase the all other manifests are applied)
+			// 2. that it should remove it once it is done
+			//   - this is necessary so it does not show up as "ouf of sync" once the "TTLSecondsAfterFinished" option kicks in
+			//   - if we would not remove the job at all, we would have a name clash an future updates ("field is immutable")
+			return map[string]string{
+				"argocd.argoproj.io/hook":               "Sync",
+				"argocd.argoproj.io/hook-delete-policy": "HookSucceeded",
+			}
+		}),
 	}
 
 	return []runtime.Object{


### PR DESCRIPTION
## Description



<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a40957f</samp>

Updated the TypeScript code and the Kubernetes job for SpiceDB to use the latest version and features of the SpiceDB schema and API. Added a `dispatchVersion` property to the `V1Cursor` type to track the dispatcher version. Simplified the code generation command for the SpiceDB proto files.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of EXP-792

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
