### PR TITLE
Print information after login

### DIFF
--- a/components/local-app/cmd/login.go
+++ b/components/local-app/cmd/login.go
@@ -66,7 +66,8 @@ var loginCmd = &cobra.Command{
 
 		err = auth.SetToken(loginOpts.Host, token)
 		if err != nil {
-			slog.Warn("could not write token to keyring, storing in config file instead", "err", err)
+			slog.Debug("could not write token to keyring, storing in config file instead")
+			slog.Warn("could not write token to keyring, storing in config file instead. Use -v to see the error.")
 			gpctx.Token = token
 		}
 
@@ -115,7 +116,18 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
-		return nil
+		client, err := getGitpodClient(config.ToContext(cmd.Context(), cfg))
+		if err != nil {
+			return err
+		}
+		who, err := whoami(cmd.Context(), client, gpctx)
+		if err != nil {
+			return err
+		}
+
+		slog.Info("Login succesfull")
+		fmt.Println()
+		return WriteTabular(who, formatOpts{}, prettyprint.WriterFormatNarrow)
 	},
 }
 

--- a/components/local-app/cmd/login.go
+++ b/components/local-app/cmd/login.go
@@ -66,8 +66,11 @@ var loginCmd = &cobra.Command{
 
 		err = auth.SetToken(loginOpts.Host, token)
 		if err != nil {
-			slog.Debug("could not write token to keyring, storing in config file instead")
-			slog.Warn("could not write token to keyring, storing in config file instead. Use -v to see the error.")
+			if slog.Default().Enabled(cmd.Context(), slog.LevelDebug) {
+				slog.Debug("could not write token to keyring, storing in config file instead", "err", err)
+			} else {
+				slog.Warn("could not write token to keyring, storing in config file instead. Use -v to see the error.")
+			}
 			gpctx.Token = token
 		}
 

--- a/components/local-app/cmd/whoami.go
+++ b/components/local-app/cmd/whoami.go
@@ -40,7 +40,7 @@ var whoamiCmd = &cobra.Command{
 	},
 }
 
-// printWhoami prints information about the currently logged in user
+// whoami returns information about the currently logged in user
 func whoami(ctx context.Context, client *client.Gitpod, gpctx *config.ConnectionContext) ([]whoamiResult, error) {
 	user, err := client.User.GetAuthenticatedUser(ctx, &connect.Request[v1.GetAuthenticatedUserRequest]{})
 	if err != nil {

--- a/components/local-app/cmd/whoami.go
+++ b/components/local-app/cmd/whoami.go
@@ -5,7 +5,10 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
+	"github.com/gitpod-io/gitpod/components/public-api/go/client"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
 	"github.com/gitpod-io/local-app/pkg/config"
 	"github.com/gitpod-io/local-app/pkg/prettyprint"
@@ -28,25 +31,35 @@ var whoamiCmd = &cobra.Command{
 			return err
 		}
 
-		user, err := client.User.GetAuthenticatedUser(cmd.Context(), &connect.Request[v1.GetAuthenticatedUserRequest]{})
-		if err != nil {
-			return err
-		}
-		org, err := client.Teams.GetTeam(cmd.Context(), &connect.Request[v1.GetTeamRequest]{Msg: &v1.GetTeamRequest{TeamId: gpctx.OrganizationID}})
+		who, err := whoami(cmd.Context(), client, gpctx)
 		if err != nil {
 			return err
 		}
 
-		return WriteTabular([]whoamiResult{
-			{
-				Name:  user.Msg.GetUser().Name,
-				ID:    user.Msg.GetUser().Id,
-				Org:   org.Msg.GetTeam().Name,
-				OrgID: org.Msg.GetTeam().Id,
-				Host:  gpctx.Host.String(),
-			},
-		}, whoamiOpts.Format, prettyprint.WriterFormatNarrow)
+		return WriteTabular(who, whoamiOpts.Format, prettyprint.WriterFormatNarrow)
 	},
+}
+
+// printWhoami prints information about the currently logged in user
+func whoami(ctx context.Context, client *client.Gitpod, gpctx *config.ConnectionContext) ([]whoamiResult, error) {
+	user, err := client.User.GetAuthenticatedUser(ctx, &connect.Request[v1.GetAuthenticatedUserRequest]{})
+	if err != nil {
+		return nil, err
+	}
+	org, err := client.Teams.GetTeam(ctx, &connect.Request[v1.GetTeamRequest]{Msg: &v1.GetTeamRequest{TeamId: gpctx.OrganizationID}})
+	if err != nil {
+		return nil, err
+	}
+
+	return []whoamiResult{
+		{
+			Name:  user.Msg.GetUser().Name,
+			ID:    user.Msg.GetUser().Id,
+			Org:   org.Msg.GetTeam().Name,
+			OrgID: org.Msg.GetTeam().Id,
+			Host:  gpctx.Host.String(),
+		},
+	}, nil
 }
 
 type whoamiResult struct {


### PR DESCRIPTION
## Description
Once login is successful, we now print more details about the login user. It's essentially the same as running "Who am I?" right after the login.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cffb2f4</samp>

This pull request enhances the user experience of the local-app `login` and `whoami` commands. It adds more logging and feedback for the `login` command, and simplifies the code for both commands by using the `context` package and a shared helper function.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-886

## How to test
```
gitpod login
```

<img width="810" alt="image" src="https://github.com/gitpod-io/gitpod/assets/3210701/63526f45-5cd5-403a-86f0-d597f442d997">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
