### PR TITLE
[e2e] Fix multi-repo test

### DIFF
--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -39,10 +39,10 @@ var repos = []struct {
 		CheckoutLocation: "gitpod",
 	},
 	{
-		RemoteUri:        "https://github.com/gitpod-io/website",
+		RemoteUri:        "https://github.com/gitpod-io/workspace-images",
 		CloneTarget:      "main",
 		ExpectedBranch:   "main",
-		CheckoutLocation: "website",
+		CheckoutLocation: "workspace-images",
 	},
 	{
 		RemoteUri:        "https://github.com/gitpod-io/dazzle",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix the multi-repo e2e test failures

See https://gitpod.slack.com/archives/C05KJ2Z10AH/p1697445835709499?thread_ts=1697443989.424369&cid=C05KJ2Z10AH for context

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9801be9</samp>

Update the test case for multi-repo workspaces to use a smaller and more stable repo. This change affects the file `multi_repo_test.go` in the `wsmanager` package.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Ran the e2e test in a preview env successfully

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
