### PR TITLE
Automatically accept privacy policy upon registering

### DIFF
--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -74,7 +74,7 @@ export class UserService {
         }
         if (newUser.additionalData) {
             // When a user is created, it does not have `additionalData.profile` set, so it's ok to rewrite it here.
-            // todo:revert newUser.additionalData.profile = { acceptedPrivacyPolicyDate: new Date().toISOString() };
+            newUser.additionalData.profile = { acceptedPrivacyPolicyDate: new Date().toISOString() };
         }
     }
 


### PR DESCRIPTION
## Description

Fixes a regression from #18985 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2a9d67</samp>

Uncommented a line in `user-service.ts` that sets the privacy policy acceptance date for new users. This is part of the feature that requires users to agree to the privacy policy before using Gitpod.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
