### PR TITLE
[server] JWT cookie management tests

### DIFF
--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -8,8 +8,8 @@ import { suite, test } from "@testdeck/mocha";
 import { AuthJWT, sign, verify } from "./jwt";
 import { Container } from "inversify";
 import { Config } from "../config";
-import * as crypto from "crypto";
 import * as chai from "chai";
+import { mockAuthConfig } from "../test/service-testing-container-module";
 
 const expect = chai.expect;
 
@@ -17,21 +17,8 @@ const expect = chai.expect;
 class TestAuthJWT {
     private container: Container;
 
-    private signingKeyPair = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
-    private validatingKeyPair1 = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
-    private validatingKeyPair2 = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
-
     private config: Config = {
-        auth: {
-            pki: {
-                signing: toKeyPair("0001", this.signingKeyPair),
-                validating: [toKeyPair("0002", this.validatingKeyPair1), toKeyPair("0003", this.validatingKeyPair2)],
-            },
-            session: {
-                issuer: "https://mp-server-d7650ec945.preview.gitpod-dev.com",
-                lifetimeSeconds: 7 * 24 * 60 * 60,
-            },
-        },
+        auth: mockAuthConfig,
     } as Config;
 
     async before() {
@@ -88,31 +75,6 @@ class TestAuthJWT {
         expect(decoded["sub"]).to.equal(subject);
         expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");
     }
-}
-
-function toKeyPair(
-    id: string,
-    kp: crypto.KeyPairKeyObjectResult,
-): {
-    id: string;
-    privateKey: string;
-    publicKey: string;
-} {
-    return {
-        id,
-        privateKey: kp.privateKey
-            .export({
-                type: "pkcs1",
-                format: "pem",
-            })
-            .toString(),
-        publicKey: kp.publicKey
-            .export({
-                type: "pkcs1",
-                format: "pem",
-            })
-            .toString(),
-    };
 }
 
 module.exports = new TestAuthJWT();

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -37,28 +37,30 @@ export type Config = Omit<
         credentialsPath: string;
     };
 
-    auth: {
-        // Public/Private key for signing authenticated sessions
-        pki: {
-            signing: {
-                id: string;
-                privateKey: string;
-                publicKey: string;
-            };
-            validating: {
-                id: string;
-                privateKey: string;
-                publicKey: string;
-            }[];
-        };
-
-        session: {
-            lifetimeSeconds: number;
-            issuer: string;
-            cookie: CookieConfig;
-        };
-    };
+    auth: AuthConfig;
 };
+
+export interface AuthConfig {
+    // Public/Private key for signing authenticated sessions
+    pki: {
+        signing: {
+            id: string;
+            privateKey: string;
+            publicKey: string;
+        };
+        validating: {
+            id: string;
+            privateKey: string;
+            publicKey: string;
+        }[];
+    };
+
+    session: {
+        lifetimeSeconds: number;
+        issuer: string;
+        cookie: CookieConfig;
+    };
+}
 
 export interface WorkspaceDefaults {
     workspaceImage: string;

--- a/components/server/src/session-handler.spec.db.ts
+++ b/components/server/src/session-handler.spec.db.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM, resetDB } from "@gitpod/gitpod-db/lib";
+import { User } from "@gitpod/gitpod-protocol";
+import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
+import { expect } from "chai";
+import * as express from "express";
+import { Container } from "inversify";
+import { v4 } from "uuid";
+import { SessionHandler } from "./session-handler";
+import { createTestContainer } from "./test/service-testing-container-module";
+import { UserService } from "./user/user-service";
+
+describe("SessionHandler", () => {
+    let container: Container;
+    let sessionHandler: SessionHandler;
+    let existingUser: User;
+    let jwtSessionHandler: express.Handler;
+    interface Response {
+        status?: number;
+        value?: string;
+        cookie?: string;
+    }
+    const handle = async (user?: User, cookie?: string): Promise<Response> => {
+        const deferred = new Deferred<Response>();
+        const result: Response = {
+            status: undefined,
+            value: undefined,
+            cookie: undefined,
+        };
+        jwtSessionHandler(
+            { user, headers: { cookie } } as express.Request,
+            {
+                status: function (statusCode: number) {
+                    result.status = statusCode;
+                    return this;
+                },
+                send: function (value: string) {
+                    result.value = value;
+                    deferred.resolve(result);
+                },
+                cookie: function (name: string, value: string, opts: express.CookieOptions) {
+                    result.cookie = `${name}=${value}; `;
+                },
+            } as any as express.Response,
+            () => {},
+        );
+        return await deferred.promise;
+    };
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        sessionHandler = container.get(SessionHandler);
+        jwtSessionHandler = sessionHandler.jwtSessionConvertor();
+        const userService = container.get(UserService);
+        // insert some users to the DB to reproduce INC-379
+        await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
+        existingUser = await userService.createUser({
+            identity: {
+                authName: "github",
+                authProviderId: "github",
+                authId: "1234",
+            },
+        });
+    });
+
+    afterEach(async () => {
+        const typeorm = container.get(TypeORM);
+        await resetDB(typeorm);
+    });
+
+    describe("verify", () => {
+        it("should return undefined for an empty cookie", async () => {
+            const user = await sessionHandler.verify("");
+            expect(user).to.be.undefined;
+        });
+        it("should return undefined for an invalid cookie", async () => {
+            const user = await sessionHandler.verify("invalid");
+            expect(user).to.be.undefined;
+        });
+        it("should return the user for a valid JWT with correct 'sub' claim", async () => {
+            const cookie = await sessionHandler.createJWTSessionCookie(existingUser.id);
+            const user = await sessionHandler.verify(`${cookie.name}=${cookie.value}`);
+            expect(user?.id).to.be.equal(existingUser.id);
+        });
+        it("should return undefined for a valid JWT with incorrect 'sub' claim", async () => {
+            const unexisingUserId = v4();
+            const cookie = await sessionHandler.createJWTSessionCookie(unexisingUserId);
+            const user = await sessionHandler.verify(`${cookie.name}=${cookie.value}`);
+            expect(user).to.be.undefined;
+        });
+    });
+    describe("createJWTSessionCookie", () => {
+        it("should create a valid JWT token with correct attributes and cookie options", async () => {
+            const maxAge = 7 * 24 * 60 * 60;
+            const issuedAfter = Math.floor(new Date().getTime() / 1000);
+            const expiresAfter = issuedAfter + maxAge;
+            const { name, value: token, opts } = await sessionHandler.createJWTSessionCookie("1");
+
+            const decoded = await sessionHandler.verifyJWTCookie(`${name}=${token}`);
+            expect(decoded, "Verify the JWT is valid").to.not.be.null;
+
+            expect(decoded!.sub).to.equal("1", "Check the 'sub' claim");
+            expect(decoded!.iat || 0).to.be.greaterThanOrEqual(issuedAfter, "Check the 'iat' claim");
+            expect(decoded!.exp || 0).to.be.greaterThanOrEqual(expiresAfter, "Check the 'exp' claim");
+
+            // Check cookie options
+            expect(opts.httpOnly).to.equal(true);
+            expect(opts.secure).to.equal(true);
+            expect(opts.maxAge).to.equal(maxAge * 1000);
+            expect(opts.sameSite).to.equal("strict");
+
+            expect(name, "Check cookie name").to.equal("_gitpod_dev_jwt_");
+        });
+    });
+    describe("jwtSessionConvertor", () => {
+        it("user is not authenticated", async () => {
+            const res = await handle();
+            expect(res.status).to.equal(401);
+            expect(res.value).to.equal("User has no valid session.");
+            expect(res.cookie).to.be.undefined;
+        });
+        it("JWT cookie is not present", async () => {
+            const res = await handle(existingUser);
+            expect(res.status).to.equal(200);
+            expect(res.value).to.equal("New JWT cookie issued.");
+            expect(res.cookie).not.to.be.undefined;
+        });
+        it("JWT cookie is present and valid", async () => {
+            const cookie = await sessionHandler.createJWTSessionCookie(existingUser.id);
+            const res = await handle(existingUser, `${cookie.name}=${cookie.value}`);
+            expect(res.status).to.equal(200);
+            expect(res.value).to.equal("User session already has a valid JWT session.");
+            expect(res.cookie).to.be.undefined;
+        });
+        it("JWT cookie is present and refreshed", async () => {
+            const cookieToRefresh = await sessionHandler.createJWTSessionCookie(existingUser.id, {
+                issuedAtMs: Date.now() - SessionHandler.JWT_REFRESH_THRESHOLD - 1,
+            });
+            const res = await handle(existingUser, `${cookieToRefresh.name}=${cookieToRefresh.value}`);
+            expect(res.status).to.equal(200);
+            expect(res.value).to.equal("Refreshed JWT cookie issued.");
+            expect(res.cookie).not.to.be.undefined;
+        });
+        it("JWT cookie is present and expired", async () => {
+            const expiredCookie = await sessionHandler.createJWTSessionCookie(existingUser.id, {
+                expirySeconds: 0,
+            });
+            const res = await handle(existingUser, `${expiredCookie.name}=${expiredCookie.value}`);
+            expect(res.status).to.equal(401);
+            expect(res.value).to.equal("JWT Session is invalid");
+            expect(res.cookie).to.be.undefined;
+        });
+        it("JWT cookie is present but invalid", async () => {
+            const res = await handle(existingUser, "_gitpod_dev_jwt_=invalid");
+            expect(res.status).to.equal(401);
+            expect(res.value).to.equal("JWT Session is invalid");
+            expect(res.cookie).to.be.undefined;
+        });
+    });
+});


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR:
- covers SessionHandler entirely with integration tests against DB
- makes the necessary refactoring to SessionHandler to allow brining back rate limiting for Public API

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8f6a38</samp>

Refactored the JWT authentication logic and tests in the server component. Extracted the `AuthConfig` type from `config.ts` and used a mock configuration object for testing. Added a new file `session-handler.spec.db.ts` with tests for the `SessionHandler` class. Simplified the tests in `jwt.spec.ts` by using a mock configuration object. Moved the `toKeyPair` function to a different file.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a Gitpod workspace on this PR and run tests.
- To validate that indeed would catch the issue, apply the bug:
```
diff --git a/components/server/src/session-handler.ts b/components/server/src/session-handler.ts
index ae8e7715e..088fe7538 100644
--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -116,7 +116,7 @@ export class SessionHandler {
                 throw new Error("Subject is missing from JWT session claims");
             }
 
-            return await this.userService.findUserById(subject, subject);
+            return await this.userService.findUserById(claims.subject, claims.subject);
         } catch (err) {
             log.warn("Failed to authenticate user with JWT Session", err);
             // Remove the existing cookie, to force the user to re-sing in, and hence refresh it
```
- Go further and rollback @svenefftinge's guard on user DB:
```
diff --git a/components/gitpod-db/src/typeorm/user-db-impl.ts b/components/gitpod-db/src/typeorm/user-db-impl.ts
index d1f76e043..d4c4e68bf 100644
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -133,9 +133,9 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
     }
 
     public async findUserById(id: string): Promise<MaybeUser> {
-        if (!id || id.trim() === "") {
+        /*if (!id || id.trim() === "") {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Cannot find user without id");
-        }
+        }*/
         return this.cache.get(getUserCacheKey(id), async () => {
             const userRepo = await this.getUserRepo();
             const result = await userRepo.findOne(id);
```

In my case following tests are failing now with returning a wrong user
<img width="1904" alt="Screenshot 2023-10-20 at 17 24 49" src="https://github.com/gitpod-io/gitpod/assets/3082655/8362f341-a0ab-4dfc-b0d8-4dd0c457af7b">
<img width="1904" alt="Screenshot 2023-10-20 at 17 24 52" src="https://github.com/gitpod-io/gitpod/assets/3082655/3d1985ee-1afc-4572-9065-bf0380afba1f">

Test preview envs:
- Sign-in
- Start workspace
- Sign-out
- Try to break it somehow

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-jwt-mand55a65b0f5</li>
	<li><b>🔗 URL</b> - <a href="https://ak-jwt-mand55a65b0f5.preview.gitpod-dev.com/workspaces" target="_blank">ak-jwt-mand55a65b0f5.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-jwt_management_tests-gha.18870</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-jwt-mand55a65b0f5%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
