### PR TITLE
Repository Config list page

### DIFF
--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -4,10 +4,10 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import classNames from "classnames";
 import { FunctionComponent, memo, ReactNode, useCallback } from "react";
 import { useId } from "../../hooks/useId";
 import { InputField } from "./InputField";
+import { cn } from "@podkit/lib/cn";
 
 type TextInputFieldTypes = "text" | "password" | "email" | "url";
 
@@ -97,7 +97,7 @@ export const TextInput: FunctionComponent<TextInputProps> = memo(
         return (
             <input
                 id={id}
-                className={classNames("w-full max-w-lg dark:text-[#A8A29E]", className)}
+                className={cn("w-full max-w-lg dark:text-[#A8A29E]", className)}
                 value={value}
                 type={type}
                 placeholder={placeholder}

--- a/components/dashboard/src/components/podkit/buttons/Button.tsx
+++ b/components/dashboard/src/components/podkit/buttons/Button.tsx
@@ -20,14 +20,14 @@ export const buttonVariants = cva(
                 outline: "border border-input bg-transparent hover:bg-kumquat-ripe hover:text-gray-600",
                 secondary:
                     "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-500 dark:text-gray-100 hover:text-gray-600",
-                ghost: "hover:bg-kumquat-ripe hover:text-gray-600",
+                ghost: "bg-transparent hover:bg-gray-100 hover:text-gray-600 text-gray-500",
                 link: "text-gray-500 dark:text-gray-100 underline-offset-4 hover:underline",
             },
             size: {
                 default: "h-9 px-4 py-2",
                 sm: "h-8 rounded-md px-3 text-xs",
                 lg: "h-10 rounded-md px-8",
-                icon: "h-9 w-9",
+                icon: "h-9 w-9 p-0 rounded-sm",
             },
         },
         defaultVariants: {

--- a/components/dashboard/src/components/podkit/layout/PageHeading.tsx
+++ b/components/dashboard/src/components/podkit/layout/PageHeading.tsx
@@ -14,7 +14,7 @@ type PageHeadingProps = {
 };
 export const PageHeading: FC<PageHeadingProps> = ({ title, subtitle, action }) => {
     return (
-        <div className="flex flex-row justify-between py-8">
+        <div className="flex flex-row flex-wrap justify-between py-8 gap-2">
             <div>
                 <Heading1>{title}</Heading1>
                 {subtitle && <Subheading>{subtitle}</Subheading>}

--- a/components/dashboard/src/components/podkit/layout/PageHeading.tsx
+++ b/components/dashboard/src/components/podkit/layout/PageHeading.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Heading1, Subheading } from "@podkit/typography/Headings";
+import { FC, ReactNode } from "react";
+
+type PageHeadingProps = {
+    title: string;
+    subtitle?: string;
+    action?: ReactNode;
+};
+export const PageHeading: FC<PageHeadingProps> = ({ title, subtitle, action }) => {
+    return (
+        <div className="flex flex-row justify-between py-8">
+            <div>
+                <Heading1>{title}</Heading1>
+                {subtitle && <Subheading>{subtitle}</Subheading>}
+            </div>
+            {action && action}
+        </div>
+    );
+};

--- a/components/dashboard/src/components/podkit/tables/Table.tsx
+++ b/components/dashboard/src/components/podkit/tables/Table.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { cn } from "@podkit/lib/cn";
+import React from "react";
+
+type HideableCellProps = {
+    hideOnSmallScreen?: boolean;
+};
+
+export const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+    ({ className, ...props }, ref) => {
+        return (
+            <div className="relative w-full overflow-auto">
+                <table ref={ref} className={cn("w-full text-sm text-left", className)} {...props} />
+            </div>
+        );
+    },
+);
+Table.displayName = "Table";
+
+export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    ({ className, ...props }, ref) => {
+        return (
+            <thead
+                ref={ref}
+                className="[&_th]:p-3 [&_th]:bg-gray-100 dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold"
+                {...props}
+            />
+        );
+    },
+);
+TableHeader.displayName = "TableHeader";
+
+export const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+    ({ className, ...props }, ref) => {
+        return <tr ref={ref} className="border-b dark:border-gray-700" {...props} />;
+    },
+);
+TableRow.displayName = "TableRow";
+
+export const TableHead = React.forwardRef<
+    HTMLTableCellElement,
+    React.ThHTMLAttributes<HTMLTableCellElement> & HideableCellProps
+>(({ hideOnSmallScreen, className, ...props }, ref) => {
+    return <th ref={ref} className={cn(hideOnSmallScreen && "hidden md:table-cell", className)} {...props} />;
+});
+TableHead.displayName = "TableHead";
+
+export const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    ({ className, ...props }, ref) => {
+        return (
+            <tbody ref={ref} className="[&_td]:p-3 [&_td:last-child]:text-right [&_tr]:hover:bg-muted/5" {...props} />
+        );
+    },
+);
+TableBody.displayName = "TableBody";
+
+export const TableCell = React.forwardRef<
+    HTMLTableCellElement,
+    React.TdHTMLAttributes<HTMLTableCellElement> & HideableCellProps
+>(({ hideOnSmallScreen, className, ...props }, ref) => {
+    return <td ref={ref} className={cn(hideOnSmallScreen && "hidden md:table-cell", className)} {...props} />;
+});
+TableCell.displayName = "TableCell";

--- a/components/dashboard/src/components/podkit/typography/Headings.tsx
+++ b/components/dashboard/src/components/podkit/typography/Headings.tsx
@@ -22,7 +22,7 @@ export const Heading1: FC<HeadingProps> = ({ id, color, tracking, className, chi
     return (
         <Comp
             id={id}
-            className={cn(getHeadingColor(color), getTracking(tracking), "font-bold text-4xl truncate", className)}
+            className={cn(getHeadingColor(color), getTracking(tracking), "font-bold text-3xl truncate", className)}
         >
             {children}
         </Comp>

--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -33,10 +33,14 @@ export const useListConfigurations = ({ searchTerm = "", page, pageSize }: ListC
                 pagination: { page, pageSize },
             });
 
-            return { configurations, pagination };
+            return {
+                configurations,
+                pagination,
+            };
         },
         {
             enabled: !!org,
+            keepPreviousData: true,
         },
     );
 };

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -57,8 +57,8 @@ export default function OrganizationSelector() {
     if (currentOrg.data) {
         if (repoConfigListAndDetail) {
             linkEntries.push({
-                title: "Configurations",
-                customContent: <LinkEntry>Configurations</LinkEntry>,
+                title: "Repositories",
+                customContent: <LinkEntry>Repositories</LinkEntry>,
                 active: false,
                 separator: false,
                 link: "/repositories",

--- a/components/dashboard/src/repositories/list/PaginationControls.tsx
+++ b/components/dashboard/src/repositories/list/PaginationControls.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Button } from "@podkit/buttons/Button";
+import { cn } from "@podkit/lib/cn";
+import { TextMuted } from "@podkit/typography/TextMuted";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { FC, useCallback } from "react";
+
+type Props = {
+    currentPage: number;
+    totalPages: number;
+    pageSize: number;
+    totalRows: number;
+    currentRows: number;
+    onPageChanged: (page: number) => void;
+};
+export const PaginationControls: FC<Props> = ({
+    currentPage,
+    totalPages,
+    pageSize,
+    totalRows,
+    currentRows,
+    onPageChanged,
+}) => {
+    const prevPage = useCallback(() => {
+        onPageChanged(currentPage - 1);
+    }, [currentPage, onPageChanged]);
+
+    const nextPage = useCallback(() => {
+        onPageChanged(currentPage + 1);
+    }, [currentPage, onPageChanged]);
+
+    return (
+        <div className="flex flex-row justify-center items-center py-2 gap-2 text-sm">
+            {/* TODO: Rows per page select */}
+            <PaginationCountText
+                className="w-24"
+                currentPage={currentPage}
+                pageSize={pageSize}
+                currentRows={currentRows}
+                totalRows={totalRows}
+            />
+            <Button variant="ghost" size="icon" onClick={prevPage} disabled={currentPage === 1}>
+                <ChevronLeftIcon size={20} />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={nextPage} disabled={currentPage >= totalPages}>
+                <ChevronRightIcon size={20} />
+            </Button>
+        </div>
+    );
+};
+
+type PaginationCountTextProps = {
+    currentPage: number;
+    pageSize: number;
+    currentRows: number;
+    totalRows: number;
+    className?: string;
+    includePrefix?: boolean;
+};
+export const PaginationCountText: FC<PaginationCountTextProps> = ({
+    currentPage,
+    pageSize,
+    currentRows,
+    totalRows,
+    className,
+    includePrefix = false,
+}) => {
+    const start = (currentPage - 1) * pageSize + 1;
+    const end = start + currentRows - 1;
+
+    return (
+        <TextMuted className={cn("min-w-max text-right", className)}>
+            {includePrefix ? `Showing ${start} - ${end} of ${totalRows}` : `${start} - ${end} of ${totalRows}`}
+        </TextMuted>
+    );
+};

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -10,36 +10,53 @@ import { TextMuted } from "@podkit/typography/TextMuted";
 import { Text } from "@podkit/typography/Text";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { cn } from "@podkit/lib/cn";
+import { AlertTriangleIcon, CheckCircle2Icon } from "lucide-react";
 
 type Props = {
     configuration: Configuration;
 };
 export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     const url = usePrettyRepoURL(configuration.cloneUrl);
+    const prebuildsEnabled = !!configuration.prebuildSettings?.enabled;
+    const created =
+        configuration.creationTime
+            ?.toDate()
+            .toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) ?? "";
 
     return (
-        <tr>
-            <td className="">
-                <Text className="font-semibold">{configuration.name}</Text>
+        <tr className="border-b transition-colors hover:bg-muted/50">
+            <td>
+                <div className="flex flex-col gap-1">
+                    <Text className="font-semibold">{configuration.name}</Text>
+                    <TextMuted className="inline md:hidden text-sm">{url}</TextMuted>
+                </div>
             </td>
 
-            <td>
+            <td className="hidden md:table-cell">
                 <TextMuted className="text-sm">{url}</TextMuted>
             </td>
 
-            <td>
-                {configuration.creationTime
-                    ?.toDate()
-                    .toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+            <td className="hidden md:table-cell">{created}</td>
+
+            <td className="hidden md:table-cell">
+                <div className="flex flex-row gap-1 items-center">
+                    {prebuildsEnabled ? (
+                        <CheckCircle2Icon size={16} className="text-green-500" />
+                    ) : (
+                        <AlertTriangleIcon size={16} className="text-red-500" />
+                    )}
+
+                    <TextMuted className={cn(!prebuildsEnabled && "text-red-500")}>
+                        {prebuildsEnabled ? "Enabled" : "Disabled"}
+                    </TextMuted>
+                </div>
             </td>
 
             <td>
-                {/* TODO: add icon */}
-                {configuration.prebuildSettings?.enabled ? "Enabled" : "Disabled"}
-            </td>
-
-            <td>
-                <LinkButton href={`/repositories/${configuration.id}`}>View</LinkButton>
+                <LinkButton href={`/repositories/${configuration.id}`} variant="secondary">
+                    View
+                </LinkButton>
             </td>
         </tr>
     );

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -12,6 +12,7 @@ import { LinkButton } from "@podkit/buttons/LinkButton";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { cn } from "@podkit/lib/cn";
 import { AlertTriangleIcon, CheckCircle2Icon } from "lucide-react";
+import { TableCell, TableRow } from "@podkit/tables/Table";
 
 type Props = {
     configuration: Configuration;
@@ -25,21 +26,22 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
             .toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) ?? "";
 
     return (
-        <tr className="border-b transition-colors hover:bg-muted/50">
-            <td>
+        <TableRow>
+            <TableCell>
                 <div className="flex flex-col gap-1">
                     <Text className="font-semibold">{configuration.name}</Text>
+                    {/* We show the url on a 2nd line for smaller screens since we hide the column */}
                     <TextMuted className="inline md:hidden text-sm">{url}</TextMuted>
                 </div>
-            </td>
+            </TableCell>
 
-            <td className="hidden md:table-cell">
+            <TableCell hideOnSmallScreen>
                 <TextMuted className="text-sm">{url}</TextMuted>
-            </td>
+            </TableCell>
 
-            <td className="hidden md:table-cell">{created}</td>
+            <TableCell hideOnSmallScreen>{created}</TableCell>
 
-            <td className="hidden md:table-cell">
+            <TableCell hideOnSmallScreen>
                 <div className="flex flex-row gap-1 items-center">
                     {prebuildsEnabled ? (
                         <CheckCircle2Icon size={20} className="text-green-500" />
@@ -47,17 +49,17 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
                         <AlertTriangleIcon size={20} className="text-red-500" />
                     )}
 
-                    <TextMuted className={cn(!prebuildsEnabled && "text-red-500")}>
+                    <TextMuted className={cn(!prebuildsEnabled && "text-red-500 dark:text-red-500")}>
                         {prebuildsEnabled ? "Enabled" : "Disabled"}
                     </TextMuted>
                 </div>
-            </td>
+            </TableCell>
 
-            <td>
+            <TableCell>
                 <LinkButton href={`/repositories/${configuration.id}`} variant="secondary">
                     View
                 </LinkButton>
-            </td>
-        </tr>
+            </TableCell>
+        </TableRow>
     );
 };

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -42,9 +42,9 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
             <td className="hidden md:table-cell">
                 <div className="flex flex-row gap-1 items-center">
                     {prebuildsEnabled ? (
-                        <CheckCircle2Icon size={16} className="text-green-500" />
+                        <CheckCircle2Icon size={20} className="text-green-500" />
                     ) : (
-                        <AlertTriangleIcon size={16} className="text-red-500" />
+                        <AlertTriangleIcon size={20} className="text-red-500" />
                     )}
 
                     <TextMuted className={cn(!prebuildsEnabled && "text-red-500")}>

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -19,17 +19,24 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     const url = usePrettyRepoURL(configuration.cloneUrl);
 
     return (
-        <li key={configuration.id} className="flex flex-row w-full space-between items-center">
-            <div className="flex flex-col flex-grow gap-1">
+        <tr key={configuration.id} className="flex flex-row w-full space-between items-center">
+            <td className="">
                 <Text className="font-semibold">{configuration.name}</Text>
+            </td>
+            <td>
                 <TextMuted className="text-sm">{url}</TextMuted>
-            </div>
+            </td>
+            <td>
+                {configuration.creationTime
+                    ?.toDate()
+                    .toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+            </td>
 
             <div>
                 <Link to={`/repositories/${configuration.id}`}>
                     <Button type="secondary">View</Button>
                 </Link>
             </div>
-        </li>
+        </tr>
     );
 };

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -18,7 +18,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     const url = usePrettyRepoURL(configuration.cloneUrl);
 
     return (
-        <tr key={configuration.id} className="flex flex-row w-full space-between items-center">
+        <tr>
             <td className="">
                 <Text className="font-semibold">{configuration.name}</Text>
             </td>

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -8,8 +8,7 @@ import { FC } from "react";
 import { usePrettyRepoURL } from "../../hooks/use-pretty-repo-url";
 import { TextMuted } from "@podkit/typography/TextMuted";
 import { Text } from "@podkit/typography/Text";
-import { Link } from "react-router-dom";
-import { Button } from "../../components/Button";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 
 type Props = {
@@ -23,20 +22,25 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
             <td className="">
                 <Text className="font-semibold">{configuration.name}</Text>
             </td>
+
             <td>
                 <TextMuted className="text-sm">{url}</TextMuted>
             </td>
+
             <td>
                 {configuration.creationTime
                     ?.toDate()
                     .toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
             </td>
 
-            <div>
-                <Link to={`/repositories/${configuration.id}`}>
-                    <Button type="secondary">View</Button>
-                </Link>
-            </div>
+            <td>
+                {/* TODO: add icon */}
+                {configuration.prebuildSettings?.enabled ? "Enabled" : "Disabled"}
+            </td>
+
+            <td>
+                <LinkButton href={`/repositories/${configuration.id}`}>View</LinkButton>
+            </td>
         </tr>
     );
 };

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -33,6 +33,7 @@ const RepositoryListPage: FC = () => {
         setCurrentPage(1);
     }, [debouncedSearchTerm]);
 
+    // Have this set to a low value for now to test pagination while we develop this
     // TODO: move this into state and add control for changing it
     const pageSize = 5;
 

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -29,8 +29,9 @@ const RepositoryListPage: FC = () => {
     const { data, isLoading } = useListConfigurations({ searchTerm: debouncedSearchTerm, page: currentPage, pageSize });
     const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);
 
+    const totalRows = data?.pagination?.total ?? 0;
     // TODO: add this to response payload for pagination
-    const totalPages = data?.pagination?.total ?? 0 / pageSize;
+    const totalPages = totalRows / pageSize;
 
     const handleProjectCreated = useCallback(
         (project: Project) => {
@@ -52,7 +53,7 @@ const RepositoryListPage: FC = () => {
                 </div>
 
                 {/* Search/Filter bar */}
-                <div className="flex flex-row justify-between">
+                <div className="flex flex-row justify-between items-center">
                     <div>
                         <TextInput
                             value={searchTerm}
@@ -61,7 +62,8 @@ const RepositoryListPage: FC = () => {
                         />
                         {/* TODO: Add prebuild status filter dropdown */}
                     </div>
-                    <div>{/* TODO: Add copy explaining what records we're showing & total records count */}</div>
+                    {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
+                    <div>{totalRows === 1 ? "Showing 1 repo" : `Showing ${totalRows} repos`}</div>
                 </div>
 
                 {isLoading && <Loader2 className="animate-spin" />}

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -73,6 +73,8 @@ const RepositoryListPage: FC = () => {
                             <th>Repository URL</th>
                             <th>Created</th>
                             <th>Prebuilds</th>
+                            {/* Action column */}
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -66,7 +66,7 @@ const RepositoryListPage: FC = () => {
 
                 {isLoading && <Loader2 className="animate-spin" />}
 
-                <table>
+                <table className="w-full text-left">
                     <thead>
                         <tr>
                             <th>Name</th>

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -48,7 +48,7 @@ const RepositoryListPage: FC = () => {
     // This will fix issues w/ relying on some server provided state and some client state (like current page)
     const rowCount = data?.configurations.length ?? 0;
     const totalRows = data?.pagination?.total ?? 0;
-    const totalPages = totalRows / pageSize;
+    const totalPages = Math.ceil(totalRows / pageSize);
 
     const handleProjectCreated = useCallback(
         (project: Project) => {

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useState } from "react";
-import { ChevronLeftIcon, ChevronRightIcon, Loader2 } from "lucide-react";
+import { FC, useCallback, useEffect, useState } from "react";
+import { LoaderIcon } from "lucide-react";
 import { useHistory } from "react-router-dom";
 import { Project } from "@gitpod/gitpod-protocol";
 import { CreateProjectModal } from "../../projects/create-project-modal/CreateProjectModal";
@@ -17,6 +17,7 @@ import { TextMuted } from "@podkit/typography/TextMuted";
 import { PageHeading } from "@podkit/layout/PageHeading";
 import { Button } from "@podkit/buttons/Button";
 import { useDocumentTitle } from "../../hooks/use-document-title";
+import { PaginationControls, PaginationCountText } from "./PaginationControls";
 
 const RepositoryListPage: FC = () => {
     useDocumentTitle("Repository configuration");
@@ -27,13 +28,25 @@ const RepositoryListPage: FC = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const [searchTerm, setSearchTerm, debouncedSearchTerm] = useStateWithDebounce("");
 
-    const pageSize = 10;
+    // Reset to page 1 when debounced search term changes (when we perform a new search)
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [debouncedSearchTerm]);
 
-    const { data, isLoading } = useListConfigurations({ searchTerm: debouncedSearchTerm, page: currentPage, pageSize });
+    // TODO: move this into state and add control for changing it
+    const pageSize = 5;
+
+    const { data, isFetching, isPreviousData } = useListConfigurations({
+        searchTerm: debouncedSearchTerm,
+        page: currentPage,
+        pageSize,
+    });
     const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);
 
+    // TODO: Adding these to response payload to avoid having to calculate them here
+    // This will fix issues w/ relying on some server provided state and some client state (like current page)
+    const rowCount = data?.configurations.length ?? 0;
     const totalRows = data?.pagination?.total ?? 0;
-    // TODO: add this to response payload for pagination
     const totalPages = totalRows / pageSize;
 
     const handleProjectCreated = useCallback(
@@ -46,7 +59,6 @@ const RepositoryListPage: FC = () => {
     return (
         <>
             <div className="app-container">
-                {/* TODO: Consider updating Header to have an action button prop */}
                 <PageHeading
                     title="Repository configuration"
                     subtitle="Configure and refine the experience of working with a repository in Gitpod"
@@ -55,7 +67,8 @@ const RepositoryListPage: FC = () => {
 
                 {/* Search/Filter bar */}
                 <div className="flex flex-row justify-between items-center">
-                    <div>
+                    <div className="flex flex-row gap-2 items-center">
+                        {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
                         <TextInput
                             className="w-80"
                             value={searchTerm}
@@ -67,23 +80,38 @@ const RepositoryListPage: FC = () => {
                     {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
                     <div>
                         <TextMuted className="text-sm">
-                            {totalRows === 1 ? "Showing 1 repo" : `Showing ${totalRows} repos`}
+                            {rowCount < totalRows ? (
+                                <PaginationCountText
+                                    currentPage={currentPage}
+                                    pageSize={pageSize}
+                                    currentRows={rowCount}
+                                    totalRows={totalRows}
+                                    includePrefix
+                                />
+                            ) : (
+                                <>{totalRows === 1 ? "Showing 1 repo" : `Showing ${totalRows} repos`}</>
+                            )}
                         </TextMuted>
                     </div>
                 </div>
 
-                {isLoading && <Loader2 className="animate-spin" />}
-
                 <div className="relative w-full overflow-auto mt-2">
                     <table className="w-full text-left text-sm">
+                        {/* TODO: Add sorting controls */}
                         <thead className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold">
                             <tr className="border-b">
-                                <th className="bg-gray-100">Name</th>
+                                <th className="w-48">Name</th>
                                 <th className="hidden md:table-cell">Repository URL</th>
-                                <th className="hidden md:table-cell">Created</th>
-                                <th className="hidden md:table-cell">Prebuilds</th>
-                                {/* Action column */}
-                                <th></th>
+                                <th className="hidden md:table-cell w-32">Created</th>
+                                <th className="hidden md:table-cell w-24">Prebuilds</th>
+                                {/* Action column, loading status in header */}
+                                <th className="w-24 text-right">
+                                    {isFetching && isPreviousData && (
+                                        <div className="flex flex-right justify-end items-center">
+                                            <LoaderIcon className="animate-spin text-gray-500" size={20} />
+                                        </div>
+                                    )}
+                                </th>
                             </tr>
                         </thead>
                         <tbody className="[&_td]:p-3 [&_td:last-child]:text-right">
@@ -94,26 +122,14 @@ const RepositoryListPage: FC = () => {
                     </table>
 
                     {totalPages > 1 && (
-                        <div className="flex flex-row justify-center items-center py-2 gap-2">
-                            {/* TODO: Rows per page select */}
-                            {/* TODO: Current records copy, i.e. "1-50 of 95" */}
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => setCurrentPage(currentPage - 1)}
-                                disabled={currentPage === 1}
-                            >
-                                <ChevronLeftIcon size={20} />
-                            </Button>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => setCurrentPage(currentPage + 1)}
-                                disabled={currentPage >= totalPages}
-                            >
-                                <ChevronRightIcon size={20} />
-                            </Button>
-                        </div>
+                        <PaginationControls
+                            currentPage={currentPage}
+                            totalPages={totalPages}
+                            totalRows={totalRows}
+                            pageSize={pageSize}
+                            currentRows={rowCount}
+                            onPageChanged={setCurrentPage}
+                        />
                     )}
                 </div>
             </div>

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -18,6 +18,7 @@ import { PageHeading } from "@podkit/layout/PageHeading";
 import { Button } from "@podkit/buttons/Button";
 import { useDocumentTitle } from "../../hooks/use-document-title";
 import { PaginationControls, PaginationCountText } from "./PaginationControls";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@podkit/tables/Table";
 
 const RepositoryListPage: FC = () => {
     useDocumentTitle("Imported repositories");
@@ -97,30 +98,38 @@ const RepositoryListPage: FC = () => {
                 </div>
 
                 <div className="relative w-full overflow-auto mt-2">
-                    <table className="w-full text-left text-sm">
+                    <Table>
                         {/* TODO: Add sorting controls */}
-                        <thead className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold">
-                            <tr className="border-b">
-                                <th className="w-48">Name</th>
-                                <th className="hidden md:table-cell">Repository</th>
-                                <th className="hidden md:table-cell w-32">Created</th>
-                                <th className="hidden md:table-cell w-24">Prebuilds</th>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-52">Name</TableHead>
+                                <TableHead hideOnSmallScreen>Repository</TableHead>
+                                <TableHead className="w-32" hideOnSmallScreen>
+                                    Created
+                                </TableHead>
+                                <TableHead className="w-24" hideOnSmallScreen>
+                                    Prebuilds
+                                </TableHead>
                                 {/* Action column, loading status in header */}
-                                <th className="w-24 text-right">
+                                <TableHead className="w-24 text-right">
                                     {isFetching && isPreviousData && (
                                         <div className="flex flex-right justify-end items-center">
-                                            <LoaderIcon className="animate-spin text-gray-500" size={20} />
+                                            {/* TODO: Make a LoadingIcon component */}
+                                            <LoaderIcon
+                                                className="animate-spin text-gray-500 dark:text-gray-300"
+                                                size={20}
+                                            />
                                         </div>
                                     )}
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody className="[&_td]:p-3 [&_td:last-child]:text-right">
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
                             {data?.configurations.map((configuration) => (
                                 <RepositoryListItem key={configuration.id} configuration={configuration} />
                             ))}
-                        </tbody>
-                    </table>
+                        </TableBody>
+                    </Table>
 
                     {totalPages > 1 && (
                         <PaginationControls

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -5,19 +5,22 @@
  */
 
 import { FC, useCallback, useState } from "react";
-import Header from "../../components/Header";
-import { Loader2 } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, Loader2 } from "lucide-react";
 import { useHistory } from "react-router-dom";
 import { Project } from "@gitpod/gitpod-protocol";
 import { CreateProjectModal } from "../../projects/create-project-modal/CreateProjectModal";
-import { Button } from "../../components/Button";
 import { RepositoryListItem } from "./RepoListItem";
 import { useListConfigurations } from "../../data/configurations/configuration-queries";
 import { useStateWithDebounce } from "../../hooks/use-state-with-debounce";
 import { TextInput } from "../../components/forms/TextInputField";
-import Pagination from "../../Pagination/Pagination";
+import { TextMuted } from "@podkit/typography/TextMuted";
+import { PageHeading } from "@podkit/layout/PageHeading";
+import { Button } from "@podkit/buttons/Button";
+import { useDocumentTitle } from "../../hooks/use-document-title";
 
 const RepositoryListPage: FC = () => {
+    useDocumentTitle("Repository configuration");
+
     const history = useHistory();
 
     // TODO: Consider pushing this state into query params
@@ -44,18 +47,17 @@ const RepositoryListPage: FC = () => {
         <>
             <div className="app-container">
                 {/* TODO: Consider updating Header to have an action button prop */}
-                <div className="flex flex-row justify-between">
-                    <Header
-                        title="Repository Configuration"
-                        subtitle="Configure and refine the experience of working with a repository in Gitpod"
-                    />
-                    <Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>
-                </div>
+                <PageHeading
+                    title="Repository configuration"
+                    subtitle="Configure and refine the experience of working with a repository in Gitpod"
+                    action={<Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>}
+                />
 
                 {/* Search/Filter bar */}
                 <div className="flex flex-row justify-between items-center">
                     <div>
                         <TextInput
+                            className="w-80"
                             value={searchTerm}
                             onChange={setSearchTerm}
                             placeholder="Search imported repositories"
@@ -63,31 +65,57 @@ const RepositoryListPage: FC = () => {
                         {/* TODO: Add prebuild status filter dropdown */}
                     </div>
                     {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
-                    <div>{totalRows === 1 ? "Showing 1 repo" : `Showing ${totalRows} repos`}</div>
+                    <div>
+                        <TextMuted className="text-sm">
+                            {totalRows === 1 ? "Showing 1 repo" : `Showing ${totalRows} repos`}
+                        </TextMuted>
+                    </div>
                 </div>
 
                 {isLoading && <Loader2 className="animate-spin" />}
 
-                <table className="w-full text-left">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Repository URL</th>
-                            <th>Created</th>
-                            <th>Prebuilds</th>
-                            {/* Action column */}
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {data?.configurations.map((configuration) => (
-                            <RepositoryListItem key={configuration.id} configuration={configuration} />
-                        ))}
-                    </tbody>
-                </table>
+                <div className="relative w-full overflow-auto mt-2">
+                    <table className="w-full text-left text-sm">
+                        <thead className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold">
+                            <tr className="border-b">
+                                <th className="bg-gray-100">Name</th>
+                                <th className="hidden md:table-cell">Repository URL</th>
+                                <th className="hidden md:table-cell">Created</th>
+                                <th className="hidden md:table-cell">Prebuilds</th>
+                                {/* Action column */}
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody className="[&_td]:p-3 [&_td:last-child]:text-right">
+                            {data?.configurations.map((configuration) => (
+                                <RepositoryListItem key={configuration.id} configuration={configuration} />
+                            ))}
+                        </tbody>
+                    </table>
 
-                {/* TODO: Refactor Pagination into podkit or to use podkit components internally */}
-                <Pagination currentPage={currentPage} setPage={setCurrentPage} totalNumberOfPages={totalPages} />
+                    {totalPages > 1 && (
+                        <div className="flex flex-row justify-center items-center py-2 gap-2">
+                            {/* TODO: Rows per page select */}
+                            {/* TODO: Current records copy, i.e. "1-50 of 95" */}
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setCurrentPage(currentPage - 1)}
+                                disabled={currentPage === 1}
+                            >
+                                <ChevronLeftIcon size={20} />
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setCurrentPage(currentPage + 1)}
+                                disabled={currentPage >= totalPages}
+                            >
+                                <ChevronRightIcon size={20} />
+                            </Button>
+                        </div>
+                    )}
+                </div>
             </div>
 
             {showCreateProjectModal && (

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -20,7 +20,7 @@ import { useDocumentTitle } from "../../hooks/use-document-title";
 import { PaginationControls, PaginationCountText } from "./PaginationControls";
 
 const RepositoryListPage: FC = () => {
-    useDocumentTitle("Repository configuration");
+    useDocumentTitle("Imported repositories");
 
     const history = useHistory();
 
@@ -61,14 +61,14 @@ const RepositoryListPage: FC = () => {
         <>
             <div className="app-container">
                 <PageHeading
-                    title="Repository configuration"
+                    title="Imported repositories"
                     subtitle="Configure and refine the experience of working with a repository in Gitpod"
                     action={<Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>}
                 />
 
                 {/* Search/Filter bar */}
-                <div className="flex flex-row justify-between items-center">
-                    <div className="flex flex-row gap-2 items-center">
+                <div className="flex flex-row flex-wrap justify-between items-center">
+                    <div className="flex flex-row flex-wrap gap-2 items-center">
                         {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
                         <TextInput
                             className="w-80"
@@ -102,7 +102,7 @@ const RepositoryListPage: FC = () => {
                         <thead className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold">
                             <tr className="border-b">
                                 <th className="w-48">Name</th>
-                                <th className="hidden md:table-cell">Repository URL</th>
+                                <th className="hidden md:table-cell">Repository</th>
                                 <th className="hidden md:table-cell w-32">Created</th>
                                 <th className="hidden md:table-cell w-24">Prebuilds</th>
                                 {/* Action column, loading status in header */}

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -24,7 +24,7 @@ const RepositoryListPage: FC = () => {
 
     const history = useHistory();
 
-    // TODO: Consider pushing this state into query params
+    // TODO: Move this state into url search params
     const [currentPage, setCurrentPage] = useState(1);
     const [searchTerm, setSearchTerm, debouncedSearchTerm] = useStateWithDebounce("");
 

--- a/components/gitpod-db/src/project-db.spec.db.ts
+++ b/components/gitpod-db/src/project-db.spec.db.ts
@@ -127,13 +127,11 @@ class ProjectDBSpec {
         const storedProject4 = await this.projectDb.storeProject(project4);
         const storedProject5 = await this.projectDb.storeProject(project5);
 
-        // TODO: omit searchTerm
         const allResults = await this.projectDb.findProjectsBySearchTerm({
             offset: 0,
             limit: 10,
             orderBy: "name",
             orderDir: "ASC",
-            searchTerm: "",
         });
         expect(allResults.total).equals(5);
         expect(allResults.rows.length).equal(5);
@@ -144,13 +142,11 @@ class ProjectDBSpec {
         expect(allResults.rows[4].id).to.eq(storedProject5.id);
 
         const pageSize = 3;
-        // TODO: omit searchTerm
         const page1 = await this.projectDb.findProjectsBySearchTerm({
             offset: 0,
             limit: pageSize,
             orderBy: "name",
             orderDir: "ASC",
-            searchTerm: "",
         });
         expect(page1.total).equals(5);
         expect(page1.rows.length).equal(3);
@@ -158,13 +154,11 @@ class ProjectDBSpec {
         expect(page1.rows[1].id).to.eq(storedProject2.id);
         expect(page1.rows[2].id).to.eq(storedProject3.id);
 
-        // TODO: omit searchTerm
         const page2 = await this.projectDb.findProjectsBySearchTerm({
             offset: pageSize * 1,
             limit: pageSize,
             orderBy: "name",
             orderDir: "ASC",
-            searchTerm: "",
         });
         expect(page2.total).equals(5);
         expect(page2.rows.length).equal(2);

--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -12,13 +12,7 @@ export interface ProjectDB extends TransactionalDB<ProjectDB> {
     findProjectById(projectId: string): Promise<Project | undefined>;
     findProjectsByCloneUrl(cloneUrl: string): Promise<Project[]>;
     findProjects(orgID: string): Promise<Project[]>;
-    findProjectsBySearchTerm(
-        offset: number,
-        limit: number,
-        orderBy: keyof Project,
-        orderDir: "ASC" | "DESC",
-        searchTerm: string,
-    ): Promise<{ total: number; rows: Project[] }>;
+    findProjectsBySearchTerm(args: FindProjectsBySearchTermArgs): Promise<{ total: number; rows: Project[] }>;
     storeProject(project: Project): Promise<Project>;
     updateProject(partialProject: PartialProject): Promise<void>;
     markDeleted(projectId: string): Promise<void>;
@@ -37,3 +31,12 @@ export interface ProjectDB extends TransactionalDB<ProjectDB> {
     getProjectUsage(projectId: string): Promise<ProjectUsage | undefined>;
     updateProjectUsage(projectId: string, usage: Partial<ProjectUsage>): Promise<void>;
 }
+
+export type FindProjectsBySearchTermArgs = {
+    offset: number;
+    limit: number;
+    orderBy: keyof Project;
+    orderDir: "ASC" | "DESC";
+    searchTerm?: string;
+    organizationId?: string;
+};

--- a/components/gitpod-protocol/src/public-api-converter.spec.ts
+++ b/components/gitpod-protocol/src/public-api-converter.spec.ts
@@ -666,6 +666,7 @@ describe("PublicAPIConverter", () => {
             expect(result.organizationId).to.equal(project.teamId);
             expect(result.name).to.equal(project.name);
             expect(result.cloneUrl).to.equal(project.cloneUrl);
+            expect(result.creationTime).to.deep.equal(Timestamp.fromDate(new Date(project.creationTime)));
             expect(result.workspaceSettings).to.deep.equal(
                 new WorkspaceSettings({
                     workspaceClass: project.settings?.workspaceClasses?.regular,

--- a/components/gitpod-protocol/src/public-api-converter.ts
+++ b/components/gitpod-protocol/src/public-api-converter.ts
@@ -403,6 +403,7 @@ export class PublicAPIConverter {
         result.organizationId = project.teamId;
         result.name = project.name;
         result.cloneUrl = project.cloneUrl;
+        result.creationTime = Timestamp.fromDate(new Date(project.creationTime));
         result.workspaceSettings = this.toWorkspaceSettings(project.settings?.workspaceClasses?.regular);
         result.prebuildSettings = this.toPrebuildSettings(project.settings?.prebuilds);
         return result;

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -79,7 +79,7 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
 
         const limit = req.pagination?.pageSize || 25;
         const currentPage = req.pagination?.page ?? 1;
-        const offset = currentPage > 1 ? currentPage * limit : 0;
+        const offset = currentPage > 1 ? (currentPage - 1) * limit : 0;
 
         const { rows, total } = await this.projectService.findProjects(context.user.id, {
             searchTerm: req.searchTerm,

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -92,6 +92,7 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
 
         return new ListConfigurationsResponse({
             configurations: rows.map((project) => this.apiConverter.toConfiguration(project)),
+            // TODO: add additional pagination metadata to response
             pagination: new PaginationResponse({
                 total,
             }),

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -78,7 +78,8 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
         }
 
         const limit = req.pagination?.pageSize || 25;
-        const offset = (req.pagination?.page ?? 0) * limit;
+        const currentPage = req.pagination?.page ?? 1;
+        const offset = currentPage > 1 ? currentPage * limit : 0;
 
         const { rows, total } = await this.projectService.findProjects(context.user.id, {
             searchTerm: req.searchTerm,

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -82,6 +82,7 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
         const offset = currentPage > 1 ? (currentPage - 1) * limit : 0;
 
         const { rows, total } = await this.projectService.findProjects(context.user.id, {
+            organizationId: req.organizationId,
             searchTerm: req.searchTerm,
             orderBy: "name",
             orderDir: "ASC",

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -68,15 +68,18 @@ export class ProjectsService {
             orderBy?: keyof Project;
             orderDir?: "ASC" | "DESC";
             searchTerm?: string;
+            organizationId?: string;
         },
     ): Promise<{ total: number; rows: Project[] }> {
-        const projects = await this.projectDB.findProjectsBySearchTerm(
-            searchOptions.offset || 0,
-            searchOptions.limit || 1000,
-            searchOptions.orderBy || "creationTime",
-            searchOptions.orderDir || "ASC",
-            searchOptions.searchTerm || "",
-        );
+        const projects = await this.projectDB.findProjectsBySearchTerm({
+            offset: searchOptions.offset || 0,
+            limit: searchOptions.limit || 1000,
+            orderBy: searchOptions.orderBy || "creationTime",
+            orderDir: searchOptions.orderDir || "ASC",
+            searchTerm: searchOptions.searchTerm || "",
+            organizationId: searchOptions.organizationId,
+        });
+        // TODO: adjust this to not filter entities, but log errors if any are not accessible for current user
         const rows = await this.filterByReadAccess(userId, projects.rows);
         const total = projects.total;
         return {

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -71,6 +71,12 @@ export class ProjectsService {
             organizationId?: string;
         },
     ): Promise<{ total: number; rows: Project[] }> {
+        if (searchOptions.organizationId) {
+            await this.auth.checkPermissionOnOrganization(userId, "read_info", searchOptions.organizationId);
+        } else {
+            // If no org is provided need to check that user has installation admin scope
+        }
+
         const projects = await this.projectDB.findProjectsBySearchTerm({
             offset: searchOptions.offset || 0,
             limit: searchOptions.limit || 1000,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the Repository Configuration list page to implement the latest designs. There's still some work to do, but wanted to get this as a first milestone to keep the PR from growing too big. Most of the look and feel are here, and basic functionality of searching/paging should work as well. There are some details around loading indicators, and pagination related state that I plan on addressing in the next round of this UI.

| Header | Header | Header |
|--------|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/8c3a8e44-a4dc-4e12-83f2-63250c9dd3bc) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/48af723b-f1b1-49d1-99cc-129f80f2cef0) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/74e870ac-f015-4c2d-b20f-13f9b0b18b77) | 

Things that aren't accounted for yet but will be in followups. I've called them out in comments in the code, but for summary:

* Need the prebuild status filter
* Ability to change rows per page (it's set to 5 now to ease development).
* Search input is missing some details (icon, proper search input type). I plan on pulling this into podkit and formalizing it a bit from our current TextInput component.
* Import modal needs attention and swapping to use new grpc api
* Pagination/Search state handling (need to update api response to include some more pagination details and need to shift state into query params instead of component state).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09d9d9e</samp>

Fixed pagination bug in `getProjects` method of `ConfigurationServiceAPI`. This method lists the user's projects in the dashboard.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-876

## How to test
<!-- Provide steps to test this PR -->

* Import at least 6 repositories (so you have some paging)
* Play with paging a bit (there are some edge cases I need to address still but happy path should work)
* Make sure dark mode & light mode look right w/ the Table components

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-exp-84ec419e928</li>
	<li><b>🔗 URL</b> - <a href="https://brad-exp-84ec419e928.preview.gitpod-dev.com/workspaces" target="_blank">brad-exp-84ec419e928.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-exp-876-repositories-list-page-gha.19667</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-exp-84ec419e928%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
