### PR TITLE
[installer] Change cookie name

### DIFF
--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -58,5 +58,5 @@ func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount
 func cookieNameFromDomain(domain string) string {
 	// replace all non-word characters with underscores
 	derived := regexp.MustCompile(`[\W_]+`).ReplaceAllString(domain, "_")
-	return "_" + derived + "_jwt_"
+	return "_" + derived + "_jwt2_"
 }

--- a/install/installer/pkg/components/auth/config_test.go
+++ b/install/installer/pkg/components/auth/config_test.go
@@ -15,42 +15,42 @@ func TestCookieNameFromDomain(t *testing.T) {
 		{
 			name:            "Simple Domain",
 			domain:          "example.com",
-			expectedOutcome: "_example_com_jwt_",
+			expectedOutcome: "_example_com_jwt2_",
 		},
 		{
 			name:            "Domain with Underscore",
 			domain:          "example_test.com",
-			expectedOutcome: "_example_test_com_jwt_",
+			expectedOutcome: "_example_test_com_jwt2_",
 		},
 		{
 			name:            "Domain with Hyphen",
 			domain:          "example-test.com",
-			expectedOutcome: "_example_test_com_jwt_",
+			expectedOutcome: "_example_test_com_jwt2_",
 		},
 		{
 			name:            "Domain with Special Characters",
 			domain:          "example&test.com",
-			expectedOutcome: "_example_test_com_jwt_",
+			expectedOutcome: "_example_test_com_jwt2_",
 		},
 		{
 			name:            "Subdomain",
 			domain:          "subdomain.example.com",
-			expectedOutcome: "_subdomain_example_com_jwt_",
+			expectedOutcome: "_subdomain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Hyphen",
 			domain:          "sub-domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt_",
+			expectedOutcome: "_sub_domain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Underscore",
 			domain:          "sub_domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt_",
+			expectedOutcome: "_sub_domain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Special Characters",
 			domain:          "sub&domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt_",
+			expectedOutcome: "_sub_domain_example_com_jwt2_",
 		},
 	}
 

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -63,7 +63,7 @@ func TestConfigMap(t *testing.T) {
 				LifetimeSeconds: int64((24 * 7 * time.Hour).Seconds()),
 				Issuer:          "https://test.domain.everything.awesome.is",
 				Cookie: config.CookieConfig{
-					Name:     "_test_domain_everything_awesome_is_jwt_",
+					Name:     "_test_domain_everything_awesome_is_jwt2_",
 					MaxAge:   int64((24 * 7 * time.Hour).Seconds()),
 					SameSite: "lax",
 					Secure:   true,

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -69,7 +69,7 @@ func TestConfigMap(t *testing.T) {
 				LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
 				Issuer:          "https://awesome.domain",
 				Cookie: auth.CookieConfig{
-					Name:     "_awesome_domain_jwt_",
+					Name:     "_awesome_domain_jwt2_",
 					MaxAge:   int64((7 * 24 * time.Hour).Seconds()),
 					SameSite: "lax",
 					Secure:   true,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08dea59</samp>

Change cookie name suffix for Gitpod authentication. This avoids cookie conflicts and prepares for further auth improvements.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
