### PR TITLE
Add "more elements" hint to repo search.

### DIFF
--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -10,18 +10,19 @@ import { useCurrentOrg } from "../organizations/orgs-query";
 import { useDebounce } from "../../hooks/use-debounce";
 import { useFeatureFlag } from "../featureflag-query";
 
-export const useSearchRepositories = ({ searchString }: { searchString: string }) => {
+export const useSearchRepositories = ({ searchString, limit }: { searchString: string; limit: number }) => {
     // This disables the search behavior when flag is disabled
     const repositoryFinderSearchEnabled = useFeatureFlag("repositoryFinderSearch");
     const { data: org } = useCurrentOrg();
     const debouncedSearchString = useDebounce(searchString);
 
     return useQuery(
-        ["search-repositories", { organizationId: org?.id || "", searchString: debouncedSearchString }],
+        ["search-repositories", { organizationId: org?.id || "", searchString: debouncedSearchString, limit }],
         async () => {
             return await getGitpodService().server.searchRepositories({
                 searchString,
                 organizationId: org?.id ?? "",
+                limit,
             });
         },
         {

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -17,15 +17,18 @@ type UnifiedRepositorySearchArgs = {
 // Combines the suggested repositories and the search repositories query into one hook
 export const useUnifiedRepositorySearch = ({ searchString, excludeProjects = false }: UnifiedRepositorySearchArgs) => {
     const suggestedQuery = useSuggestedRepositories();
-    const searchQuery = useSearchRepositories({ searchString });
+    const searchLimit = 30;
+    const searchQuery = useSearchRepositories({ searchString, limit: searchLimit });
 
     const filteredRepos = useMemo(() => {
         const flattenedRepos = [suggestedQuery.data || [], searchQuery.data || []].flat();
+
         return deduplicateAndFilterRepositories(searchString, excludeProjects, flattenedRepos);
     }, [excludeProjects, searchQuery.data, searchString, suggestedQuery.data]);
 
     return {
         data: filteredRepos,
+        hasMore: searchQuery.data?.length === searchLimit,
         isLoading: suggestedQuery.isLoading,
         isSearching: searchQuery.isFetching,
         isError: suggestedQuery.isError || searchQuery.isError,

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -354,7 +354,7 @@ export function CreateWorkspacePage() {
     if (needsGitAuthorization) {
         return (
             <div className="flex flex-col mt-32 mx-auto ">
-                <div className="flex flex-col max-h-screen max-w-lg mx-auto items-center w-full">
+                <div className="flex flex-col max-h-screen max-w-xl mx-auto items-center w-full">
                     <Heading1>New Workspace</Heading1>
                     <div className="text-gray-500 text-center text-base">
                         Start a new workspace with the following options.
@@ -367,7 +367,7 @@ export function CreateWorkspacePage() {
 
     return (
         <div className="flex flex-col mt-32 mx-auto ">
-            <div className="flex flex-col max-h-screen max-w-lg mx-auto items-center w-full">
+            <div className="flex flex-col max-h-screen max-w-xl mx-auto items-center w-full">
                 <Heading1>New Workspace</Heading1>
                 <div className="text-gray-500 text-center text-base">
                     Create a new workspace in the{" "}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -318,6 +318,7 @@ export interface GetProviderRepositoriesParams {
 export interface SearchRepositoriesParams {
     organizationId: string;
     searchString: string;
+    limit?: number; // defaults to 30
 }
 export interface ProviderRepository {
     name: string;

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -208,9 +208,9 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
         return commits.map((c) => c.id);
     }
 
-    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
-        // Only load 1 page of 10 results for our searchString
-        const results = await this.api.getRepos(user, { maxPages: 1, limit: 30, searchString });
+    public async searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]> {
+        // Only load 1 page of limit results for our searchString
+        const results = await this.api.getRepos(user, { maxPages: 1, limit, searchString });
 
         const repos: RepositoryInfo[] = [];
         results.forEach((r) => {

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -164,10 +164,10 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     // 1. Get all workspaces for the user
     // 2. Fan out and search each workspace for the repos
     //
-    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+    public async searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]> {
         const api = await this.apiFactory.create(user);
 
-        const workspaces = await api.workspaces.getWorkspaces({ pagelen: 25 });
+        const workspaces = await api.workspaces.getWorkspaces({ pagelen: limit });
 
         const workspaceSlugs: string[] = (
             workspaces.data.values?.map((w) => {

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -230,7 +230,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         return repos;
     }
 
-    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+    public async searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]> {
         // graphql api only returns public orgs, so we need to use the rest api to get both public & private orgs
         const orgs = await this.github.run(user, async (api) => {
             return api.orgs.listMembershipsForAuthenticatedUser({
@@ -245,7 +245,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         const query = JSON.stringify(`${searchString} in:name user:@me ${orgFilters}`);
         const repoSearchQuery = `
             query SearchRepos {
-                search (type: REPOSITORY, first: 10, query: ${query}){
+                search (type: REPOSITORY, first: ${limit}, query: ${query}){
                     edges {
                         node {
                             ... on Repository {

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -140,11 +140,12 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
         return result.slice(1).map((c: GitLab.Commit) => c.id);
     }
 
-    public async searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]> {
+    public async searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]> {
         const result = await this.gitlab.run<GitLab.Project[]>(user, async (gitlab) => {
             return gitlab.Projects.all({
                 membership: true,
                 search: searchString,
+                perPage: limit,
                 simple: true,
             });
         });

--- a/components/server/src/repohost/repository-provider.ts
+++ b/components/server/src/repohost/repository-provider.ts
@@ -15,5 +15,5 @@ export interface RepositoryProvider {
     getUserRepos(user: User): Promise<RepositoryInfo[]>;
     hasReadAccess(user: User, owner: string, repo: string): Promise<boolean>;
     getCommitHistory(user: User, owner: string, repo: string, ref: string, maxDepth: number): Promise<string[]>;
-    searchRepos(user: User, searchString: string): Promise<RepositoryInfo[]>;
+    searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]>;
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1694,6 +1694,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkAndBlockUser("searchRepositories");
 
         const logCtx: LogContext = { userId: user.id };
+        const limit: number = params.limit || 30;
 
         // Search repos across scm providers for this user
         // Will search personal, and org repos
@@ -1708,7 +1709,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                         log.error(logCtx, "Unsupported repository host: " + p.host);
                         return [];
                     }
-                    const repos = await services.repositoryProvider.searchRepos(user, params.searchString);
+                    const repos = await services.repositoryProvider.searchRepos(user, params.searchString, limit);
 
                     return repos.map((r) =>
                         suggestionFromUserRepo({
@@ -1726,7 +1727,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const sortedRepos = sortSuggestedRepositories(providerRepos.flat());
 
-        return sortedRepos.map(
+        //return only the first 'limit' results
+        return sortedRepos.slice(0, limit).map(
             (repo): SuggestedRepository => ({
                 url: repo.url,
                 repositoryName: repo.repositoryName,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds an extra element for users when the search results were cut off.

Truncated searches will show a hint on the bottom of the list:
<img width="560" alt="Screenshot 2023-11-06 at 18 13 09" src="https://github.com/gitpod-io/gitpod/assets/372735/692a9ecf-e5b9-4151-92ee-9742a2d23b60">
<img width="558" alt="Screenshot 2023-11-06 at 18 13 24" src="https://github.com/gitpod-io/gitpod/assets/372735/0d5a28bd-12e0-48af-844a-e87e42e977b6">
<img width="719" alt="Screenshot 2023-11-06 at 18 12 57" src="https://github.com/gitpod-io/gitpod/assets/372735/0e747d18-df57-41fe-b7d3-e15526e7da1b">

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 038a228</samp>

This pull request adds a limit feature to the repository search functionality of the dashboard. It allows the user to specify the maximum number of repositories to show from a search query, and indicates if there are more results available. It implements the limit feature on the server-side API and the different repository providers, and passes the limit parameter from the client-side hook to the API. It affects the files `RepositoryFinder.tsx`, `search-repositories-query.ts`, `unified-repositories-search-query.ts`, `gitpod-server-impl.ts`, `gitpod-service.ts`, and the files for each repository provider.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-871

## How to test
<!-- Provide steps to test this PR -->

 - [join this org](https://se-bbs-search.preview.gitpod-dev.com/orgs/join?inviteId=1d802d8f-5353-4ffc-96b2-e02ff57cdc14) 
 - [go to new](https://se-bbs-search.preview.gitpod-dev.com/new)
 - type in '2k-test' and scroll down

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-bbs-search</li>
	<li><b>🔗 URL</b> - <a href="https://se-bbs-search.preview.gitpod-dev.com/workspaces" target="_blank">se-bbs-search.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-bbs-search-gha.19415</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-bbs-search%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
