### PR TITLE
Detect Kotlin Gradle DSL & populate .gitpod.yml suggestions

### DIFF
--- a/components/server/src/config/config-inferrer.spec.ts
+++ b/components/server/src/config/config-inferrer.spec.ts
@@ -196,6 +196,40 @@ describe("config inferrer", () => {
                     },
                 },
             )),
+        it("[kotlin] gradle", async () =>
+            expect(
+                {
+                    "build.gradle.kts": "",
+                    "pom.xml": "",
+                },
+                {
+                    tasks: [
+                        {
+                            init: "gradle build",
+                        },
+                    ],
+                    vscode: {
+                        extensions: ["fwcd.kotlin"],
+                    },
+                },
+            )),
+        it("[kotlin] gradle wrapper", async () =>
+            expect(
+                {
+                    "build.gradle.kts": "",
+                    gradlew: "",
+                },
+                {
+                    tasks: [
+                        {
+                            init: "./gradlew build",
+                        },
+                    ],
+                    vscode: {
+                        extensions: ["fwcd.kotlin"],
+                    },
+                },
+            )),
         it("[python] pip install", async () =>
             expect(
                 {

--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -83,6 +83,16 @@ export class ConfigInferrer {
             this.addExtension(ctx, "vscjava.vscode-java-debug");
             return;
         }
+        // Gradle Kotlin DSL
+        if (await ctx.exists("build.gradle.kts")) {
+            let cmd = "gradle";
+            if (await ctx.exists("gradlew")) {
+                cmd = "./gradlew";
+            }
+            this.addCommand(ctx.config, cmd + " build", "init");
+            this.addExtension(ctx, "fwcd.kotlin");
+            return;
+        }
         if (await ctx.exists("pom.xml")) {
             let cmd = "mvn";
             if (await ctx.exists("mvnw")) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces improvements to our existing file detection logic. It now recognizes the `build.gradle.kts` file, which is indicative of a project using the Kotlin Gradle DSL. It would suggest [fwcd/kotlin](https://open-vsx.org/extension/fwcd/kotlin) extension.

I have also added the related tests. Test results:

  ![image](https://github.com/gitpod-io/gitpod/assets/55068936/1cbf826c-1d05-4675-a7f4-00c5660ae1ce)


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dde829d</samp>

Add support for inferring configuration for Kotlin projects that use Gradle Kotlin DSL. Update the `ConfigInferrer` class and its test cases to handle `build.gradle.kts` files and add appropriate commands and extensions.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-646

## How to test
<!-- Provide steps to test this PR -->

- Open [this repository](https://github.com/square/okhttp) in preview environment. And, you will now see the `.gitpod.yml` with relevant build commands :) (unlike in production right now)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-exp-646</li>
	<li><b>🔗 URL</b> - <a href="https://fix-exp-646.preview.gitpod-dev.com/workspaces" target="_blank">fix-exp-646.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-EXP-646-gha.18967</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-exp-646%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
