### PR TITLE
add new repo list/detail routes behind flag

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -39,6 +39,7 @@ import PersonalAccessTokenCreateView from "../user-settings/PersonalAccessTokens
 import { CreateWorkspacePage } from "../workspaces/CreateWorkspacePage";
 import { WebsocketClients } from "./WebsocketClients";
 import { BlockedEmailDomains } from "../admin/BlockedEmailDomains";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));
 const Account = React.lazy(() => import(/* webpackPrefetch: true */ "../user-settings/Account"));
@@ -75,12 +76,17 @@ const WorkspacesSearch = React.lazy(() => import(/* webpackPrefetch: true */ "..
 const ProjectsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "../admin/ProjectsSearch"));
 const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "../admin/TeamsSearch"));
 const Usage = React.lazy(() => import(/* webpackPrefetch: true */ "../Usage"));
+const RepositoryListPage = React.lazy(() => import(/* webpackPrefetch: true */ "../repositories/list/RepositoryList"));
+const RepositoryDetailPage = React.lazy(
+    () => import(/* webpackPrefetch: true */ "../repositories/detail/RepositoryDetail"),
+);
 
 export const AppRoutes = () => {
     const hash = getURLHash();
     const user = useCurrentUser();
     const [isWhatsNewShown, setWhatsNewShown] = useState(user && shouldSeeWhatsNew(user));
     const location = useLocation();
+    const repoConfigListAndDetail = useFeatureFlag("repoConfigListAndDetail");
 
     // TODO: Add a Route for this instead of inspecting location manually
     if (location.pathname.startsWith("/blocked")) {
@@ -207,6 +213,13 @@ export const AppRoutes = () => {
                     <Route exact path={`/projects/:projectSlug/settings`} component={ProjectSettings} />
                     <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
                     <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
+
+                    {repoConfigListAndDetail && (
+                        <>
+                            <Route exact path="/repositories" component={RepositoryListPage} />
+                            <Route exact path="/repositories/:id" component={RepositoryDetailPage} />
+                        </>
+                    )}
                     {/* basic redirect for old team slugs */}
                     <Route path={["/t/"]} exact>
                         <Redirect to="/projects" />

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -27,6 +27,7 @@ const featureFlags = {
     newProjectIncrementalRepoSearchBBS: false,
     includeProjectsOnCreateWorkspace: false,
     repositoryFinderSearch: false,
+    repoConfigListAndDetail: false,
 };
 
 type FeatureFlags = typeof featureFlags;

--- a/components/dashboard/src/repositories/detail/RepositoryDetail.tsx
+++ b/components/dashboard/src/repositories/detail/RepositoryDetail.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import Header from "../../components/Header";
+import { useParams } from "react-router";
+
+type PageRouteParams = {
+    id: string;
+};
+const RepositoryDetailPage: FC = () => {
+    const { id } = useParams<PageRouteParams>();
+
+    return (
+        <>
+            <Header title="Repository Detail" subtitle="" />
+            <div className="app-container">
+                <span>id: {id}</span>
+            </div>
+        </>
+    );
+};
+
+export default RepositoryDetailPage;

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import Header from "../../components/Header";
+
+const RepositoryListPage: FC = () => {
+    return (
+        <>
+            <Header title="Repositories" subtitle="" />
+        </>
+    );
+};
+
+export default RepositoryListPage;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds new placeholder pages and routes for the following pages behind a feature flag - `repoConfigListAndDetail` : 

* `/repositories` - Repository List
* `/repositories/:id` - Repository Config Detail

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 526729c</samp>

This pull request adds new components and routes for the repository list and detail pages, which are hidden behind a feature flag. It also adds the feature flag property to the `featureFlags` object and the `featureflag-query` module.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-794

## How to test
<!-- Provide steps to test this PR -->
Visit both of the routes by manually entering in the urls and making sure they render the placeholder page.

* `/repositories`
* `/repositories/sample-id`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-repos-routes</li>
	<li><b>🔗 URL</b> - <a href="https://brad-repos-routes.preview.gitpod-dev.com/workspaces" target="_blank">brad-repos-routes.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-repos-routes-gha.18518</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-repos-routes%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
