### PR TITLE
[installer] make sure dashboard is deployed after server and papi-server

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -20,6 +20,7 @@ const (
 	teamNameAttribute       = "team_name"
 	vscodeClientIDAttribute = "vscode_client_id"
 	gitpodHost              = "gitpod_host"
+	component               = "component"
 )
 
 func newConfigCatClient(config configcat.Config) *configCatClient {
@@ -83,6 +84,10 @@ func attributesToUser(attributes Attributes) *configcat.UserData {
 
 	if attributes.GitpodHost != "" {
 		custom[gitpodHost] = attributes.GitpodHost
+	}
+
+	if attributes.Component != "" {
+		custom[component] = attributes.Component
 	}
 
 	return &configcat.UserData{

--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -11,6 +11,7 @@ const (
 	OIDCServiceEnabledFlag                         = "oidcServiceEnabled"
 	SupervisorPersistServerAPIChannelWhenStartFlag = "supervisor_persist_serverapi_channel_when_start"
 	SupervisorUsePublicAPIFlag                     = "supervisor_experimental_publicapi"
+	ServiceWaiterSkipComponentsFlag                = "service_waiter_skip_components"
 )
 
 func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attributes Attributes) bool {

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -49,10 +49,19 @@ func WithGitpodProxy(gitpodHost string) ClientOpt {
 	}
 }
 
+func WithDefaultClient(defaultClient Client) ClientOpt {
+	return func(o *options) {
+		o.defaultClient = defaultClient
+		o.hasDefaultClient = true
+	}
+}
+
 type options struct {
-	pollInterval time.Duration
-	baseURL      string
-	sdkKey       string
+	pollInterval     time.Duration
+	baseURL          string
+	sdkKey           string
+	defaultClient    Client
+	hasDefaultClient bool
 }
 
 // NewClient constructs a new experiments.Client. This is NOT A SINGLETON.
@@ -70,6 +79,9 @@ func NewClient(opts ...ClientOpt) Client {
 	}
 
 	if opt.sdkKey == "" {
+		if opt.hasDefaultClient {
+			return opt.defaultClient
+		}
 		return NewAlwaysReturningDefaultValueClient()
 	}
 	logger := log.Log.Dup()

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -33,6 +33,10 @@ type Attributes struct {
 	VSCodeClientID string
 
 	GitpodHost string
+
+	// Component is using in components/service-waiter
+	// Feature Flag key is `service_waiter_skip_component`
+	Component string
 }
 
 type ClientOpt func(o *options)

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -49,6 +49,12 @@ func WithGitpodProxy(gitpodHost string) ClientOpt {
 	}
 }
 
+func WithPollInterval(interval time.Duration) ClientOpt {
+	return func(o *options) {
+		o.pollInterval = interval
+	}
+}
+
 func WithDefaultClient(defaultClient Client) ClientOpt {
 	return func(o *options) {
 		o.defaultClient = defaultClient

--- a/components/service-waiter/cmd/component.go
+++ b/components/service-waiter/cmd/component.go
@@ -156,9 +156,9 @@ func startWaitFeatureFlag(ctx context.Context, timeout time.Duration) {
 		return
 	}
 	startTime := time.Now()
-	value, _, fetchTimes := ActualWaitFeatureFlag(featureFlagCtx, client, defaultSkip)
+	value, isActualValue, fetchTimes := ActualWaitFeatureFlag(featureFlagCtx, client, defaultSkip)
 	avgTime := time.Since(startTime) / time.Duration(fetchTimes)
-	log.WithField("fetchTimes", fetchTimes).WithField("avgTime", avgTime).WithField("value", value).Info("get final value of feature flag")
+	log.WithField("fetchTimes", fetchTimes).WithField("avgTime", avgTime).WithField("isActualValue", isActualValue).WithField("value", value).Info("get final value of feature flag")
 	shouldSkipComponentWaiter = value
 }
 

--- a/components/service-waiter/cmd/component.go
+++ b/components/service-waiter/cmd/component.go
@@ -148,8 +148,7 @@ func init() {
 func startWaitFeatureFlag(ctx context.Context, timeout time.Duration) {
 	featureFlagCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	client := experiments.NewClient()
-
+	client := experiments.NewClient(experiments.WithDefaultClient(nil))
 	defaultSkip := true
 	if client == nil {
 		log.Error("failed to create experiments client, skip immediately")

--- a/components/service-waiter/cmd/component.go
+++ b/components/service-waiter/cmd/component.go
@@ -155,8 +155,10 @@ func startWaitFeatureFlag(ctx context.Context, timeout time.Duration) {
 		shouldSkipComponentWaiter = defaultSkip
 		return
 	}
+	startTime := time.Now()
 	value, _, fetchTimes := ActualWaitFeatureFlag(featureFlagCtx, client, defaultSkip)
-	log.WithField("fetchTimes", fetchTimes).WithField("value", value).Info("get final value of feature flag")
+	avgTime := time.Since(startTime) / time.Duration(fetchTimes)
+	log.WithField("fetchTimes", fetchTimes).WithField("avgTime", avgTime).WithField("value", value).Info("get final value of feature flag")
 	shouldSkipComponentWaiter = value
 }
 

--- a/components/service-waiter/cmd/component_test.go
+++ b/components/service-waiter/cmd/component_test.go
@@ -27,6 +27,7 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 		values          []*string
 		defaultValue    bool
 		nilClient       bool
+		clientHanging   time.Duration
 	}
 	tests := []struct {
 		name          string
@@ -42,6 +43,7 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 				values:          []*string{nil, nil, &trueValue},
 				defaultValue:    false,
 				nilClient:       false,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: true,
 			wantOk:        true,
@@ -54,6 +56,20 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 				values:          []*string{nil, nil, nil, &falseValue},
 				defaultValue:    false,
 				nilClient:       false,
+				clientHanging:   time.Second * 0,
+			},
+			wantFlagValue: false,
+			wantOk:        true,
+			fetchTimes:    4,
+		},
+		{
+			name: "happy path 3",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, nil, &falseValue},
+				defaultValue:    false,
+				nilClient:       false,
+				clientHanging:   baseDuration * 10,
 			},
 			wantFlagValue: false,
 			wantOk:        true,
@@ -66,6 +82,7 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
 				defaultValue:    false,
 				nilClient:       false,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: false,
 			wantOk:        true,
@@ -78,6 +95,7 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
 				defaultValue:    false,
 				nilClient:       true,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: false,
 			wantOk:        false,
@@ -90,58 +108,75 @@ func Test_actualWaitFeatureFlag(t *testing.T) {
 				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
 				defaultValue:    true,
 				nilClient:       true,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: true,
 			wantOk:        false,
 			fetchTimes:    0,
 		},
 		{
-			name: "timed out with default value: true",
+			name: "ctx timed out should get default value: true",
 			args: args{
 				timeoutDuration: baseDuration * 30,
 				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
 				defaultValue:    true,
 				nilClient:       false,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: true,
 			wantOk:        false,
 			fetchTimes:    2,
 		},
 		{
-			name: "timed out with default value: false",
+			name: "ctx timed out should get default value: false",
 			args: args{
 				timeoutDuration: baseDuration * 30,
 				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
 				defaultValue:    false,
 				nilClient:       false,
+				clientHanging:   time.Second * 0,
 			},
 			wantFlagValue: false,
 			wantOk:        false,
 			fetchTimes:    2,
+		},
+		{
+			name: "client hanging should get default value",
+			args: args{
+				timeoutDuration: baseDuration * 30,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    true,
+				nilClient:       false,
+				clientHanging:   baseDuration * 60,
+			},
+			wantFlagValue: true,
+			wantOk:        false,
+			fetchTimes:    1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tt.args.timeoutDuration)
 			defer cancel()
-			client := newMockClient(tt.args.values, tt.args.nilClient)
-			gotFlagValue, gotOk, gotWaitTimes := cmd.ActualWaitFeatureFlag(ctx, client, tt.args.defaultValue)
+			client := newMockClient(tt.args.values, tt.args.nilClient, tt.args.clientHanging)
+			gotFlagValue, gotOk, gotFetchTimes := cmd.ActualWaitFeatureFlag(ctx, client, tt.args.defaultValue)
 			if gotFlagValue != tt.wantFlagValue {
 				t.Errorf("actualWaitFeatureFlag() gotFlagValue = %v, want %v", gotFlagValue, tt.wantFlagValue)
 			}
 			if gotOk != tt.wantOk {
 				t.Errorf("actualWaitFeatureFlag() gotOk = %v, want %v", gotOk, tt.wantOk)
 			}
-			if gotWaitTimes != tt.fetchTimes {
-				t.Errorf("actualWaitFeatureFlag() gotWaitTimes = %v, want %v", gotWaitTimes, tt.fetchTimes)
+			if gotFetchTimes != tt.fetchTimes {
+				t.Errorf("actualWaitFeatureFlag() gotFetchTimes = %v, want %v", gotFetchTimes, tt.fetchTimes)
 			}
 		})
 	}
 }
 
 type mockClient struct {
-	values []*string
-	i      int
+	values          []*string
+	i               int
+	hangingDuration time.Duration
 }
 
 // GetBoolValue implements experiments.Client.
@@ -159,11 +194,11 @@ func (*mockClient) GetIntValue(ctx context.Context, experimentName string, defau
 	panic("unimplemented")
 }
 
-func newMockClient(values []*string, isNil bool) experiments.Client {
+func newMockClient(values []*string, isNil bool, hangingDuration time.Duration) experiments.Client {
 	if isNil {
 		return nil
 	}
-	return &mockClient{values: values, i: 0}
+	return &mockClient{values: values, i: 0, hangingDuration: hangingDuration}
 }
 
 // GetStringValue implements experiments.Client.
@@ -171,6 +206,7 @@ func (c *mockClient) GetStringValue(ctx context.Context, experimentName string, 
 	defer func() {
 		c.i += 1
 	}()
+	time.Sleep(c.hangingDuration)
 	if c.i >= len(c.values) {
 		return defaultValue
 	}

--- a/components/service-waiter/cmd/component_test.go
+++ b/components/service-waiter/cmd/component_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/experiments"
+	"github.com/gitpod-io/gitpod/service-waiter/cmd"
+)
+
+var trueValue = "true"
+var falseValue = "false"
+var unknownValue = "unknown"
+
+func Test_actualWaitFeatureFlag(t *testing.T) {
+	baseDuration := time.Millisecond
+	// use longer time if you want to debug
+	// baseDuration := time.Second * 10
+	cmd.FeatureSleepDuration = baseDuration * 20
+	type args struct {
+		timeoutDuration time.Duration
+		values          []*string
+		defaultValue    bool
+		nilClient       bool
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantFlagValue bool
+		wantOk        bool
+		fetchTimes    int
+	}{
+		{
+			name: "happy path",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, &trueValue},
+				defaultValue:    false,
+				nilClient:       false,
+			},
+			wantFlagValue: true,
+			wantOk:        true,
+			fetchTimes:    3,
+		},
+		{
+			name: "happy path 2",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, nil, &falseValue},
+				defaultValue:    false,
+				nilClient:       false,
+			},
+			wantFlagValue: false,
+			wantOk:        true,
+			fetchTimes:    4,
+		},
+		{
+			name: "should keep wait even with unknown value",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    false,
+				nilClient:       false,
+			},
+			wantFlagValue: false,
+			wantOk:        true,
+			fetchTimes:    5,
+		},
+		{
+			name: "nil client goes to default value: false",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    false,
+				nilClient:       true,
+			},
+			wantFlagValue: false,
+			wantOk:        false,
+			fetchTimes:    0,
+		},
+		{
+			name: "nil client goes to default value: true",
+			args: args{
+				timeoutDuration: baseDuration * 1000,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    true,
+				nilClient:       true,
+			},
+			wantFlagValue: true,
+			wantOk:        false,
+			fetchTimes:    0,
+		},
+		{
+			name: "timed out with default value: true",
+			args: args{
+				timeoutDuration: baseDuration * 30,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    true,
+				nilClient:       false,
+			},
+			wantFlagValue: true,
+			wantOk:        false,
+			fetchTimes:    2,
+		},
+		{
+			name: "timed out with default value: false",
+			args: args{
+				timeoutDuration: baseDuration * 30,
+				values:          []*string{nil, nil, nil, &unknownValue, &falseValue},
+				defaultValue:    false,
+				nilClient:       false,
+			},
+			wantFlagValue: false,
+			wantOk:        false,
+			fetchTimes:    2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tt.args.timeoutDuration)
+			defer cancel()
+			client := newMockClient(tt.args.values, tt.args.nilClient)
+			gotFlagValue, gotOk, gotWaitTimes := cmd.ActualWaitFeatureFlag(ctx, client, tt.args.defaultValue)
+			if gotFlagValue != tt.wantFlagValue {
+				t.Errorf("actualWaitFeatureFlag() gotFlagValue = %v, want %v", gotFlagValue, tt.wantFlagValue)
+			}
+			if gotOk != tt.wantOk {
+				t.Errorf("actualWaitFeatureFlag() gotOk = %v, want %v", gotOk, tt.wantOk)
+			}
+			if gotWaitTimes != tt.fetchTimes {
+				t.Errorf("actualWaitFeatureFlag() gotWaitTimes = %v, want %v", gotWaitTimes, tt.fetchTimes)
+			}
+		})
+	}
+}
+
+type mockClient struct {
+	values []*string
+	i      int
+}
+
+// GetBoolValue implements experiments.Client.
+func (*mockClient) GetBoolValue(ctx context.Context, experimentName string, defaultValue bool, attributes experiments.Attributes) bool {
+	panic("unimplemented")
+}
+
+// GetFloatValue implements experiments.Client.
+func (*mockClient) GetFloatValue(ctx context.Context, experimentName string, defaultValue float64, attributes experiments.Attributes) float64 {
+	panic("unimplemented")
+}
+
+// GetIntValue implements experiments.Client.
+func (*mockClient) GetIntValue(ctx context.Context, experimentName string, defaultValue int, attributes experiments.Attributes) int {
+	panic("unimplemented")
+}
+
+func newMockClient(values []*string, isNil bool) experiments.Client {
+	if isNil {
+		return nil
+	}
+	return &mockClient{values: values, i: 0}
+}
+
+// GetStringValue implements experiments.Client.
+func (c *mockClient) GetStringValue(ctx context.Context, experimentName string, defaultValue string, attributes experiments.Attributes) string {
+	defer func() {
+		c.i += 1
+	}()
+	if c.i >= len(c.values) {
+		return defaultValue
+	}
+	value := c.values[c.i]
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}
+
+var _ experiments.Client = &mockClient{}

--- a/components/service-waiter/go.mod
+++ b/components/service-waiter/go.mod
@@ -16,7 +16,9 @@ require (
 )
 
 require (
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/configcat/go-sdk/v7 v7.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/components/service-waiter/go.sum
+++ b/components/service-waiter/go.sum
@@ -24,6 +24,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
@@ -34,6 +36,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/configcat/go-sdk/v7 v7.6.0 h1:CthQJ7DMz4bvUrpc8aek6VouJjisCvZCfuTG2gyNzL4=
+github.com/configcat/go-sdk/v7 v7.6.0/go.mod h1:2245V6Igy1Xz6GXvcYuK5z996Ct0VyzyuI470XS6aTw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -56,6 +60,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/frankban/quicktest v1.11.2 h1:mjwHjStlXWibxOohM7HYieIViKyh56mmt3+6viyhDDI=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -110,6 +116,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/components/service-waiter/pkg/metrics/metrics.go
+++ b/components/service-waiter/pkg/metrics/metrics.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+)
+
+// service_waiter_skip_components
+const WaitComponentFeatureFlagMetricName = "service_waiter_skip_components_result_total"
+
+func AddSkipComponentsCounter(host, value string, isActual bool) {
+	labels := map[string]string{
+		"value": value,
+		"ok":    strconv.FormatBool(isActual),
+	}
+	addCounter(host, WaitComponentFeatureFlagMetricName, labels)
+}
+
+func addCounter(host, metricName string, labels map[string]string) {
+	if host == "" {
+		log.Error("host is empty")
+		return
+	}
+	body := map[string]interface{}{
+		"labels": labels,
+		"value":  1,
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		log.WithError(err).Error("cannot marshal body")
+		return
+	}
+	resp, err := http.Post(host+"/metrics-api/metrics/counter/add/"+metricName, "application/json", bytes.NewReader(b))
+	if err != nil {
+		log.WithError(err).Error("cannot post metrics")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.WithField("status", resp.Status).Error("failed to post metrics")
+	}
+	log.Info("metric reported")
+}

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -512,7 +512,6 @@ func RedisWaiterContainer(ctx *RenderContext) *corev1.Container {
 // ServerComponentWaiterContainer is the container used to wait for the deployment/server to be ready
 // it requires
 //   - pods list access to the cluster
-//   - configcat env
 func ServerComponentWaiterContainer(ctx *RenderContext) *corev1.Container {
 	image := ctx.ImageName(ctx.Config.Repository, ServerComponent, ctx.VersionManifest.Components.Server.Version)
 	return componentWaiterContainer(ctx, ServerComponent, DefaultLabelSelector(ServerComponent), image)
@@ -521,7 +520,6 @@ func ServerComponentWaiterContainer(ctx *RenderContext) *corev1.Container {
 // PublicApiServerComponentWaiterContainer is the container used to wait for the deployment/public-api-server to be ready
 // it requires
 //   - pods list access to the cluster
-//   - configcat env
 func PublicApiServerComponentWaiterContainer(ctx *RenderContext) *corev1.Container {
 	image := ctx.ImageName(ctx.Config.Repository, PublicApiComponent, ctx.VersionManifest.Components.PublicAPIServer.Version)
 	return componentWaiterContainer(ctx, PublicApiComponent, DefaultLabelSelector(PublicApiComponent), image)
@@ -534,6 +532,10 @@ func componentWaiterContainer(ctx *RenderContext, component, labels, image strin
 		Args: []string{
 			"-v",
 			"component",
+			"--gitpod-host",
+			ctx.Config.Domain,
+			"--ide-metrics-host",
+			"http://" + IDEMetricsComponent + ":" + strconv.Itoa(IDEMetricsPort),
 			"--namespace",
 			ctx.Namespace,
 			"--component",
@@ -548,6 +550,7 @@ func componentWaiterContainer(ctx *RenderContext, component, labels, image strin
 			AllowPrivilegeEscalation: pointer.Bool(false),
 			RunAsUser:                pointer.Int64(31001),
 		},
+		Env: ConfigcatEnv(ctx),
 	}
 }
 

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -510,14 +510,18 @@ func RedisWaiterContainer(ctx *RenderContext) *corev1.Container {
 }
 
 // ServerComponentWaiterContainer is the container used to wait for the deployment/server to be ready
-// it requires pods list access to the cluster
+// it requires
+//   - pods list access to the cluster
+//   - configcat env
 func ServerComponentWaiterContainer(ctx *RenderContext) *corev1.Container {
 	image := ctx.ImageName(ctx.Config.Repository, ServerComponent, ctx.VersionManifest.Components.Server.Version)
 	return componentWaiterContainer(ctx, ServerComponent, DefaultLabelSelector(ServerComponent), image)
 }
 
 // PublicApiServerComponentWaiterContainer is the container used to wait for the deployment/public-api-server to be ready
-// it requires pods list access to the cluster
+// it requires
+//   - pods list access to the cluster
+//   - configcat env
 func PublicApiServerComponentWaiterContainer(ctx *RenderContext) *corev1.Container {
 	image := ctx.ImageName(ctx.Config.Repository, PublicApiComponent, ctx.VersionManifest.Components.PublicAPIServer.Version)
 	return componentWaiterContainer(ctx, PublicApiComponent, DefaultLabelSelector(PublicApiComponent), image)

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestKubeRBACProxyContainer_DefaultPorts(t *testing.T) {
@@ -47,4 +46,28 @@ func TestKubeRBACProxyContainerWithConfig(t *testing.T) {
 	require.Equal(t, []corev1.ContainerPort{
 		{Name: baseserver.BuiltinMetricsPortName, ContainerPort: baseserver.BuiltinMetricsPort},
 	}, container.Ports)
+}
+
+func TestPublicApiServerComponentWaiterContainer(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	ctx.Config.Repository = "eu.gcr.io/gitpod-core-dev/testing/installer"
+	ctx.VersionManifest.Components.ServiceWaiter.Version = "test"
+	ctx.VersionManifest.Components.PublicAPIServer.Version = "happy_path_papi_image"
+	container := common.PublicApiServerComponentWaiterContainer(ctx)
+	labels := common.DefaultLabelSelector(common.PublicApiComponent)
+	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
+}
+
+func TestServerComponentWaiterContainer(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	ctx.Config.Repository = "eu.gcr.io/gitpod-core-dev/testing/installer"
+	ctx.VersionManifest.Components.ServiceWaiter.Version = "test"
+	ctx.VersionManifest.Components.Server.Version = "happy_path_server_image"
+	container := common.ServerComponentWaiterContainer(ctx)
+	labels := common.DefaultLabelSelector(common.ServerComponent)
+	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
 }

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -6,6 +6,7 @@ package common_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -58,7 +59,8 @@ func TestPublicApiServerComponentWaiterContainer(t *testing.T) {
 	container := common.PublicApiServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.PublicApiComponent)
 	require.Equal(t, labels, "app=gitpod,component=public-api-server")
-	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
+	ideMetricsHost := "http://" + common.IDEMetricsComponent + ":" + strconv.Itoa(common.IDEMetricsPort)
+	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideMetricsHost, "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
 }
 
 func TestServerComponentWaiterContainer(t *testing.T) {
@@ -71,5 +73,6 @@ func TestServerComponentWaiterContainer(t *testing.T) {
 	container := common.ServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.ServerComponent)
 	require.Equal(t, labels, "app=gitpod,component=server")
-	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
+	ideMetricsHost := "http://" + common.IDEMetricsComponent + ":" + strconv.Itoa(common.IDEMetricsPort)
+	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideMetricsHost, "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
 }

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -57,6 +57,7 @@ func TestPublicApiServerComponentWaiterContainer(t *testing.T) {
 	ctx.VersionManifest.Components.PublicAPIServer.Version = "happy_path_papi_image"
 	container := common.PublicApiServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.PublicApiComponent)
+	require.Equal(t, labels, "app=gitpod,component=public-api-server")
 	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
 }
 
@@ -69,5 +70,6 @@ func TestServerComponentWaiterContainer(t *testing.T) {
 	ctx.VersionManifest.Components.Server.Version = "happy_path_server_image"
 	container := common.ServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.ServerComponent)
+	require.Equal(t, labels, "app=gitpod,component=server")
 	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
 }

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -62,6 +62,9 @@ const (
 	AuthPKISecretName           = "auth-pki"
 	IDEServiceComponent         = "ide-service"
 	OpenVSXProxyComponent       = "openvsx-proxy"
+	DashboardComponent          = "dashboard"
+	IDEMetricsComponent         = "ide-metrics"
+	IDEMetricsPort              = 3000
 )
 
 var (

--- a/install/installer/pkg/components/dashboard/constants.go
+++ b/install/installer/pkg/components/dashboard/constants.go
@@ -4,8 +4,10 @@
 
 package dashboard
 
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
 const (
-	Component     = "dashboard"
+	Component     = common.DashboardComponent
 	ContainerPort = 80
 	PortName      = "http"
 	ServicePort   = 3001

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -72,7 +72,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.ConfigcatEnv(ctx),
 							)),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -48,6 +48,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						DNSPolicy:                     corev1.DNSClusterFirst,
 						RestartPolicy:                 corev1.RestartPolicyAlways,
 						TerminationGracePeriodSeconds: pointer.Int64(30),
+						InitContainers: []corev1.Container{
+							*common.PublicApiServerComponentWaiterContainer(ctx),
+							*common.ServerComponentWaiterContainer(ctx),
+						},
 						Containers: []corev1.Container{{
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Dashboard.Version),

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -72,6 +72,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
+								common.ConfigcatEnv(ctx),
 							)),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -352,6 +352,23 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+		{
+			Name: "service_waiter_skip_components_result_total",
+			Help: "Total number of wait result of service_waiter/component service_waiter_skip_components flag",
+			Labels: []config.LabelAllowList{
+				{
+					Name: "value",
+					// possible values "true", "false"
+					AllowValues:  []string{"*"},
+					DefaultValue: "NONE",
+				},
+				{
+					Name:         "ok",
+					AllowValues:  []string{"true", "false"},
+					DefaultValue: "false",
+				},
+			},
+		},
 	}
 
 	histogramMetrics := []config.HistogramMetricsConfiguration{

--- a/install/installer/pkg/components/ide-metrics/constants.go
+++ b/install/installer/pkg/components/ide-metrics/constants.go
@@ -4,11 +4,13 @@
 
 package ide_metrics
 
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
 const (
-	Component     = "ide-metrics"
-	ContainerPort = 3000
+	Component     = common.IDEMetricsComponent
+	ContainerPort = common.IDEMetricsPort
 	PortName      = "http"
-	ServicePort   = 3000
-	ReadinessPort = 3000
+	ServicePort   = common.IDEMetricsPort
+	ReadinessPort = common.IDEMetricsPort
 	VolumeConfig  = "config"
 )

--- a/install/installer/pkg/components/ide-metrics/networkpolicy.go
+++ b/install/installer/pkg/components/ide-metrics/networkpolicy.go
@@ -41,6 +41,10 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": ideproxy.Component,
 					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.DashboardComponent,
+					}},
 				}},
 			}},
 		},

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -100,6 +100,10 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": common.OpenVSXProxyComponent,
 					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.DashboardComponent,
+					}},
 				}},
 			}},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8857387</samp>

This pull request adds a feature flag mechanism to the service-waiter component using the ConfigCat SDK, and uses it to control the waiting for the public-api-server and the server components in the dashboard deployment. It also adds the component name as a custom attribute for experiments. The changes affect the `components/common-go/experiments`, `components/service-waiter/cmd`, and `install/installer/pkg/components/dashboard` packages.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-822

## How to test
<!-- Provide steps to test this PR -->
- Open PR with Gitpod
- Change anything in server i.e. add a console.log
- Exec `leeway dev:preview` pods should deployed successfully
- Change anything in public-api-server i.e. fmt.Println
- Exec `leeway dev:preview` pods should deployed successfully

**Control with Feature Flag**
- Change Feature Flag `service_waiter_skip_components` value to skip true
- It should skip all components' service-waiter
- With attribute `component` set with `server` or `public-api-server` or `server,public-api-server`, it should skip target service waiter

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-exp-822</li>
	<li><b>🔗 URL</b> - <a href="https://hw-exp-822.preview.gitpod-dev.com/workspaces" target="_blank">hw-exp-822.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-EXP-822-gha.19713</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-exp-822%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
