### PR TITLE
[eng-874] workspace creating time metric

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -248,7 +248,6 @@ func (m *controllerMetrics) forgetWorkspace(ws *workspacev1.Workspace) {
 type metricState struct {
 	phase                   workspacev1.WorkspacePhase
 	creatingStartTime       time.Time
-	recordedCreatingTimeEnd bool
 	recordedStartTime       bool
 	recordedInitFailure     bool
 	recordedStartFailure    bool

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -329,11 +329,11 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 		lastState.recordedFailure = true
 	}
 
-	if !lastState.recordedCreatingTimeStart && workspace.Status.Phase == workspacev1.WorkspacePhaseCreating {
-		lastState.recordedCreatingTimeStart = true
-	} else if lastState.recordedCreatingTimeStart && !lastState.recordedCreatingTimeEnd && workspace.Status.Phase != workspacev1.WorkspacePhaseCreating {
-		r.metrics.recordWorkspaceCreatingTime(&log, workspace)
-		lastState.recordedCreatingTimeEnd = true
+	if lastState.creatingStartTime.IsZero() && workspace.Status.Phase == workspacev1.WorkspacePhaseCreating {
+		lastState.creatingStartTime = time.Now()
+	} else if !lastState.creatingStartTime.IsZero() && workspace.Status.Phase != workspacev1.WorkspacePhaseCreating {
+		r.metrics.recordWorkspaceCreatingTime(&log, workspace, lastState.creatingStartTime)
+		lastState.creatingStartTime = time.Time{}
 	}
 
 	if !lastState.recordedContentReady && workspace.IsConditionTrue(workspacev1.WorkspaceConditionContentReady) {

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -329,6 +329,13 @@ func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *work
 		lastState.recordedFailure = true
 	}
 
+	if !lastState.recordedCreatingTimeStart && workspace.Status.Phase == workspacev1.WorkspacePhaseCreating {
+		lastState.recordedCreatingTimeStart = true
+	} else if lastState.recordedCreatingTimeStart && !lastState.recordedCreatingTimeEnd && workspace.Status.Phase != workspacev1.WorkspacePhaseCreating {
+		r.metrics.recordWorkspaceCreatingTime(&log, workspace)
+		lastState.recordedCreatingTimeEnd = true
+	}
+
 	if !lastState.recordedContentReady && workspace.IsConditionTrue(workspacev1.WorkspaceConditionContentReady) {
 		r.metrics.countTotalRestores(&log, workspace)
 		lastState.recordedContentReady = true

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -90,16 +90,6 @@ var _ = Describe("WorkspaceController", func() {
 				}}
 			})
 
-			// Transition Pod to running, and expect workspace to reach Running phase.
-			// This should also cause e.g. startup time metrics to be recorded.
-			updateObjWithRetries(k8sClient, pod, true, func(pod *corev1.Pod) {
-				pod.Status.Phase = corev1.PodRunning
-				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-					Name:  "workspace",
-					Ready: true,
-				}}
-			})
-
 			updateObjWithRetries(k8sClient, ws, true, func(ws *workspacev1.Workspace) {
 				ws.Status.SetCondition(workspacev1.NewWorkspaceConditionContentReady(metav1.ConditionTrue, workspacev1.ReasonInitializationSuccess, ""))
 			})

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -64,6 +64,32 @@ var _ = Describe("WorkspaceController", func() {
 				g.Expect(ws.Status.URL).ToNot(BeEmpty())
 			}, timeout, interval).Should(Succeed())
 
+			// Transition Pod to running, and expect workspace to reach Creating  phase.
+			// This should also cause create time metrics to be recorded.
+			updateObjWithRetries(k8sClient, pod, true, func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ContainerCreating",
+						},
+					},
+					Name: "workspace",
+				}}
+			})
+
+			expectPhaseEventually(ws, workspacev1.WorkspacePhaseCreating)
+
+			// Transition Pod to running, and expect workspace to reach Running phase.
+			// This should also cause e.g. startup time metrics to be recorded.
+			updateObjWithRetries(k8sClient, pod, true, func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  "workspace",
+					Ready: true,
+				}}
+			})
+
 			// Transition Pod to running, and expect workspace to reach Running phase.
 			// This should also cause e.g. startup time metrics to be recorded.
 			updateObjWithRetries(k8sClient, pod, true, func(pod *corev1.Pod) {
@@ -96,10 +122,11 @@ var _ = Describe("WorkspaceController", func() {
 			}, duration, interval).Should(Succeed(), "pod came back")
 
 			expectMetricsDelta(m, collectMetricCounts(wsMetrics, ws), metricCounts{
-				starts:   1,
-				restores: 1,
-				stops:    map[StopReason]int{StopReasonRegular: 1},
-				backups:  1,
+				starts:         1,
+				creatingCounts: 1,
+				restores:       1,
+				stops:          map[StopReason]int{StopReasonRegular: 1},
+				backups:        1,
 			})
 		})
 
@@ -799,6 +826,7 @@ func createSecret(name, namespace string) *corev1.Secret {
 
 type metricCounts struct {
 	starts          int
+	creatingCounts  int
 	startFailures   int
 	failures        int
 	stops           map[StopReason]int
@@ -823,12 +851,14 @@ func collectMetricCounts(wsMetrics *controllerMetrics, ws *workspacev1.Workspace
 	tpe := string(ws.Spec.Type)
 	cls := ws.Spec.Class
 	startHist := wsMetrics.startupTimeHistVec.WithLabelValues(tpe, cls).(prometheus.Histogram)
+	creatingHist := wsMetrics.creatingTimeHistVec.WithLabelValues(tpe, cls).(prometheus.Histogram)
 	stopCounts := make(map[StopReason]int)
 	for _, reason := range stopReasons {
 		stopCounts[reason] = int(testutil.ToFloat64(wsMetrics.totalStopsCounterVec.WithLabelValues(string(reason), tpe, cls)))
 	}
 	return metricCounts{
 		starts:          int(collectHistCount(startHist)),
+		creatingCounts:  int(collectHistCount(creatingHist)),
 		startFailures:   int(testutil.ToFloat64(wsMetrics.totalStartsFailureCounterVec.WithLabelValues(tpe, cls))),
 		failures:        int(testutil.ToFloat64(wsMetrics.totalFailuresCounterVec.WithLabelValues(tpe, cls))),
 		stops:           stopCounts,
@@ -843,6 +873,7 @@ func expectMetricsDelta(initial metricCounts, cur metricCounts, expectedDelta me
 	GinkgoHelper()
 	By("checking metrics have been recorded")
 	Expect(cur.starts-initial.starts).To(Equal(expectedDelta.starts), "expected metric count delta for starts")
+	Expect(cur.creatingCounts-initial.creatingCounts).To(Equal(expectedDelta.creatingCounts), "expected metric count delta for creating count")
 	Expect(cur.startFailures-initial.startFailures).To(Equal(expectedDelta.startFailures), "expected metric count delta for startFailures")
 	Expect(cur.failures-initial.failures).To(Equal(expectedDelta.failures), "expected metric count delta for failures")
 	for _, reason := range stopReasons {

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -64,10 +64,10 @@ var _ = Describe("WorkspaceController", func() {
 				g.Expect(ws.Status.URL).ToNot(BeEmpty())
 			}, timeout, interval).Should(Succeed())
 
-			// Transition Pod to running, and expect workspace to reach Creating  phase.
+			// Transition Pod to pending, and expect workspace to reach Creating  phase.
 			// This should also cause create time metrics to be recorded.
 			updateObjWithRetries(k8sClient, pod, true, func(pod *corev1.Pod) {
-				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Phase = corev1.PodPending
 				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
 					State: corev1.ContainerState{
 						Waiting: &corev1.ContainerStateWaiting{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds `workspace_creating_seconds` histogram metric.

This feels...wrong, though.  

Also I'm tempted to store the time when the ws went into creating phase, and just ignore the case between the controller restarts and lose info for some workspaces - which should be slightly better.

I'm not really familiar with ws-manager, so let me know if you can think of another way to get that metric.

cc @WVerlaek as I see you wrote a big chunk of that
cc @Furisto as I guess that was your idea per [the issue](https://linear.app/gitpod/issue/ENG-874/export-containerd-metrics-to-get-workspace-image-pull-duration#comment-1d24535e)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b99200c</samp>

Add a new metric to measure workspace creation time. The metric, `workspaceCreatingSeconds`, is defined and exposed in the `controllers` package. It is recorded in the `workspace_controller.go` file based on the workspace state transitions.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
