### PR TITLE
Only show privacy policy notice on Gitpod Cloud

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -15,10 +15,16 @@ export type Event =
     | "organisation_authorised"
     | "dotfile_repo_changed"
     | "feedback_submitted"
-    | "workspace_class_changed";
+    | "workspace_class_changed"
+    | "privacy_policy_update_accepted";
 type InternalEvent = Event | "path_changed" | "dashboard_clicked";
 
-export type EventProperties = TrackOrgAuthorised | TrackInviteUrlRequested | TrackDotfileRepo | TrackFeedback;
+export type EventProperties =
+    | TrackOrgAuthorised
+    | TrackInviteUrlRequested
+    | TrackDotfileRepo
+    | TrackFeedback
+    | TrackPolicyUpdateClick;
 type InternalEventProperties = EventProperties | TrackDashboardClick | TrackPathChanged;
 
 export interface TrackOrgAuthorised {
@@ -43,6 +49,12 @@ export interface TrackFeedback {
     error_object?: StartWorkspaceError;
     error_message?: string;
 }
+
+export interface TrackPolicyUpdateClick {
+    path: string;
+    success: boolean;
+}
+
 interface TrackDashboardClick {
     dnt?: boolean;
     path: string;

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -4,12 +4,13 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import dayjs from "dayjs";
+import deepMerge from "deepmerge";
 import { useCallback, useEffect, useState } from "react";
 import Alert, { AlertType } from "./components/Alert";
-import dayjs from "dayjs";
 import { useUserLoader } from "./hooks/use-user-loader";
 import { getGitpodService } from "./service/service";
-import deepMerge from "deepmerge";
+import { isGitpodIo } from "./utils";
 
 const KEY_APP_DISMISSED_NOTIFICATIONS = "gitpod-app-notifications-dismissed";
 const PRIVACY_POLICY_LAST_UPDATED = "2023-10-17";
@@ -48,10 +49,10 @@ export function AppNotifications() {
 
     useEffect(() => {
         const notifications = [];
-        if (!loading && user?.additionalData?.profile) {
+        if (!loading && isGitpodIo()) {
             if (
-                !user.additionalData.profile.acceptedPrivacyPolicyDate ||
-                new Date(PRIVACY_POLICY_LAST_UPDATED) > new Date(user.additionalData.profile?.acceptedPrivacyPolicyDate)
+                !user?.additionalData?.profile?.acceptedPrivacyPolicyDate ||
+                new Date(PRIVACY_POLICY_LAST_UPDATED) > new Date(user.additionalData.profile.acceptedPrivacyPolicyDate)
             ) {
                 notifications.push(UPDATED_PRIVACY_POLICY);
             }

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -74,7 +74,7 @@ export class UserService {
         }
         if (newUser.additionalData) {
             // When a user is created, it does not have `additionalData.profile` set, so it's ok to rewrite it here.
-            newUser.additionalData.profile = { acceptedPrivacyPolicyDate: new Date().toISOString() };
+            // todo:revert newUser.additionalData.profile = { acceptedPrivacyPolicyDate: new Date().toISOString() };
         }
     }
 


### PR DESCRIPTION
## Description

This PR enables the Updated privacy policy alert to be more flexible, and only show for users on Gitpod Cloud. It also makes sure that users with incomplete profiles (like those who have not finished onboarding) have the alert show up as well.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e0c360</samp>

Improved dashboard notifications for self-hosted and gitpod.io users. Refactored `AppNotifications.tsx` to reorder imports and limit privacy policy notification to `gitpod.io` domain.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

If you inspect the WebSocket connection on the Dashboard, the first request should be for getting the logged-in user. If you take a look at the response, there should be a `acceptedPrivacyPolicyDate` under `additionalData.profile`. Make sure it's there and that the alert is not showing up because of the auto-accept during login.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-better-b89531dbe8</li>
	<li><b>🔗 URL</b> - <a href="https://ft-better-b89531dbe8.preview.gitpod-dev.com/workspaces" target="_blank">ft-better-b89531dbe8.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-better-privacy-policy-gha.19073</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-better-b89531dbe8%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
