### PR TITLE
[server] fix deleteUser permissions

### DIFF
--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -5,48 +5,33 @@
  */
 
 import { injectable, inject } from "inversify";
-import { UserDB, WorkspaceDB, TeamDB, ProjectDB } from "@gitpod/gitpod-db/lib";
+import { WorkspaceDB, TeamDB, ProjectDB } from "@gitpod/gitpod-db/lib";
 import { User, Workspace } from "@gitpod/gitpod-protocol";
 import { StorageClient } from "../storage/storage-client";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { AuthProviderService } from "../auth/auth-provider-service";
-import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { WorkspaceService } from "../workspace/workspace-service";
-import { Authorizer } from "../authorization/authorizer";
-import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { UserService } from "./user-service";
+import { TransactionalContext } from "@gitpod/gitpod-db/lib/typeorm/transactional-db-impl";
 
 @injectable()
 export class UserDeletionService {
     constructor(
-        @inject(UserDB) private readonly db: UserDB,
+        @inject(UserService) private readonly userService: UserService,
         @inject(WorkspaceDB) private readonly workspaceDb: WorkspaceDB,
         @inject(TeamDB) private readonly teamDb: TeamDB,
         @inject(ProjectDB) private readonly projectDb: ProjectDB,
         @inject(StorageClient) private readonly storageClient: StorageClient,
         @inject(WorkspaceService) private readonly workspaceService: WorkspaceService,
         @inject(AuthProviderService) private readonly authProviderService: AuthProviderService,
-        @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
-        @inject(Authorizer) private readonly authorizer: Authorizer,
-    ) {}
+    ) {
+        this.userService.onDeleteUser(async (subjectId, user, ctx) => {
+            await this.contributeToDeleteUser(subjectId, user, ctx);
+        });
+    }
 
-    /**
-     * This method deletes a User logically. The contract here is that after running this method without receiving an
-     * error, the system does not contain any data that is relatable to the actual person in the sense of the GDPR.
-     * To guarantee that, but also maintain traceability
-     * we anonymize data that might contain user related/relatable data and keep the entities itself (incl. ids).
-     */
-    async deleteUser(userId: string, targetUserId: string): Promise<void> {
-        await this.authorizer.checkPermissionOnUser(userId, "delete", targetUserId);
-        const user = await this.db.findUserById(targetUserId);
-        if (!user) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, `No user with id ${targetUserId} found!`);
-        }
-
-        if (user.markedDeleted === true) {
-            log.debug({ userId: targetUserId }, "Is deleted but markDeleted already set. Continuing.");
-        }
-
+    private async contributeToDeleteUser(userId: string, user: User, ctx: TransactionalContext): Promise<void> {
         // Stop all workspaces
         await this.workspaceService.stopRunningWorkspacesForUser(
             {},
@@ -62,70 +47,20 @@ export class UserDeletionService {
             try {
                 await this.authProviderService.deleteAuthProvider(provider);
             } catch (error) {
-                log.error({ userId: targetUserId }, "Failed to delete user's auth provider.", error);
+                log.error({ userId: user.id }, "Failed to delete user's auth provider.", error);
             }
         }
 
-        // User
-        await this.db.transaction(async (db) => {
-            this.anonymizeUser(user);
-            this.deleteIdentities(user);
-            await this.deleteTokens(db, user);
-            user.lastVerificationTime = undefined;
-            user.markedDeleted = true;
-            await db.storeUser(user);
-        });
-
         await Promise.all([
             // Workspace
-            this.anonymizeAllWorkspaces(targetUserId),
+            this.anonymizeAllWorkspaces(user.id),
             // Bucket
-            this.deleteUserBucket(targetUserId),
+            this.deleteUserBucket(user.id),
             // Teams owned only by this user
-            this.deleteSoleOwnedTeams(targetUserId),
+            this.deleteSoleOwnedTeams(user.id),
             // Team memberships
-            this.deleteTeamMemberships(targetUserId),
+            this.deleteTeamMemberships(user.id),
         ]);
-
-        // Track the deletion Event for Analytics Purposes
-        this.analytics.track({
-            userId: user.id,
-            event: "deletion",
-            properties: {
-                deleted_at: new Date().toISOString(),
-            },
-        });
-        this.analytics.identify({
-            userId: user.id,
-            traits: {
-                github_slug: "deleted-user",
-                gitlab_slug: "deleted-user",
-                bitbucket_slug: "deleted-user",
-                email: "deleted-user",
-                full_name: "deleted-user",
-                name: "deleted-user",
-            },
-        });
-    }
-
-    private anonymizeUser(user: User) {
-        user.avatarUrl = "deleted-avatarUrl";
-        user.fullName = "deleted-fullName";
-        user.name = "deleted-Name";
-        if (user.verificationPhoneNumber) {
-            user.verificationPhoneNumber = "deleted-phoneNumber";
-        }
-    }
-
-    private deleteIdentities(user: User) {
-        for (const identity of user.identities) {
-            identity.deleted = true; // This triggers the HARD DELETION of the identity
-        }
-    }
-
-    private async deleteTokens(db: UserDB, user: User) {
-        const tokenDeletions = user.identities.map((identity) => db.deleteTokens(identity));
-        await Promise.all(tokenDeletions);
     }
 
     private async anonymizeAllWorkspaces(userId: string) {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -111,7 +111,6 @@ import { NotFoundError, UnauthorizedError } from "../errors";
 import { RepoURL } from "../repohost/repo-url";
 import { AuthorizationService } from "../user/authorization-service";
 import { TokenProvider } from "../user/token-provider";
-import { UserDeletionService } from "../user/user-deletion-service";
 import { UserAuthentication } from "../user/user-authentication";
 import { ContextParser } from "./context-parser-service";
 import { GitTokenScopeGuesser } from "./git-token-scope-guesser";
@@ -214,7 +213,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         @inject(TokenProvider) private readonly tokenProvider: TokenProvider,
         @inject(UserAuthentication) private readonly userAuthentication: UserAuthentication,
         @inject(UserService) private readonly userService: UserService,
-        @inject(UserDeletionService) private readonly userDeletionService: UserDeletionService,
         @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
         @inject(AuthorizationService) private readonly authorizationService: AuthorizationService,
         @inject(SSHKeyService) private readonly sshKeyservice: SSHKeyService,
@@ -710,7 +708,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkAndBlockUser("deleteAccount");
         await this.guardAccess({ kind: "user", subject: user! }, "delete");
 
-        await this.userDeletionService.deleteUser(user.id, user.id);
+        await this.userService.deleteUser(user.id, user.id);
     }
 
     public async getWorkspace(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInfo> {
@@ -2689,7 +2687,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const admin = await this.guardAdminAccess("adminDeleteUser", { id: userId }, Permission.ADMIN_PERMISSIONS);
 
-        await this.userDeletionService.deleteUser(admin.id, userId);
+        await this.userService.deleteUser(admin.id, userId);
     }
 
     async adminVerifyUser(ctx: TraceContext, userId: string): Promise<User> {

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -13,7 +13,7 @@ schema: |-
     // permissions
     permission read_info = self + organization->member + organization->owner + installation->admin
     permission write_info = self
-    permission delete = self
+    permission delete = self + organization->owner + installation->admin
 
     permission make_admin = installation->admin + organization->installation_admin
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes the `delete`permission on users, so that admins and org owners can delete their users.
Also moves the `deleteUser` function to `UserService` and introduces an event hook for other services to participate in a user deletion.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c498999</samp>

Refactored user deletion logic to use UserService as the main entry point and UserDeletionService as a listener. Added tests and updated permissions for deleting users. Simplified and removed unused code.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-833

## How to test
<!-- Provide steps to test this PR -->

Signup with two users. make one an admin and delete the other one.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-delete-fix</li>
	<li><b>🔗 URL</b> - <a href="https://se-delete-fix.preview.gitpod-dev.com/workspaces" target="_blank">se-delete-fix.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-delete-fix-gha.19100</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-delete-fix%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
