### PR TITLE
[authorization] Extend metric gitpod_guard_access_checks_total by "function-access"

### DIFF
--- a/components/server/src/auth/function-access.ts
+++ b/components/server/src/auth/function-access.ts
@@ -5,6 +5,7 @@
  */
 
 import { injectable } from "inversify";
+import { reportGuardAccessCheck } from "../prometheus-metrics";
 
 export interface FunctionAccessGuard {
     canAccess(name: string): boolean;
@@ -28,6 +29,7 @@ export class ExplicitFunctionAccessGuard {
     constructor(protected readonly allowedCalls: string[]) {}
 
     canAccess(name: string): boolean {
+        reportGuardAccessCheck("function-access");
         return this.allowedCalls.some((c) => c === name);
     }
 }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -348,7 +348,7 @@ export const guardAccessChecksTotal = new prometheusClient.Counter({
     labelNames: ["type"],
 });
 
-export type GuardAccessCheckType = "fga" | "resource-access";
+export type GuardAccessCheckType = "fga" | "resource-access" | "function-access";
 export function reportGuardAccessCheck(type: GuardAccessCheckType) {
     guardAccessChecksTotal.labels(type).inc();
 }


### PR DESCRIPTION
## Description
In preparation of EXP-438

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1f6155</samp>

This pull request adds a new metric for tracking function access checks by user roles. It modifies the `ExplicitFunctionAccessGuard` class and the `prometheus-metrics` module to record and label the guard invocations and outcomes.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
