### PR TITLE
[obs] remove GitpodImagebuildStartSuccess warning

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -94,15 +94,3 @@ spec:
         description: imagebuilds are not reaching done at too high of a rate in cluster {{ $labels.cluster }}.
       expr: |
         (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.60
-
-    - alert: GitpodImagebuildStartSuccess
-      labels:
-        severity: warning
-        team: engine
-      for: 2h
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildStartSuccess.md
-        summary: imagebuild start success rate is failing in cluster {{ $labels.cluster }}.
-        description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
-      expr: |
-        (1 - (sum(rate(gitpod_ws_manager_mk2_workspace_starts_failure_total{type="ImageBuild",cluster!~"ephemeral.*"}[8h])) / sum(rate(gitpod_ws_manager_mk2_workspace_starts_total{type="ImageBuild", cluster!~"ephemeral.*"}[4h])))) < 0.99


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This expression has dips regularly, and does not provide value as a notification in its current form.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f003f87</samp>

Removed an unreliable alert for image build start success and added a new alert for image build duration. This improves the observability of image build performance and user experience.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
n/a

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
