### PR TITLE
[server] move FGA calls into AuthProviderService

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
@@ -18,7 +18,11 @@ export class DBAuthProviderEntry implements AuthProviderEntry {
     @Column()
     ownerId: string;
 
-    @Column()
+    @Column({
+        ...TypeORM.UUID_COLUMN_TYPE,
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
     organizationId?: string;
 
     @Column("varchar")

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -81,15 +81,30 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     updateLoggedInUser(user: Partial<User>): Promise<User>;
     sendPhoneNumberVerificationToken(phoneNumber: string): Promise<{ verificationId: string }>;
     verifyPhoneNumberVerificationToken(phoneNumber: string, token: string, verificationId: string): Promise<boolean>;
-    getAuthProviders(): Promise<AuthProviderInfo[]>;
-    getOwnAuthProviders(): Promise<AuthProviderEntry[]>;
-    updateOwnAuthProvider(params: GitpodServer.UpdateOwnAuthProviderParams): Promise<AuthProviderEntry>;
-    deleteOwnAuthProvider(params: GitpodServer.DeleteOwnAuthProviderParams): Promise<void>;
     getConfiguration(): Promise<Configuration>;
     getToken(query: GitpodServer.GetTokenSearchOptions): Promise<Token | undefined>;
     getGitpodTokenScopes(tokenHash: string): Promise<string[]>;
     deleteAccount(): Promise<void>;
     getClientRegion(): Promise<string | undefined>;
+
+    // Auth Provider API
+    getAuthProviders(): Promise<AuthProviderInfo[]>;
+    // user-level
+    getOwnAuthProviders(): Promise<AuthProviderEntry[]>;
+    updateOwnAuthProvider(params: GitpodServer.UpdateOwnAuthProviderParams): Promise<AuthProviderEntry>;
+    deleteOwnAuthProvider(params: GitpodServer.DeleteOwnAuthProviderParams): Promise<void>;
+    // org-level
+    createOrgAuthProvider(params: GitpodServer.CreateOrgAuthProviderParams): Promise<AuthProviderEntry>;
+    updateOrgAuthProvider(params: GitpodServer.UpdateOrgAuthProviderParams): Promise<AuthProviderEntry>;
+    getOrgAuthProviders(params: GitpodServer.GetOrgAuthProviderParams): Promise<AuthProviderEntry[]>;
+    deleteOrgAuthProvider(params: GitpodServer.DeleteOrgAuthProviderParams): Promise<void>;
+    // public-api compatibility
+    /** @deprecated used for public-api compatibility only */
+    getAuthProvider(id: string): Promise<AuthProviderEntry>;
+    /** @deprecated used for public-api compatibility only */
+    deleteAuthProvider(id: string): Promise<void>;
+    /** @deprecated used for public-api compatibility only */
+    updateAuthProvider(id: string, update: AuthProviderEntry.UpdateOAuth2Config): Promise<AuthProviderEntry>;
 
     // Query/retrieve workspaces
     getWorkspaces(options: GitpodServer.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;
@@ -167,10 +182,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     deleteTeam(teamId: string): Promise<void>;
     getOrgSettings(orgId: string): Promise<OrganizationSettings>;
     updateOrgSettings(teamId: string, settings: Partial<OrganizationSettings>): Promise<OrganizationSettings>;
-    createOrgAuthProvider(params: GitpodServer.CreateOrgAuthProviderParams): Promise<AuthProviderEntry>;
-    updateOrgAuthProvider(params: GitpodServer.UpdateOrgAuthProviderParams): Promise<AuthProviderEntry>;
-    getOrgAuthProviders(params: GitpodServer.GetOrgAuthProviderParams): Promise<AuthProviderEntry[]>;
-    deleteOrgAuthProvider(params: GitpodServer.DeleteOrgAuthProviderParams): Promise<void>;
 
     getDefaultWorkspaceImage(params: GetDefaultWorkspaceImageParams): Promise<GetDefaultWorkspaceImageResult>;
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1529,7 +1529,6 @@ export interface AuthProviderInfo {
     readonly ownerId?: string;
     readonly organizationId?: string;
     readonly verified: boolean;
-    readonly isReadonly?: boolean;
     readonly hiddenOnDashboard?: boolean;
     readonly disallowLogin?: boolean;
     readonly icon?: string;
@@ -1588,6 +1587,7 @@ export namespace AuthProviderEntry {
         clientSecret: string;
         organizationId: string;
     };
+    export type UpdateOAuth2Config = Pick<OAuth2Config, "clientId" | "clientSecret">;
     export function redact(entry: AuthProviderEntry): AuthProviderEntry {
         return {
             ...entry,

--- a/components/server/src/auth/auth-provider-scopes.ts
+++ b/components/server/src/auth/auth-provider-scopes.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { GitHubScope } from "../github/scopes";
+import { GitLabScope } from "../gitlab/scopes";
+import { BitbucketOAuthScopes } from "../bitbucket/bitbucket-oauth-scopes";
+import { BitbucketServerOAuthScopes } from "../bitbucket-server/bitbucket-server-oauth-scopes";
+
+export function getRequiredScopes(entry: AuthProviderEntry) {
+    switch (entry.type) {
+        case "GitHub":
+            return {
+                default: GitHubScope.Requirements.DEFAULT,
+                publicRepo: GitHubScope.Requirements.PUBLIC_REPO,
+                privateRepo: GitHubScope.Requirements.PRIVATE_REPO,
+            };
+        case "GitLab":
+            return {
+                default: GitLabScope.Requirements.DEFAULT,
+                publicRepo: GitLabScope.Requirements.DEFAULT,
+                privateRepo: GitLabScope.Requirements.REPO,
+            };
+        case "Bitbucket":
+            return {
+                default: BitbucketOAuthScopes.Requirements.DEFAULT,
+                publicRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
+                privateRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
+            };
+        case "BitbucketServer":
+            return {
+                default: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                publicRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                privateRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+            };
+    }
+}
+export function getScopesOfProvider(entry: AuthProviderEntry) {
+    switch (entry.type) {
+        case "GitHub":
+            return GitHubScope.All;
+        case "GitLab":
+            return GitLabScope.All;
+        case "Bitbucket":
+            return BitbucketOAuthScopes.ALL;
+        case "BitbucketServer":
+            return BitbucketServerOAuthScopes.ALL;
+    }
+}

--- a/components/server/src/auth/auth-provider-service.spec.db.ts
+++ b/components/server/src/auth/auth-provider-service.spec.db.ts
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM } from "@gitpod/gitpod-db/lib";
+import { AuthProviderInfo, Organization, User } from "@gitpod/gitpod-protocol";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { UserService } from "../user/user-service";
+import { AuthProviderService } from "./auth-provider-service";
+import { Config } from "../config";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { expectError } from "../test/expect-utils";
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { AuthProviderParams } from "./auth-provider";
+import { OrganizationService } from "../orgs/organization-service";
+
+const expect = chai.expect;
+
+describe("AuthProviderService", async () => {
+    let service: AuthProviderService;
+    let userService: UserService;
+    let container: Container;
+    let currentUser: User;
+    let org: Organization;
+
+    const newEntry = () =>
+        <AuthProviderEntry.NewEntry>{
+            host: "github.com",
+            ownerId: currentUser.id,
+            type: "GitHub",
+            clientId: "123",
+            clientSecret: "secret-123",
+        };
+    const expectedEntry = () =>
+        <Partial<AuthProviderEntry>>{
+            host: "github.com",
+            oauth: {
+                authorizationUrl: "https://github.com/login/oauth/authorize",
+                callBackUrl: "https://gitpod.io/auth/callback",
+                clientId: "123",
+                clientSecret: "redacted",
+                tokenUrl: "https://github.com/login/oauth/access_token",
+            },
+            organizationId: undefined,
+            type: "GitHub",
+            status: "pending",
+            ownerId: currentUser.id,
+        };
+    const expectedParams = () =>
+        <Partial<AuthProviderParams>>{
+            builtin: false,
+            disallowLogin: false,
+            verified: false,
+            ...expectedEntry(),
+            oauth: { ...expectedEntry().oauth, clientSecret: "secret-123" },
+        };
+
+    const newOrgEntry = () =>
+        <AuthProviderEntry.NewOrgEntry>{
+            host: "github.com",
+            ownerId: currentUser.id,
+            type: "GitHub",
+            clientId: "123",
+            clientSecret: "secret-123",
+            organizationId: org.id,
+        };
+    const expectedOrgEntry = () =>
+        <Partial<AuthProviderEntry>>{
+            host: "github.com",
+            oauth: {
+                authorizationUrl: "https://github.com/login/oauth/authorize",
+                callBackUrl: "https://gitpod.io/auth/callback",
+                clientId: "123",
+                clientSecret: "redacted",
+                tokenUrl: "https://github.com/login/oauth/access_token",
+            },
+            organizationId: org.id,
+            type: "GitHub",
+            status: "pending",
+            ownerId: currentUser.id,
+        };
+    const expectedOrgParams = () =>
+        <Partial<AuthProviderParams>>{
+            builtin: false,
+            disallowLogin: true,
+            verified: false,
+            ...expectedOrgEntry(),
+            oauth: { ...expectedOrgEntry().oauth, clientSecret: "secret-123" },
+        };
+
+    const addBuiltInProvider = (host: string = "github.com") => {
+        const config = container.get<Config>(Config);
+        config.builtinAuthProvidersConfigured = true;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        config.authProviderConfigs.push((<Partial<AuthProviderParams>>{
+            host,
+            id: "Public-GitHub",
+            verified: true,
+        }) as any);
+    };
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+        service = container.get(AuthProviderService);
+        userService = container.get<UserService>(UserService);
+        currentUser = await userService.createUser({
+            identity: {
+                authId: "gh-user-1",
+                authName: "user",
+                authProviderId: "public-github",
+            },
+        });
+        const os = container.get<OrganizationService>(OrganizationService);
+        org = await os.createOrganization(currentUser.id, "myorg");
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    describe("createAuthProviderOfUser", async () => {
+        it("should create user-level provider", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            await service.createAuthProviderOfUser(currentUser.id, newEntry());
+
+            const providers = await service.getAllAuthProviderParams();
+            expect(providers).to.have.lengthOf(1);
+            expect(providers[0]).to.deep.include(expectedParams());
+        });
+
+        it("should fail in case of conflict with built-in provider", async () => {
+            addBuiltInProvider();
+
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            await expectError(ErrorCodes.CONFLICT, service.createAuthProviderOfUser(currentUser.id, newEntry()));
+        });
+        it("should fail if host is not reachable", async () => {
+            await expectError(
+                ErrorCodes.BAD_REQUEST,
+                service.createAuthProviderOfUser(currentUser.id, {
+                    ...newEntry(),
+                    host: "please-dont-register-this-domain.com:666",
+                }),
+            );
+        });
+        it("should fail if trying to register same host", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            await service.createAuthProviderOfUser(currentUser.id, newEntry());
+
+            await expectError(ErrorCodes.CONFLICT, service.createAuthProviderOfUser(currentUser.id, newEntry()));
+        });
+    });
+
+    describe("createOrgAuthProvider", async () => {
+        it("should create org-level provider", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
+
+            const providers = await service.getAllAuthProviderParams();
+            expect(providers).to.have.lengthOf(1);
+            expect(providers[0]).to.deep.include(expectedOrgParams());
+        });
+        it("should fail if host is not reachable", async () => {
+            await expectError(
+                ErrorCodes.BAD_REQUEST,
+                service.createOrgAuthProvider(currentUser.id, {
+                    ...newOrgEntry(),
+                    host: "please-dont-register-this-domain.com:666",
+                }),
+            );
+        });
+        it("should fail if trying to register same host", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
+
+            await expectError(ErrorCodes.CONFLICT, service.createAuthProviderOfUser(currentUser.id, newOrgEntry()));
+        });
+    });
+    describe("getAuthProvider", async () => {
+        it("should find org-level provider", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            const created = await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
+
+            const retrieved = await service.getAuthProvider(currentUser.id, created.id);
+            expect(retrieved).to.deep.include(expectedOrgEntry());
+        });
+        it("should find user-level provider", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            const created = await service.createAuthProviderOfUser(currentUser.id, newEntry());
+
+            const retrieved = await service.getAuthProvider(currentUser.id, created.id);
+            expect(retrieved).to.deep.include(expectedEntry());
+        });
+        it("should not find org-level provider for non-members", async () => {
+            const providersAtStart = await service.getAllAuthProviderParams();
+            expect(providersAtStart).to.be.empty;
+
+            const created = await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
+
+            const nonMember = await userService.createUser({
+                identity: {
+                    authId: "gh-user-2",
+                    authName: "user2",
+                    authProviderId: "public-github",
+                },
+            });
+
+            // expecting 404, as Orgs shall not be enumerable to non-members
+            await expectError(ErrorCodes.NOT_FOUND, service.getAuthProvider(nonMember.id, created.id));
+        });
+    });
+
+    describe("getAuthProviderDescriptionsUnauthenticated", async () => {
+        it("should find built-in provider", async () => {
+            addBuiltInProvider();
+
+            const providers = await service.getAuthProviderDescriptionsUnauthenticated();
+            expect(providers).to.has.lengthOf(1);
+            expect(providers[0].authProviderId).to.be.equal("Public-GitHub");
+        });
+        it("should find only built-in providers but no user-level providers", async () => {
+            addBuiltInProvider("localhost");
+
+            const created = await service.createAuthProviderOfUser(currentUser.id, newEntry());
+            await service.markAsVerified({ userId: currentUser.id, id: created.id });
+
+            const providers = await service.getAuthProviderDescriptionsUnauthenticated();
+            expect(providers).to.has.lengthOf(1);
+            expect(providers[0].host).to.be.equal("localhost");
+        });
+        it("should find user-level providers if no built-in providers present", async () => {
+            const created = await service.createAuthProviderOfUser(currentUser.id, newEntry());
+            await service.markAsVerified({ userId: currentUser.id, id: created.id });
+
+            const providers = await service.getAuthProviderDescriptionsUnauthenticated();
+            expect(providers).to.has.lengthOf(1);
+            expect(providers[0]).to.deep.include(<Partial<AuthProviderInfo>>{
+                authProviderId: created.id,
+                authProviderType: created.type,
+                host: created.host,
+            });
+
+            const privateProperties: (keyof AuthProviderEntry)[] = ["oauth", "organizationId", "ownerId"];
+            for (const privateProperty of privateProperties) {
+                expect(providers[0]).to.not.haveOwnProperty(privateProperty);
+            }
+        });
+    });
+
+    describe("getAuthProviderDescriptions", async () => {
+        it("should find built-in provider", async () => {
+            addBuiltInProvider();
+
+            const providers = await service.getAuthProviderDescriptions(currentUser);
+            expect(providers).to.has.lengthOf(1);
+            expect(providers[0].authProviderId).to.be.equal("Public-GitHub");
+        });
+        it("should find built-in providers and _own_ user-level providers", async () => {
+            addBuiltInProvider("localhost");
+
+            const created = await service.createAuthProviderOfUser(currentUser.id, newEntry());
+            await service.markAsVerified({ userId: currentUser.id, id: created.id });
+
+            const providers = await service.getAuthProviderDescriptions(currentUser);
+            expect(providers).to.has.lengthOf(2);
+            expect(providers[0].host).to.be.equal(created.host);
+            expect(providers[1].host).to.be.equal("localhost");
+        });
+        it("should find user-level providers if no built-in providers present", async () => {
+            const created = await service.createAuthProviderOfUser(currentUser.id, newEntry());
+            await service.markAsVerified({ userId: currentUser.id, id: created.id });
+
+            const providers = await service.getAuthProviderDescriptions(currentUser);
+            expect(providers).to.has.lengthOf(1);
+            expect(providers[0]).to.deep.include(<Partial<AuthProviderInfo>>{
+                authProviderId: created.id,
+                authProviderType: created.type,
+                host: created.host,
+                organizationId: created.organizationId,
+                ownerId: created.ownerId,
+            });
+
+            const oauthProperty: keyof AuthProviderEntry = "oauth";
+            expect(providers[0]).to.not.haveOwnProperty(oauthProperty);
+        });
+    });
+});

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { AuthProviderEntry as AuthProviderEntry, User } from "@gitpod/gitpod-protocol";
+import { AuthProviderEntry as AuthProviderEntry, AuthProviderInfo, User } from "@gitpod/gitpod-protocol";
 import { AuthProviderParams } from "./auth-provider";
 import { AuthProviderEntryDB, TeamDB } from "@gitpod/gitpod-db/lib";
 import { Config } from "../config";
@@ -16,22 +16,29 @@ import { oauthUrls as bbsUrls } from "../bitbucket-server/bitbucket-server-urls"
 import { oauthUrls as bbUrls } from "../bitbucket/bitbucket-urls";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import fetch from "node-fetch";
+import { Authorizer } from "../authorization/authorizer";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { GitHubScope } from "../github/scopes";
+import { GitLabScope } from "../gitlab/scopes";
+import { BitbucketOAuthScopes } from "../bitbucket/bitbucket-oauth-scopes";
+import { BitbucketServerOAuthScopes } from "../bitbucket-server/bitbucket-server-oauth-scopes";
 
 @injectable()
 export class AuthProviderService {
-    @inject(AuthProviderEntryDB)
-    protected authProviderDB: AuthProviderEntryDB;
-
-    @inject(TeamDB)
-    protected teamDB: TeamDB;
-
-    @inject(Config)
-    protected readonly config: Config;
+    constructor(
+        @inject(AuthProviderEntryDB) private readonly authProviderDB: AuthProviderEntryDB,
+        @inject(TeamDB) private readonly teamDB: TeamDB,
+        @inject(Config) protected readonly config: Config,
+        @inject(Authorizer) private readonly auth: Authorizer,
+    ) {}
 
     /**
-     * Returns all auth providers.
+     * Returns all **unredacted** auth provider params to be used in the internal
+     * authenticator parts.
+     *
+     * Known internal client `HostContextProviderImpl`
      */
-    async getAllAuthProviders(exceptOAuthRevisions: string[] = []): Promise<AuthProviderParams[]> {
+    async getAllAuthProviderParams(exceptOAuthRevisions: string[] = []): Promise<AuthProviderParams[]> {
         const all = await this.authProviderDB.findAll(exceptOAuthRevisions);
         return all.map((provider) => this.toAuthProviderParams(provider));
     }
@@ -40,7 +47,7 @@ export class AuthProviderService {
         return this.authProviderDB.findAllHosts();
     }
 
-    protected toAuthProviderParams = (oap: AuthProviderEntry) =>
+    private toAuthProviderParams = (oap: AuthProviderEntry) =>
         <AuthProviderParams>{
             ...oap,
             // HINT: host is expected to be lower case
@@ -56,77 +63,279 @@ export class AuthProviderService {
             },
         };
 
+    private isBuiltIn = (info: AuthProviderInfo | AuthProviderParams) => !info.ownerId;
+    private isNotHidden = (info: AuthProviderInfo | AuthProviderParams) => !info.hiddenOnDashboard;
+    private isVerified = (info: AuthProviderInfo | AuthProviderParams) => info.verified;
+    private isNotOrgProvider = (info: AuthProviderInfo | AuthProviderParams) => !info.organizationId;
+
+    async getAuthProviderDescriptionsUnauthenticated(): Promise<AuthProviderInfo[]> {
+        const { builtinAuthProvidersConfigured } = this.config;
+
+        const authProviders = [...(await this.getAllAuthProviderParams()), ...this.config.authProviderConfigs];
+
+        const toPublic = (ap: AuthProviderParams) =>
+            <AuthProviderInfo>{
+                authProviderId: ap.id,
+                authProviderType: ap.type,
+                disallowLogin: ap.disallowLogin,
+                host: ap.host,
+                icon: ap.icon,
+                description: ap.description,
+            };
+        let result = authProviders.filter(this.isNotHidden).filter(this.isVerified).filter(this.isNotOrgProvider);
+        if (builtinAuthProvidersConfigured) {
+            result = result.filter(this.isBuiltIn);
+        }
+        return result.map(toPublic);
+    }
+
+    async getAuthProviderDescriptions(user: User): Promise<AuthProviderInfo[]> {
+        const { builtinAuthProvidersConfigured } = this.config;
+
+        const authProviders = [...(await this.getAllAuthProviderParams()), ...this.config.authProviderConfigs];
+
+        // explicitly copy to avoid bleeding sensitive details
+        const toInfo = (ap: AuthProviderParams) =>
+            <AuthProviderInfo>{
+                authProviderId: ap.id,
+                authProviderType: ap.type,
+                ownerId: ap.ownerId,
+                organizationId: ap.organizationId,
+                verified: ap.verified,
+                host: ap.host,
+                icon: ap.icon,
+                hiddenOnDashboard: ap.hiddenOnDashboard,
+                disallowLogin: ap.disallowLogin,
+                description: ap.description,
+                scopes: this.toScopes(ap),
+                requirements: this.toScopeRequirements(ap),
+            };
+
+        const result: AuthProviderInfo[] = [];
+        for (const p of authProviders) {
+            const identity = user.identities.find((i) => i.authProviderId === p.id);
+            if (identity) {
+                result.push(toInfo(p));
+                continue;
+            }
+            if (p.ownerId === user.id) {
+                result.push(toInfo(p));
+                continue;
+            }
+            if (builtinAuthProvidersConfigured && !this.isBuiltIn(p)) {
+                continue;
+            }
+            if (this.isNotHidden(p) && this.isVerified(p)) {
+                result.push(toInfo(p));
+            }
+        }
+        return result;
+    }
+    /**
+     * This is extracted from auth provider handlers in order to avoid a
+     * dependency to host contexts.
+     *
+     * TODO(at) these defaults of provider types needs to be centralized.
+     */
+    private toScopeRequirements(entry: AuthProviderEntry) {
+        switch (entry.type) {
+            case "GitHub":
+                return {
+                    default: GitHubScope.Requirements.DEFAULT,
+                    publicRepo: GitHubScope.Requirements.PUBLIC_REPO,
+                    privateRepo: GitHubScope.Requirements.PRIVATE_REPO,
+                };
+            case "GitLab":
+                return {
+                    default: GitLabScope.Requirements.DEFAULT,
+                    publicRepo: GitLabScope.Requirements.DEFAULT,
+                    privateRepo: GitLabScope.Requirements.REPO,
+                };
+            case "Bitbucket":
+                return {
+                    default: BitbucketOAuthScopes.Requirements.DEFAULT,
+                    publicRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
+                    privateRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
+                };
+            case "Bitbucket":
+                return {
+                    default: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                    publicRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                    privateRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                };
+        }
+    }
+    private toScopes(entry: AuthProviderEntry) {
+        switch (entry.type) {
+            case "GitHub":
+                return GitHubScope.All;
+            case "GitLab":
+                return GitLabScope.All;
+            case "Bitbucket":
+                return BitbucketOAuthScopes.ALL;
+            case "Bitbucket":
+                return BitbucketServerOAuthScopes.ALL;
+        }
+    }
+
     async getAuthProvidersOfUser(user: User | string): Promise<AuthProviderEntry[]> {
-        const result = await this.authProviderDB.findByUserId(User.is(user) ? user.id : user);
-        return result;
+        const userId = User.is(user) ? user.id : user;
+        await this.auth.checkPermissionOnUser(userId, "read_info", userId);
+
+        const result = await this.authProviderDB.findByUserId(userId);
+        return result.map((ap) => AuthProviderEntry.redact(ap));
     }
 
-    async getAuthProvidersOfOrg(organizationId: string): Promise<AuthProviderEntry[]> {
+    async getAuthProvidersOfOrg(userId: string, organizationId: string): Promise<AuthProviderEntry[]> {
+        await this.auth.checkPermissionOnOrganization(userId, "read_git_provider", organizationId);
         const result = await this.authProviderDB.findByOrgId(organizationId);
-        return result;
+        return result.map((ap) => AuthProviderEntry.redact(ap));
     }
 
-    async deleteAuthProvider(authProvider: AuthProviderEntry): Promise<void> {
+    async deleteAuthProviderOfUser(userId: string, authProviderId: string): Promise<void> {
+        await this.auth.checkPermissionOnUser(userId, "write_info", userId);
+
+        const ownProviders = await this.getAuthProvidersOfUser(userId);
+        const authProvider = ownProviders.find((p) => p.id === authProviderId);
+        if (!authProvider) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "User resource not found.");
+        }
+
         await this.authProviderDB.delete(authProvider);
     }
 
-    async updateAuthProvider(
-        entry: AuthProviderEntry.UpdateEntry | AuthProviderEntry.NewEntry,
-    ): Promise<AuthProviderEntry> {
-        let authProvider: AuthProviderEntry;
-        if ("id" in entry) {
-            const { id, ownerId } = entry;
-            const existing = (await this.authProviderDB.findByUserId(ownerId)).find((p) => p.id === id);
-            if (!existing) {
-                throw new Error("Provider does not exist.");
-            }
-            const changed =
-                entry.clientId !== existing.oauth.clientId ||
-                (entry.clientSecret && entry.clientSecret !== existing.oauth.clientSecret);
+    async deleteAuthProviderOfOrg(userId: string, organizationId: string, authProviderId: string): Promise<void> {
+        await this.auth.checkPermissionOnOrganization(userId, "write_git_provider", organizationId);
 
-            if (!changed) {
-                return existing;
-            }
-
-            // update config on demand
-            const oauth = {
-                ...existing.oauth,
-                clientId: entry.clientId,
-                clientSecret: entry.clientSecret || existing.oauth.clientSecret, // FE may send empty ("") if not changed
-            };
-            authProvider = {
-                ...existing,
-                oauth,
-                status: "pending",
-            };
-        } else {
-            const existing = await this.authProviderDB.findByHost(entry.host);
-            if (existing) {
-                throw new Error("Provider for this host already exists.");
-            }
-            authProvider = this.initializeNewProvider(entry);
+        // Find the matching auth provider we're attempting to delete
+        const orgProviders = await this.getAuthProvidersOfOrg(userId, organizationId);
+        const authProvider = orgProviders.find((p) => p.id === authProviderId && p.organizationId === organizationId);
+        if (!authProvider) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Provider resource not found.");
         }
-        return await this.authProviderDB.storeAuthProvider(authProvider as AuthProviderEntry, true);
+
+        await this.authProviderDB.delete(authProvider);
     }
 
-    async createOrgAuthProvider(entry: AuthProviderEntry.NewOrgEntry): Promise<AuthProviderEntry> {
-        const orgProviders = await this.authProviderDB.findByOrgId(entry.organizationId);
-        const existing = orgProviders.find((p) => p.host === entry.host);
+    /**
+     * Returns the provider identified by the specified `id`. Throws `NOT_FOUND` error if the resource
+     * is not found.
+     */
+    async getAuthProvider(userId: string, id: string): Promise<AuthProviderEntry> {
+        const result = await this.authProviderDB.findById(id);
+        if (!result) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Provider resource not found.");
+        }
+
+        if (result.organizationId) {
+            await this.auth.checkPermissionOnOrganization(userId, "read_git_provider", result.organizationId);
+        } else {
+            await this.auth.checkPermissionOnUser(userId, "read_info", userId);
+        }
+
+        return AuthProviderEntry.redact(result);
+    }
+
+    async createAuthProviderOfUser(userId: string, entry: AuthProviderEntry.NewEntry): Promise<AuthProviderEntry> {
+        await this.auth.checkPermissionOnUser(userId, "write_info", userId);
+
+        const host = entry.host && entry.host.toLowerCase();
+
+        // reachability test
+        if (!(await this.isHostReachable(host))) {
+            log.info(`Host could not be reached.`, { entry });
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Host could not be reached.`);
+        }
+
+        // checking for already existing runtime providers
+        const isBuiltInProvider = this.isBuiltInProvider(host);
+        if (isBuiltInProvider) {
+            log.info(`Attempt to override an existing provider.`, { entry });
+            throw new ApplicationError(ErrorCodes.CONFLICT, `Attempt to override an existing provider.`);
+        }
+        const existing = await this.authProviderDB.findByHost(entry.host);
         if (existing) {
-            throw new Error("Provider for this host already exists.");
+            log.info(`Provider for this host already exists.`, { entry });
+            throw new ApplicationError(ErrorCodes.CONFLICT, `Provider for this host already exists.`);
         }
 
         const authProvider = this.initializeNewProvider(entry);
-
-        return await this.authProviderDB.storeAuthProvider(authProvider as AuthProviderEntry, true);
+        const result = await this.authProviderDB.storeAuthProvider(authProvider, true);
+        return AuthProviderEntry.redact(result);
     }
 
-    async updateOrgAuthProvider(entry: AuthProviderEntry.UpdateOrgEntry): Promise<AuthProviderEntry> {
+    private isBuiltInProvider(host: string) {
+        return this.config.authProviderConfigs.some((config) => config.host.toLowerCase() === host.toLocaleLowerCase());
+    }
+
+    async updateAuthProviderOfUser(userId: string, entry: AuthProviderEntry.UpdateEntry): Promise<AuthProviderEntry> {
+        await this.auth.checkPermissionOnUser(userId, "write_info", userId);
+
+        const { id, ownerId } = entry;
+        const existing = (await this.authProviderDB.findByUserId(ownerId)).find((p) => p.id === id);
+        if (!existing) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Provider resource not found.");
+        }
+        const changed =
+            entry.clientId !== existing.oauth.clientId ||
+            (entry.clientSecret && entry.clientSecret !== existing.oauth.clientSecret);
+
+        if (!changed) {
+            return existing;
+        }
+
+        // update config on demand
+        const oauth = {
+            ...existing.oauth,
+            clientId: entry.clientId,
+            clientSecret: entry.clientSecret || existing.oauth.clientSecret, // FE may send empty ("") if not changed
+        };
+        const authProvider: AuthProviderEntry = {
+            ...existing,
+            oauth,
+            status: "pending",
+        };
+        const result = await this.authProviderDB.storeAuthProvider(authProvider, true);
+        return AuthProviderEntry.redact(result);
+    }
+
+    async createOrgAuthProvider(userId: string, newEntry: AuthProviderEntry.NewOrgEntry): Promise<AuthProviderEntry> {
+        await this.auth.checkPermissionOnOrganization(userId, "write_git_provider", newEntry.organizationId);
+
+        // on creating we're are checking for already existing runtime providers
+        const host = newEntry.host && newEntry.host.toLowerCase();
+
+        if (!(await this.isHostReachable(host))) {
+            log.info(`Host could not be reached.`, { newEntry });
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Host could not be reached.`);
+        }
+
+        const isBuiltInProvider = this.isBuiltInProvider(host);
+        if (isBuiltInProvider) {
+            log.info(`Attempt to override an existing provider.`, { newEntry });
+            throw new ApplicationError(ErrorCodes.CONFLICT, `Attempt to override an existing provider.`);
+        }
+
+        const orgProviders = await this.authProviderDB.findByOrgId(newEntry.organizationId);
+        const existing = orgProviders.find((p) => p.host === host);
+        if (existing) {
+            log.info(`Provider for this host already exists.`, { newEntry });
+            throw new ApplicationError(ErrorCodes.CONFLICT, `Provider for this host already exists.`);
+        }
+
+        const authProvider = this.initializeNewProvider(newEntry);
+        const result = await this.authProviderDB.storeAuthProvider(authProvider, true);
+        return AuthProviderEntry.redact(result);
+    }
+
+    async updateOrgAuthProvider(userId: string, entry: AuthProviderEntry.UpdateOrgEntry): Promise<AuthProviderEntry> {
         const { id, organizationId } = entry;
+        await this.auth.checkPermissionOnOrganization(userId, "write_git_provider", organizationId);
+
         // TODO can we change this to query for the provider by id and org instead of loading all from org?
         const existing = (await this.authProviderDB.findByOrgId(organizationId)).find((p) => p.id === id);
         if (!existing) {
-            throw new Error("Provider does not exist.");
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "Provider resource not found.");
         }
         const changed =
             entry.clientId !== existing.oauth.clientId ||
@@ -148,10 +357,11 @@ export class AuthProviderService {
             status: "pending",
         };
 
-        return await this.authProviderDB.storeAuthProvider(authProvider as AuthProviderEntry, true);
+        const result = await this.authProviderDB.storeAuthProvider(authProvider as AuthProviderEntry, true);
+        return AuthProviderEntry.redact(result);
     }
 
-    protected initializeNewProvider(newEntry: AuthProviderEntry.NewEntry): AuthProviderEntry {
+    private initializeNewProvider(newEntry: AuthProviderEntry.NewEntry): AuthProviderEntry {
         const { host, type, clientId, clientSecret } = newEntry;
         let urls;
         switch (type) {
@@ -169,7 +379,7 @@ export class AuthProviderService {
                 break;
         }
         if (!urls) {
-            throw new Error("Unexpected service type.");
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unexpected service type.");
         }
         const oauth: AuthProviderEntry["oauth"] = {
             ...urls,
@@ -237,7 +447,7 @@ export class AuthProviderService {
         }
     }
 
-    protected callbackUrl = () => {
+    private callbackUrl = () => {
         const pathname = `/auth/callback`;
         return this.config.hostUrl.with({ pathname }).toString();
     };

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -157,7 +157,7 @@ export class AuthProviderService {
                     publicRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
                     privateRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
                 };
-            case "Bitbucket":
+            case "BitbucketServer":
                 return {
                     default: BitbucketServerOAuthScopes.Requirements.DEFAULT,
                     publicRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
@@ -173,7 +173,7 @@ export class AuthProviderService {
                 return GitLabScope.All;
             case "Bitbucket":
                 return BitbucketOAuthScopes.ALL;
-            case "Bitbucket":
+            case "BitbucketServer":
                 return BitbucketServerOAuthScopes.ALL;
         }
     }

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -5,31 +5,35 @@
  */
 
 import express from "express";
-import { AuthProviderInfo, User, OAuth2Config, AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { AuthProviderInfo, User, AuthProviderEntry } from "@gitpod/gitpod-protocol";
 
 import { UserEnvVarValue } from "@gitpod/gitpod-protocol";
 
 export const AuthProviderParams = Symbol("AuthProviderParams");
 export interface AuthProviderParams extends AuthProviderEntry {
-    readonly builtin: boolean; // true, if `ownerId` == ""
-    readonly verified: boolean; // true, if `status` == "verified"
+    /**
+     * computed value: `true`, if `ownerId` == ""
+     */
+    readonly builtin: boolean;
+    /**
+     * computed value: `true`, if `status` == "verified"
+     */
+    readonly verified: boolean;
 
-    readonly oauth: OAuth2Config;
-
-    // for special auth providers only
-    readonly params?: {
-        [key: string]: string;
-        readonly authUrl: string;
-        readonly callBackUrl: string;
-        readonly githubToken: string;
-    };
-
-    // properties to control behavior
     readonly hiddenOnDashboard?: boolean;
-    readonly disallowLogin?: boolean;
-    readonly requireTOS?: boolean;
 
+    /**
+     * @deprecated unused
+     */
+    readonly disallowLogin?: boolean;
+
+    /**
+     * @deprecated unused
+     */
     readonly description: string;
+    /**
+     * @deprecated unused
+     */
     readonly icon: string;
 }
 export function parseAuthProviderParamsFromEnv(json: object): AuthProviderParams[] {

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -16,7 +16,6 @@ import { TokenProvider } from "../user/token-provider";
 import { UserAuthentication } from "../user/user-authentication";
 import { UserService } from "../user/user-service";
 import { AuthFlow, AuthProvider } from "./auth-provider";
-import { AuthProviderService } from "./auth-provider-service";
 import { HostContextProvider } from "./host-context-provider";
 import { SignInJWT } from "./jwt";
 
@@ -29,7 +28,6 @@ export class Authenticator {
     @inject(TeamDB) protected teamDb: TeamDB;
     @inject(HostContextProvider) protected hostContextProvider: HostContextProvider;
     @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
-    @inject(AuthProviderService) protected readonly authProviderService: AuthProviderService;
     @inject(UserAuthentication) protected readonly userAuthentication: UserAuthentication;
     @inject(SignInJWT) protected readonly signInJWT: SignInJWT;
 

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -113,7 +113,7 @@ export abstract class GenericAuthProvider implements AuthProvider {
             disallowLogin,
             description,
             scopes,
-            settingsUrl: this.oauthConfig.settingsUrl,
+            settingsUrl: this.oauthConfig.settingsUrl, // unused
             requirements: {
                 default: scopes,
                 publicRepo: scopes,

--- a/components/server/src/auth/host-context-provider-impl.ts
+++ b/components/server/src/auth/host-context-provider-impl.ts
@@ -75,7 +75,7 @@ export class HostContextProviderImpl implements HostContextProvider {
         const knownOAuthRevisions = Array.from(this.dynamicHosts.entries())
             .map(([_, hostContext]) => hostContext.authProvider.params.oauthRevision)
             .filter((rev) => !!rev) as string[];
-        const newAndUpdatedAuthProviders = await this.authProviderService.getAllAuthProviders(knownOAuthRevisions);
+        const newAndUpdatedAuthProviders = await this.authProviderService.getAllAuthProviderParams(knownOAuthRevisions);
         ctx.span?.setTag("updateDynamicHosts.newAndUpdatedAuthProviders", newAndUpdatedAuthProviders.length);
 
         for (const config of newAndUpdatedAuthProviders) {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -195,6 +195,9 @@ const defaultFunctions: FunctionsConfig = {
     getIDToken: { group: "default", points: 1 },
     reportErrorBoundary: { group: "default", points: 1 },
     getOnboardingState: { group: "default", points: 1 },
+    getAuthProvider: { group: "default", points: 1 },
+    deleteAuthProvider: { group: "default", points: 1 },
+    updateAuthProvider: { group: "default", points: 1 },
 };
 
 function getConfig(config: RateLimiterConfig): RateLimiterConfig {

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -45,7 +45,7 @@ export class UserDeletionService {
         const authProviders = await this.authProviderService.getAuthProvidersOfUser(user);
         for (const provider of authProviders) {
             try {
-                await this.authProviderService.deleteAuthProvider(provider);
+                await this.authProviderService.deleteAuthProviderOfUser(user.id, provider.id);
             } catch (error) {
                 log.error({ userId: user.id }, "Failed to delete user's auth provider.", error);
             }


### PR DESCRIPTION
## Description
This change set was extracted out of https://github.com/gitpod-io/gitpod/pull/19008.

What happens here is a refactoring of the json-rpc api and implementation in order to make it, i.e. the AuthProviderService, reusable to implement the public-api interfaces. 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1010fde</samp>

This pull request refactors the auth provider API and the `GitpodServer` interface to improve the security, clarity, and modularity of the auth provider operations. It introduces new methods for managing auth providers at the user and org level, and applies rate limiting and authorization checks to them. It also updates the `UserDeletionService` class to use the new method for deleting the user's own auth providers.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- [ ] verify managing scopes works as usual, i.e. you can update your git token in user settings
- [ ] verify creating of new git integrations works as usual, on user-level as well as on Org-level 
- [ ] verify no credentials are sent over the websocket channel (as we're touching mapping of shapes in this PR)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-server-e1c45418cc</li>
	<li><b>🔗 URL</b> - <a href="https://at-server-e1c45418cc.preview.gitpod-dev.com/workspaces" target="_blank">at-server-e1c45418cc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-server-authprovider-service-gha.19431</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-server-e1c45418cc%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
