### PR TITLE
Fix `?until` in BBS commit contexts

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -29,7 +29,7 @@ class TestBitbucketServerContextParser {
     static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
         id: "MyBitbucketServer",
         type: "BitbucketServer",
-        host: "bitbucket.gitpod-self-hosted.com",
+        host: "bitbucket.gitpod-dev.com",
     };
 
     public before() {
@@ -194,6 +194,7 @@ class TestBitbucketServerContextParser {
         );
 
         expect(result).to.deep.include({
+            ref: "my-branch",
             refType: "branch",
             revision: "3ca42b45bc693973cb21a112a418c13f8b4d11a5",
             path: "",

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -29,7 +29,7 @@ class TestBitbucketServerContextParser {
     static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
         id: "MyBitbucketServer",
         type: "BitbucketServer",
-        host: "bitbucket.gitpod-dev.com",
+        host: "bitbucket.gitpod-self-hosted.com",
     };
 
     public before() {
@@ -186,7 +186,7 @@ class TestBitbucketServerContextParser {
         });
     }
 
-    @test async test_commit_context_02() {
+    @test async test_branch_context_01() {
         const result = await this.parser.handle(
             {},
             this.user,

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -186,6 +186,32 @@ class TestBitbucketServerContextParser {
         });
     }
 
+    @test async test_commit_context_02() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/commits?until=refs%2Fheads%2Fmy-branch&merges=include",
+        );
+
+        expect(result).to.deep.include({
+            refType: "branch",
+            revision: "3ca42b45bc693973cb21a112a418c13f8b4d11a5",
+            path: "",
+            isFile: false,
+            repository: {
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/~svenefftinge/browser-extension-test.git",
+                defaultBranch: "main",
+                host: "bitbucket.gitpod-dev.com",
+                name: "browser-extension-test",
+                owner: "svenefftinge",
+                repoKind: "users",
+                private: false,
+                webUrl: "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test",
+            },
+            title: "svenefftinge/browser-extension-test - my-branch",
+        });
+    }
+
     @test async test_PR_context_01() {
         const result = await this.parser.handle(
             {},

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
@@ -35,6 +35,10 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
                 const branchName = this.toSimpleBranchName(decodeURIComponent(searchParams.get("at")!));
                 more.ref = branchName;
                 more.refType = "branch";
+            } else if (searchParams.has("until")) {
+                const branchName = this.toSimpleBranchName(decodeURIComponent(searchParams.get("until")!));
+                more.ref = branchName;
+                more.refType = "branch";
             }
 
             if (moreSegments[0] === "pull-requests" && !!moreSegments[1]) {
@@ -72,11 +76,11 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
 
         const host = this.host; // as per contract, cf. `canHandle(user, contextURL)`
 
-        const lenghtOfRelativePath = host.split("/").length - 1; // e.g. "123.123.123.123/gitlab" => length of 1
-        if (lenghtOfRelativePath > 0) {
+        const lengthOfRelativePath = host.split("/").length - 1; // e.g. "123.123.123.123/gitlab" => length of 1
+        if (lengthOfRelativePath > 0) {
             // remove segments from the path to be consider further, which belong to the relative location of the host
             // cf. https://github.com/gitpod-io/gitpod/issues/2637
-            segments.splice(0, lenghtOfRelativePath);
+            segments.splice(0, lengthOfRelativePath);
         }
 
         const firstSegment = segments[0];


### PR DESCRIPTION
## Description

In Bitbucket server, the commits view works a bit differently than on https://bitbucket.org. Instead of containing the concerned branch name in the URL path, it is stored in the `until` search parameter. We did not account for that. 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72bc2b0</samp>

This pull request enhances the `BitbucketServerContextParser` class and its tests to support commit context URLs with branch names. This allows users to open Gitpod workspaces from such URLs and see the correct branch and commit information.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-844

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-bbs-until-fix</li>
	<li><b>🔗 URL</b> - <a href="https://ft-bbs-until-fix.preview.gitpod-dev.com/workspaces" target="_blank">ft-bbs-until-fix.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-bbs-until-fix-gha.19096</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-bbs-until-fix%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## How to test

I had to do some code gymnastics to get the tests working properly with our BBS instance, but here they run, successfully.

<img width="868" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/01889c99-a133-4d75-bf3b-e2946e04c63c">


## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
