### PR TITLE
[a11y] User setting Git providers 📱 improvement

### DIFF
--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -178,7 +178,7 @@ export const ModalBody: FC<ModalBodyProps> = ({ children, hideDivider = false, n
     return (
         // Allows the first tabbable element in the body to receive focus on mount
         <AutoFocusInside
-            className={cn("flex-grow relative border-gray-200 dark:border-gray-800 -mx-6 px-6 pb-6", {
+            className={cn("md:flex-grow relative border-gray-200 dark:border-gray-800 -mx-6 px-6 pb-6", {
                 "border-t border-b mt-2 py-4": !hideDivider,
                 "overflow-y-auto": !noScroll,
             })}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Accessibility improvement for mobile/tablet on Git providers User settings modal.


|Before|After|
|:---:|:---:|
|![image](https://github.com/gitpod-io/gitpod/assets/55068936/c5eb0c9f-f96a-49dd-8855-bdb5f45f1c57)|![image](https://github.com/gitpod-io/gitpod/assets/55068936/7851bda5-db69-4d26-b862-8f68a61fe3e8)|

> _Preview on iPhone 14 plus_

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b4ffdd</samp>

Added `md:flex-grow` class to modal body in `Modal.tsx` to improve responsiveness. This is part of a pull request to make the dashboard more mobile-friendly.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes WEB-464

## How to test
<!-- Provide steps to test this PR -->

- Open preview url and Go to `/user/integrations`.
- Open in Mobile view using Browser DevTools.
- Click on three vertical dots next to Git provider name
- Click on `Edit Permissions`
- See accesible button for `Update Permissions`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-web-464</li>
	<li><b>🔗 URL</b> - <a href="https://fix-web-464.preview.gitpod-dev.com/workspaces" target="_blank">fix-web-464.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-WEB-464-gha.18998</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-web-464%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
