### PR TITLE
Fix Alert close icon colors

### DIFF
--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -46,6 +46,7 @@ interface AlertInfo {
     txtCls: string;
     icon: React.ReactNode;
     iconColor?: string;
+    closeIconColor?: string;
 }
 
 const infoMap: Record<AlertType, AlertInfo> = {
@@ -84,6 +85,7 @@ const infoMap: Record<AlertType, AlertInfo> = {
         txtCls: "text-white",
         icon: <Exclamation className="w-4 h-4"></Exclamation>,
         iconColor: "filter-brightness-10",
+        closeIconColor: "text-white",
     },
 };
 
@@ -124,12 +126,17 @@ export default function Alert(props: AlertProps) {
                 <span className={`ml-4`}>
                     {/* Use an IconButton component once we make it */}
                     <Button
-                        type="secondary"
-                        className="bg-transparent hover:bg-transparent"
+                        type="transparent"
+                        className="hover:bg-transparent"
                         onClick={handleClose}
                         autoFocus={autoFocusClose}
                     >
-                        <XSvg className="w-3 h-4 cursor-pointer text-white" />
+                        <XSvg
+                            className={classNames(
+                                "w-3 h-4 cursor-pointer dark:text-white",
+                                info.closeIconColor || "text-gray-700",
+                            )}
+                        />
                     </Button>
                 </span>
             )}


### PR DESCRIPTION
## Description

Fixes the close icon color for correct contrasts across the board. Currently, the info type's close icon is barely visible at all.

| Light | Dark |
|--------|--------|
| <img width="667" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/5a208db6-076b-4b36-a84e-86284bd850d9"> | <img width="667" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/0b17ef99-1086-4d63-ba92-ab011b806451"> | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7669301</samp>

Add custom close icon color for dashboard alerts. Improve default alert appearance by using consistent colors and buttons.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
