### PR TITLE
remove supervisor_live_git_status

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -28,10 +28,3 @@ func SupervisorPersistServerAPIChannelWhenStart(ctx context.Context, client Clie
 func SupervisorUsePublicAPI(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, SupervisorUsePublicAPIFlag, false, attributes)
 }
-
-func SupervisorLiveGitStatus(ctx context.Context, client Client, attributes Attributes) bool {
-	if client == nil {
-		return false
-	}
-	return client.GetBoolValue(ctx, "supervisor_live_git_status", false, attributes)
-}

--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -4,19 +4,12 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
+import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import ContextMenu, { ContextMenuEntry } from "./ContextMenu";
 import CaretDown from "../icons/CaretDown.svg";
-import { useFeatureFlag } from "../data/featureflag-query";
 
 export default function PendingChangesDropdown(props: { workspaceInstance?: WorkspaceInstance }) {
-    const liveGitStatus = useFeatureFlag("supervisor_live_git_status");
-    let repo: WorkspaceInstanceRepoStatus | undefined;
-    if (liveGitStatus) {
-        repo = props.workspaceInstance?.gitStatus;
-    } else {
-        repo = props.workspaceInstance?.status?.repo;
-    }
+    const repo = props.workspaceInstance?.gitStatus;
     const headingStyle = "text-gray-500 dark:text-gray-400 text-left";
     const itemStyle = "text-gray-400 dark:text-gray-500 text-left -mt-5";
     const menuEntries: ContextMenuEntry[] = [];

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -22,7 +22,6 @@ const featureFlags = {
     doRetryUserLoader: true,
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,
-    supervisor_live_git_status: false,
     enabledOrbitalDiscoveries: "",
     newProjectIncrementalRepoSearchBBS: false,
     includeProjectsOnCreateWorkspace: false,

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -4,13 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import {
-    CommitContext,
-    Workspace,
-    WorkspaceInfo,
-    ContextURL,
-    WorkspaceInstanceRepoStatus,
-} from "@gitpod/gitpod-protocol";
+import { CommitContext, Workspace, WorkspaceInfo, ContextURL } from "@gitpod/gitpod-protocol";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { FunctionComponent, useMemo, useState } from "react";
 import { Item, ItemField, ItemFieldIcon } from "../components/ItemsList";
@@ -19,7 +13,6 @@ import Tooltip from "../components/Tooltip";
 import dayjs from "dayjs";
 import { WorkspaceEntryOverflowMenu } from "./WorkspaceOverflowMenu";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
-import { useFeatureFlag } from "../data/featureflag-query";
 
 type Props = {
     info: WorkspaceInfo;
@@ -29,13 +22,7 @@ type Props = {
 export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion }) => {
     const [menuActive, setMenuActive] = useState(false);
 
-    const liveGitStatus = useFeatureFlag("supervisor_live_git_status");
-    let repo: WorkspaceInstanceRepoStatus | undefined;
-    if (liveGitStatus) {
-        repo = info.latestInstance?.gitStatus;
-    } else {
-        repo = info.latestInstance?.status.repo;
-    }
+    const repo = info.latestInstance?.gitStatus;
 
     const workspace = info.workspace;
     const currentBranch = repo?.branch || Workspace.getBranchName(info.workspace) || "<unknown>";

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1835,7 +1835,6 @@ type WorkspaceInstanceStatus struct {
 	NodeName     string                       `json:"nodeName,omitempty"`
 	OwnerToken   string                       `json:"ownerToken,omitempty"`
 	Phase        string                       `json:"phase,omitempty"`
-	Repo         *WorkspaceInstanceRepoStatus `json:"repo,omitempty"`
 	Timeout      string                       `json:"timeout,omitempty"`
 	Version      int                          `json:"version,omitempty"`
 }

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -91,14 +91,6 @@ export interface WorkspaceInstanceStatus {
     // exposedPorts is the list of currently exposed ports
     exposedPorts?: WorkspaceInstancePort[];
 
-    /**
-     * repo contains information about the Git working copy inside the workspace
-     * @deprecated use WorkspaceInstance.gitStatus instead if supervisor_live_git_status feature flag is enabled
-     *
-     * TODO(ak) remove after migration to live git status
-     */
-    repo?: WorkspaceInstanceRepoStatus;
-
     // timeout is a non-default timeout value configured for a workspace
     timeout?: string;
 

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -771,7 +771,7 @@ func TestConvertWorkspaceInfo(t *testing.T) {
 				act Expectation
 				err error
 			)
-			act.Result, err = convertWorkspaceInfo(&test.Input, false)
+			act.Result, err = convertWorkspaceInfo(&test.Input)
 			if err != nil {
 				act.Error = err.Error()
 			}
@@ -792,7 +792,7 @@ func FuzzConvertWorkspaceInfo(f *testing.F) {
 		}
 
 		// we really just care for panics
-		_, _ = convertWorkspaceInfo(&nfo, false)
+		_, _ = convertWorkspaceInfo(&nfo)
 	})
 }
 

--- a/components/supervisor/pkg/supervisor/git.go
+++ b/components/supervisor/pkg/supervisor/git.go
@@ -182,12 +182,6 @@ func (s *GitStatusService) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *GitStatusService) update(ctx context.Context, updateContext *gitStatusUpdateContext) {
-	liveGitStatus := experiments.SupervisorLiveGitStatus(ctx, s.experiments, experiments.Attributes{
-		UserID: s.cfg.OwnerId,
-	})
-	if !liveGitStatus {
-		return
-	}
 	status, err := s.git.Status(ctx)
 	if err != nil {
 		log.WithError(err).Error("git: error getting status")

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -269,22 +269,6 @@ export class WorkspaceManagerBridge implements Disposable {
             instance.status.nodeIp = instance.status.nodeIp || status.runtime?.nodeIp;
             instance.status.ownerToken = status.auth!.ownerToken;
 
-            if (status.repo) {
-                const r = status.repo;
-                const undefinedIfEmpty = <T>(l: T[]) => (l.length > 0 ? l : undefined);
-
-                instance.status.repo = {
-                    branch: r.branch,
-                    latestCommit: r.latestCommit,
-                    uncommitedFiles: undefinedIfEmpty(r.uncommitedFilesList),
-                    totalUncommitedFiles: r.totalUncommitedFiles,
-                    unpushedCommits: undefinedIfEmpty(r.unpushedCommitsList),
-                    totalUntrackedFiles: r.totalUntrackedFiles,
-                    untrackedFiles: undefinedIfEmpty(r.untrackedFilesList),
-                    totalUnpushedCommits: r.totalUnpushedCommits,
-                };
-            }
-
             let lifecycleHandler: (() => Promise<void>) | undefined;
             switch (status.phase) {
                 case WorkspacePhase.PENDING:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We deployed live git status in all installations for some time already. This PR removes supervisor_live_git_status and deprecated instance.status.repo.

This PR does not remove though status capture by ws-manager on stop.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 027403c</samp>

This pull request removes the deprecated and unused code related to the `repo` property and the `supervisor_live_git_status` feature flag from various components and files. It also simplifies the usage of the `gitStatus` property to reflect the live git status of the workspace instances.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace, change branch, do some commits, go to the dashboard check that changes are reflected.
- Stop the workspace, check that changes are still reflected.
- Restart the workspace, check that changes are still reflected. Do more changes.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-always-6a19c47da7</li>
	<li><b>🔗 URL</b> - <a href="https://ak-always-6a19c47da7.preview.gitpod-dev.com/workspaces" target="_blank">ak-always-6a19c47da7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-always_live_git_status-gha.18567</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-always-6a19c47da7%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
