### PR TITLE
Increase project name max length

### DIFF
--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header(p: HeaderProps) {
     return (
         <div className="app-container border-gray-200 dark:border-gray-800">
             <div className="flex pb-8 pt-6">
-                <div>
+                <div className="w-full">
                     {p.complexTitle ? p.complexTitle : <Heading1 tracking="tight">{p.title}</Heading1>}
                     {typeof p.subtitle === "string" ? (
                         <Subheading tracking="wide">{p.subtitle}</Subheading>

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -18,7 +18,12 @@ export const Heading1: FC<HeadingProps> = ({ id, color, tracking, className, chi
     return (
         <h1
             id={id}
-            className={classNames(getHeadingColor(color), getTracking(tracking), "font-bold text-4xl", className)}
+            className={classNames(
+                getHeadingColor(color),
+                getTracking(tracking),
+                "font-bold text-4xl truncate",
+                className,
+            )}
         >
             {children}
         </h1>

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -136,7 +136,7 @@ type ProjectLinkProps = {
 };
 const ProjectLink: FunctionComponent<ProjectLinkProps> = ({ project }) => {
     return (
-        <Link to={`/projects/${project.id}`} className="truncate">
+        <Link to={`/projects/${project.id}`} className="truncate" title={project.name}>
             <span className="text-xl font-semibold">{project.name}</span>
         </Link>
     );

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -136,7 +136,7 @@ type ProjectLinkProps = {
 };
 const ProjectLink: FunctionComponent<ProjectLinkProps> = ({ project }) => {
     return (
-        <Link to={`/projects/${project.id}`}>
+        <Link to={`/projects/${project.id}`} className="truncate">
             <span className="text-xl font-semibold">{project.name}</span>
         </Link>
     );

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -24,6 +24,8 @@ import { InputField } from "../components/forms/InputField";
 import { SelectInputField } from "../components/forms/SelectInputField";
 import debounce from "lodash.debounce";
 
+const MAX_PROJECT_NAME_LENGTH = 100;
+
 export function ProjectSettingsPage(props: { project?: Project; children?: React.ReactNode }) {
     return (
         <PageWithSubMenu
@@ -49,8 +51,8 @@ export default function ProjectSettingsView() {
     let badProjectName: string | undefined;
     if (project) {
         badProjectName = projectName.length > 0 ? undefined : "Project name can not be blank.";
-        if (projectName.length > 32) {
-            badProjectName = "Project name can not be longer than 32 characters.";
+        if (projectName.length > MAX_PROJECT_NAME_LENGTH) {
+            badProjectName = `Project name can not be longer than ${MAX_PROJECT_NAME_LENGTH} characters.`;
         }
     }
     const history = useHistory();
@@ -221,7 +223,7 @@ export default function ProjectSettingsView() {
             <Heading2>Project Name</Heading2>
             <form onSubmit={updateProjectName}>
                 <TextInputField
-                    hint="The name can be up to 32 characters long."
+                    hint={`The name can be up to ${MAX_PROJECT_NAME_LENGTH} characters long.`}
                     value={projectName}
                     error={badProjectName}
                     onChange={setProjectName}

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -32,6 +32,8 @@ import { TransactionalContext } from "@gitpod/gitpod-db/lib/typeorm/transactiona
 import { ScmService } from "./scm-service";
 import { daysBefore, isDateSmaller } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 
+const MAX_PROJECT_NAME_LENGTH = 100;
+
 @injectable()
 export class ProjectsService {
     constructor(
@@ -205,8 +207,11 @@ export class ProjectsService {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Clone URL must be less than 1k characters.");
         }
 
-        if (name.length > 32) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Project name cannot be longer than 32 characters.");
+        if (name.length > MAX_PROJECT_NAME_LENGTH) {
+            throw new ApplicationError(
+                ErrorCodes.BAD_REQUEST,
+                `Project name cannot be longer than ${MAX_PROJECT_NAME_LENGTH} characters.`,
+            );
         }
 
         try {
@@ -245,7 +250,7 @@ export class ProjectsService {
 
         const project = Project.create({
             // Default to repository name
-            name: name || parsedUrl.repo.substring(0, 32),
+            name: name || parsedUrl.repo.substring(0, MAX_PROJECT_NAME_LENGTH),
             cloneUrl,
             teamId,
             appInstallationId,
@@ -369,9 +374,11 @@ export class ProjectsService {
         const partial: PartialProject = { id: partialProject.id };
         if (partialProject.name) {
             partialProject.name = partialProject.name.trim();
-            // check it is between 0 and 32 characters
-            if (partialProject.name.length > 32) {
-                throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Project name must be less than 32 characters.");
+            if (partialProject.name.length > MAX_PROJECT_NAME_LENGTH) {
+                throw new ApplicationError(
+                    ErrorCodes.BAD_REQUEST,
+                    `Project name must be less than ${MAX_PROJECT_NAME_LENGTH} characters.`,
+                );
             }
             if (partialProject.name.length === 0) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Project name must not be empty.");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Increase project name max length to 100 chars, max db value is 255.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f2ff58</samp>

Refactor project name length validation and hint text to use a constant value of `MAX_PROJECT_NAME_LENGTH`. This affects the files `ProjectSettings.tsx` and `projects-service.ts` in the dashboard and server components respectively.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/CUS-153

## How to test
<!-- Provide steps to test this PR -->
- Create a project with a long name

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-ruling-zebra</li>
	<li><b>🔗 URL</b> - <a href="https://jp-ruling-zebra.preview.gitpod-dev.com/workspaces" target="_blank">jp-ruling-zebra.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-ruling-zebra-gha.18687</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-ruling-zebra%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
