### PR TITLE
local cli: support additional ssh arguments

### DIFF
--- a/components/local-app/cmd/workspace-ssh.go
+++ b/components/local-app/cmd/workspace-ssh.go
@@ -15,7 +15,16 @@ var dryRun bool
 var workspaceSSHCmd = &cobra.Command{
 	Use:   "ssh <workspace-id>",
 	Short: "Connects to a workspace via SSH",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MinimumNArgs(1),
+	Example: `  # connect to workspace with current terminal session
+  $ gitpod workspace ssh <workspace-id>
+
+  # Execute simple command in the workspace
+  $ gitpod workspace ssh <workspace-id> -- ls -la
+
+  # Get all SSH features with --dry-run
+  $ $(gitpod workspace ssh <workspace-id> --dry-run) -- ls -la
+  $ $(gitpod workspace ssh <workspace-id> --dry-run) -t watch date`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -26,7 +35,14 @@ var workspaceSSHCmd = &cobra.Command{
 			return err
 		}
 
-		return helper.SSHConnectToWorkspace(cmd.Context(), gitpod, workspaceID, dryRun)
+		dashDashIndex := cmd.ArgsLenAtDash()
+
+		sshArgs := []string{}
+		if dashDashIndex != -1 {
+			sshArgs = args[dashDashIndex:]
+		}
+
+		return helper.SSHConnectToWorkspace(cmd.Context(), gitpod, workspaceID, dryRun, sshArgs...)
 	},
 }
 

--- a/components/local-app/cmd/workspace-ssh.go
+++ b/components/local-app/cmd/workspace-ssh.go
@@ -21,6 +21,7 @@ var workspaceSSHCmd = &cobra.Command{
 
   # Execute with ssh command
   $ gitpod workspace ssh <workspace-id> -- ls -la
+  $ gitpod ws ssh <workspace-id> -- -t watch date
 
   # Get all SSH features with --dry-run
   $ $(gitpod workspace ssh <workspace-id> --dry-run) -- ls -la

--- a/components/local-app/cmd/workspace-ssh.go
+++ b/components/local-app/cmd/workspace-ssh.go
@@ -19,7 +19,7 @@ var workspaceSSHCmd = &cobra.Command{
 	Example: `  # connect to workspace with current terminal session
   $ gitpod workspace ssh <workspace-id>
 
-  # Execute simple command in the workspace
+  # Execute with ssh command
   $ gitpod workspace ssh <workspace-id> -- ls -la
 
   # Get all SSH features with --dry-run

--- a/components/local-app/go.mod
+++ b/components/local-app/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230913181813-007df8e322eb // indirect

--- a/components/local-app/pkg/helper/workspace.go
+++ b/components/local-app/pkg/helper/workspace.go
@@ -123,10 +123,10 @@ func SSHConnectToWorkspace(ctx context.Context, clnt *client.Gitpod, workspaceID
 		fmt.Println(strings.Join(command.Args, " "))
 		return nil
 	}
+	slog.Debug("Connecting to", "context", wsInfo.Description)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
-	slog.Debug("Connecting to", "context", wsInfo.Description)
 	err = command.Run()
 	if err != nil {
 		return err

--- a/components/local-app/pkg/helper/workspace.go
+++ b/components/local-app/pkg/helper/workspace.go
@@ -117,7 +117,7 @@ func SSHConnectToWorkspace(ctx context.Context, clnt *client.Gitpod, workspaceID
 	command := exec.Command("ssh", fmt.Sprintf("%s#%s@%s", wsInfo.WorkspaceId, ownerToken, host), "-o", "StrictHostKeyChecking=no")
 	if len(sshArgs) > 0 {
 		slog.Debug("With additional SSH args and command", "with", sshArgs)
-		command.Args = append(command.Args, "--", strings.Join(sshArgs, " "))
+		command.Args = append(command.Args, sshArgs...)
 	}
 	if runDry {
 		fmt.Println(strings.Join(command.Args, " "))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 025d64b</samp>

Add support for passing additional arguments to SSH command in `gitpod workspace ssh` and remove unused dependency from `local-app` module. This improves the usability and maintainability of the `gitpod` CLI tool.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-902

## How to test
<!-- Provide steps to test this PR -->
- Open Gitpod with this PR
- Exec commands
```
leeway run components/local-app:install-cli
leeway run components/local-app:cli-completion

gitpod login --token <you_pat_token>
gitpod ws ssh $(gp info --json | jq -r .workspace_id) -- cat /workspace/gitpod/components/local-app/cmd/workspace-ssh.go
```

‼️  Case like `echo 'echo hello' | gitpod ws ssh gitpodio-gitpod-er1bcypgceo cat` is not covert, let's ignore it first ()

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
