### PR TITLE
Update k3s to gen 106

### DIFF
--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202309220725"
+  default     = "gitpod-k3s-202311030912"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202309220725"
+  default     = "gitpod-k3s-202311030912"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202309220725"
+  default     = "gitpod-k3s-202311030912"
 }
 
 variable "cert_issuer" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the preview environments to use the latest gcp k3s packer image fit for gen 106

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47a4cdc</samp>

This pull request refactors the `image` variable for the Gitpod preview environment on GCP. It updates the default image to the latest version, moves the variable definition to the `gce` module, and removes unused references to the variable.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
