### PR TITLE
Revert service-waiter (components) for dashboard

### DIFF
--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -48,10 +48,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						DNSPolicy:                     corev1.DNSClusterFirst,
 						RestartPolicy:                 corev1.RestartPolicyAlways,
 						TerminationGracePeriodSeconds: pointer.Int64(30),
-						InitContainers: []corev1.Container{
-							*common.PublicApiServerComponentWaiterContainer(ctx),
-							*common.ServerComponentWaiterContainer(ctx),
-						},
 						Containers: []corev1.Container{{
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Dashboard.Version),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Revert https://github.com/gitpod-io/gitpod/pull/18995

Until we have way to control skip service-waiter (like feature flag)

See also [internal chat](https://gitpod.slack.com/archives/C05GP09J0MD/p1699358437726449)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2f3aa5</samp>

Refactor the installer and the service-waiter components to improve security, readability, maintainability, and scalability. Remove unused dependencies and code, use a cluster role and a pod security policy for the dashboard component, and replace the init containers with the service-waiter component. Delete `components/service-waiter/cmd/component.go` and `install/installer/pkg/components/dashboard/role.go` as they are no longer needed.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. `kubectl describe pod dashboard-...` check that there are not any more any init containers + dashboard deployed without issues
2. do hot deployment of server, restart dashboard, still should work

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-revert-waiter</li>
	<li><b>🔗 URL</b> - <a href="https://hw-revert-waiter.preview.gitpod-dev.com/workspaces" target="_blank">hw-revert-waiter.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-revert-waiter-gha.19518</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-revert-waiter%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
