### PR TITLE
Update kube-rbac-proxy to v0.15.0

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -505,6 +505,7 @@ func KubeRBACProxyContainerWithConfig(ctx *RenderContext) *corev1.Container {
 			"--logtostderr",
 			fmt.Sprintf("--insecure-listen-address=[$(IP)]:%d", baseserver.BuiltinMetricsPort),
 			fmt.Sprintf("--upstream=http://127.0.0.1:%d/", baseserver.BuiltinMetricsPort),
+			"--http2-disable",
 		},
 		Ports: []corev1.ContainerPort{
 			{Name: baseserver.BuiltinMetricsPortName, ContainerPort: baseserver.BuiltinMetricsPort},

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -26,6 +26,7 @@ func TestKubeRBACProxyContainer_DefaultPorts(t *testing.T) {
 		"--logtostderr",
 		fmt.Sprintf("--insecure-listen-address=[$(IP)]:%v", baseserver.BuiltinMetricsPort),
 		fmt.Sprintf("--upstream=http://%v/", common.LocalhostPrometheusAddr()),
+		"--http2-disable",
 	}, container.Args)
 	require.Equal(t, []corev1.ContainerPort{
 		{Name: baseserver.BuiltinMetricsPortName, ContainerPort: baseserver.BuiltinMetricsPort},
@@ -41,6 +42,7 @@ func TestKubeRBACProxyContainerWithConfig(t *testing.T) {
 		"--logtostderr",
 		fmt.Sprintf("--insecure-listen-address=[$(IP)]:%d", baseserver.BuiltinMetricsPort),
 		fmt.Sprintf("--upstream=http://%v/", common.LocalhostPrometheusAddr()),
+		"--http2-disable",
 	}, container.Args)
 	require.Equal(t, []corev1.ContainerPort{
 		{Name: baseserver.BuiltinMetricsPortName, ContainerPort: baseserver.BuiltinMetricsPort},

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -22,7 +22,7 @@ const (
 	InClusterDbSecret           = "mysql"
 	KubeRBACProxyRepo           = "quay.io"
 	KubeRBACProxyImage          = "brancz/kube-rbac-proxy"
-	KubeRBACProxyTag            = "v0.14.2"
+	KubeRBACProxyTag            = "v0.15.0"
 	MinioServiceAPIPort         = 9000
 	MonitoringChart             = "monitoring"
 	ProxyComponent              = "proxy"


### PR DESCRIPTION
## Description

Also disables HTTP2.
Changelog https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.15.0

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2251e37</samp>

Update kube-rbac-proxy image and disable HTTP/2 support. This improves the security and compatibility of the proxy with the Kubernetes API server.

</details>

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-kub1d5d566f0a</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-kub1d5d566f0a.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-kub1d5d566f0a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-kube-rbac-proxy-gha.19070</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-kub1d5d566f0a%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
