### PR TITLE
Fix incorrect start workspace url

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -120,7 +120,7 @@ export class GitpodHostUrl {
     }
 
     asStart(workspaceId = this.workspaceId): GitpodHostUrl {
-        return this.withoutWorkspacePrefix().with({
+        return this.with({
             pathname: "/start/",
             hash: "#" + workspaceId,
         });

--- a/components/supervisor/frontend/src/shared/urls.ts
+++ b/components/supervisor/frontend/src/shared/urls.ts
@@ -10,4 +10,4 @@ export const workspaceUrl = new GitpodHostUrl(window.location.href);
 
 export const serverUrl = workspaceUrl.withoutWorkspacePrefix();
 
-export const startUrl = workspaceUrl.asStart();
+export const startUrl = serverUrl.asStart(workspaceUrl.workspaceId);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix incorrect start workspace url, working for both case


|  workspace url |  dashboard url |
|---|---|
| <img width="1182" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/d0a7ce4d-b55f-45be-9ef4-2f519bde2bcf">  | <img width="1100" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/5819da53-6287-4463-bf34-7539d6272475">  | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 852de59</samp>

Refactor `GitpodHostUrl` class and fix start URL bug. This pull request simplifies the URL manipulation logic in the `GitpodHostUrl` class and fixes a bug that caused the start URL to include the workspace ID twice in the `urls.ts` module.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-inc545912bf38</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-inc545912bf38.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-inc545912bf38.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-incorrect-redirect-url-gha.18636</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-inc545912bf38%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
