### PR TITLE
[obs] remove noisy GitpodWorkspaceStuckOnStoppedMk2

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -14,18 +14,6 @@ spec:
 
   - name: workspace-alerts
     rules:
-    - alert: GitpodWorkspaceStuckOnStoppedMk2
-      labels:
-        severity: warning
-        team: engine
-      for: 20m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopped.md
-        summary: Workspaces are stuck in STOPPED phase on cluster {{ $labels.cluster }}.
-        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on stopped for more than 20 minutes. Current status: {{ $labels.reason }}'
-      expr: |
-        sum(gitpod_ws_manager_mk2_workspace_phase_total{phase="Stopped", cluster!~"ephemeral.*"}) > 5
-
     - alert: GitpodWorkspaceStuckOnStoppingMk2
       labels:
         severity: critical


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Pods stuck in Stopped are removed after the 30m grace period: https://github.com/gitpod-io/gitpod/blob/c346773e50f4a15d9af4a663c5f1004c962f4d58/components/ws-manager-mk2/controllers/create.go#L54

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at def2205</samp>

Removed an obsolete alert rule for workspaces stuck on stopped. Simplified the alerting logic for `GitpodWorkspaceStuckOnStopped` in `workspaces.yaml`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
We deploy this to monitoring-central and stop receiving this warning in Slack [(like so)](https://gitpod.slack.com/archives/C05LAUU29RN/p1698872953875129).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
