### PR TITLE
[dashboard] deduplicate repositories

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { SuggestedRepository } from "@gitpod/gitpod-protocol";
+import { deduplicateAndFilterRepositories } from "./unified-repositories-search-query";
+
+function repo(name: string, project?: string): SuggestedRepository {
+    return {
+        url: `http://github.com/efu3he4rf/${name}`,
+        repositoryName: name,
+        projectName: project,
+        projectId: project,
+    };
+}
+
+test("it should deduplicate non-project entries", () => {
+    const suggestedRepos: SuggestedRepository[] = [repo("foo"), repo("foo2"), repo("foo", "project-foo")];
+    const deduplicated = deduplicateAndFilterRepositories("foo", false, suggestedRepos);
+    expect(deduplicated.length).toEqual(2);
+    expect(deduplicated[1].projectName).toEqual("project-foo");
+});
+
+test("it should not deduplicate project entries", () => {
+    const suggestedRepos: SuggestedRepository[] = [
+        repo("foo", "project-foo2"),
+        repo("foo2"),
+        repo("foo", "project-foo"),
+    ];
+    const deduplicated = deduplicateAndFilterRepositories("foo", false, suggestedRepos);
+    expect(deduplicated.length).toEqual(3);
+});
+
+test("it should exclude project entries", () => {
+    const suggestedRepos: SuggestedRepository[] = [
+        repo("foo", "project-foo2"),
+        repo("foo2"),
+        repo("foo", "project-foo"),
+    ];
+    const deduplicated = deduplicateAndFilterRepositories("foo", true, suggestedRepos);
+    expect(deduplicated.length).toEqual(1);
+});
+
+test("it should match entries in url as well as poject name", () => {
+    const suggestedRepos: SuggestedRepository[] = [
+        repo("somefOOtest"),
+        repo("Footest"),
+        repo("somefoO"),
+        repo("bar", "somefOO"),
+        repo("bar", "someFootest"),
+        repo("bar", "FOOtest"),
+    ];
+    var deduplicated = deduplicateAndFilterRepositories("foo", false, suggestedRepos);
+    expect(deduplicated.length).toEqual(6);
+    deduplicated = deduplicateAndFilterRepositories("foot", false, suggestedRepos);
+    expect(deduplicated.length).toEqual(4);
+    deduplicated = deduplicateAndFilterRepositories("FOOT", false, suggestedRepos);
+    expect(deduplicated.length).toEqual(4);
+});
+
+test("it keeps the order", () => {
+    const suggestedRepos: SuggestedRepository[] = [
+        repo("somefOOtest"),
+        repo("Footest"),
+        repo("somefoO"),
+        repo("bar", "somefOO"),
+        repo("bar", "someFootest"),
+        repo("bar", "FOOtest"),
+    ];
+    const deduplicated = deduplicateAndFilterRepositories("foot", false, suggestedRepos);
+    expect(deduplicated[0].repositoryName).toEqual("somefOOtest");
+    expect(deduplicated[1].repositoryName).toEqual("Footest");
+    expect(deduplicated[2].projectName).toEqual("someFootest");
+    expect(deduplicated[3].projectName).toEqual("FOOtest");
+});

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -210,7 +210,7 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
 
     public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
         // Only load 1 page of 10 results for our searchString
-        const results = await this.api.getRepos(user, { maxPages: 1, limit: 10, searchString });
+        const results = await this.api.getRepos(user, { maxPages: 1, limit: 30, searchString });
 
         const repos: RepositoryInfo[] = [];
         results.forEach((r) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a bug with the repository search query, so that duplicates get filtered out properly.

Before this change I would see two entries for a repo if I were adding a project for a repo.
After this change you only see the one that contains the project.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ee6854</samp>

This pull request improves the unified repository search feature for the dashboard component, by simplifying and testing the hook and function that filter repositories from different git providers. It also increases the limit of results returned by the Bitbucket Server provider in the server component, to match the other providers and provide more options.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-869

## How to test
<!-- Provide steps to test this PR -->

Add a project for a repo and verify that the repo is not listed twice in the create workspace page.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-dedupe-repos</li>
	<li><b>🔗 URL</b> - <a href="https://se-dedupe-repos.preview.gitpod-dev.com/workspaces" target="_blank">se-dedupe-repos.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-dedupe-repos-gha.19347</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-dedupe-repos%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
