### PR TITLE
[public-api] put back rate limiting

### DIFF
--- a/components/server/src/api/rate-limited.ts
+++ b/components/server/src/api/rate-limited.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { IRateLimiterOptions } from "rate-limiter-flexible";
+
+const RATE_LIMIT_METADATA_KEY = Symbol("RateLimited");
+
+export function RateLimited(options: IRateLimiterOptions) {
+    return Reflect.metadata(RATE_LIMIT_METADATA_KEY, options);
+}
+
+export namespace RateLimited {
+    const defaultOptions: IRateLimiterOptions = {
+        points: 200,
+        duration: 60,
+    };
+    export function getOptions(target: Object, properyKey: string | symbol): IRateLimiterOptions {
+        return Reflect.getMetadata(RATE_LIMIT_METADATA_KEY, target, properyKey) || defaultOptions;
+    }
+}

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -30,6 +30,13 @@ import { APIStatsService as StatsServiceAPI } from "./stats";
 import { APITeamsService as TeamsServiceAPI } from "./teams";
 import { APIUserService as UserServiceAPI } from "./user";
 import { WorkspaceServiceAPI } from "./workspace-service-api";
+import { IRateLimiterOptions, RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible";
+import { Redis } from "ioredis";
+import { RateLimited } from "./rate-limited";
+import { Config } from "../config";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { UserService } from "../user/user-service";
+import { User } from "@gitpod/gitpod-protocol";
 
 decorate(injectable(), PublicAPIConverter);
 
@@ -46,6 +53,9 @@ export class API {
     @inject(HelloServiceAPI) private readonly helloServiceApi: HelloServiceAPI;
     @inject(SessionHandler) private readonly sessionHandler: SessionHandler;
     @inject(PublicAPIConverter) private readonly apiConverter: PublicAPIConverter;
+    @inject(Redis) private readonly redis: Redis;
+    @inject(Config) private readonly config: Config;
+    @inject(UserService) private readonly userService: UserService;
 
     listenPrivate(): http.Server {
         const app = express();
@@ -174,9 +184,30 @@ export class API {
 
                     const context = args[1] as HandlerContext;
 
+                    const rateLimit = async (subjectId: string) => {
+                        const key = `${grpc_service}/${grpc_method}`;
+                        const options = self.config.rateLimits?.[key] || RateLimited.getOptions(target, prop);
+                        try {
+                            await self.getRateLimitter(options).consume(`${subjectId}_${key}`);
+                        } catch (e) {
+                            if (e instanceof RateLimiterRes) {
+                                throw new ConnectError("rate limit exceeded", Code.ResourceExhausted, {
+                                    // http compatibility, can be respected by gRPC clients as well
+                                    // instead of doing an ad-hoc retry, the client can wait for the given amount of seconds
+                                    "Retry-After": e.msBeforeNext / 1000,
+                                    "X-RateLimit-Limit": options.points,
+                                    "X-RateLimit-Remaining": e.remainingPoints,
+                                    "X-RateLimit-Reset": new Date(Date.now() + e.msBeforeNext),
+                                });
+                            }
+                            throw e;
+                        }
+                    };
+
                     const apply = async <T>(): Promise<T> => {
-                        const user = await self.verify(context);
-                        context.user = user;
+                        const subjectId = await self.verify(context);
+                        await rateLimit(subjectId);
+                        context.user = await self.ensureFgaMigration(subjectId);
 
                         return Reflect.apply(target[prop as any], target, args);
                     };
@@ -211,17 +242,50 @@ export class API {
         };
     }
 
-    private async verify(context: HandlerContext) {
-        const cookieHeader: string = context.requestHeader.get("cookie") || "";
-        const user = await this.sessionHandler.verify(cookieHeader);
-        if (!user) {
+    private async verify(context: HandlerContext): Promise<string> {
+        const cookieHeader = (context.requestHeader.get("cookie") || "") as string;
+        const claims = await this.sessionHandler.verifyJWTCookie(cookieHeader);
+        const subjectId = claims?.sub;
+        if (!subjectId) {
             throw new ConnectError("unauthenticated", Code.Unauthenticated);
         }
-        const fgaChecksEnabled = await isFgaChecksEnabled(user.id);
+        return subjectId;
+    }
+
+    private async ensureFgaMigration(userId: string): Promise<User> {
+        const fgaChecksEnabled = await isFgaChecksEnabled(userId);
         if (!fgaChecksEnabled) {
             throw new ConnectError("unauthorized", Code.PermissionDenied);
         }
-        return user;
+        try {
+            return await this.userService.findUserById(userId, userId);
+        } catch (e) {
+            if (e instanceof ApplicationError && e.code === ErrorCodes.NOT_FOUND) {
+                throw new ConnectError("unauthorized", Code.PermissionDenied);
+            }
+            throw e;
+        }
+    }
+
+    private readonly rateLimiters = new Map<string, RateLimiterRedis>();
+    private getRateLimitter(options: IRateLimiterOptions): RateLimiterRedis {
+        const sortedKeys = Object.keys(options).sort();
+        const sortedObject: { [key: string]: any } = {};
+        for (const key of sortedKeys) {
+            sortedObject[key] = options[key as keyof IRateLimiterOptions];
+        }
+        const key = JSON.stringify(sortedObject);
+
+        let rateLimiter = this.rateLimiters.get(key);
+        if (!rateLimiter) {
+            rateLimiter = new RateLimiterRedis({
+                storeClient: this.redis,
+                ...options,
+                insuranceLimiter: new RateLimiterMemory(options),
+            });
+            this.rateLimiters.set(key, rateLimiter);
+        }
+        return rateLimiter;
     }
 
     static bindAPI(bind: interfaces.Bind): void {

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -21,6 +21,9 @@ import { UserAuthentication } from "../user/user-authentication";
 import { WorkspaceService } from "../workspace/workspace-service";
 import { API } from "./server";
 import { SessionHandler } from "../session-handler";
+import { Redis } from "ioredis";
+import { UserService } from "../user/user-service";
+import { Config } from "../config";
 
 const expect = chai.expect;
 
@@ -39,6 +42,9 @@ export class APITeamsServiceSpec {
         this.container.bind(WorkspaceService).toConstantValue({} as WorkspaceService);
         this.container.bind(UserAuthentication).toConstantValue({} as UserAuthentication);
         this.container.bind(SessionHandler).toConstantValue({} as SessionHandler);
+        this.container.bind(Config).toConstantValue({} as Config);
+        this.container.bind(Redis).toConstantValue({} as Redis);
+        this.container.bind(UserService).toConstantValue({} as UserService);
 
         // Clean-up database
         const typeorm = testContainer.get<TypeORM>(TypeORM);

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -17,6 +17,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 import { WorkspaceClassesConfig } from "./workspace/workspace-classes";
 import { PrebuildRateLimiters } from "./workspace/prebuild-rate-limiter";
+import { IRateLimiterOptions } from "rate-limiter-flexible";
 
 export const Config = Symbol("Config");
 export type Config = Omit<
@@ -174,8 +175,19 @@ export interface ConfigSerialized {
 
     /**
      * The configuration for the rate limiter we (mainly) use for the websocket API
+     * @deprecated used for JSON-RPC API, for gRPC use rateLimits
      */
     rateLimiter: RateLimiterConfig;
+
+    /**
+     * The configuration for the rate limiter we use for the gRPC API.
+     * As a primary means use RateLimited decorator.
+     * Only use this if you need to adjst in production, make sure to apply changes to the decorator as well.
+     * Key is of the form `<grpc_service>/<grpc_method>`
+     */
+    rateLimits?: {
+        [key: string]: IRateLimiterOptions;
+    };
 
     /**
      * The address content service clients connect to


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This reverts commit 7f3b3c773cf99fa43da0f66a067b9a5adf0ab263.


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f82375</samp>

This pull request adds rate limiting functionality to the gRPC API of the server component. It uses a decorator `RateLimited` to apply rate limiting options to the API methods in the `server.ts` file. It also updates the `config.ts` file to support the new options and adds some tests and error handling logic.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

The preview env has gRPC api enabled from the dashboard plus rate limit is configured for getWorkspace as 1 call per a minute via a configmap.
<img width="630" alt="Screenshot 2023-10-19 at 12 54 31" src="https://github.com/gitpod-io/gitpod/assets/3082655/1fbc1d8a-44d5-47f7-b44c-a41f8fa2bcef">

Open a dev tool, and start a workspace, in dev tools filter to getWorkspace calls. You should see 429 error codes, investigate headers (`Retry-After` + `X-Ratelimit-*`)  for additional info about rate limiting. If you reload the page you should see that eventually it is successful. 
<img width="751" alt="Screenshot 2023-10-19 at 12 52 16" src="https://github.com/gitpod-io/gitpod/assets/3082655/9958839a-e1a5-4113-bfda-d90f60c667aa">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-rate-limit-api</li>
	<li><b>🔗 URL</b> - <a href="https://ak-rate-limit-api.preview.gitpod-dev.com/workspaces" target="_blank">ak-rate-limit-api.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-rate_limit_api-gha.18896</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-rate-limit-api%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
