### PR TITLE
Setup podkit folder and move Combobox into it

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@connectrpc/connect-web": "1.1.2",
     "@connectrpc/connect": "1.1.2",
+    "@connectrpc/connect-web": "1.1.2",
     "@gitpod/gitpod-protocol": "0.1.5",
     "@gitpod/public-api": "0.1.5",
     "@radix-ui/react-popover": "^1.0.7",
@@ -26,6 +26,7 @@
     "idb-keyval": "^6.2.0",
     "js-cookie": "^3.0.1",
     "lodash.debounce": "^4.0.8",
+    "lucide-react": "^0.287.0",
     "monaco-editor": "^0.25.2",
     "pretty-bytes": "^6.1.0",
     "process": "^0.11.10",

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -5,7 +5,7 @@
  */
 
 import { FC, useCallback, useMemo, useState } from "react";
-import { DropDown2, DropDown2Element, DropDown2SelectedElement } from "./DropDown2";
+import { Combobox, ComboboxElement, ComboboxSelectedItem } from "./podkit/combobox/Combobox";
 import RepositorySVG from "../icons/Repository.svg";
 import { ReactComponent as RepositoryIcon } from "../icons/RepositoryWithColor.svg";
 import { SuggestedRepository } from "@gitpod/gitpod-protocol";
@@ -92,14 +92,14 @@ export default function RepositoryFinder({
                     id: repo.projectId || repo.url,
                     element: <SuggestedRepositoryOption repo={repo} />,
                     isSelectable: true,
-                } as DropDown2Element;
+                } as ComboboxElement;
             });
         },
         [repos],
     );
 
     return (
-        <DropDown2
+        <Combobox
             getElements={getElements}
             expanded={expanded}
             // we use this to track the search string so we can search for repos via the api and filter in useUnifiedRepositorySearch
@@ -110,7 +110,7 @@ export default function RepositoryFinder({
             searchPlaceholder="Paste repository URL or type to find suggestions"
             onSearchChange={setSearchString}
         >
-            <DropDown2SelectedElement
+            <ComboboxSelectedItem
                 icon={RepositorySVG}
                 htmlTitle={displayContextUrl(selectedContextURL) || "Repository"}
                 title={
@@ -130,7 +130,7 @@ export default function RepositoryFinder({
                 }
                 loading={isLoading}
             />
-        </DropDown2>
+        </Combobox>
     );
 }
 

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -6,7 +6,7 @@
 
 import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import { FC, useCallback, useEffect, useMemo } from "react";
-import { DropDown2, DropDown2Element, DropDown2SelectedElement } from "./DropDown2";
+import { Combobox, ComboboxElement, ComboboxSelectedItem } from "./podkit/combobox/Combobox";
 import Editor from "../icons/Editor.svg";
 import { useIDEOptions } from "../data/ide-options/ide-options-query";
 
@@ -58,7 +58,7 @@ export default function SelectIDEComponent({
             if (!options) {
                 return [];
             }
-            const result: DropDown2Element[] = [];
+            const result: ComboboxElement[] = [];
             for (const ide of options.filter((ide) =>
                 `${ide.label}${ide.title}${ide.notes}${ide.id}`.toLowerCase().includes(search.toLowerCase()),
             )) {
@@ -98,7 +98,7 @@ export default function SelectIDEComponent({
         }
     }, [ide, ideOptions, setError]);
     return (
-        <DropDown2
+        <Combobox
             getElements={getElements}
             onSelectionChange={internalOnSelectionChange}
             searchPlaceholder={"Select Editor"}
@@ -110,7 +110,7 @@ export default function SelectIDEComponent({
                 useLatest={!!useLatest}
                 loading={ideOptionsLoading || loading}
             />
-        </DropDown2>
+        </Combobox>
     );
 }
 
@@ -141,7 +141,7 @@ const IdeOptionElementSelected: FC<IdeOptionElementProps> = ({ option, useLatest
     }
 
     return (
-        <DropDown2SelectedElement
+        <ComboboxSelectedItem
             icon={Editor}
             loading={loading}
             htmlTitle={title}

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -7,7 +7,7 @@
 import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
 import { FC, useCallback, useEffect, useMemo } from "react";
 import WorkspaceClass from "../icons/WorkspaceClass.svg";
-import { DropDown2, DropDown2Element, DropDown2SelectedElement } from "./DropDown2";
+import { Combobox, ComboboxElement, ComboboxSelectedItem } from "./podkit/combobox/Combobox";
 import { useWorkspaceClasses } from "../data/workspaces/workspace-classes-query";
 
 interface SelectWorkspaceClassProps {
@@ -27,7 +27,7 @@ export default function SelectWorkspaceClassComponent({
 }: SelectWorkspaceClassProps) {
     const { data: workspaceClasses, isLoading: workspaceClassesLoading } = useWorkspaceClasses();
 
-    const getElements = useCallback((): DropDown2Element[] => {
+    const getElements = useCallback((): ComboboxElement[] => {
         return (workspaceClasses || [])?.map((c) => ({
             id: c.id,
             element: <WorkspaceClassDropDownElement wsClass={c} />,
@@ -61,7 +61,7 @@ export default function SelectWorkspaceClassComponent({
         return workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
     }, [selectedWorkspaceClass, workspaceClasses]);
     return (
-        <DropDown2
+        <Combobox
             getElements={getElements}
             onSelectionChange={internalOnSelectionChange}
             searchPlaceholder="Select class"
@@ -73,7 +73,7 @@ export default function SelectWorkspaceClassComponent({
                 wsClass={selectedWsClass}
                 loading={workspaceClassesLoading || loading}
             />
-        </DropDown2>
+        </Combobox>
     );
 }
 
@@ -89,7 +89,7 @@ const WorkspaceClassDropDownElementSelected: FC<WorkspaceClassDropDownElementSel
     const title = wsClass?.displayName ?? "Select class";
 
     return (
-        <DropDown2SelectedElement
+        <ComboboxSelectedItem
             icon={WorkspaceClass}
             loading={loading}
             htmlTitle={title}

--- a/components/dashboard/src/components/podkit/combobox/Combobox.tsx
+++ b/components/dashboard/src/components/podkit/combobox/Combobox.tsx
@@ -5,20 +5,19 @@
  */
 
 import React, { FC, FunctionComponent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Arrow from "./Arrow";
-import classNames from "classnames";
-import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import * as RadixPopover from "@radix-ui/react-popover";
+import { ChevronDown, CircleDashed } from "lucide-react";
+import classNames from "classnames";
 
-export interface DropDown2Element {
+export interface ComboboxElement {
     id: string;
     element: JSX.Element;
     isSelectable?: boolean;
 }
 
-export interface DropDown2Props {
+export interface ComboboxProps {
     initialValue?: string;
-    getElements: (searchString: string) => DropDown2Element[];
+    getElements: (searchString: string) => ComboboxElement[];
     disabled?: boolean;
     loading?: boolean;
     searchPlaceholder?: string;
@@ -29,7 +28,7 @@ export interface DropDown2Props {
     onSearchChange?: (searchString: string) => void;
 }
 
-export const DropDown2: FunctionComponent<DropDown2Props> = ({
+export const Combobox: FunctionComponent<ComboboxProps> = ({
     initialValue = "",
     disabled = false,
     loading = false,
@@ -188,8 +187,14 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
             >
                 {children}
                 <div className="flex-grow" />
-                <div className="mr-2">
-                    <Arrow direction={showDropDown ? "up" : "down"} />
+                <div
+                    className={classNames(
+                        // TODO: work on abstracting icon colors once we have a few places using lucide icons
+                        "mr-2 text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-400 transition-transform",
+                        showDropDown && "rotate-180 transition-all",
+                    )}
+                >
+                    <ChevronDown />
                 </div>
             </RadixPopover.Trigger>
             <RadixPopover.Portal>
@@ -213,8 +218,8 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                                 onChange={handleInputChange}
                             />
                             {showInputLoadingIndicator && (
-                                <div className="absolute top-0 right-0 h-full flex items-center pr-2">
-                                    <Spinner className="h-4 w-4 opacity-25 animate-spin" />
+                                <div className="absolute top-0 right-0 h-full flex items-center pr-2 animate-fade-in-fast">
+                                    <CircleDashed className="opacity-10 animate-spin-slow" />
                                 </div>
                             )}
                         </div>
@@ -229,7 +234,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
                         {!showResultsLoadingIndicator && filteredOptions.length > 0 ? (
                             filteredOptions.map((element) => {
                                 return (
-                                    <Dropdown2Element
+                                    <ComboboxItem
                                         key={element.id}
                                         element={element}
                                         isActive={element.id === selectedElementTemp}
@@ -250,7 +255,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = ({
     );
 };
 
-type DropDown2SelectedElementProps = {
+type ComboboxSelectedItemProps = {
     // Either a string of the icon source or an element
     icon: ReactNode;
     loading?: boolean;
@@ -259,7 +264,7 @@ type DropDown2SelectedElementProps = {
     htmlTitle?: string;
 };
 
-export const DropDown2SelectedElement: FC<DropDown2SelectedElementProps> = ({
+export const ComboboxSelectedItem: FC<ComboboxSelectedItemProps> = ({
     icon,
     loading = false,
     title,
@@ -297,14 +302,14 @@ export const DropDown2SelectedElement: FC<DropDown2SelectedElementProps> = ({
     );
 };
 
-type Dropdown2ElementProps = {
-    element: DropDown2Element;
+type ComboboxItemProps = {
+    element: ComboboxElement;
     isActive: boolean;
     onSelected: (id: string) => void;
     onFocused: (id: string) => void;
 };
 
-export const Dropdown2Element: FC<Dropdown2ElementProps> = ({ element, isActive, onSelected, onFocused }) => {
+export const ComboboxItem: FC<ComboboxItemProps> = ({ element, isActive, onSelected, onFocused }) => {
     let selectionClasses = `dark:bg-gray-800 cursor-pointer`;
     if (isActive) {
         selectionClasses = `bg-gray-200 dark:bg-gray-700 cursor-pointer focus:outline-none focus:ring-0`;

--- a/components/dashboard/src/hooks/use-debounce.ts
+++ b/components/dashboard/src/hooks/use-debounce.ts
@@ -20,7 +20,8 @@ export const useDebounce = <T>(value: T, delay = 500, options?: DebounceOptions)
         return debounce(setDebouncedValue, delay, {
             leading: options?.leading || false,
             trailing: options?.trailing || true,
-            maxWait: options?.maxWait ?? undefined,
+            // ensures debounced value is updated at least every 1s
+            maxWait: options?.maxWait ?? 1000,
         });
     }, [delay, options?.leading, options?.maxWait, options?.trailing]);
 

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -65,6 +65,8 @@ module.exports = {
             animation: {
                 "toast-in-right": "toast-in-right 0.3s ease-in-out",
                 "fade-in": "fade-in 3s linear",
+                "fade-in-fast": "fade-in .3s ease-in-out",
+                "spin-slow": "spin 2s linear infinite",
             },
             transitionProperty: {
                 width: "width",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10374,6 +10374,11 @@ lru_map@^0.3.3:
   resolved "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz"
   integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
+lucide-react@^0.287.0:
+  version "0.287.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.287.0.tgz#efa49872a91fa97b7ef650c4b40396b6880d0088"
+  integrity sha512-auxP2bTGiMoELzX+6ItTeNzLmhGd/O+PHBsrXV2YwPXYCxarIFJhiMOSzFT9a1GWeYPSZtnWdLr79IVXr/5JqQ==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
### Podkit
Sets up a new `podkit` directory in dashboard components meant to start housing components that are built on [radix-ui](https://www.radix-ui.com/primitives/docs/overview/introduction) primitives and meet a certain level of accessibility and design standards as well as being generic/decoupled enough to use across any UI surface we build (web/desktop clients). We plan on filling this out more by refactoring our existing components into this pattern as we have opportunities.

Eventually we can see opportunity to encapsulate this component library into it's own package in our monorepo, but for now we'll start w/ it in our dashboard components since that's the primary consumer.

I've refactored our `Dropdown2` component into a `Combobox` component as the first step. I've also incorporate [lucide](https://lucide.dev/icons/) icons that we should use for any components in the podkit directory vs. the one-off svg files we currently rely on. This should also help us w/ consistency and move quicker when building out new components that rely on iconography.

https://github.com/gitpod-io/gitpod/assets/367275/85836cb2-70ca-42b5-9094-44bd88b6fb24

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7dd60e2</samp>

Refactor dashboard components to use `Combobox` component from `podkit` library instead of `DropDown2` component. Replace custom icons with `lucide-react` icons. Improve UI consistency, accessibility, and responsiveness of the dashboard. Update `tailwind.config.js` to add custom animation classes.

</details>

## How to test
<!-- Provide steps to test this PR -->
Take a look at the UI that uses Combobox and verify it looks right still. 
* Create Workspace page has 3 uses
* Project Settings
* User Preferences

There's a few new treats in this component:
* animated chevron icons and it opens/closes
* updated loading spinner w/ fade-in animation

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-podkit-setup</li>
	<li><b>🔗 URL</b> - <a href="https://brad-podkit-setup.preview.gitpod-dev.com/workspaces" target="_blank">brad-podkit-setup.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-podkit-setup-gha.18645</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-podkit-setup%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
