### PR TITLE
[spicedb] Apply migrations in the ArgoCD PreSync hook

### DIFF
--- a/install/installer/pkg/components/spicedb/migrations.go
+++ b/install/installer/pkg/components/spicedb/migrations.go
@@ -33,12 +33,13 @@ func migrations(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Labels:    common.CustomizeLabel(ctx, Component, common.TypeMetaBatchJob),
 		Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaBatchJob, func() map[string]string {
 			// Because we are using ArgoCD to deploy, we need to add these annotations so:
-			// 1. it knows when to apply it (during the "Sync" hook, the same phase the all other manifests are applied)
+			// 1. it knows when to apply it (during the "PreSync" hook, before other manifests are applied)
 			// 2. that it should remove it once it is done
 			//   - this is necessary so it does not show up as "ouf of sync" once the "TTLSecondsAfterFinished" option kicks in
 			//   - if we would not remove the job at all, we would have a name clash an future updates ("field is immutable")
+			// docs: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#usage
 			return map[string]string{
-				"argocd.argoproj.io/hook":               "Sync",
+				"argocd.argoproj.io/hook":               "PreSync",
 				"argocd.argoproj.io/hook-delete-policy": "HookSucceeded",
 			}
 		}),


### PR DESCRIPTION
## Description
Follow up for https://github.com/gitpod-io/gitpod/pull/18910

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e639039</samp>

Use ArgoCD PreSync hook for spicedb migrations job. This ensures that the database schema is updated before the spicedb service starts.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-793

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
