### PR TITLE
[gitpod-cli] Fix workspace creation

### DIFF
--- a/components/local-app/cmd/workspace-create.go
+++ b/components/local-app/cmd/workspace-create.go
@@ -101,6 +101,11 @@ var workspaceCreateCmd = &cobra.Command{
 					},
 					WorkspaceClass: workspaceCreateOpts.WorkspaceClass,
 				},
+				// Without this flag we might not create a new workspce because there's already one running on the same commit.
+				IgnoreRunningWorkspaceOnSameCommit: true,
+				// Note(cw): the CLI cannot handle running prebuilds yet, so we ignore them for now.
+				IgnoreRunningPrebuild:       true,
+				AllowUsingPreviousPrebuilds: true,
 			},
 		))
 		if err != nil {


### PR DESCRIPTION
## Description
Fixes repeated workspace creation on the same context.

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-887

## How to test
```
gitpod ws create https://github.com/gitpod-io/empty
gitpod ws create https://github.com/gitpod-io/empty
gitpod ws create https://github.com/gitpod-io/empty
```

results in
<img width="1406" alt="image" src="https://github.com/gitpod-io/gitpod/assets/3210701/edddf97c-f4c5-4367-96f9-933ea6a57660">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
