### PR TITLE
Migrate more of the Dashboard to Podkit buttons

### DIFF
--- a/components/dashboard/src/FromReferrer.tsx
+++ b/components/dashboard/src/FromReferrer.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Link } from "react-router-dom";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 export default function FromReferrer() {
     const contextUrl = document.referrer;
@@ -36,9 +36,9 @@ export default function FromReferrer() {
                         </p>
                     </div>
                     <span>
-                        <Link to="/">
-                            <button className="secondary">Go to Dashboard</button>
-                        </Link>
+                        <LinkButton href="/" variant={"secondary"}>
+                            Go to Dashboard
+                        </LinkButton>
                     </span>
                 </div>
             </div>

--- a/components/dashboard/src/components/AuthorizeGit.tsx
+++ b/components/dashboard/src/components/AuthorizeGit.tsx
@@ -16,6 +16,7 @@ import { Button } from "./Button";
 import { Heading2, Heading3, Subheading } from "./typography/headings";
 import classNames from "classnames";
 import { iconForAuthProvider, simplifyProviderName } from "../provider-utils";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 export function useNeedsGitAuthorization() {
     const authProviders = useAuthProviders();
@@ -60,9 +61,9 @@ export const AuthorizeGit: FC<{ className?: string }> = ({ className }) => {
                     {!!org.data?.isOwner ? (
                         <div className="px-6">
                             <Subheading>You need to configure at least one Git integration.</Subheading>
-                            <Link to="/settings/git">
-                                <Button className="mt-6 w-full">Add a Git integration</Button>
-                            </Link>
+                            <LinkButton className="mt-6 w-full" href="/settings/git">
+                                Add a Git integration
+                            </LinkButton>
                         </div>
                     ) : (
                         <>

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -23,6 +23,8 @@ import { getProjectTabs } from "./projects.routes";
 import { shortCommitMessage, toRemoteURL } from "./render-utils";
 import search from "../icons/search.svg";
 import Tooltip from "../components/Tooltip";
+import { Button } from "@podkit/buttons/Button";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 export default function ProjectsPage() {
     const history = useHistory();
@@ -213,12 +215,9 @@ export default function ProjectsPage() {
                                 Authorize {showAuthBanner.host} <br />
                                 to access branch information.
                             </div>
-                            <button
-                                className={`primary mr-2 py-2`}
-                                onClick={() => onConfirmShowAuthModal(showAuthBanner.host)}
-                            >
+                            <Button className="mr-2 py-2" onClick={() => onConfirmShowAuthModal(showAuthBanner.host)}>
                                 Authorize Provider
-                            </button>
+                            </Button>
                         </div>
                     </div>
                 ) : (
@@ -272,12 +271,12 @@ export default function ProjectsPage() {
                                         </span>
                                     )}
                                     {!isResuming && (
-                                        <button
+                                        <Button
                                             className="gp-link hover:text-gray-600"
                                             onClick={() => resumePrebuilds()}
                                         >
                                             Resume prebuilds
-                                        </button>
+                                        </Button>
                                     )}
                                 </Alert>
                             )}
@@ -368,13 +367,12 @@ export default function ProjectsPage() {
                                                         )}
                                                     </a>
                                                     <span className="flex-grow" />
-                                                    <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
-                                                        <button
-                                                            className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}
-                                                        >
-                                                            New Workspace
-                                                        </button>
-                                                    </a>
+                                                    <LinkButton
+                                                        href={gitpodHostUrl.withContext(branch.url).toRelative()}
+                                                        className={`mr-2 py-2 opacity-0 group-hover:opacity-100`}
+                                                    >
+                                                        New Workspace
+                                                    </LinkButton>
                                                     <ItemFieldContextMenu
                                                         className="py-0.5"
                                                         menuEntries={[

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -7,7 +7,6 @@
 import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_pb";
 import { useCallback, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
-import { Link } from "react-router-dom";
 import { personalAccessTokensService } from "../service/public-api";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { settingsPathPersonalAccessTokenCreate, settingsPathPersonalAccessTokenEdit } from "./settings.routes";
@@ -23,6 +22,8 @@ import ShowTokenModal from "./ShowTokenModal";
 import Pagination from "../Pagination/Pagination";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { useFeatureFlag } from "../data/featureflag-query";
+import { LinkButton } from "@podkit/buttons/LinkButton";
+import { Button } from "@podkit/buttons/Button";
 
 export default function PersonalAccessTokens() {
     const enablePersonalAccessTokens = useFeatureFlag("personalAccessTokensEnabled");
@@ -179,9 +180,7 @@ function ListAccessTokensView() {
                     </Subheading>
                 </div>
                 {tokens.length > 0 && (
-                    <Link to={settingsPathPersonalAccessTokenCreate}>
-                        <button>New Access Token</button>
-                    </Link>
+                    <LinkButton href={settingsPathPersonalAccessTokenCreate}>New Access Token</LinkButton>
                 )}
             </div>
             {errorMsg.length > 0 && (
@@ -215,9 +214,9 @@ function ListAccessTokensView() {
                         <div className="mb-2 font-medium text-sm text-gray-500 dark:text-gray-300">
                             Make sure to copy your access token — you won't be able to access it again.
                         </div>
-                        <button className="secondary" onClick={handleCopyToken}>
+                        <Button variant="secondary" onClick={handleCopyToken}>
                             Copy Token to Clipboard
-                        </button>
+                        </Button>
                     </div>
                 </div>
             )}
@@ -233,9 +232,7 @@ function ListAccessTokensView() {
                             <Subheading className="text-center pb-6 w-96">
                                 Generate an access token for applications that need access to the Gitpod API.{" "}
                             </Subheading>
-                            <Link to={settingsPathPersonalAccessTokenCreate}>
-                                <button>New Access Token</button>
-                            </Link>
+                            <LinkButton href={settingsPathPersonalAccessTokenCreate}>New Access Token</LinkButton>
                         </div>
                     ) : (
                         <>

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -22,6 +22,7 @@ import { Timestamp } from "@bufbuild/protobuf";
 import arrowDown from "../images/sort-arrow.svg";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { useFeatureFlag } from "../data/featureflag-query";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 interface EditPATData {
     name: string;
@@ -152,14 +153,12 @@ function PersonalAccessTokenCreateView() {
         <div>
             <PageWithSettingsSubMenu>
                 <div className="mb-4 flex gap-2">
-                    <Link to={settingsPathPersonalAccessTokens}>
-                        <button className="secondary">
-                            <div className="flex place-content-center">
-                                <img src={arrowDown} className="w-4 mr-2 transform rotate-90 mb-0" alt="Back arrow" />
-                                <span>Back to list</span>
-                            </div>
-                        </button>
-                    </Link>
+                    <LinkButton variant={"secondary"} href={settingsPathPersonalAccessTokens}>
+                        <div className="flex place-content-center">
+                            <img src={arrowDown} className="w-4 mr-2 transform rotate-90 mb-0" alt="Back arrow" />
+                            <span>Back to list</span>
+                        </div>
+                    </LinkButton>
                     {editToken && (
                         <button
                             className="danger bg-red-50 dark:bg-red-600 text-red-600 dark:text-red-50"

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -23,6 +23,7 @@ import arrowDown from "../images/sort-arrow.svg";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { useFeatureFlag } from "../data/featureflag-query";
 import { LinkButton } from "@podkit/buttons/LinkButton";
+import { Button } from "@podkit/buttons/Button";
 
 interface EditPATData {
     name: string;
@@ -160,12 +161,13 @@ function PersonalAccessTokenCreateView() {
                         </div>
                     </LinkButton>
                     {editToken && (
-                        <button
-                            className="danger bg-red-50 dark:bg-red-600 text-red-600 dark:text-red-50"
+                        <Button
+                            variant={"destructive"}
+                            className="bg-red-50 dark:bg-red-600 text-red-600 dark:text-red-50"
                             onClick={() => setModalData({ token: editToken })}
                         >
                             Regenerate
-                        </button>
+                        </Button>
                     )}
                 </div>
                 {errorMsg.length > 0 && (
@@ -256,14 +258,14 @@ function PersonalAccessTokenCreateView() {
                     <div className="flex gap-2">
                         {isEditing && (
                             <Link to={settingsPathPersonalAccessTokens}>
-                                <button className="secondary" onClick={handleConfirm}>
+                                <Button variant={"secondary"} onClick={handleConfirm}>
                                     Cancel
-                                </button>
+                                </Button>
                             </Link>
                         )}
-                        <button onClick={handleConfirm} disabled={isEditing && !editToken}>
+                        <Button onClick={handleConfirm} disabled={isEditing && !editToken}>
                             {isEditing ? "Update" : "Create"} Access Token
-                        </button>
+                        </Button>
                     </div>
                 </SpinnerOverlayLoader>
             </PageWithSettingsSubMenu>

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -4,10 +4,9 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Link } from "react-router-dom";
 import { Heading2 } from "../components/typography/headings";
 import { StartWorkspaceModalKeyBinding } from "../App";
-import { Button } from "../components/Button";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 export const EmptyWorkspacesContent = () => {
     return (
@@ -30,12 +29,10 @@ export const EmptyWorkspacesContent = () => {
                         </a>
                     </div>
                     <span>
-                        <Link to={"/new"}>
-                            <Button>
-                                New Workspace{" "}
-                                <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
-                            </Button>
-                        </Link>
+                        <LinkButton className="mt-6 w-full" href="/new">
+                            New Workspace{" "}
+                            <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                        </LinkButton>
                     </span>
                 </div>
             </div>

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -179,7 +179,7 @@ const sortWorkspaces = (a: WorkspaceInfo, b: WorkspaceInfo) => {
 };
 
 /**
- * Given a WorkspaceInfo, return a timestamp of the last related activitiy
+ * Given a WorkspaceInfo, return a timestamp of the last related activity
  *
  * @param info WorkspaceInfo
  * @returns string timestamp

--- a/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
@@ -5,11 +5,10 @@
  */
 
 import { FunctionComponent } from "react";
-import { Link } from "react-router-dom";
 import { StartWorkspaceModalKeyBinding } from "../App";
 import DropDown from "../components/DropDown";
 import search from "../icons/search.svg";
-import { Button } from "../components/Button";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 type WorkspacesSearchBarProps = {
     searchTerm: string;
@@ -67,11 +66,9 @@ export const WorkspacesSearchBar: FunctionComponent<WorkspacesSearchBarProps> = 
                     ]}
                 />
             </div>
-            <Link to={"/new"}>
-                <Button className="ml-2">
-                    New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
-                </Button>
-            </Link>
+            <LinkButton href={"/new"} className="ml-2">
+                New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+            </LinkButton>
         </div>
     );
 };

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -138,6 +138,10 @@ export class GitpodHostUrl {
         return this.url.toString();
     }
 
+    toRelative(): string {
+        return this.url.pathname + this.url.search + this.url.hash;
+    }
+
     toStringWoRootSlash() {
         let result = this.toString();
         if (result.endsWith("/")) {


### PR DESCRIPTION
## Description

Fixes some double-focus issues and continues on EXP-838. I am not sure about buttons with `.gp-link` and will need to look into transitioning them further.

This brings our non-admin `<button>` total from 76 to 65.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8eeeb20</samp>

This pull request updates several dashboard components to use the `LinkButton` component from the `@podkit/buttons` package, which improves the code readability and the UI consistency. It also fixes a typo in a comment and adds a new method to the `GitpodHostUrl` class.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Supersedes #18007

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-button-migrations</li>
	<li><b>🔗 URL</b> - <a href="https://ft-button-migrations.preview.gitpod-dev.com/workspaces" target="_blank">ft-button-migrations.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-button-migrations-gha.19326</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-button-migrations%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
