### PR TITLE
Setup data loading for repos list

### DIFF
--- a/components/dashboard/craco.config.js
+++ b/components/dashboard/craco.config.js
@@ -4,6 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 const { when } = require("@craco/craco");
+const path = require("path");
 const webpack = require("webpack");
 
 module.exports = {
@@ -18,6 +19,9 @@ module.exports = {
     webpack: {
         configure: {
             resolve: {
+                alias: {
+                    "@podkit": path.resolve(__dirname, "./src/components/podkit/"),
+                },
                 fallback: {
                     crypto: require.resolve("crypto-browserify"),
                     stream: require.resolve("stream-browserify"),

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -44,6 +44,7 @@
     "react-router-dom": "^5.2.0",
     "setimmediate": "^1.0.5",
     "stream-browserify": "^2.0.1",
+    "tailwind-merge": "^1.14.0",
     "url": "^0.11.1",
     "util": "^0.11.1",
     "validator": "^13.9.0",

--- a/components/dashboard/src/components/RepositoryURL.tsx
+++ b/components/dashboard/src/components/RepositoryURL.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+
+type Props = {
+    className?: string;
+    children: string;
+};
+export const RepositoryURL: FC<Props> = ({ className, children }) => {
+    const cleanURL = children.endsWith(".git") ? children.slice(0, -4) : children;
+
+    return <span className={className}>{cleanURL}</span>;
+};

--- a/components/dashboard/src/components/podkit/lib/cn.ts
+++ b/components/dashboard/src/components/podkit/lib/cn.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames, { Argument } from "classnames";
+import { twMerge } from "tailwind-merge";
+
+// Helper type to add a className prop to a component
+export type PropsWithClassName<Props = {}> = {
+    className?: string;
+} & Props;
+
+// Helper fn to merge tailwind classes with a className prop
+export function cn(...inputs: Argument[]) {
+    return twMerge(classNames(inputs));
+}

--- a/components/dashboard/src/components/podkit/typography/Text.tsx
+++ b/components/dashboard/src/components/podkit/typography/Text.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, PropsWithChildren } from "react";
+import { PropsWithClassName, cn } from "@podkit/lib/cn";
+
+type TextProps = PropsWithChildren<PropsWithClassName>;
+
+export const Text: FC<TextProps> = ({ className, children }) => {
+    return <span className={cn("text-black dark:text-white", className)}>{children}</span>;
+};

--- a/components/dashboard/src/components/podkit/typography/TextMuted.tsx
+++ b/components/dashboard/src/components/podkit/typography/TextMuted.tsx
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, PropsWithChildren } from "react";
+import { PropsWithClassName, cn } from "@podkit/lib/cn";
+
+type TextMutedProps = PropsWithChildren<PropsWithClassName>;
+
+export const TextMuted: FC<TextMutedProps> = ({ className, children }) => {
+    return <span className={cn("text-gray-500 dark:text-gray-400", className)}>{children}</span>;
+};

--- a/components/dashboard/src/data/projects/create-project-mutation.ts
+++ b/components/dashboard/src/data/projects/create-project-mutation.ts
@@ -7,13 +7,13 @@
 import { useMutation } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 import { useCurrentOrg } from "../organizations/orgs-query";
-import { useRefreshProjects } from "./list-projects-query";
+import { useRefreshAllProjects } from "./list-all-projects-query";
 import { CreateProjectParams, Project } from "@gitpod/gitpod-protocol";
 
 export type CreateProjectArgs = Omit<CreateProjectParams, "teamId">;
 
 export const useCreateProject = () => {
-    const refreshProjects = useRefreshProjects();
+    const refreshProjects = useRefreshAllProjects();
     const { data: org } = useCurrentOrg();
 
     return useMutation<Project, Error, CreateProjectArgs>(async ({ name, slug, cloneUrl, appInstallationId }) => {

--- a/components/dashboard/src/data/projects/list-all-projects-query.ts
+++ b/components/dashboard/src/data/projects/list-all-projects-query.ts
@@ -10,16 +10,16 @@ import { useCallback } from "react";
 import { listAllProjects } from "../../service/public-api";
 import { useCurrentOrg } from "../organizations/orgs-query";
 
-export type ListProjectsQueryResults = {
+export type ListAllProjectsQueryResults = {
     projects: Project[];
 };
 
 export const useListAllProjectsQuery = () => {
     const org = useCurrentOrg().data;
     const orgId = org?.id;
-    return useQuery<ListProjectsQueryResults>({
+    return useQuery<ListAllProjectsQueryResults>({
         enabled: !!orgId,
-        queryKey: getListProjectsQueryKey(orgId || ""),
+        queryKey: getListAllProjectsQueryKey(orgId || ""),
         cacheTime: 1000 * 60 * 60 * 1, // 1 hour
         queryFn: async () => {
             if (!orgId) {
@@ -38,7 +38,7 @@ export const useListAllProjectsQuery = () => {
 };
 
 // helper to force a refresh of the list projects query
-export const useRefreshProjects = () => {
+export const useRefreshAllProjects = () => {
     const queryClient = useQueryClient();
 
     return useCallback(
@@ -49,13 +49,13 @@ export const useRefreshProjects = () => {
             }
 
             return await queryClient.refetchQueries({
-                queryKey: getListProjectsQueryKey(orgId),
+                queryKey: getListAllProjectsQueryKey(orgId),
             });
         },
         [queryClient],
     );
 };
 
-export const getListProjectsQueryKey = (orgId: string) => {
-    return ["projects", "list", { orgId }];
+export const getListAllProjectsQueryKey = (orgId: string) => {
+    return ["projects", "list-all", { orgId }];
 };

--- a/components/dashboard/src/data/projects/list-projects-query.ts
+++ b/components/dashboard/src/data/projects/list-projects-query.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useCurrentOrg } from "../organizations/orgs-query";
+import { projectsService } from "../../service/public-api";
+
+type ListProjectsQueryArgs = {
+    page: number;
+    pageSize: number;
+};
+
+export const useListProjectsQuery = ({ page, pageSize }: ListProjectsQueryArgs) => {
+    const { data: org } = useCurrentOrg();
+
+    return useQuery(
+        getListProjectsQueryKey(org?.id || "", { page, pageSize }),
+        async () => {
+            if (!org) {
+                throw new Error("No org currently selected");
+            }
+
+            return projectsService.listProjects({ teamId: org.id, pagination: { page, pageSize } });
+        },
+        {
+            enabled: !!org,
+        },
+    );
+};
+
+export const getListProjectsQueryKey = (orgId: string, { page, pageSize }: ListProjectsQueryArgs) => {
+    return ["projects", "list", { orgId, page, pageSize }];
+};

--- a/components/dashboard/src/data/projects/list-projects-query.ts
+++ b/components/dashboard/src/data/projects/list-projects-query.ts
@@ -14,7 +14,7 @@ export type ListProjectsQueryResults = {
     projects: Project[];
 };
 
-export const useListProjectsQuery = () => {
+export const useListAllProjectsQuery = () => {
     const org = useCurrentOrg().data;
     const orgId = org?.id;
     return useQuery<ListProjectsQueryResults>({

--- a/components/dashboard/src/hooks/use-pretty-repo-url.ts
+++ b/components/dashboard/src/hooks/use-pretty-repo-url.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export const usePrettyRepoURL = (url: string) => {
+    return url.endsWith(".git") ? url.slice(0, -4) : url;
+};

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -12,6 +12,7 @@ import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-quer
 import { useLocation } from "react-router";
 import { User } from "@gitpod/gitpod-protocol";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 export default function OrganizationSelector() {
     const user = useCurrentUser();
@@ -19,6 +20,7 @@ export default function OrganizationSelector() {
     const currentOrg = useCurrentOrg();
     const { data: billingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
+    const repoConfigListAndDetail = useFeatureFlag("repoConfigListAndDetail");
 
     // we should have an API to ask for permissions, until then we duplicate the logic here
     const canCreateOrgs = user && !User.isOrganizationOwned(user);
@@ -56,6 +58,15 @@ export default function OrganizationSelector() {
 
     // Show members if we have an org selected
     if (currentOrg.data) {
+        if (repoConfigListAndDetail) {
+            linkEntries.push({
+                title: "Repositories",
+                customContent: <LinkEntry>Repositories</LinkEntry>,
+                active: false,
+                separator: false,
+                link: "/repositories",
+            });
+        }
         linkEntries.push({
             title: "Members",
             customContent: <LinkEntry>Members</LinkEntry>,

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -17,7 +17,7 @@ import { RemoveProjectModal } from "./RemoveProjectModal";
 import SelectWorkspaceClassComponent from "../components/SelectWorkspaceClassComponent";
 import { TextInputField } from "../components/forms/TextInputField";
 import { Button } from "../components/Button";
-import { useRefreshProjects } from "../data/projects/list-projects-query";
+import { useRefreshAllProjects } from "../data/projects/list-all-projects-query";
 import { useToast } from "../components/toasts/Toasts";
 import classNames from "classnames";
 import { InputField } from "../components/forms/InputField";
@@ -54,7 +54,7 @@ export default function ProjectSettingsView() {
         }
     }
     const history = useHistory();
-    const refreshProjects = useRefreshProjects();
+    const refreshProjects = useRefreshAllProjects();
     const { toast } = useToast();
     const [prebuildBranchPattern, setPrebuildBranchPattern] = useState("");
 

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -12,7 +12,7 @@ import Alert from "../components/Alert";
 import Header from "../components/Header";
 import { SpinnerLoader } from "../components/Loader";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
-import { useListProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
 import search from "../icons/search.svg";
 import { Heading2 } from "../components/typography/headings";
 import projectsEmptyDark from "../images/projects-empty-dark.svg";
@@ -27,7 +27,7 @@ export default function ProjectsPage() {
     const createProjectModal = useFeatureFlag("createProjectModal");
     const history = useHistory();
     const team = useCurrentOrg().data;
-    const { data, isLoading, isError, refetch } = useListProjectsQuery();
+    const { data, isLoading, isError, refetch } = useListAllProjectsQuery();
     const { isDark } = useContext(ThemeContext);
     const [searchFilter, setSearchFilter] = useState<string | undefined>();
     const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -12,7 +12,7 @@ import Alert from "../components/Alert";
 import Header from "../components/Header";
 import { SpinnerLoader } from "../components/Loader";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
-import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-all-projects-query";
 import search from "../icons/search.svg";
 import { Heading2 } from "../components/typography/headings";
 import projectsEmptyDark from "../images/projects-empty-dark.svg";

--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -10,7 +10,7 @@ import { useHistory, useLocation, useRouteMatch } from "react-router";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { listAllProjects } from "../service/public-api";
 import { useCurrentUser } from "../user-context";
-import { useListProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
 
 export const ProjectContext = createContext<{
     project?: Project;
@@ -36,7 +36,7 @@ export function useCurrentProject(): { project: Project | undefined; loading: bo
     const projectIdFromRoute = useRouteMatch<{ projectId?: string }>("/projects/:projectId")?.params?.projectId;
     const location = useLocation();
     const history = useHistory();
-    const listProjects = useListProjectsQuery();
+    const listProjects = useListAllProjectsQuery();
 
     useEffect(() => {
         setLoading(true);

--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -10,7 +10,7 @@ import { useHistory, useLocation, useRouteMatch } from "react-router";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { listAllProjects } from "../service/public-api";
 import { useCurrentUser } from "../user-context";
-import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-all-projects-query";
 
 export const ProjectContext = createContext<{
     project?: Project;

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { usePrettyRepoURL } from "../../hooks/use-pretty-repo-url";
+import { TextMuted } from "@podkit/typography/TextMuted";
+import { Text } from "@podkit/typography/Text";
+import { Link } from "react-router-dom";
+import { Button } from "../../components/Button";
+import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_pb";
+
+type Props = {
+    project: Project;
+};
+export const RepositoryListItem: FC<Props> = ({ project }) => {
+    const url = usePrettyRepoURL(project.cloneUrl);
+
+    return (
+        <li key={project.id} className="flex flex-row w-full space-between items-center">
+            <div className="flex flex-col flex-grow gap-1">
+                <Text className="font-semibold">{project.name}</Text>
+                <TextMuted className="text-sm">{url}</TextMuted>
+            </div>
+
+            <div>
+                <Link to={`/repositories/${project.id}`}>
+                    <Button type="secondary">View</Button>
+                </Link>
+            </div>
+        </li>
+    );
+};

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -6,11 +6,25 @@
 
 import { FC } from "react";
 import Header from "../../components/Header";
+import { useListProjectsQuery } from "../../data/projects/list-projects-query";
+import { Loader2 } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const RepositoryListPage: FC = () => {
+    const { data, isLoading } = useListProjectsQuery({ page: 1, pageSize: 10 });
+
     return (
         <>
             <Header title="Repositories" subtitle="" />
+
+            {isLoading && <Loader2 className="animate-spin" />}
+            {!isLoading &&
+                data?.projects.map((project) => (
+                    <div key={project.id}>
+                        <span>{project.name}</span>
+                        <Link to={`/repositories/${project.id}`}>View</Link>
+                    </div>
+                ))}
         </>
     );
 };

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -4,27 +4,48 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC } from "react";
+import { FC, useCallback, useState } from "react";
 import Header from "../../components/Header";
 import { useListProjectsQuery } from "../../data/projects/list-projects-query";
 import { Loader2 } from "lucide-react";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+import { Project } from "@gitpod/gitpod-protocol";
+import { CreateProjectModal } from "../../projects/create-project-modal/CreateProjectModal";
+import { Button } from "../../components/Button";
+import { RepositoryListItem } from "./RepoListItem";
 
 const RepositoryListPage: FC = () => {
+    const history = useHistory();
     const { data, isLoading } = useListProjectsQuery({ page: 1, pageSize: 10 });
+    const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);
+
+    const handleProjectCreated = useCallback(
+        (project: Project) => {
+            history.push(`/repositories/${project.id}`);
+        },
+        [history],
+    );
 
     return (
         <>
             <Header title="Repositories" subtitle="" />
 
-            {isLoading && <Loader2 className="animate-spin" />}
-            {!isLoading &&
-                data?.projects.map((project) => (
-                    <div key={project.id}>
-                        <span>{project.name}</span>
-                        <Link to={`/repositories/${project.id}`}>View</Link>
-                    </div>
-                ))}
+            <div className="app-container">
+                <div className="py-4 text-right">
+                    <Button onClick={() => setShowCreateProjectModal(true)}>Configure Repository</Button>
+                </div>
+
+                {isLoading && <Loader2 className="animate-spin" />}
+
+                <ul className="space-y-2 mt-8">
+                    {!isLoading &&
+                        data?.projects.map((project) => <RepositoryListItem key={project.id} project={project} />)}
+                </ul>
+            </div>
+
+            {showCreateProjectModal && (
+                <CreateProjectModal onClose={() => setShowCreateProjectModal(false)} onCreated={handleProjectCreated} />
+            )}
         </>
     );
 };

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -29,7 +29,7 @@ import { InputField } from "../components/forms/InputField";
 import { Heading1 } from "../components/typography/headings";
 import { useAuthProviders } from "../data/auth-providers/auth-provider-query";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
-import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-all-projects-query";
 import { useCreateWorkspaceMutation } from "../data/workspaces/create-workspace-mutation";
 import { useListWorkspacesQuery } from "../data/workspaces/list-workspaces-query";
 import { useWorkspaceContext } from "../data/workspaces/resolve-context-query";

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -29,7 +29,7 @@ import { InputField } from "../components/forms/InputField";
 import { Heading1 } from "../components/typography/headings";
 import { useAuthProviders } from "../data/auth-providers/auth-provider-query";
 import { useCurrentOrg } from "../data/organizations/orgs-query";
-import { useListProjectsQuery } from "../data/projects/list-projects-query";
+import { useListAllProjectsQuery } from "../data/projects/list-projects-query";
 import { useCreateWorkspaceMutation } from "../data/workspaces/create-workspace-mutation";
 import { useListWorkspacesQuery } from "../data/workspaces/list-workspaces-query";
 import { useWorkspaceContext } from "../data/workspaces/resolve-context-query";
@@ -47,7 +47,7 @@ import { WorkspaceEntry } from "./WorkspaceEntry";
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
     const currentOrg = useCurrentOrg().data;
-    const projects = useListProjectsQuery();
+    const projects = useListAllProjectsQuery();
     const workspaces = useListWorkspacesQuery({ limit: 50 });
     const location = useLocation();
     const history = useHistory();

--- a/components/dashboard/tsconfig.json
+++ b/components/dashboard/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "paths": {
+      "@podkit/*": ["./src/components/podkit/*"]
+    },
     "target": "es6",
     "lib": [
       "dom",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14216,6 +14216,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tailwind-merge@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.14.0.tgz#e677f55d864edc6794562c63f5001f45093cdb8b"
+  integrity sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==
+
 tailwind-underline-utils@^1.1.2:
   version "1.1.3"
   resolved "https://registry.npmjs.org/tailwind-underline-utils/-/tailwind-underline-utils-1.1.3.tgz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This sets up basics to load the first page of configured repositories (projects) and lists them w/ links to their respective detail pages. This is all behind a flag still and is meant to enable followup/adjacent work. 

_This isn't intended to match our design target, just unlock some functionality and get data on the UI._

* Renamed the current `useListProjectsQuery` to `useListAllProjectsQuery` as that's what it was doing.
* Added a `useListProjectsQuery` that loads a single page of projects instead.
* Added a `@podkit` alias for the `src/components/podkit` folder
* Added a `cn()` helper to assist in merging tailwind classNames (as suggested [here](https://ui.shadcn.com/docs/installation/manual#add-a-cn-helper) in shadcn)
* Added a `<Text>` and `<TextMuted>` component to encapsulate text colors & dark mode (I'm not sure if this is the best way to go about this yet, but wanted to start w/ it).

![image](https://github.com/gitpod-io/gitpod/assets/367275/829580f0-8640-4e2a-9bfd-e0a78ece9b58)


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48f8c15</samp>

Added a new query hook and component for listing all projects without pagination, and updated existing components to use either the new or the old query hook depending on the context. This improves the performance and usability of the dashboard for creating and managing projects and their repositories. The affected files are `create-project-mutation.ts`, `project-context.tsx`, `Projects.tsx`, `ProjectSettings.tsx`, `CreateWorkspacePage.tsx`, `list-all-projects-query.ts`, `list-projects-query.ts`, and `RepositoryList.tsx`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-795 & EXP-802 & EXP-796

## How to test
<!-- Provide steps to test this PR -->
* Create at least one project on the preview env.
* Manually visit `/repositories` and verify your project you created is listed.
* Click the View link and verify it links to the corresponding detail page, `/repositories/:id` (data not loaded there yet, verify url)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-7b0663031f2</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-7b0663031f2.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-7b0663031f2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-797-list-repo-configs-gha.18680</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-exp-7b0663031f2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
