### PR TITLE
local cli: better logging for `ws stop`

### DIFF
--- a/components/local-app/cmd/workspace-stop.go
+++ b/components/local-app/cmd/workspace-stop.go
@@ -44,8 +44,10 @@ var workspaceStopCommand = &cobra.Command{
 		switch wsPhase {
 		case v1.WorkspaceInstanceStatus_PHASE_STOPPED:
 			slog.Info("workspace is already stopped")
+			return nil
 		case v1.WorkspaceInstanceStatus_PHASE_STOPPING:
 			slog.Info("workspace is already stopping")
+			return nil
 		}
 
 		if stopDontWait {

--- a/components/local-app/cmd/workspace-stop.go
+++ b/components/local-app/cmd/workspace-stop.go
@@ -60,6 +60,8 @@ var workspaceStopCommand = &cobra.Command{
 			return err
 		}
 
+		defer stream.Close()
+
 		slog.Info("waiting for workspace to stop...")
 
 		previousStatus := ""

--- a/components/local-app/cmd/workspace-stop.go
+++ b/components/local-app/cmd/workspace-stop.go
@@ -34,38 +34,33 @@ var workspaceStopCommand = &cobra.Command{
 			return err
 		}
 
-		slog.Info("stopping workspace...")
+		slog.Debug("stopping workspace...")
 		wsInfo, err := gitpod.Workspaces.StopWorkspace(ctx, connect.NewRequest(&v1.StopWorkspaceRequest{WorkspaceId: workspaceID}))
 		if err != nil {
 			return err
 		}
 
-		currentPhase := wsInfo.Msg.GetResult().Status.Instance.Status.Phase
-
-		if currentPhase == v1.WorkspaceInstanceStatus_PHASE_STOPPED {
+		wsPhase := wsInfo.Msg.GetResult().Status.Instance.Status.Phase
+		switch wsPhase {
+		case v1.WorkspaceInstanceStatus_PHASE_STOPPED:
 			slog.Info("workspace is already stopped")
-			return nil
-		}
-		if currentPhase == v1.WorkspaceInstanceStatus_PHASE_STOPPING {
+		case v1.WorkspaceInstanceStatus_PHASE_STOPPING:
 			slog.Info("workspace is already stopping")
-			return nil
 		}
+
 		if stopDontWait {
 			slog.Info("workspace stopping")
 			return nil
 		}
 
 		stream, err := gitpod.Workspaces.StreamWorkspaceStatus(ctx, connect.NewRequest(&v1.StreamWorkspaceStatusRequest{WorkspaceId: workspaceID}))
-
 		if err != nil {
 			return err
 		}
 
 		slog.Info("waiting for workspace to stop...")
-		slog.Info("workspace " + prettyprint.FormatWorkspacePhase(currentPhase))
 
 		previousStatus := ""
-
 		for stream.Receive() {
 			msg := stream.Msg()
 			if msg == nil {
@@ -73,15 +68,26 @@ var workspaceStopCommand = &cobra.Command{
 				continue
 			}
 
-			if msg.GetResult().Instance.Status.Phase == v1.WorkspaceInstanceStatus_PHASE_STOPPED {
-				slog.Info("workspace stopped")
+			wsPhase = msg.GetResult().Instance.Status.Phase
+			switch wsPhase {
+			case v1.WorkspaceInstanceStatus_PHASE_STOPPED:
+				{
+					slog.Info("workspace stopped")
+					return nil
+				}
+			case v1.WorkspaceInstanceStatus_PHASE_RUNNING:
+				// Skip reporting the "running" status as it is often the initial state and seems confusing to the user.
+				// There is some delay between requesting a workspace to stop and it actually stopping, so we don't want
+				// to report "running" in the meantime.
 				break
-			}
-
-			currentStatus := prettyprint.FormatWorkspacePhase(msg.GetResult().Instance.Status.Phase)
-			if currentStatus != previousStatus {
-				slog.Info("workspace " + currentStatus)
-				previousStatus = currentStatus
+			default:
+				{
+					currentStatus := prettyprint.FormatWorkspacePhase(wsPhase)
+					if currentStatus != previousStatus {
+						slog.Info("workspace status: " + currentStatus)
+						previousStatus = currentStatus
+					}
+				}
 			}
 		}
 

--- a/components/local-app/pkg/helper/workspace.go
+++ b/components/local-app/pkg/helper/workspace.go
@@ -188,6 +188,8 @@ func ObserveWorkspaceUntilStarted(ctx context.Context, clnt *client.Gitpod, work
 			continue
 		}
 
+		defer stream.Close()
+
 		for stream.Receive() {
 			msg := stream.Msg()
 			if msg == nil {

--- a/components/local-app/pkg/helper/workspace.go
+++ b/components/local-app/pkg/helper/workspace.go
@@ -164,9 +164,11 @@ func ObserveWorkspaceUntilStarted(ctx context.Context, clnt *client.Gitpod, work
 		return ws.Status, nil
 	}
 
+	var wsStatus string
 	slog.Info("waiting for workspace to start...", "workspaceID", workspaceID)
 	if HasInstanceStatus(wsInfo.Msg.Result) {
-		slog.Info("workspace " + prettyprint.FormatWorkspacePhase(wsInfo.Msg.Result.Status.Instance.Status.Phase))
+		slog.Info("workspace status: " + prettyprint.FormatWorkspacePhase(wsInfo.Msg.Result.Status.Instance.Status.Phase))
+		wsStatus = prettyprint.FormatWorkspacePhase(wsInfo.Msg.Result.Status.Instance.Status.Phase)
 	}
 
 	var (
@@ -186,7 +188,6 @@ func ObserveWorkspaceUntilStarted(ctx context.Context, clnt *client.Gitpod, work
 			continue
 		}
 
-		previousStatus := ""
 		for stream.Receive() {
 			msg := stream.Msg()
 			if msg == nil {
@@ -200,13 +201,13 @@ func ObserveWorkspaceUntilStarted(ctx context.Context, clnt *client.Gitpod, work
 				return ws, nil
 			}
 
-			var currentStatus string
 			if HasInstanceStatus(wsInfo.Msg.Result) {
-				currentStatus = prettyprint.FormatWorkspacePhase(wsInfo.Msg.Result.Status.Instance.Status.Phase)
-			}
-			if currentStatus != previousStatus {
-				slog.Info("workspace " + currentStatus)
-				previousStatus = currentStatus
+				newWsStatus := prettyprint.FormatWorkspacePhase(ws.Instance.Status.Phase)
+				// De-duplicate status messages
+				if wsStatus != newWsStatus {
+					slog.Info("workspace status: " + newWsStatus)
+					wsStatus = newWsStatus
+				}
 			}
 		}
 		if err := stream.Err(); err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2662c48</samp>

Refactored the `workspace-stop` command in the local app to improve logging and loop logic. Made the output more concise and user-friendly.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-883

## How to test

In `/workspace/gitpod/components/local-app/main/gitpod-cli`,
```
go run . login --token <pat>
go run . ws create https://github.com/gitpod-io/gitpod/pull/18878
go run . ws stop <ws-id>
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
