### PR TITLE
[usage] export creation and stopped time

### DIFF
--- a/components/dashboard/src/usage/download/transform-usage-record.ts
+++ b/components/dashboard/src/usage/download/transform-usage-record.ts
@@ -27,6 +27,8 @@ export const transformUsageRecord = (usage: Usage): UsageCSVRow | undefined => {
         endTime: metadata.endTime ?? "",
         userName: metadata.userName,
         startTime: metadata.startTime,
+        creationTime: metadata.creationTime ?? "",
+        stoppedTime: metadata.stoppedTime ?? "",
         contextURL: metadata.contextURL,
         workspaceId: metadata.workspaceId,
         userAvatarURL: metadata.userAvatarURL,
@@ -47,9 +49,11 @@ export type UsageCSVRow = {
     workspaceInstanceId: string;
     kind: string;
     userId: string;
-    endTime: string;
-    userName: string;
+    creationTime: string;
     startTime: string;
+    endTime: string;
+    stoppedTime: string;
+    userName: string;
     contextURL: string;
     workspaceId: string;
     userAvatarURL: string;

--- a/components/gitpod-db/go/usage.go
+++ b/components/gitpod-db/go/usage.go
@@ -85,8 +85,10 @@ type WorkspaceInstanceUsageData struct {
 	WorkspaceType  WorkspaceType `json:"workspaceType"`
 	WorkspaceClass string        `json:"workspaceClass"`
 	ContextURL     string        `json:"contextURL"`
+	CreationTime   string        `json:"creationTime"`
 	StartTime      string        `json:"startTime"`
 	EndTime        string        `json:"endTime"`
+	StoppedTime    string        `json:"stoppedTime"`
 	UserID         uuid.UUID     `json:"userId"`
 	UserName       string        `json:"userName"`
 	UserAvatarURL  string        `json:"userAvatarURL"`

--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -135,6 +135,7 @@ func queryWorkspaceInstanceForUsage(ctx context.Context, conn *gorm.DB) *gorm.DB
 			"ws.type as workspaceType, "+
 			"wsi.workspaceClass as workspaceClass, "+
 			"wsi.usageAttributionId as usageAttributionId, "+
+			"wsi.creationTime as creationTime, "+
 			"wsi.startedTime as startedTime, "+
 			"wsi.stoppingTime as stoppingTime, "+
 			"wsi.stoppedTime as stoppedTime, "+
@@ -206,6 +207,7 @@ type WorkspaceInstanceForUsage struct {
 	UserName           string         `gorm:"column:userName;type:varchar;size:255;" json:"userName"`
 	UserAvatarURL      string         `gorm:"column:userAvatarURL;type:varchar;size:255;" json:"userAvatarURL"`
 
+	CreationTime VarcharTime `gorm:"column:creationTime;type:varchar;size:255;" json:"creationTime"`
 	StartedTime  VarcharTime `gorm:"column:startedTime;type:varchar;size:255;" json:"startedTime"`
 	StoppingTime VarcharTime `gorm:"column:stoppingTime;type:varchar;size:255;" json:"stoppingTime"`
 	StoppedTime  VarcharTime `gorm:"column:stoppedTime;type:varchar;size:255;" json:"stoppedTime"`

--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -58,8 +58,10 @@ export interface WorkspaceInstanceUsageData {
     workspaceType: WorkspaceType;
     workspaceClass: string;
     contextURL: string;
+    creationTime?: string;
     startTime: string;
     endTime?: string;
+    stoppedTime?: string;
     userId: string;
     userName: string;
     userAvatarURL: string;

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -409,6 +409,10 @@ func newUsageFromInstance(instance db.WorkspaceInstanceForUsage, pricer *Workspa
 		Draft:               draft,
 	}
 
+	creationTime := ""
+	if instance.CreationTime.IsSet() {
+		creationTime = db.TimeToISO8601(instance.CreationTime.Time())
+	}
 	startedTime := ""
 	if instance.StartedTime.IsSet() {
 		startedTime = db.TimeToISO8601(instance.StartedTime.Time())
@@ -417,13 +421,19 @@ func newUsageFromInstance(instance db.WorkspaceInstanceForUsage, pricer *Workspa
 	if stopTime.IsSet() {
 		endTime = db.TimeToISO8601(stopTime.Time())
 	}
+	stoppedTime := ""
+	if instance.StoppedTime.IsSet() {
+		stoppedTime = db.TimeToISO8601(instance.StoppedTime.Time())
+	}
 	err := usage.SetMetadataWithWorkspaceInstance(db.WorkspaceInstanceUsageData{
 		WorkspaceId:    instance.WorkspaceID,
 		WorkspaceType:  instance.Type,
 		WorkspaceClass: instance.WorkspaceClass,
 		ContextURL:     instance.ContextURL,
+		CreationTime:   creationTime,
 		StartTime:      startedTime,
 		EndTime:        endTime,
+		StoppedTime:    stoppedTime,
 		UserID:         instance.UserID,
 		UserName:       instance.UserName,
 		UserAvatarURL:  instance.UserAvatarURL,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR exports the creationTime and the stoppedTime in addition to the already exported startedTime and the stoppingTime . It only does that for new workspace sessions happening after this change landed.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e98d4a</samp>

This pull request adds creation and stop times to the workspace instance usage data and CSV export. It updates the Go and TypeScript types and interfaces, as well as the CSV generation logic, to include these new fields. The goal is to provide more insight into the workspace instance lifecycle for users and admins.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-904

## How to test
<!-- Provide steps to test this PR -->

[Join my org](https://se-add-usage-data.preview.gitpod-dev.com/orgs/join?inviteId=c32dc39b-f43d-49a5-be66-c3b5bd587fe8) and check the usage export. it should have stoppedTime and creationTime exported with reasonable values.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-add-usage-data</li>
        <li><b>🔗 URL</b> - <a href="https://se-add-usage-data.preview.gitpod-dev.com/workspaces" target="_blank">se-add-usage-data.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-add-usage-data%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
