### PR TITLE
Update PAPI component, should cause a new build

### DIFF
--- a/components/public-api-server/README.md
+++ b/components/public-api-server/README.md
@@ -19,11 +19,6 @@ from development environments and will enable richer integrations with Integrate
 The public API will initially be offered as a gRPC service. Clients for various languages will be available. At the moment, the API is in early stages and clients are not available.
 
 
-## Roadmap
-The roadmap and progress towards a stable release of the API is tracked in [Epic: Public Gitpod API](https://github.com/gitpod-io/gitpod/issues/7900).
-
-
 ## Architecture
-* The API will be exposed on `api.gitpod.io` or `api.<domain>` for self-hosted or managed installations.
+* The API will be exposed on `api.gitpod.io` or `api.<domain>` for Dedicated installations.
 * The API is structured into services with definitions available in [components/public-api/gitpod/](../public-api/gitpod) as protobuf definitions.
-

--- a/components/public-api-server/pkg/oidc/service_test.go
+++ b/components/public-api-server/pkg/oidc/service_test.go
@@ -144,7 +144,7 @@ func TestGetClientConfigFromStartRequest(t *testing.T) {
 func TestGetClientConfigFromStartRequestSingleOrg(t *testing.T) {
 	issuer := newFakeIdP(t)
 	service, dbConn := setupOIDCServiceForTests(t)
-	// make sure no other teams are in the db anymore
+	// make sure no other organizations are in the db anymore
 	dbConn.Delete(&db.Organization{}, "1=1")
 	config, team := createConfig(t, dbConn, &ClientConfig{
 		Issuer:         issuer,


### PR DESCRIPTION
## Description
Motivation is to force a new build of PAPI component.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4f6bd5</samp>

This pull request removes the `Roadmap` section from the `Usage` section of the `components/public-api-server/README.md` file. This simplifies the documentation and avoids duplication of the public API server roadmap.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
