### PR TITLE
[supervisor] Don't panic if connection is already closed

### DIFF
--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -166,7 +166,9 @@ func (rc *ReconnectingWebsocket) Dial(ctx context.Context) error {
 		case connCh := <-rc.connCh:
 			connCh <- conn
 		case <-rc.errCh:
-			conn.Close()
+			if conn != nil {
+				conn.Close()
+			}
 
 			time.Sleep(1 * time.Second)
 			conn = rc.connect(ctx)


### PR DESCRIPTION
## Description
Fixes this issue
<img width="1616" alt="image" src="https://github.com/gitpod-io/gitpod/assets/3210701/99ed20ae-4462-4064-b0dd-19b27d76546f">

The issue arrises if prior connection attempts fail and we don't actually have a connection.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3db30d6</samp>

Fix a potential panic in the reconnecting websocket client. Add a nil check before closing the connection in `reconnecting-ws.go`.

</details>

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
