### PR TITLE
[db] userById fails on undefined

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -49,6 +49,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { DataCache } from "../data-cache";
 import { TransactionalDBImpl } from "./transactional-db-impl";
 import { TypeORM } from "./typeorm";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 // OAuth token expiry
 const tokenExpiryInFuture = new DateInterval("7d");
@@ -132,6 +133,9 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
     }
 
     public async findUserById(id: string): Promise<MaybeUser> {
+        if (!id || id.trim() === "") {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Cannot find user without id");
+        }
         return this.cache.get(getUserCacheKey(id), async () => {
             const userRepo = await this.getUserRepo();
             const result = await userRepo.findOne(id);

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -98,6 +98,36 @@ class UserDBSpec {
     }
 
     @test(timeout(10000))
+    public async findUserById() {
+        const user = await this.db.newUser();
+        user.identities.push(this.IDENTITY1);
+        await this.db.storeUser(user);
+
+        const foundUser = await this.db.findUserById(user.id);
+        expect(foundUser!.id).to.eq(user.id);
+    }
+
+    @test(timeout(10000))
+    public async findUserById_undefined() {
+        const user = await this.db.newUser();
+        user.identities.push(this.IDENTITY1);
+        await this.db.storeUser(user);
+
+        try {
+            await this.db.findUserById(undefined!);
+            expect.fail("Should have failed");
+        } catch (error) {
+            expect(error.code).to.eq(400);
+        }
+        try {
+            await this.db.findUserById("");
+            expect.fail("Should have failed");
+        } catch (error) {
+            expect(error.code).to.eq(400);
+        }
+    }
+
+    @test(timeout(10000))
     public async findUsersByEmail_multiple_users_identities() {
         let user1 = await this.db.newUser();
         user1.name = "Old";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make findUserById fail on `undefined`.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6e31f0</samp>

This pull request improves the error handling and testing of the `findUserById` method in the user database module. It adds custom errors using the `ApplicationError` class and two new test cases in `user-db.spec.db.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
