### PR TITLE
Revert "Revert "Relax assumptions in supervisor (#18782)" (#18857)"

### DIFF
--- a/components/content-service/pkg/executor/executor.go
+++ b/components/content-service/pkg/executor/executor.go
@@ -44,7 +44,7 @@ func Prepare(req *csapi.WorkspaceInitializer, urls map[string]string) ([]byte, e
 
 // Execute runs an initializer to place content in destination based on the configuration read
 // from the cfgin stream.
-func Execute(ctx context.Context, destination string, cfgin io.Reader, forceGitUser bool, opts ...initializer.InitializeOpt) (src csapi.WorkspaceInitSource, err error) {
+func Execute(ctx context.Context, destination string, cfgin io.Reader, runAs *initializer.User, opts ...initializer.InitializeOpt) (src csapi.WorkspaceInitSource, err error) {
 	var cfg config
 	err = json.NewDecoder(cfgin).Decode(&cfg)
 	if err != nil {
@@ -64,7 +64,7 @@ func Execute(ctx context.Context, destination string, cfgin io.Reader, forceGitU
 
 		rs = &storage.NamedURLDownloader{URLs: cfg.URLs}
 		ilr, err = initializer.NewFromRequest(ctx, destination, rs, &req, initializer.NewFromRequestOpts{
-			ForceGitpodUserForGit: forceGitUser,
+			RunAs: runAs,
 		})
 		if err != nil {
 			return "", err

--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/xerrors"
@@ -93,8 +94,12 @@ type Client struct {
 	// UpstreamCloneURI is the fork upstream of a repository
 	UpstreamRemoteURI string
 
-	// if true will run git command as gitpod user (should be executed as root that has access to sudo in this case)
-	RunAsGitpodUser bool
+	// RunAs runs the Git commands as a particular user - if not nil
+	RunAs *User
+}
+
+type User struct {
+	UID, GID uint32
 }
 
 // Status describes the status of a Git repo/working copy akin to "git status"
@@ -178,8 +183,6 @@ func (c *Client) GitWithOutput(ctx context.Context, ignoreErr *string, subcomman
 		env = append(env, fmt.Sprintf("GIT_AUTH_PASSWORD=%s", pwd))
 	}
 
-	env = append(env, "HOME=/home/gitpod")
-
 	fullArgs = append(fullArgs, subcommand)
 	fullArgs = append(fullArgs, args...)
 
@@ -201,13 +204,19 @@ func (c *Client) GitWithOutput(ctx context.Context, ignoreErr *string, subcomman
 	span.LogKV("args", fullArgs)
 
 	cmdName := "git"
-	if c.RunAsGitpodUser {
-		cmdName = "sudo"
-		fullArgs = append([]string{"-u", "gitpod", "git"}, fullArgs...)
-	}
 	cmd := exec.Command(cmdName, fullArgs...)
 	cmd.Dir = c.Location
 	cmd.Env = env
+	if c.RunAs != nil {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		if cmd.SysProcAttr.Credential == nil {
+			cmd.SysProcAttr.Credential = &syscall.Credential{}
+		}
+		cmd.SysProcAttr.Credential.Uid = c.RunAs.UID
+		cmd.SysProcAttr.Credential.Gid = c.RunAs.UID
+	}
 
 	res, err := cmd.CombinedOutput()
 	if err != nil {

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -95,8 +95,8 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 
 		// make sure that folder itself is owned by gitpod user prior to doing git clone
 		// this is needed as otherwise git clone will fail if the folder is owned by root
-		if ws.RunAsGitpodUser {
-			args := []string{"gitpod", ws.Location}
+		if ws.RunAs != nil {
+			args := []string{fmt.Sprintf("%d:%d", ws.RunAs.UID, ws.RunAs.GID), ws.Location}
 			cmd := exec.Command("chown", args...)
 			res, cerr := cmd.CombinedOutput()
 			if cerr != nil && !process.IsNotChildProcess(cerr) {

--- a/components/supervisor/cmd/dump-initializer.go
+++ b/components/supervisor/cmd/dump-initializer.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"fmt"
+
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
+	"github.com/spf13/cobra"
+)
+
+var dumpInitializer = &cobra.Command{
+	Use:    "dump-init",
+	Hidden: true, // this is not official user-facing functionality, but just for debugging
+	Run: func(cmd *cobra.Command, args []string) {
+		fc, _ := executor.Prepare(&csapi.WorkspaceInitializer{
+			Spec: &csapi.WorkspaceInitializer_Git{
+				Git: &csapi.GitInitializer{
+					RemoteUri:        "https://github.com/gitpod-io/gitpod",
+					CheckoutLocation: "gitpod",
+					TargetMode:       csapi.CloneTargetMode_REMOTE_BRANCH,
+					CloneTaget:       "main",
+					Config: &csapi.GitConfig{
+						Authentication: csapi.GitAuthMethod_NO_AUTH,
+					},
+				},
+			},
+		}, nil)
+		fmt.Println(string(fc))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dumpInitializer)
+}

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -329,6 +328,35 @@ type WorkspaceConfig struct {
 
 	// ConfigcatEnabled controls whether configcat is enabled
 	ConfigcatEnabled bool `env:"GITPOD_CONFIGCAT_ENABLED"`
+
+	WorkspaceLinuxUID uint32 `env:"GITPOD_WORKSPACE_LINUX_UID,default=33333"`
+	WorkspaceLinuxGID uint32 `env:"GITPOD_WORKSPACE_LINUX_GID,default=33333"`
+
+	// ContentInitializer - if set - will run the content initializer instead of waiting for the ready file
+	ContentInitializer string `env:"SUPERVISOR_CONTENT_INITIALIZER"`
+
+	// WorkspaceRuntime configures the runtime supervisor is running in
+	WorkspaceRuntime WorkspaceRuntime `env:"SUPERVISOR_WORKSPACE_RUNTIME,default=container"`
+}
+
+type WorkspaceRuntime string
+
+const (
+	WorkspaceRuntimeContainer WorkspaceRuntime = "container"
+	WorkspaceRuntimeNextgen   WorkspaceRuntime = "nextgen"
+	WorkspaceRuntimeRunGP     WorkspaceRuntime = "rungp"
+)
+
+func (rt *WorkspaceRuntime) UnmarshalEnvironmentValue(data string) error {
+	switch WorkspaceRuntime(data) {
+	case WorkspaceRuntimeContainer, WorkspaceRuntimeNextgen, WorkspaceRuntimeRunGP:
+		// everything's fine
+	default:
+		return fmt.Errorf("unknown workspace runtime: %s", data)
+	}
+
+	*rt = WorkspaceRuntime(data)
+	return nil
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service.
@@ -587,7 +615,7 @@ func loadDesktopIDEs(static *StaticConfig) ([]*IDEConfig, error) {
 		uniqueDesktopIDEs[desktopIDE.Name] = struct{}{}
 	}
 
-	files, err := ioutil.ReadDir(static.DesktopIDERoot)
+	files, err := os.ReadDir(static.DesktopIDERoot)
 	if err != nil {
 		return nil, err
 	}

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -57,7 +57,7 @@ func socketActivationForDocker(parentCtx context.Context, wg *sync.WaitGroup, te
 		return
 	}
 
-	logFile, err := openDockerUpLogFile()
+	logFile, err := openDockerUpLogFile(int(cfg.WorkspaceLinuxUID), int(cfg.WorkspaceLinuxGID))
 	if err != nil {
 		log.WithError(err).Error("docker-up: cannot open log file")
 	} else {
@@ -164,7 +164,7 @@ func listenToDockerSocket(parentCtx context.Context, term *terminal.Mux, cfg *Co
 		l.Close()
 	}()
 
-	_ = os.Chown(fn, gitpodUID, gitpodGID)
+	_ = os.Chown(fn, int(cfg.WorkspaceLinuxUID), int(cfg.WorkspaceLinuxGID))
 
 	var lastExitErrorTime time.Time
 	burstAttempts := 0
@@ -267,11 +267,11 @@ func listenToDockerSocket(parentCtx context.Context, term *terminal.Mux, cfg *Co
 	return ctx.Err()
 }
 
-func openDockerUpLogFile() (*os.File, error) {
+func openDockerUpLogFile(uid, gid int) (*os.File, error) {
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
 		return nil, xerrors.Errorf("cannot create logs dir: %w", err)
 	}
-	if err := os.Chown(logsDir, gitpodUID, gitpodGID); err != nil {
+	if err := os.Chown(logsDir, uid, gid); err != nil {
 		return nil, xerrors.Errorf("cannot chown logs dir: %w", err)
 	}
 	logFile, err := os.OpenFile(dockerUpLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -279,7 +279,7 @@ func openDockerUpLogFile() (*os.File, error) {
 		return nil, xerrors.Errorf("cannot open docker-up log file: %w", err)
 	}
 
-	if err := os.Chown(dockerUpLogFilePath, gitpodUID, gitpodGID); err != nil {
+	if err := os.Chown(dockerUpLogFilePath, uid, gid); err != nil {
 		_ = logFile.Close()
 		return nil, xerrors.Errorf("cannot chown docker-up log file: %w", err)
 	}

--- a/components/supervisor/pkg/supervisor/git.go
+++ b/components/supervisor/pkg/supervisor/git.go
@@ -92,7 +92,7 @@ func (p *GitTokenProvider) openAccessControl() error {
 		return err
 	}
 	gpCmd := exec.Command(gpPath, "preview", "--external", p.workspaceConfig.GitpodHost+"/access-control")
-	runAsGitpodUser(gpCmd)
+	runAsUser(gpCmd, p.workspaceConfig.WorkspaceLinuxUID, p.workspaceConfig.WorkspaceLinuxGID)
 	if b, err := gpCmd.CombinedOutput(); err != nil {
 		log.WithField("Stdout", string(b)).WithError(err).Error("failed to exec gp preview to open access control")
 		return err

--- a/components/supervisor/pkg/supervisor/user.go
+++ b/components/supervisor/pkg/supervisor/user.go
@@ -35,26 +35,33 @@ func (osLookup) LookupId(id string) (grp *user.User, err error)       { return u
 
 var defaultLookup lookup = osLookup{}
 
+const (
+	legacyGitpodUID       = 33333
+	legacyGitpodGID       = 33333
+	legacyGitpodUserName  = "gitpod"
+	legacyGitpodGroupName = "gitpod"
+)
+
 func AddGitpodUserIfNotExists() error {
-	ok, err := hasGroup(gitpodGroupName, gitpodGID)
+	ok, err := hasGroup(legacyGitpodGroupName, legacyGitpodGID)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		err = addGroup(gitpodGroupName, gitpodGID)
+		err = addGroup(legacyGitpodGroupName, legacyGitpodGID)
 		if err != nil {
 			return err
 		}
 	}
-	if err := addSudoer(gitpodGroupName); err != nil {
+	if err := addSudoer(legacyGitpodGroupName); err != nil {
 		log.WithError(err).Error("add gitpod sudoers")
 	}
 
 	targetUser := &user.User{
-		Uid:      strconv.Itoa(gitpodUID),
-		Gid:      strconv.Itoa(gitpodGID),
-		Username: gitpodUserName,
-		HomeDir:  "/home/" + gitpodUserName,
+		Uid:      strconv.Itoa(legacyGitpodUID),
+		Gid:      strconv.Itoa(legacyGitpodGID),
+		Username: legacyGitpodUserName,
+		HomeDir:  "/home/" + legacyGitpodUserName,
 	}
 	ok, err = hasUser(targetUser)
 	if err != nil {
@@ -93,7 +100,7 @@ func hasGroup(name string, gid int) (bool, error) {
 	}
 	if grpByID == nil && grpByName != nil {
 		// a group with this name already exists, but has a different GID
-		return true, xerrors.Errorf("group named %s exists but uses different GID %s, should be: %d", name, grpByName.Gid, gitpodGID)
+		return true, xerrors.Errorf("group named %s exists but uses different GID %s, should be: %d", name, grpByName.Gid, gid)
 	}
 
 	// group exists and all is well
@@ -127,7 +134,7 @@ func hasUser(u *user.User) (bool, error) {
 	}
 	if userByID == nil && userByName != nil {
 		// a user with this name already exists, but has a different GID
-		return true, xerrors.Errorf("user named %s exists but uses different UID %s, should be: %d", u.Username, userByName.Uid, gitpodUID)
+		return true, xerrors.Errorf("user named %s exists but uses different UID %s, should be: %s", u.Username, userByName.Uid, u.Uid)
 	}
 
 	// at this point it doesn't matter if we use userByID or byName - they're likely the same

--- a/components/supervisor/pkg/supervisor/user_test.go
+++ b/components/supervisor/pkg/supervisor/user_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHasUser(t *testing.T) {
-	gitpodUser := user.User{Username: gitpodUserName, Uid: strconv.Itoa(gitpodUID), HomeDir: "/home/gitpod", Gid: strconv.Itoa(gitpodGID)}
+	gitpodUser := user.User{Username: legacyGitpodUserName, Uid: strconv.Itoa(legacyGitpodUID), HomeDir: "/home/gitpod", Gid: strconv.Itoa(legacyGitpodGID)}
 	mod := func(u user.User, m func(u *user.User)) *user.User {
 		m(&u)
 		return &u
@@ -39,15 +39,15 @@ func TestHasUser(t *testing.T) {
 		{
 			Name: "does not exist",
 			Ops: ops{
-				RLookup:   opsResult{Err: user.UnknownUserError(gitpodUserName)},
-				RLookupId: opsResult{Err: user.UnknownUserIdError(gitpodUID)},
+				RLookup:   opsResult{Err: user.UnknownUserError(legacyGitpodUserName)},
+				RLookupId: opsResult{Err: user.UnknownUserIdError(legacyGitpodUID)},
 			},
 		},
 		{
 			Name: "different UID",
 			Ops: ops{
 				RLookup:   opsResult{User: mod(gitpodUser, func(u *user.User) { u.Uid = "1000" })},
-				RLookupId: opsResult{Err: user.UnknownUserIdError(gitpodUID)},
+				RLookupId: opsResult{Err: user.UnknownUserIdError(legacyGitpodUID)},
 			},
 			Expectation: Expectation{
 				Exists: true,
@@ -57,7 +57,7 @@ func TestHasUser(t *testing.T) {
 		{
 			Name: "different name",
 			Ops: ops{
-				RLookup:   opsResult{Err: user.UnknownUserError(gitpodUserName)},
+				RLookup:   opsResult{Err: user.UnknownUserError(legacyGitpodUserName)},
 				RLookupId: opsResult{User: mod(gitpodUser, func(u *user.User) { u.Username = "foobar" })},
 			},
 			Expectation: Expectation{
@@ -107,7 +107,7 @@ func TestHasUser(t *testing.T) {
 }
 
 func TestHasGroup(t *testing.T) {
-	gitpodGroup := user.Group{Name: gitpodGroupName, Gid: strconv.Itoa(gitpodGID)}
+	gitpodGroup := user.Group{Name: legacyGitpodGroupName, Gid: strconv.Itoa(legacyGitpodGID)}
 	mod := func(u user.Group, m func(u *user.Group)) *user.Group {
 		m(&u)
 		return &u
@@ -133,7 +133,7 @@ func TestHasGroup(t *testing.T) {
 		{
 			Name: "does not exist",
 			Ops: ops{
-				RLookupGroup:   opsResult{Err: user.UnknownGroupError(gitpodGroupName)},
+				RLookupGroup:   opsResult{Err: user.UnknownGroupError(legacyGitpodGroupName)},
 				RLookupGroupId: opsResult{Err: user.UnknownGroupIdError(gitpodGroup.Gid)},
 			},
 		},
@@ -151,7 +151,7 @@ func TestHasGroup(t *testing.T) {
 		{
 			Name: "different name",
 			Ops: ops{
-				RLookupGroup:   opsResult{Err: user.UnknownGroupError(gitpodGroupName)},
+				RLookupGroup:   opsResult{Err: user.UnknownGroupError(legacyGitpodGroupName)},
 				RLookupGroupId: opsResult{Group: mod(gitpodGroup, func(u *user.Group) { u.Name = "foobar" })},
 			},
 			Expectation: Expectation{
@@ -164,7 +164,7 @@ func TestHasGroup(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			defaultLookup = test.Ops
-			exists, err := hasGroup(gitpodGroupName, gitpodGID)
+			exists, err := hasGroup(legacyGitpodGroupName, legacyGitpodGID)
 			var act Expectation
 			act.Exists = exists
 			if err != nil {

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -329,7 +329,7 @@ func RunInitializerChild() (err error) {
 	rs := &remoteContentStorage{RemoteContent: initmsg.RemoteContent}
 
 	dst := initmsg.Destination
-	initializer, err := wsinit.NewFromRequest(ctx, dst, rs, &req, wsinit.NewFromRequestOpts{ForceGitpodUserForGit: false})
+	initializer, err := wsinit.NewFromRequest(ctx, dst, rs, &req, wsinit.NewFromRequestOpts{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This reverts commit 40c39f531212176475985a54d972d20768b5d5c7.

## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
