### PR TITLE
[ops] change team from Workspace to Engine

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -16,7 +16,7 @@ spec:
       - alert: GitpodImageBuildDurationAnomaly
         labels:
           severity: warning
-          team: workspace
+          team: engine
         annotations:
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuildDurationAnomaly.md
           summary: image builds are happening too frequently in cluster {{ $labels.cluster }}

--- a/operations/observability/mixins/workspace/rules/central/ipfs.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ipfs.yaml
@@ -16,7 +16,7 @@ spec:
         - alert: IPFSStorageLow
           labels:
             severity: warning
-            team: workspace
+            team: engine
           for: 10m
           annotations:
             runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/IPFSAlmostOutOfStorage.md
@@ -26,7 +26,7 @@ spec:
         - alert: IPFSStorageCritical
           labels:
             severity: critical
-            team: workspace
+            team: engine
           for: 10m
           annotations:
             runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/IPFSAlmostOutOfStorage.md

--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -27,7 +27,7 @@ spec:
               - alert: GitpodWorkspaceNodeHighNormalizedLoadAverage
                 labels:
                     severity: warning
-                    team: workspace
+                    team: engine
                 for: 60m
                 annotations:
                     runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
@@ -47,7 +47,7 @@ spec:
               - alert: AutoscaleFailure
                 labels:
                     severity: warning
-                    team: workspace
+                    team: engine
                 annotations:
                     runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscaleFailure.md
                     summary: Automatic scale-up failed for some reason.
@@ -58,7 +58,7 @@ spec:
               - alert: NodePoolLoad
                 labels:
                     severity: critical
-                    team: workspace
+                    team: engine
                 for: 60m
                 annotations:
                     runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodePoolLoad.md

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -17,7 +17,7 @@ spec:
     - alert: GitpodWorkspaceStuckOnStoppedMk2
       labels:
         severity: warning
-        team: workspace
+        team: engine
       for: 20m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopped.md
@@ -98,7 +98,7 @@ spec:
     - alert: GitpodImagebuildDoneSuccess
       labels:
         severity: warning
-        team: workspace
+        team: engine
       for: 12h
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildDoneSuccess.md
@@ -110,7 +110,7 @@ spec:
     - alert: GitpodImagebuildStartSuccess
       labels:
         severity: warning
-        team: workspace
+        team: engine
       for: 2h
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildStartSuccess.md


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Alertmanager's receivers are setup to look for team engine and the related Slack webhook, these warnings should start notifying once deployed to a workspace cluster.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1f7fd1</samp>

Changed the team label for several alerts related to image building and image builder nodes from `workspace` to `engine` in various `operations/observability/mixins/workspace/rules/central/*.yaml` files, to align them with the actual team ownership.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
Tested manually [here](https://gitpod.slack.com/archives/C05LAUU29RN/p1698871290907359). These steps were followed:

```
# auth with gcp
./scripts/install-context.sh
kubectx gitpod-monitor-europe-west1-01
kubectl port-forward svc/alertmanager-operated -n monitoring-central 9093
curl -d '[{"labels": {"Alertname": "Fake", "severity": "warning", "team": "engine" , "cluster": "fake101-central", "container": "ws-daemon", "node": "foo", "description":"this is from central","instance": "10.20.169.66:8443"}}]' http://localhost:9093/api/v1/alerts
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
