### PR TITLE
[a11y] Add dark mode support to `InputWithCopy` and `TextInputField` components

### DIFF
--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -31,7 +31,7 @@ export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", classNa
     return (
         // max-w-lg is to mirror width of TextInput so Tooltip is positioned correctly
         <div className={`w-full relative max-w-lg ${className ?? ""}`}>
-            <TextInput value={value} disabled className="w-full pr-8 overscroll-none" />
+            <TextInput value={value} disabled className="w-full pr-8 overscroll-none dark:text-[#A8A29E]" />
 
             <Tooltip content={tip} className="absolute top-1.5 right-1">
                 <Button

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -97,7 +97,7 @@ export const TextInput: FunctionComponent<TextInputProps> = memo(
         return (
             <input
                 id={id}
-                className={classNames("w-full max-w-lg", className)}
+                className={classNames("w-full max-w-lg dark:text-[#A8A29E]", className)}
                 value={value}
                 type={type}
                 placeholder={placeholder}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Text inside disabled modal is more readable now in dark mode.

| Before | After |
|--------|--------|
| <img width="594" alt="Screenshot 2023-11-04 at 4 05 02 PM" src="https://github.com/gitpod-io/gitpod/assets/55068936/74baf226-515d-43a1-88c0-2e37b1df4b5f"> | ![Screenshot 2023-11-04 at 4 03 48 PM](https://github.com/gitpod-io/gitpod/assets/55068936/f835952b-7129-4bd2-9fb6-848cf9c0664f) |
| <img width="606" alt="Screenshot 2023-11-04 at 4 07 24 PM" src="https://github.com/gitpod-io/gitpod/assets/55068936/09707b53-82e3-4612-99fd-7f98216f5f48"> | ![Screenshot 2023-11-04 at 4 07 01 PM](https://github.com/gitpod-io/gitpod/assets/55068936/c0483514-6195-485e-9f98-5c936fc8d36b) | 





<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 080cfa3</samp>

Improve text contrast and readability of `TextInput` components in dark mode. Apply a dark text color to `TextInput` in `components/dashboard/src/components/forms/TextInputField.tsx` and `components/dashboard/src/components/InputWithCopy.tsx`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal conversation](https://gitpod.slack.com/archives/C01KPEPNBD0/p1699046451990929)

## How to test
<!-- Provide steps to test this PR -->

- Open preview in dark mode
- Go to Org./User settings, see Org. Id/User ID in text
- Also, Open workspace in VS Code Desktop, Click `More Actions...` & then click on `Connect via SSH` and see SSH command is more readable now 👀 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-a11y-dark-mode</li>
	<li><b>🔗 URL</b> - <a href="https://fix-a11y-dark-mode.preview.gitpod-dev.com/workspaces" target="_blank">fix-a11y-dark-mode.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-a11y-dark-mode-gha.19317</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-a11y-dark-mode%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
