### PR TITLE
Configure git using --global

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -76,13 +76,13 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 	}
 
 	// https://github.blog/2019-11-03-highlights-from-git-2-24/
-	err = ws.Git(ctx, "config", "feature.manyFiles", "true")
+	err = ws.Git(ctx, "config", "--global", "feature.manyFiles", "true")
 	if err != nil {
 		log.WithError(err).Error("cannot configure feature.manyFiles")
 	}
 
 	// commit-graph after every git fetch command that downloads a pack-file from a remote
-	err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
+	err = ws.Git(ctx, "config", "--global", "fetch.writeCommitGraph", "true")
 	if err != nil {
 		log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
 	}

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -75,22 +75,22 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		return
 	}
 
-	// https://github.blog/2019-11-03-highlights-from-git-2-24/
-	err = ws.Git(ctx, "config", "--global", "feature.manyFiles", "true")
-	if err != nil {
-		log.WithError(err).Error("cannot configure feature.manyFiles")
-	}
-
-	// commit-graph after every git fetch command that downloads a pack-file from a remote
-	err = ws.Git(ctx, "config", "--global", "fetch.writeCommitGraph", "true")
-	if err != nil {
-		log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
-	}
-
 	gitClone := func() error {
 		if err := os.MkdirAll(ws.Location, 0775); err != nil {
 			log.WithError(err).WithField("location", ws.Location).Error("cannot create directory")
 			return err
+		}
+
+		// https://github.blog/2019-11-03-highlights-from-git-2-24/
+		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
+		if err != nil {
+			log.WithError(err).Error("cannot configure feature.manyFiles")
+		}
+
+		// commit-graph after every git fetch command that downloads a pack-file from a remote
+		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
+		if err != nil {
+			log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
 		}
 
 		// make sure that folder itself is owned by gitpod user prior to doing git clone

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -82,13 +82,13 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		}
 
 		// https://github.blog/2019-11-03-highlights-from-git-2-24/
-		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
+		err = ws.Git(ctx, "config", "--global", "feature.manyFiles", "true")
 		if err != nil {
 			log.WithError(err).Error("cannot configure feature.manyFiles")
 		}
 
 		// commit-graph after every git fetch command that downloads a pack-file from a remote
-		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
+		err = ws.Git(ctx, "config", "--global", "fetch.writeCommitGraph", "true")
 		if err != nil {
 			log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bd397d</samp>

Improved Git performance in workspaces by setting global config flags in `git.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-global</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-global.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-global.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-global-gha.18627</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-global%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
