### PR TITLE
[LocalCLI] add completion for `--class` and `--editor` flags

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,6 +42,11 @@ tasks:
             gp env -u GCP_ADC_FILE
           fi
           exit 0
+    - name: Install `gitpod` CLI
+      command: |
+        leeway run components/local-app:install-cli
+        leeway run components/local-app:cli-completion
+        exit 0
     # This task takes care of configuring your workspace so it can manage and interact
     # with preview environments.
     - name: Preview environment configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.gitpod.io">
-    <img src="https://raw.githubusercontent.com/gitpod-io/gitpod/master/components/dashboard/src/icons/gitpod.svg" alt="Gitpod Logo" height="60" />1
+    <img src="https://raw.githubusercontent.com/gitpod-io/gitpod/master/components/dashboard/src/icons/gitpod.svg" alt="Gitpod Logo" height="60" />
     <br />
     <strong>Gitpod</strong>
   </a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.gitpod.io">
-    <img src="https://raw.githubusercontent.com/gitpod-io/gitpod/master/components/dashboard/src/icons/gitpod.svg" alt="Gitpod Logo" height="60" />
+    <img src="https://raw.githubusercontent.com/gitpod-io/gitpod/master/components/dashboard/src/icons/gitpod.svg" alt="Gitpod Logo" height="60" />1
     <br />
     <strong>Gitpod</strong>
   </a>

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -20,8 +20,6 @@ scripts:
     script: |
       go build -o gitpod ./main/gitpod-cli
       sudo mv gitpod /usr/bin/gitpod
-      # add exec permission
       sudo chmod +x /usr/bin/gitpod
-
-      # pipe completion to bash-completion with sudo
+      # pipe completion
       sudo /usr/bin/gitpod completion bash | sudo tee /usr/share/bash-completion/completions/gitpod

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -13,3 +13,15 @@ packages:
       image:
         - ${imageRepoBase}/local-app:${version}
         - ${imageRepoBase}/local-app:commit-${__git_commit}
+
+scripts:
+  - name: install-cli
+    description: "Install gitpod-cli as gitpod command and add auto-completion. Usage: '. $(leeway run components/local-app:install-cli)'"
+    script: |
+      go build -o gitpod ./main/gitpod-cli
+      sudo mv gitpod /usr/bin/gitpod
+      # add exec permission
+      sudo chmod +x /usr/bin/gitpod
+
+      # pipe completion to bash-completion with sudo
+      sudo /usr/bin/gitpod completion bash | sudo tee /usr/share/bash-completion/completions/gitpod

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -16,10 +16,12 @@ packages:
 
 scripts:
   - name: install-cli
-    description: "Install gitpod-cli as gitpod command and add auto-completion. Usage: '. $(leeway run components/local-app:install-cli)'"
+    description: "Install gitpod-cli as `gitpod` command and add auto-completion. Usage: '. $(leeway run components/local-app:install-cli)'"
     script: |
       go build -o gitpod ./main/gitpod-cli
       sudo mv gitpod /usr/bin/gitpod
       sudo chmod +x /usr/bin/gitpod
-      # pipe completion
-      sudo /usr/bin/gitpod completion bash | sudo tee /usr/share/bash-completion/completions/gitpod
+  - name: cli-completion
+    description: "Add completion of gitpod-cli to bash-completion. Usage: '. $(leeway run components/local-app:cli-completion)'"
+    script: |
+      sudo /usr/bin/gitpod completion bash | sudo tee /usr/share/bash-completion/completions/gitpod > /dev/null

--- a/components/local-app/README.md
+++ b/components/local-app/README.md
@@ -1,4 +1,4 @@
-    # local-app
+# local-app
 
 ## gitpod-cli
 
@@ -26,6 +26,20 @@ Start by logging in with `gitpod login`, which will also create a default contex
 ### Development
 
 To develop the CLI with Gitpod, you can run it just like locally, but in Gitpod workspaces, a browser and a keyring are not available. To log in despite these limitations, provide a PAT via the `GITPOD_TOKEN` environment variable, or use the `--token` flag with the login command.
+
+#### in Gitpod workspace
+
+[![Open in Gitpod](https://www.gitpod.io/svg/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/gitpod)
+
+You will have gitpod-cli ready as `gitpod` in your CDE (Cloud Development Environments) workspace, will commands below you can install again easily.
+
+```
+# Install as `gitpod` again
+leeway run components/local-app:install-cli
+
+# Add completion again
+leeway run components/local-app:cli-completion
+```
 
 ## local-app
 

--- a/components/local-app/cmd/root.go
+++ b/components/local-app/cmd/root.go
@@ -101,7 +101,13 @@ var rootTestingOpts struct {
 	WriterOut io.Writer
 }
 
+var clientCache *client.Gitpod
+
 func getGitpodClient(ctx context.Context) (*client.Gitpod, error) {
+	// There will be only one client in a command context right now
+	if clientCache != nil {
+		return clientCache, nil
+	}
 	cfg := config.FromContext(ctx)
 	gpctx, err := cfg.GetActiveContext()
 	if err != nil {
@@ -154,6 +160,7 @@ func getGitpodClient(ctx context.Context) (*client.Gitpod, error) {
 	if err != nil {
 		return nil, err
 	}
+	clientCache = res
 
 	return res, nil
 }

--- a/components/local-app/cmd/workspace-create.go
+++ b/components/local-app/cmd/workspace-create.go
@@ -187,8 +187,8 @@ func init() {
 	workspaceCmd.AddCommand(workspaceCreateCmd)
 	addWorkspaceStartOptions(workspaceCreateCmd, &workspaceCreateOpts.StartOpts)
 
-	workspaceCreateCmd.Flags().StringVar(&workspaceCreateOpts.WorkspaceClass, "class", "", "the workspace class ([tab][tab] to list available options)")
-	workspaceCreateCmd.Flags().StringVar(&workspaceCreateOpts.Editor, "editor", "code", "the editor to use ([tab][tab] to list available options)")
+	workspaceCreateCmd.Flags().StringVar(&workspaceCreateOpts.WorkspaceClass, "class", "", "the workspace class")
+	workspaceCreateCmd.Flags().StringVar(&workspaceCreateOpts.Editor, "editor", "code", "the editor to use")
 
 	_ = workspaceCreateCmd.RegisterFlagCompletionFunc("class", classCompletionFunc)
 	_ = workspaceCreateCmd.RegisterFlagCompletionFunc("editor", editorCompletionFunc)

--- a/components/local-app/cmd/workspace-create.go
+++ b/components/local-app/cmd/workspace-create.go
@@ -160,7 +160,7 @@ func classCompletionFunc(cmd *cobra.Command, args []string, toComplete string) (
 		if cls.IsDefault {
 			defaultDesc = "(default)"
 		}
-		completionStr = append(completionStr, fmt.Sprintf("%s\t%s%s - %s", cls.Id, defaultDesc, cls.DisplayName, cls.Description))
+		completionStr = append(completionStr, fmt.Sprintf("%s\t%s%s - %s", cls.Id, cls.DisplayName, defaultDesc, cls.Description))
 	}
 	return completionStr, cobra.ShellCompDirectiveNoFileComp
 }

--- a/components/local-app/cmd/workspace-up.go
+++ b/components/local-app/cmd/workspace-up.go
@@ -291,4 +291,7 @@ func init() {
 
 	workspaceUpCmd.Flags().StringVar(&workspaceCreateOpts.WorkspaceClass, "class", "", "the workspace class")
 	workspaceUpCmd.Flags().StringVar(&workspaceCreateOpts.Editor, "editor", "code", "the editor to use")
+
+	_ = workspaceUpCmd.RegisterFlagCompletionFunc("class", classCompletionFunc)
+	_ = workspaceUpCmd.RegisterFlagCompletionFunc("editor", editorCompletionFunc)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add completion for `--class` and `--editor` flags of `workspace create` command

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1eb2534</samp>

Fix a typo in the `README.md` file that breaks the HTML syntax. Reject the pull request as it does not follow the contribution guidelines and does not address any issue or feature request.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Get your PAT from preview env
- Open PR with Gitpod
```
# install `gitpod`
leeway run components/local-app:install-cli

gitpod login --host https://hw-cli.preview.gitpod-dev.com --token <your_pat_token>

## tab tab should show available editors
gitpod workspace create --editor [tab][tab]

## tab tab should show available classes
gitpod workspace create --class [tab][tab]
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-cli</li>
	<li><b>🔗 URL</b> - <a href="https://hw-cli.preview.gitpod-dev.com/workspaces" target="_blank">hw-cli.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-cli-gha.19450</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-cli%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
