### PR TITLE
Improve log level printing

### DIFF
--- a/components/local-app/cmd/root.go
+++ b/components/local-app/cmd/root.go
@@ -55,11 +55,29 @@ var rootCmd = &cobra.Command{
 		var noColor bool
 		if !isatty.IsTerminal(os.Stdout.Fd()) {
 			noColor = true
+			color.Disable()
 		}
 		slog.SetDefault(slog.New(tint.NewHandler(os.Stdout, &tint.Options{
 			Level:      level,
 			NoColor:    noColor,
 			TimeFormat: time.StampMilli,
+			ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+				if attr.Key != "level" {
+					return attr
+				}
+
+				switch attr.Value.String() {
+				case slog.LevelDebug.String():
+					attr.Value = slog.StringValue(color.Gray.Render("[DEBUG]"))
+				case slog.LevelInfo.String():
+					attr.Value = slog.StringValue(color.Green.Render("[INFO ]"))
+				case slog.LevelWarn.String():
+					attr.Value = slog.StringValue(color.Yellow.Render("[WARN ]"))
+				case slog.LevelError.String():
+					attr.Value = slog.StringValue(color.Red.Render("[ERROR]"))
+				}
+				return attr
+			},
 		})))
 
 		cfg, err := config.LoadConfig(rootOpts.ConfigLocation)


### PR DESCRIPTION
## Description
<img width="360" alt="image" src="https://github.com/gitpod-io/gitpod/assets/3210701/2a3c6844-052e-43ba-b5c0-e65b827461e5">


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce98fdc</samp>

Improve local-app logging output and add color option. This pull request adds a `--no-color` flag to the local-app command to disable colored output, and uses different colors for different log levels to make them easier to distinguish.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-888

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
