### PR TITLE
Add throughput condition

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -195,7 +195,7 @@ func (s *WorkspaceStatus) SetCondition(cond metav1.Condition) {
 	s.Conditions = wsk8s.AddUniqueCondition(s.Conditions, cond)
 }
 
-// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;EverReady;BackupComplete;BackupFailure;Refresh;NodeDisappeared
+// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;EverReady;BackupComplete;BackupFailure;Refresh;NodeDisappeared;ThroughputAdjusted
 type WorkspaceCondition string
 
 const (
@@ -243,6 +243,9 @@ const (
 
 	// NodeDisappeared is true if the workspace's node disappeared before the workspace was stopped
 	WorkspaceConditionNodeDisappeared WorkspaceCondition = "NodeDisappeared"
+
+	// ThroughputAdjusted is true if the throughput of the workspace volume has been adjusted
+	WorkspaceConditionThroughputAdjusted WorkspaceCondition = "ThroughputAdjusted"
 )
 
 func NewWorkspaceConditionDeployed() metav1.Condition {
@@ -366,6 +369,14 @@ func NewWorkspaceConditionRefresh() metav1.Condition {
 func NewWorkspaceConditionNodeDisappeared() metav1.Condition {
 	return metav1.Condition{
 		Type:               string(WorkspaceConditionNodeDisappeared),
+		LastTransitionTime: metav1.Now(),
+		Status:             metav1.ConditionTrue,
+	}
+}
+
+func NewWorkspaceConditionThroughputAdjusted() metav1.Condition {
+	return metav1.Condition{
+		Type:               string(WorkspaceConditionThroughputAdjusted),
 		LastTransitionTime: metav1.Now(),
 		Status:             metav1.ConditionTrue,
 	}


### PR DESCRIPTION
## Description
Add throughput condition that records when throughput of volumes has been adjusted.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e08db4</samp>

Add a new workspace condition `ThroughputAdjusted` to the ws-manager-api CRD. This condition signals when the volume throughput of a workspace is dynamically adjusted by the ws-manager.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1006

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
