### PR TITLE
[linting] Enable eslint/no-unsafe-argument

### DIFF
--- a/components/gitpod-db/.eslintrc
+++ b/components/gitpod-db/.eslintrc
@@ -10,6 +10,7 @@
     },
     "rules": {
         "no-var": "error",
+        "no-void": "error",
         "prefer-const": "error",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/ban-types": "off",
@@ -17,6 +18,7 @@
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-misused-promises": [
@@ -28,6 +30,7 @@
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unsafe-argument": "error",
         "@typescript-eslint/no-unused-vars": [
             "error",
             {

--- a/components/gitpod-db/src/migrate-migrations.ts
+++ b/components/gitpod-db/src/migrate-migrations.ts
@@ -7,6 +7,7 @@
 import { TypeORM } from "./typeorm/typeorm";
 import { Config } from "./config";
 import { MigrateMigrations0_2_0 } from "./typeorm/migrate-migrations-0_2_0";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 async function migrateMigrationsTable() {
     const config = new Config();
@@ -17,7 +18,7 @@ async function migrateMigrationsTable() {
     const migration_0_2_0 = new MigrateMigrations0_2_0();
     await migration_0_2_0.up(runner);
 
-    conn.close();
+    conn.close().catch((err) => log.error("cannot close connection", err));
     console.log("successfully migrated 'migrations' table.");
 }
 

--- a/components/gitpod-db/src/periodic-deleter.ts
+++ b/components/gitpod-db/src/periodic-deleter.ts
@@ -39,18 +39,13 @@ export class PeriodicDbDeleter {
         const pendingDeletions: Promise<void>[] = [];
         for (const { deletions } of toBeDeleted.reverse()) {
             for (const deletion of deletions) {
-                pendingDeletions.push(
-                    this.query(deletion).catch((err) =>
-                        log.error(
-                            `[PeriodicDbDeleter] sync error`,
-                            {
-                                periodicDeleterTickId: tickID,
-                                query: deletion,
-                            },
-                            err,
-                        ),
-                    ),
+                const promise: Promise<void> = this.query(deletion).catch((err) =>
+                    log.error(`[PeriodicDbDeleter] sync error`, err, {
+                        periodicDeleterTickId: tickID,
+                        query: deletion,
+                    }),
                 );
+                pendingDeletions.push(promise);
             }
         }
         await Promise.all(pendingDeletions);

--- a/components/gitpod-db/src/redis/publisher.spec.ts
+++ b/components/gitpod-db/src/redis/publisher.spec.ts
@@ -31,8 +31,8 @@ class TestRedisPublisher {
 
     @test public publishInstanceUpdate() {
         const publisher = this.container.get(RedisPublisher);
-        expect(() => {
-            publisher.publishInstanceUpdate({
+        expect(async () => {
+            await publisher.publishInstanceUpdate({
                 ownerID: "123-owner",
                 instanceID: "123",
                 workspaceID: "foo-bar-123",

--- a/components/gitpod-db/src/tables.spec.ts
+++ b/components/gitpod-db/src/tables.spec.ts
@@ -19,11 +19,7 @@ class TablesSpec {
     @test(timeout(10000))
     public async createAndFindATeam() {
         const thing = new GitpodTableDescriptionProvider();
-        try {
-            thing.getSortedTables();
-        } catch (error) {
-            expect.fail(error);
-        }
+        expect(() => thing.getSortedTables()).to.not.throw();
     }
 }
 

--- a/components/gitpod-db/src/test/reset-db.ts
+++ b/components/gitpod-db/src/test/reset-db.ts
@@ -12,7 +12,7 @@ export async function resetDB(typeorm: TypeORM) {
     const conn = await typeorm.getConnection();
     const users = await conn.getRepository(DBUser).find();
     // delete all users except the builtin users
-    conn.getRepository(DBUser).remove(users.filter((u) => !isBuiltinUser(u.id)));
+    await conn.getRepository(DBUser).remove(users.filter((u) => !isBuiltinUser(u.id)));
 
     const deletions = conn.entityMetadatas
         .filter((meta) => meta.tableName !== "d_b_user")

--- a/components/gitpod-db/src/traced-db.ts
+++ b/components/gitpod-db/src/traced-db.ts
@@ -17,6 +17,7 @@ export class DBWithTracing<T> {
     public trace(ctx: TraceContext): T {
         return new Proxy(this.db, {
             get: (_target: any, name: string) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 const f = Reflect.get(_target, name);
                 if (!f) {
                     return undefined;

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -254,7 +254,7 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
         const orgSettings = await orgSettingsRepo.findOne({ where: { orgId } });
         if (orgSettings) {
             orgSettings.deleted = true;
-            orgSettingsRepo.save(orgSettings);
+            await orgSettingsRepo.save(orgSettings);
         }
     }
 

--- a/components/gitpod-db/src/typeorm/transformer.ts
+++ b/components/gitpod-db/src/typeorm/transformer.ts
@@ -64,6 +64,7 @@ export namespace Transformer {
         },
         from(value: any): any {
             // From TIMESTAMP to ISO string
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             return new Date(Date.parse(value)).toISOString();
         },
     };
@@ -74,6 +75,7 @@ export namespace Transformer {
                 return JSON.stringify(value || defaultValue);
             },
             from(value: any): any {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 return JSON.parse(value);
             },
         };
@@ -85,6 +87,7 @@ export namespace Transformer {
                 return encryptionServiceProvider().encrypt(value);
             },
             from(value: any): any {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 return encryptionServiceProvider().decrypt(value);
             },
         };

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -379,6 +379,7 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
         }
         const res = await userRepo.query(query);
         const count = res[0].cnt;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return Number.parseInt(count);
     }
 
@@ -598,7 +599,7 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
     }
     async revoke(accessTokenToken: OAuthToken): Promise<void> {
         const tokenHash = crypto.createHash("sha256").update(accessTokenToken.accessToken, "utf8").digest("hex");
-        this.deleteGitpodToken(tokenHash);
+        await this.deleteGitpodToken(tokenHash);
     }
     async isRefreshTokenRevoked(refreshToken: OAuthToken): Promise<boolean> {
         return Date.now() > (refreshToken.refreshTokenExpiresAt?.getTime() ?? 0);

--- a/components/gitpod-db/src/wait-for-db.ts
+++ b/components/gitpod-db/src/wait-for-db.ts
@@ -35,9 +35,9 @@ function connectOrReschedule(attempt: number) {
     }
 }
 
-function rescheduleConnectionAttempt(attempt: number, err: Error) {
+function rescheduleConnectionAttempt(attempt: number, err: unknown) {
     if (attempt == totalAttempts) {
-        console.log(`Could not connect within ${totalAttempts} attempts. Stopping.`);
+        console.log(`Could not connect within ${totalAttempts} attempts. Stopping.`, err);
         process.exit(1);
     }
     console.log(`Connection attempt ${attempt}/${totalAttempts} failed. Retrying in ${retryPeriod / 1000} seconds.`);

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -41,7 +41,13 @@ class WorkspaceDBSpec {
             tasks: [],
         },
         projectId: this.projectAID,
-        context: { title: "example" },
+        context: <CommitContext>{
+            title: "example",
+            repository: {
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+            },
+            revision: "abc",
+        },
         contextURL: "example.org",
         description: "blabla",
         ownerId: this.userId,
@@ -105,7 +111,13 @@ class WorkspaceDBSpec {
             tasks: [],
         },
         projectId: this.projectBID,
-        context: { title: "example" },
+        context: <CommitContext>{
+            title: "example",
+            repository: {
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+            },
+            revision: "abc",
+        },
         contextURL: "https://github.com/gitpod-io/gitpod",
         description: "Gitpod",
         ownerId: this.userId,
@@ -145,7 +157,13 @@ class WorkspaceDBSpec {
             image: "",
             tasks: [],
         },
-        context: { title: "example" },
+        context: <CommitContext>{
+            title: "example",
+            repository: {
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+            },
+            revision: "abc",
+        },
         contextURL: "example.org",
         description: "blabla",
         ownerId: this.userId,
@@ -204,6 +222,16 @@ class WorkspaceDBSpec {
             return;
         }
         fail("Rollback failed");
+    }
+
+    @test(timeout(10000))
+    public async testFindByInstanceId() {
+        await this.db.transaction(async (db) => {
+            await Promise.all([db.store(this.ws), db.storeInstance(this.wsi1)]);
+            const dbResult = await db.findByInstanceId(this.wsi1.id);
+            const expected = await db.findById(this.wsi1.workspaceId);
+            expect(dbResult).to.deep.eq(expected);
+        });
     }
 
     @test(timeout(10000))
@@ -583,6 +611,7 @@ class WorkspaceDBSpec {
                     repository: {
                         cloneUrl: inactiveRepo,
                     },
+                    revision: "abc",
                 },
                 config: {},
                 type: "regular",
@@ -599,6 +628,7 @@ class WorkspaceDBSpec {
                     repository: {
                         cloneUrl: activeRepo,
                     },
+                    revision: "abc",
                 },
                 config: {},
                 type: "regular",

--- a/components/gitpod-protocol/.eslintrc
+++ b/components/gitpod-protocol/.eslintrc
@@ -10,6 +10,7 @@
     },
     "rules": {
         "no-var": "error",
+        "no-void": "error",
         "prefer-const": "error",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/ban-types": "off",
@@ -17,6 +18,7 @@
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-misused-promises": [
@@ -28,6 +30,7 @@
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unsafe-argument": "error",
         "@typescript-eslint/no-unused-vars": [
             "error",
             {

--- a/components/gitpod-protocol/src/gitpod-file-parser.ts
+++ b/components/gitpod-protocol/src/gitpod-file-parser.ts
@@ -13,7 +13,7 @@ import { WorkspaceConfig, PortRangeConfig } from "./protocol";
 export type MaybeConfig = WorkspaceConfig | undefined;
 
 const schema = require("../data/gitpod-schema.json");
-const validate = new Ajv().compile(schema);
+const validate = new Ajv().compile(schema as object);
 const defaultParseOptions = {
     acceptPortRanges: false,
 };
@@ -33,6 +33,7 @@ export class GitpodFileParser {
         };
         try {
             const parsedConfig = yaml.safeLoad(content) as any;
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             validate(parsedConfig);
             const validationErrors = validate.errors ? validate.errors.map((e) => e.message || e.keyword) : undefined;
             if (validationErrors && validationErrors.length > 0) {

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -38,9 +38,11 @@ export namespace ApplicationError {
         }
     }
 
-    export function fromGRPCError(e: any & Error, data?: any): ApplicationError {
+    export function fromGRPCError(e: any, data?: any): ApplicationError {
         // Argument e should be ServerErrorResponse
         // But to reduce dependency requirement, we use Error here
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return new ApplicationError(categorizeRPCError(e.code), e.message, data);
     }
 

--- a/components/gitpod-protocol/src/messaging/proxy-factory.ts
+++ b/components/gitpod-protocol/src/messaging/proxy-factory.ts
@@ -99,10 +99,14 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
 
     protected waitForConnection(): void {
         this.connectionPromise = new Promise((resolve) => (this.connectionPromiseResolve = resolve));
-        this.connectionPromise.then((connection) => {
-            connection.onClose(() => this.fireConnectionClosed());
-            this.fireConnectionOpened();
-        });
+        this.connectionPromise
+            .then((connection) => {
+                connection.onClose(() => this.fireConnectionClosed());
+                this.fireConnectionOpened();
+            })
+            .catch((err) => {
+                log.error("Error while waiting for connection", err);
+            });
     }
 
     fireConnectionClosed() {
@@ -120,7 +124,9 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
      * response.
      */
     listen(connection: MessageConnection) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         connection.onRequest((method: string, ...params: any[]) => this.onRequest(method, ...params));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         connection.onNotification((method: string, ...params: any[]) => this.onNotification(method, ...params));
         connection.onDispose(() => this.waitForConnection());
         connection.listen();
@@ -172,7 +178,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
      * If `T` implements `JsonRpcServer` then a client is used as a target object for a remote target object.
      */
     createProxy(): JsonRpcProxy<T> {
-        const result = new Proxy<T>(this as any, this);
+        const result = new Proxy<T>(this as unknown as T, this);
         return result as any;
     }
 
@@ -217,11 +223,13 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
                     new Promise((resolve, reject) => {
                         try {
                             if (isNotify) {
+                                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                                 connection.sendNotification(p.toString(), ...args);
                                 resolve(undefined);
                             } else {
+                                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                                 const resultPromise = connection.sendRequest(p.toString(), ...args) as Promise<any>;
-                                resultPromise.catch((err: any) => reject(err)).then((result: any) => resolve(result));
+                                resultPromise.then(resolve, reject);
                             }
                         } catch (err) {
                             reject(err);

--- a/components/gitpod-protocol/src/public-api-converter.spec.ts
+++ b/components/gitpod-protocol/src/public-api-converter.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/gitpod-protocol/src/util/async-iterator.ts
+++ b/components/gitpod-protocol/src/util/async-iterator.ts
@@ -51,6 +51,7 @@ export class AsyncCachingIteratorImpl<T> implements AsyncIterableIterator<T>, As
         }
         this.cacheRead = true;
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const result = await this.iterable.next(value);
         if (!result.done) {
             this.cache.push(result.value);

--- a/components/gitpod-protocol/src/util/deferred.ts
+++ b/components/gitpod-protocol/src/util/deferred.ts
@@ -17,9 +17,9 @@ export class Deferred<T> {
     }
 
     promise = new Promise<T>((resolve, reject) => {
-        this.resolve = (o) => {
+        this.resolve = (o?: T) => {
             this.isResolved = true;
-            resolve(o as any);
+            resolve(o as T);
             clearTimeout(this.timer);
         };
         this.reject = (e) => {

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -25,6 +25,7 @@ export class GitpodHostUrl {
     readonly url: URL;
 
     constructor(url: string) {
+        //HACK - we don't want clients to pass in a URL object, but we need to use it internally
         const urlParam = url as any;
         if (typeof urlParam === "string") {
             // public constructor
@@ -68,6 +69,7 @@ export class GitpodHostUrl {
             update.pathname = "/" + update.pathname;
         }
         const result = Object.assign(new URL(this.toString()), update);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return new GitpodHostUrl(result);
     }
 

--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -6,7 +6,7 @@
 
 import { scrubber } from "./scrubbing";
 
-const inspect: (object: any) => string = require("util").inspect; // undefined in frontend
+const inspect: (object: unknown) => string = require("util").inspect; // undefined in frontend
 
 const plainLogging: boolean = false; // set to true during development to get non JSON output
 let jsonLogging: boolean = false;
@@ -31,6 +31,10 @@ export namespace LogContext {
     export function setAugmenter(augmenter: Augmenter): void {
         logContextAugmenter = augmenter;
     }
+
+    /**
+     * @deprecated create LogContext directly
+     */
     export function from(params: { userId?: string; user?: any; request?: any }) {
         return <LogContext>{
             sessionId: params.request?.requestID,
@@ -44,67 +48,67 @@ export interface LogPayload {
 }
 
 export namespace log {
-    export function error(context: LogContext, message: string, error: any, payload: LogPayload): void;
-    export function error(context: LogContext, message: string, error: any): void;
+    export function error(context: LogContext, message: string, error: unknown, payload: LogPayload): void;
+    export function error(context: LogContext, message: string, error: unknown): void;
     export function error(context: LogContext, message: string, payload: LogPayload): void;
     export function error(context: LogContext, message: string): void;
-    export function error(context: LogContext, error: any, payload: LogPayload): void;
-    export function error(context: LogContext, error: any): void;
-    export function error(message: string, error: any, payload: LogPayload): void;
-    export function error(message: string, error: any): void;
+    export function error(context: LogContext, error: unknown, payload: LogPayload): void;
+    export function error(context: LogContext, error: unknown): void;
+    export function error(message: string, error: unknown, payload: LogPayload): void;
+    export function error(message: string, error: unknown): void;
     export function error(message: string, payload: LogPayload): void;
     export function error(message: string): void;
-    export function error(error: any, payload: LogPayload): void;
-    export function error(error: any): void;
-    export function error(...args: any[]): void {
+    export function error(error: unknown, payload: LogPayload): void;
+    export function error(error: unknown): void;
+    export function error(...args: unknown[]): void {
         errorLog(false, args);
     }
 
-    export function warn(context: LogContext, message: string, error: any, payload: LogPayload): void;
-    export function warn(context: LogContext, message: string, error: any): void;
+    export function warn(context: LogContext, message: string, error: unknown, payload: LogPayload): void;
+    export function warn(context: LogContext, message: string, error: unknown): void;
     export function warn(context: LogContext, message: string, payload: LogPayload): void;
     export function warn(context: LogContext, message: string): void;
-    export function warn(context: LogContext, error: any, payload: LogPayload): void;
-    export function warn(context: LogContext, error: any): void;
-    export function warn(message: string, error: any, payload: LogPayload): void;
-    export function warn(message: string, error: any): void;
+    export function warn(context: LogContext, error: unknown, payload: LogPayload): void;
+    export function warn(context: LogContext, error: unknown): void;
+    export function warn(message: string, error: unknown, payload: LogPayload): void;
+    export function warn(message: string, error: unknown): void;
     export function warn(message: string, payload: LogPayload): void;
     export function warn(message: string): void;
-    export function warn(error: any, payload: LogPayload): void;
-    export function warn(error: any): void;
-    export function warn(...args: any[]): void {
+    export function warn(error: unknown, payload: LogPayload): void;
+    export function warn(error: unknown): void;
+    export function warn(...args: unknown[]): void {
         warnLog(false, args);
     }
 
-    export function info(context: LogContext, message: string, error: any, payload: LogPayload): void;
-    export function info(context: LogContext, message: string, error: any): void;
+    export function info(context: LogContext, message: string, error: unknown, payload: LogPayload): void;
+    export function info(context: LogContext, message: string, error: unknown): void;
     export function info(context: LogContext, message: string, payload: LogPayload): void;
     export function info(context: LogContext, message: string): void;
-    export function info(context: LogContext, error: any, payload: LogPayload): void;
-    export function info(context: LogContext, error: any): void;
-    export function info(message: string, error: any, payload: LogPayload): void;
-    export function info(message: string, error: any): void;
+    export function info(context: LogContext, error: unknown, payload: LogPayload): void;
+    export function info(context: LogContext, error: unknown): void;
+    export function info(message: string, error: unknown, payload: LogPayload): void;
+    export function info(message: string, error: unknown): void;
     export function info(message: string, payload: LogPayload): void;
     export function info(message: string): void;
-    export function info(error: any, payload: LogPayload): void;
-    export function info(error: any): void;
-    export function info(...args: any[]): void {
+    export function info(error: unknown, payload: LogPayload): void;
+    export function info(error: unknown): void;
+    export function info(...args: unknown[]): void {
         infoLog(false, args);
     }
 
-    export function debug(context: LogContext, message: string, error: any, payload: LogPayload): void;
-    export function debug(context: LogContext, message: string, error: any): void;
+    export function debug(context: LogContext, message: string, error: unknown, payload: LogPayload): void;
+    export function debug(context: LogContext, message: string, error: unknown): void;
     export function debug(context: LogContext, message: string, payload: LogPayload): void;
     export function debug(context: LogContext, message: string): void;
-    export function debug(context: LogContext, error: any, payload: LogPayload): void;
-    export function debug(context: LogContext, error: any): void;
-    export function debug(message: string, error: any, payload: LogPayload): void;
-    export function debug(message: string, error: any): void;
+    export function debug(context: LogContext, error: unknown, payload: LogPayload): void;
+    export function debug(context: LogContext, error: unknown): void;
+    export function debug(message: string, error: unknown, payload: LogPayload): void;
+    export function debug(message: string, error: unknown): void;
     export function debug(message: string, payload: LogPayload): void;
     export function debug(message: string): void;
-    export function debug(error: any, payload: LogPayload): void;
-    export function debug(error: any): void;
-    export function debug(...args: any[]): void {
+    export function debug(error: unknown, payload: LogPayload): void;
+    export function debug(error: unknown): void;
+    export function debug(...args: unknown[]): void {
         debugLog(false, args);
     }
 
@@ -125,16 +129,16 @@ export namespace log {
     export function setLogLevel(logLevel: LogrusLogLevel | undefined) {
         jsonLogging = true;
 
-        console.error = function (...args: any[]): void {
+        console.error = function (...args: unknown[]): void {
             errorLog(true, args);
         };
-        console.warn = function (...args: any[]): void {
+        console.warn = function (...args: unknown[]): void {
             warnLog(true, args);
         };
-        console.info = function (...args: any[]): void {
+        console.info = function (...args: unknown[]): void {
             infoLog(true, args);
         };
-        console.debug = function (...args: any[]): void {
+        console.debug = function (...args: unknown[]): void {
             debugLog(true, args);
         };
 
@@ -168,25 +172,25 @@ export namespace log {
     }
 }
 
-type DoLogFunction = (calledViaConsole: boolean, args: any[]) => void;
+type DoLogFunction = (calledViaConsole: boolean, args: unknown[]) => void;
 
 let errorLog = doErrorLog;
-function doErrorLog(calledViaConsole: boolean, args: any[]): void {
+function doErrorLog(calledViaConsole: boolean, args: unknown[]): void {
     doLog(calledViaConsole, errorConsoleLog, "ERROR", args);
 }
 
 let warnLog = doWarnLog;
-function doWarnLog(calledViaConsole: boolean, args: any[]): void {
+function doWarnLog(calledViaConsole: boolean, args: unknown[]): void {
     doLog(calledViaConsole, warnConsoleLog, "WARNING", args);
 }
 
 let infoLog = doInfoLog;
-function doInfoLog(calledViaConsole: boolean, args: any[]): void {
+function doInfoLog(calledViaConsole: boolean, args: unknown[]): void {
     doLog(calledViaConsole, infoConsoleLog, "INFO", args);
 }
 
 let debugLog = doDebugLog;
-function doDebugLog(calledViaConsole: boolean, args: any[]): void {
+function doDebugLog(calledViaConsole: boolean, args: unknown[]): void {
     doLog(calledViaConsole, debugConsoleLog, "DEBUG", args);
 }
 
@@ -242,8 +246,9 @@ namespace GoogleLogSeverity {
     };
 }
 
-function doLog(calledViaConsole: boolean, consoleLog: ConsoleLog, severity: GoogleLogSeverity, args: any[]): void {
+function doLog(calledViaConsole: boolean, consoleLog: ConsoleLog, severity: GoogleLogSeverity, args: unknown[]): void {
     if (!jsonLogging) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         consoleLog(...args);
         return;
     }
@@ -256,7 +261,7 @@ function doLog(calledViaConsole: boolean, consoleLog: ConsoleLog, severity: Goog
     let context: LogContext | undefined;
     let message: string | undefined;
     let error: Error | undefined;
-    let payloadArgs: any[];
+    let payloadArgs: unknown[];
 
     if (args[0] instanceof Error) {
         // console.xyz(Error, ...any) / log.xyz(Error) / log.xyz(Error, LogPayload)
@@ -277,7 +282,7 @@ function doLog(calledViaConsole: boolean, consoleLog: ConsoleLog, severity: Goog
         // or when passing, by mistake, log.xyz instead of console.xyz to third-party code as a callback (*))
         payloadArgs = args;
     } else {
-        context = args[0];
+        context = args[0] instanceof Object ? args[0] : undefined;
         if (args[1] instanceof Error) {
             // log.xyz(LogContext, Error) / log.xyz(LogContext, Error, LogPayload)
             error = args[1];
@@ -310,7 +315,7 @@ function makeLogItem(
     context: LogContext | undefined,
     message: string | undefined,
     error: Error | undefined,
-    payloadArgs: any[],
+    payloadArgs: unknown[],
     calledViaConsole: boolean,
 ): string | undefined {
     if (context !== undefined && Object.keys(context).length == 0) {
@@ -325,7 +330,8 @@ function makeLogItem(
     }
 
     payloadArgs = payloadArgs.map((arg) => scrubPayload(arg, plainLogging));
-    const payload: any = payloadArgs.length == 0 ? undefined : payloadArgs.length == 1 ? payloadArgs[0] : payloadArgs;
+    const payload: unknown =
+        payloadArgs.length == 0 ? undefined : payloadArgs.length == 1 ? payloadArgs[0] : payloadArgs;
     const logItem = {
         // undefined fields get eliminated in JSON.stringify()
         ...reportedErrorEvent,
@@ -366,7 +372,7 @@ function makeLogItem(
     return result;
 }
 
-function scrubPayload(payload: any, plainLogging: boolean): any {
+function scrubPayload<T>(payload: T, plainLogging: boolean): T {
     if (plainLogging) {
         return payload;
     }
@@ -375,8 +381,8 @@ function scrubPayload(payload: any, plainLogging: boolean): any {
 
 // See https://cloud.google.com/error-reporting/docs/formatting-error-messages
 // and https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent
-function makeReportedErrorEvent(error: Error | undefined) {
-    const result: any = {
+function makeReportedErrorEvent(error: Error | undefined): {} {
+    const result = {
         // Serves as marker only
         "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
         // This is useful for filtering in the UI
@@ -384,21 +390,29 @@ function makeReportedErrorEvent(error: Error | undefined) {
             service: component || "<ts-not-set>",
             version: version || "<ts-not-set>",
         },
-    };
 
-    if (error) {
         // According to: https://cloud.google.com/error-reporting/docs/formatting-error-messages#json_representation
-        const stackTrace = error.stack;
-        if (stackTrace) {
-            result.stack_trace = stackTrace;
-        }
-    }
+        stack_trace: error?.stack,
+    };
 
     return result;
 }
 
-function makeLogItemStub(logItem: any): any {
-    const result: any = {
+type LogItem = {
+    component?: string;
+    severity?: string;
+    time?: string;
+    environment?: string;
+    region?: string;
+    message?: string;
+    messageStub?: string;
+    errorStub?: string;
+    error?: unknown;
+    payload?: unknown;
+};
+
+function makeLogItemStub(logItem: LogItem): LogItem {
+    const result = <LogItem>{
         component: logItem.component,
         severity: logItem.severity,
         time: logItem.time,
@@ -412,7 +426,7 @@ function makeLogItemStub(logItem: any): any {
             result.messageStub = logItem.message.substring(0, maxMessageStubLength) + " ... (too long, truncated)";
         }
     }
-    if (logItem.error instanceof Error) {
+    if (logItem.error instanceof Error && logItem.error.stack) {
         if (logItem.error.stack.length <= maxErrorStubLength) {
             result.error = logItem.error.stack;
         } else {
@@ -422,7 +436,7 @@ function makeLogItemStub(logItem: any): any {
     return result;
 }
 
-function stringifyLogItem(logItem: any): string {
+function stringifyLogItem(logItem: LogItem): string {
     try {
         return jsonStringifyWithErrors(logItem);
     } catch (err) {
@@ -438,13 +452,13 @@ function stringifyLogItem(logItem: any): string {
 /**
  * Jsonifies Errors properly, not as {} only.
  */
-function jsonStringifyWithErrors(value: any): string {
+function jsonStringifyWithErrors(value: unknown): string {
     return JSON.stringify(value, (_, value) => {
         return value instanceof Error ? value.stack : value;
     });
 }
 
-type ConsoleLog = (message?: any, ...optionalArgs: any[]) => void; // signature of console.xyz
+type ConsoleLog = (message?: unknown, ...optionalArgs: unknown[]) => void; // signature of console.xyz
 const logConsoleLog: ConsoleLog = console.log;
 const errorConsoleLog: ConsoleLog = console.error;
 const warnConsoleLog: ConsoleLog = console.warn;

--- a/components/gitpod-protocol/src/util/queue.spec.ts
+++ b/components/gitpod-protocol/src/util/queue.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-floating-promises */
 /**
  * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/gitpod-protocol/src/util/scrubbing.ts
+++ b/components/gitpod-protocol/src/util/scrubbing.ts
@@ -115,7 +115,7 @@ function doScrub(obj: any, depth: number, nested: boolean): any {
     }
     const objType = typeof obj;
     if (objType === "string") {
-        return scrubber.scrubValue(obj);
+        return scrubber.scrubValue(obj as string);
     }
     if (objType === "boolean" || objType === "number") {
         return obj;
@@ -131,7 +131,7 @@ function doScrub(obj: any, depth: number, nested: boolean): any {
     }
     if (objType === "object") {
         const result: any = {};
-        for (const [key, value] of Object.entries(obj)) {
+        for (const [key, value] of Object.entries(obj as object)) {
             if (typeof value === "string") {
                 result[key] = scrubber.scrubKeyValue(key, value);
             } else {

--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -60,7 +60,7 @@ export namespace TraceContext {
         }
     }
 
-    export function setError(ctx: TraceContext, err: Error) {
+    export function setError(ctx: TraceContext, err: any) {
         if (!ctx.span) {
             return;
         }
@@ -169,6 +169,7 @@ export namespace TraceContext {
             for (const k of Object.keys(keyValueMap)) {
                 const v = keyValueMap[k];
                 if (v instanceof Object) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     addNestedTags(ctx, v, `${namespace}${k}`);
                 } else {
                     ctx.span.setTag(`${namespace}${k}`, v);
@@ -223,6 +224,7 @@ export class TracingManager {
 
         if (opts) {
             if (opts.perOpSampling) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 (t as any)._sampler = new PerOperationSampler((t as any)._sampler, opts.perOpSampling);
             }
         }
@@ -264,6 +266,7 @@ export class PerOperationSampler implements Sampler {
 
     onCreateSpan(span: opentracing.Span): SamplingDecision {
         const outTags = {};
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const isSampled = this.isSampled((span as any).operationName, outTags);
         // NB: return retryable=true here since we can change decision after setOperationName().
         return { sample: isSampled, retryable: true, tags: outTags };
@@ -271,6 +274,7 @@ export class PerOperationSampler implements Sampler {
 
     onSetOperationName(span: opentracing.Span, operationName: string): SamplingDecision {
         const outTags = {};
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const isSampled = this.isSampled((span as any).operationName, outTags);
         return { sample: isSampled, retryable: false, tags: outTags };
     }

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -13,6 +13,7 @@ const workspaceRegions = ["europe", "north-america", "south-america", "africa", 
 export type WorkspaceRegion = typeof workspaceRegions[number];
 
 export function isWorkspaceRegion(s: string): s is WorkspaceRegion {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return workspaceRegions.indexOf(s as any) !== -1;
 }
 

--- a/components/server/.eslintrc
+++ b/components/server/.eslintrc
@@ -30,6 +30,7 @@
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unsafe-argument": "error",
         "@typescript-eslint/no-unused-vars": [
             "error",
             {

--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -98,7 +98,7 @@ function getAnonymousId(request: Request) {
     if (!(request.cookies["gp-analytical"] === "true")) {
         return;
     }
-    return stripCookie(request.cookies.ajs_anonymous_id);
+    return stripCookie(request.cookies.ajs_anonymous_id as string);
 }
 
 function resolveIdentities(user: User) {

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -212,7 +212,8 @@ export class API {
     }
 
     private async verify(context: HandlerContext) {
-        const user = await this.sessionHandler.verify(context.requestHeader.get("cookie") || "");
+        const cookieHeader: string = context.requestHeader.get("cookie") || "";
+        const user = await this.sessionHandler.verify(cookieHeader);
         if (!user) {
             throw new ConnectError("unauthenticated", Code.Unauthenticated);
         }

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -32,7 +32,7 @@ const bearerAuthCode = "BearerAuth";
 interface BearerAuthError extends Error {
     code: typeof bearerAuthCode;
 }
-export function isBearerAuthError(error: Error): error is BearerAuthError {
+export function isBearerAuthError(error: any): error is BearerAuthError {
     return "code" in error && (error as any)["code"] === bearerAuthCode;
 }
 function createBearerAuthError(message: string): BearerAuthError {

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
@@ -371,7 +372,7 @@ export abstract class GenericAuthProvider implements AuthProvider {
          */
 
         const context = LogContext.from({
-            user: User.is(userOrIdentity) ? { userId: userOrIdentity.id } : undefined,
+            userId: User.is(userOrIdentity) ? userOrIdentity.id : undefined,
             request,
         });
 

--- a/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
@@ -40,6 +40,7 @@ class TestBitbucketServerApi {
                 bind(BitbucketServerContextParser).toSelf().inSingletonScope();
                 bind(AuthProviderParams).toConstantValue(TestBitbucketServerApi.AUTH_HOST_CONFIG);
                 bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 bind(TokenService).toConstantValue({
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -40,6 +40,7 @@ class TestBitbucketServerContextParser {
                 bind(BitbucketServerContextParser).toSelf().inSingletonScope();
                 bind(AuthProviderParams).toConstantValue(TestBitbucketServerContextParser.AUTH_HOST_CONFIG);
                 bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 bind(TokenService).toConstantValue({
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);

--- a/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
@@ -50,6 +50,7 @@ class TestBitbucketServerFileProvider {
                 bind(BitbucketServerContextParser).toSelf().inSingletonScope();
                 bind(AuthProviderParams).toConstantValue(TestBitbucketServerFileProvider.AUTH_HOST_CONFIG);
                 bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 bind(TokenService).toConstantValue({
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);
@@ -90,6 +91,7 @@ class TestBitbucketServerFileProvider {
 
     @test async test_getGitpodFileContent_ok() {
         const result = await this.service.getGitpodFileContent(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             {
                 revision: "master",
                 repository: <Repository>{

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -50,6 +50,7 @@ class TestBitbucketServerRepositoryProvider {
                 bind(BitbucketServerContextParser).toSelf().inSingletonScope();
                 bind(AuthProviderParams).toConstantValue(TestBitbucketServerRepositoryProvider.AUTH_HOST_CONFIG);
                 bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 bind(TokenService).toConstantValue({
                     createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
                 } as any);

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -77,6 +77,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
             const primaryEmail = emails.values.find((x: { is_primary: boolean; email: string }) => x.is_primary).email;
 
             const currentScopes = this.normalizeScopes(
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 (headers as any)["x-oauth-scopes"].split(",").map((s: string) => s.trim()),
             );
 

--- a/components/server/src/github/api.ts
+++ b/components/server/src/github/api.ts
@@ -27,7 +27,7 @@ export class GitHubApiError extends Error {
     }
 }
 export namespace GitHubApiError {
-    export function is(error: Error | null): error is GitHubApiError {
+    export function is(error: any): error is GitHubApiError {
         return !!error && error.name === "GitHubApiError";
     }
 }
@@ -198,7 +198,7 @@ export class GitHubRestApi {
             return response;
         } catch (error) {
             if (error.status) {
-                throw new GitHubApiError(error);
+                throw new GitHubApiError(error as OctokitResponse<any>);
             }
             throw error;
         } finally {

--- a/components/server/src/github/github-app-support.ts
+++ b/components/server/src/github/github-app-support.ts
@@ -121,6 +121,7 @@ export class GitHubAppSupport {
 
         // If hints contain an additional installationId, let's try to add the repos
         //
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const installationId = parseInt((hints as any)?.installationId, 10);
         if (!isNaN(installationId)) {
             if (!result.some((r) => r.installationId === installationId)) {

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -103,6 +103,7 @@ export class GitHubAuthProvider extends GenericAuthProvider {
             // https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
             // e.g. X-OAuth-Scopes: repo, user
             const currentScopes = this.normalizeScopes(
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 (headers as any)["x-oauth-scopes"].split(this.oauthConfig.scopeSeparator!).map((s: string) => s.trim()),
             );
 

--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -234,6 +234,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
                 if (repo.ref !== null) {
                     return {
                         ref: repo.ref.name,
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                         refType: this.toRefType({ userId: user.id }, { host, owner, repoName }, repo.ref.prefix),
                         isFile,
                         path,

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -95,7 +95,7 @@ export class GitLabAuthProvider extends GenericAuthProvider {
             if (error && typeof error.description === "string" && error.description.includes("403 Forbidden")) {
                 // If GitLab is configured to disallow OAuth-token based API access for unconfirmed users, we need to reject this attempt
                 // 403 Forbidden  - You (@...) must accept the Terms of Service in order to perform this action. Please access GitLab from a web browser to accept these terms.
-                throw UnconfirmedUserException.create(error.description, error);
+                throw UnconfirmedUserException.create(error.description as string, error);
             } else {
                 log.error(`(${this.strategyName}) Reading current user info failed`, error, { accessToken, error });
                 throw error;
@@ -105,7 +105,7 @@ export class GitLabAuthProvider extends GenericAuthProvider {
 
     protected readScopesFromVerifyParams(params: any) {
         if (params && typeof params.scope === "string") {
-            return this.normalizeScopes(params.scope.split(" "));
+            return this.normalizeScopes((params.scope as string).split(" "));
         }
         return [];
     }

--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -108,8 +108,8 @@ export async function start(container: Container) {
         const pool: any = (connection.driver as any).pool;
         interval = setInterval(async () => {
             try {
-                const activeConnections = pool._allConnections.length;
-                const freeConnections = pool._freeConnections.length;
+                const activeConnections = pool._allConnections.length as number;
+                const freeConnections = pool._freeConnections.length as number;
 
                 dbConnectionsTotal.set(activeConnections);
                 dbConnectionsFree.set(freeConnections);

--- a/components/server/src/linkedin-service.ts
+++ b/components/server/src/linkedin-service.ts
@@ -45,7 +45,7 @@ export class LinkedInService {
         if (data.error) {
             throw new Error("Could not get LinkedIn access token: " + data.error_description);
         }
-        return data.access_token;
+        return data.access_token as string;
     }
 
     // Retrieve the user's profile from LinkedIn using the following API:
@@ -96,12 +96,10 @@ export class LinkedInService {
         };
 
         try {
-            if (
-                typeof profileData.firstName?.localized === "object" &&
-                Object.values(profileData.firstName?.localized).length > 0
-            ) {
+            const localized = profileData.firstName?.localized;
+            if (typeof localized === "object" && Object.values(localized as object).length > 0) {
                 // If there are multiple first name localizations, just pick the first one
-                profile.firstName = String(Object.values(profileData.firstName.localized)[0]);
+                profile.firstName = String(Object.values(localized as object)[0]);
             }
         } catch (error) {
             log.error("Error getting LinkedIn first name", error);
@@ -110,10 +108,10 @@ export class LinkedInService {
         try {
             if (
                 typeof profileData.lastName?.localized === "object" &&
-                Object.values(profileData.lastName?.localized).length > 0
+                Object.values(profileData.lastName?.localized as object).length > 0
             ) {
                 // If there are multiple last name localizations, just pick the first one
-                profile.lastName = String(Object.values(profileData.lastName.localized)[0]);
+                profile.lastName = String(Object.values(profileData.lastName.localized as object)[0]);
             }
         } catch (error) {
             log.error("Error getting LinkedIn last name", error);

--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -146,11 +146,10 @@ export class RedisSubscriber {
             try {
                 l(ctx, prebuildWithStatus);
             } catch (err) {
-                log.error(
-                    "Failed to broadcast workspace instance update.",
-                    { projectId: update.projectID, workspaceId: update.workspaceID },
-                    err,
-                );
+                log.error("Failed to broadcast workspace instance update.", err, {
+                    projectId: update.projectID,
+                    workspaceId: update.workspaceID,
+                });
             }
         }
     }
@@ -172,7 +171,7 @@ export class RedisSubscriber {
             try {
                 l(ctx, update);
             } catch (err) {
-                log.error("Failed to broadcast headless update.", update, err);
+                log.error("Failed to broadcast headless update.", err, update);
             }
         }
     }

--- a/components/server/src/monitoring-endpoints.ts
+++ b/components/server/src/monitoring-endpoints.ts
@@ -22,6 +22,7 @@ export class MonitoringEndpointsApp {
         // Append redis metrics to default registry
         redisMetricsRegistry()
             .getMetricsAsArray()
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             .forEach((metric) => registry.registerMetric(metric as any));
 
         const monApp = express();

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -313,7 +313,8 @@ export class OrganizationService {
                 await this.auth.addOrganizationRole(orgId, memberId, membership.role);
             }
             const code = ApplicationError.hasErrorCode(err) ? err.code : ErrorCodes.INTERNAL_SERVER_ERROR;
-            throw new ApplicationError(code, err);
+            const message = ApplicationError.hasErrorCode(err) ? err.message : "" + err;
+            throw new ApplicationError(code, message);
         }
         this.analytics.track({
             userId,

--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -62,6 +62,7 @@ export class BitbucketApp {
                         return;
                     }
                     try {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                         const data = toData(req.body);
                         if (data) {
                             await this.handlePushHook({ span }, data, user, event);

--- a/components/server/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/src/prebuilds/bitbucket-server-app.ts
@@ -62,6 +62,7 @@ export class BitbucketServerApp {
                         return;
                     }
                     try {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                         await this.handlePushHook({ span }, user, payload, event);
                     } catch (err) {
                         TraceContext.setError({ span }, err);

--- a/components/server/src/prebuilds/bitbucket-server-service.spec.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -570,7 +570,7 @@ export class GithubApp {
 
         const newBody = body + `\n\n${button}\n\n`;
         const updatePrPromise = ctx.octokit.pulls.update({ ...ctx.repo(), pull_number: pr.number, body: newBody });
-        updatePrPromise.catch((err) => log.error(err, "Error while updating PR body", { contextURL }));
+        updatePrPromise.catch((err) => log.error("Error while updating PR body", err, { contextURL }));
     }
 
     private async onPrAddComment(
@@ -594,7 +594,7 @@ export class GithubApp {
 
         const newComment = ctx.issue({ body: `\n\n${button}\n\n` });
         const newCommentPromise = ctx.octokit.issues.createComment(newComment);
-        newCommentPromise.catch((err) => log.error(err, "Error while adding new PR comment", { contextURL }));
+        newCommentPromise.catch((err) => log.error("Error while adding new PR comment", err, { contextURL }));
     }
 
     private getBadgeImageURL(): string {

--- a/components/server/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/src/prebuilds/github-enterprise-app.ts
@@ -124,6 +124,7 @@ export class GitHubEnterpriseApp {
                     const sig =
                         "sha256=" +
                         createHmac("sha256", user.id + "|" + tokenEntry.token.value)
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                             .update(body)
                             .digest("hex");
                     return timingSafeEqual(Buffer.from(sig), Buffer.from(signature ?? ""));

--- a/components/server/src/prebuilds/prebuild-manager.spec.ts
+++ b/components/server/src/prebuilds/prebuild-manager.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -112,7 +112,7 @@ export class Server {
             const startTime = Date.now();
             req.on("end", () => {
                 const method = req.method;
-                const route = req.route?.path || req.baseUrl || "unknown";
+                const route = String(req.route?.path || req.baseUrl || "unknown");
                 observeHttpRequestDuration(method, route, res.statusCode, (Date.now() - startTime) / 1000);
                 increaseHttpRequestCounter(method, route, res.statusCode);
             });
@@ -162,6 +162,7 @@ export class Server {
             // We rely on the origin header being set correctly (needed by regular clients to use Gitpod:
             // CORS allows subdomains to access gitpod.io)
             const verifyOrigin = (origin: string) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 let allowedRequest = isAllowedWebsocketDomain(origin, this.config.hostUrl.url.hostname);
                 if (!allowedRequest && this.config.insecureNoDomain) {
                     log.warn("Websocket connection CSRF guard disabled");
@@ -217,6 +218,7 @@ export class Server {
             );
 
             const wsPingPongHandler = new WsConnectionHandler();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             const wsHandler = new WsExpressHandler(httpServer, verifyClient);
             this.disposables.push(wsHandler);
             wsHandler.ws(
@@ -229,6 +231,7 @@ export class Server {
                 ...initSessionHandlers,
                 wsPingPongHandler.handler(),
                 (ws: WebSocket, req: express.Request) => {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     websocketConnectionHandler.onConnection((req as any).wsConnection, req);
                 },
             );
@@ -240,6 +243,7 @@ export class Server {
                 },
                 wsPingPongHandler.handler(),
                 (ws: WebSocket, req: express.Request) => {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     websocketConnectionHandler.onConnection((req as any).wsConnection, req);
                 },
             );

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -59,7 +59,7 @@ const mockApplyingContainerModule = new ContainerModule((bind, unbound, isbound,
                 },
                 services: {
                     repositoryService: {
-                        installAutomatedPrebuilds: async (user: any, cloneUrl: any) => {
+                        installAutomatedPrebuilds: async (user: any, cloneUrl: string) => {
                             webhooks.add(cloneUrl);
                         },
                         canInstallAutomatedPrebuilds: async () => {

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -643,6 +643,7 @@ export class UserController {
             throw err;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return new AdminCredentials(payload.tokenHash, payload.expiresAt, payload.algo);
     }
 }

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -14,6 +14,7 @@ import { AuthProviderService } from "../auth/auth-provider-service";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { WorkspaceService } from "../workspace/workspace-service";
 import { Authorizer } from "../authorization/authorizer";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class UserDeletionService {
@@ -39,7 +40,7 @@ export class UserDeletionService {
         await this.authorizer.checkPermissionOnUser(userId, "delete", targetUserId);
         const user = await this.db.findUserById(targetUserId);
         if (!user) {
-            throw new Error(`No user with id ${targetUserId} found!`);
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, `No user with id ${targetUserId} found!`);
         }
 
         if (user.markedDeleted === true) {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -142,7 +142,7 @@ export class UserService {
             try {
                 WorkspaceTimeoutDuration.validate(setting.workspaceTimeout);
             } catch (err) {
-                throw new ApplicationError(ErrorCodes.BAD_REQUEST, err.message);
+                throw new ApplicationError(ErrorCodes.BAD_REQUEST, String(err));
             }
         }
 
@@ -179,8 +179,8 @@ export class UserService {
                 }
             }
             return result;
-        } catch (e) {
-            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
+        } catch (err) {
+            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, String(err));
         }
     }
 

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -386,6 +386,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
             },
             () => {
                 try {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     return this.internalOnRequest(span, requestId, method, ...args);
                 } finally {
                     span.finish();
@@ -475,7 +476,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
                 TraceContext.setJsonRPCError(ctx, method, err, true);
 
                 log.error({ userId }, `Request ${method} failed with internal server error`, e, { method, args });
-                throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.message);
+                throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, String(e));
             }
         }
     }

--- a/components/server/src/workspace/config-provider.spec.ts
+++ b/components/server/src/workspace/config-provider.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -312,7 +312,7 @@ export class InvalidGitpodYMLError extends Error {
 }
 
 export namespace InvalidGitpodYMLError {
-    export function is(obj: object): obj is InvalidGitpodYMLError {
+    export function is(obj: any): obj is InvalidGitpodYMLError {
         return "errorType" in obj && (obj as any).errorType === "invalidGitpodYML" && "validationErrors" in obj;
     }
 }

--- a/components/server/src/workspace/envvar-prefix-context-parser.spec.ts
+++ b/components/server/src/workspace/envvar-prefix-context-parser.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /**
  * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -791,6 +791,7 @@ export class WorkspaceService {
                         chunk = chunk.replace("\n", WorkspaceImageBuild.LogLine.DELIMITER);
                         lineCount += chunk.split(WorkspaceImageBuild.LogLine.DELIMITER_REGEX).length;
 
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                         client.onWorkspaceImageBuildLogs(undefined as any, {
                             text: chunk,
                             isDiff: true,
@@ -911,7 +912,7 @@ export class WorkspaceService {
 }
 
 // TODO(gpl) Make private after FGA rollout
-export function mapGrpcError(err: Error): Error {
+export function mapGrpcError(err: any): Error {
     if (!isGrpcError(err)) {
         return err;
     }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -179,7 +179,7 @@ export async function getWorkspaceClassForInstance(
 }
 
 class StartInstanceError extends Error {
-    constructor(public readonly reason: FailedInstanceStartReason, public readonly cause: Error) {
+    constructor(public readonly reason: FailedInstanceStartReason, public readonly cause: any) {
         super("Starting workspace instance failed: " + cause.message);
     }
 }
@@ -778,7 +778,7 @@ export class WorkspaceStarter {
      */
     private async failInstanceStart(
         ctx: TraceContext,
-        err: Error,
+        err: any,
         workspace: Workspace,
         instance: WorkspaceInstance,
         abortSignal: RedlockAbortSignal,
@@ -819,7 +819,7 @@ export class WorkspaceStarter {
         }
     }
 
-    private async failPrebuildWorkspace(ctx: TraceContext, err: Error, workspace: Workspace) {
+    private async failPrebuildWorkspace(ctx: TraceContext, err: any, workspace: Workspace) {
         const span = TraceContext.startSpan("failInstanceStart", ctx);
         try {
             if (workspace.type === "prebuild") {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Enable "@typescript-eslint/no-unsafe-argument": "error" ([docs](https://typescript-eslint.io/rules/no-unsafe-assignment/)) as a linting rule. 

It flags any assignments from any to a more specific type and forces us to explicitly handle use of `any`. 
Since we have a few places where this flags, I went through those cases and either fixed or explicitly ignored (only in unit tests and very old code where fixing is riskier).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3ebeae</samp>

This pull request improves the reliability, readability, and type safety of the code in the `gitpod-db` and `gitpod-protocol` components, by adding and fixing ESLint rules, error handling, type annotations, and test cases. It also refactors and simplifies some of the database and proxy-factory modules.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-lint-unsafe-arg</li>
	<li><b>🔗 URL</b> - <a href="https://se-lint-unsafe-arg.preview.gitpod-dev.com/workspaces" target="_blank">se-lint-unsafe-arg.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-lint-unsafe-arg-gha.18886</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-lint-unsafe-arg%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
