### PR TITLE
[dashboard] fix list repositories without projects

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
@@ -40,7 +40,9 @@ test("it should exclude project entries", () => {
         repo("foo", "project-foo"),
     ];
     const deduplicated = deduplicateAndFilterRepositories("foo", true, suggestedRepos);
-    expect(deduplicated.length).toEqual(1);
+    expect(deduplicated.length).toEqual(2);
+    expect(deduplicated[0].repositoryName).toEqual("foo");
+    expect(deduplicated[1].repositoryName).toEqual("foo2");
 });
 
 test("it should match entries in url as well as poject name", () => {
@@ -74,4 +76,18 @@ test("it keeps the order", () => {
     expect(deduplicated[1].repositoryName).toEqual("Footest");
     expect(deduplicated[2].projectName).toEqual("someFootest");
     expect(deduplicated[3].projectName).toEqual("FOOtest");
+});
+
+test("it should return all repositories without duplicates when excludeProjects is true", () => {
+    const suggestedRepos: SuggestedRepository[] = [
+        repo("foo"),
+        repo("foo", "project-foo"),
+        repo("foo", "project-bar"),
+        repo("bar", "project-foo"),
+        repo("bar", "project-bar"),
+    ];
+    const deduplicated = deduplicateAndFilterRepositories("foo", true, suggestedRepos);
+    expect(deduplicated.length).toEqual(2);
+    expect(deduplicated[0].repositoryName).toEqual("foo");
+    expect(deduplicated[1].repositoryName).toEqual("bar");
 });

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -53,10 +53,6 @@ export function deduplicateAndFilterRepositories(
         });
     }
     for (const repo of suggestedRepos) {
-        // filter out project entries if excludeProjects is true
-        if (repo.projectId && excludeProjects) {
-            continue;
-        }
         // filter out project-less entries if an entry with a project exists
         if (!repo.projectId && reposWithProject.has(repo.url)) {
             continue;
@@ -66,7 +62,7 @@ export function deduplicateAndFilterRepositories(
             continue;
         }
         // filter out duplicates
-        const key = `${repo.url}:${repo.projectId || "no-project"}`;
+        const key = `${repo.url}:${excludeProjects ? "" : repo.projectId || "no-project"}`;
         if (collected.has(key)) {
             continue;
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes a bug where repositories that had a project were not listed.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1301872</samp>

Fix a bug in the unified search feature for repositories. Improve the `deduplicateAndFilterRepositories` function and add more test cases.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-901

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-exp-901</li>
	<li><b>🔗 URL</b> - <a href="https://se-exp-901.preview.gitpod-dev.com/workspaces" target="_blank">se-exp-901.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-EXP-901-gha.19699</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-exp-901%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
