### PR TITLE
fix lint errors

### DIFF
--- a/components/gitpod-protocol/src/generate-async-generator.spec.ts
+++ b/components/gitpod-protocol/src/generate-async-generator.spec.ts
@@ -9,6 +9,7 @@ import * as chai from "chai";
 
 import { generateAsyncGenerator } from "./generate-async-generator";
 import { Disposable } from "./util/disposable";
+import EventIterator from "event-iterator";
 
 const expect = chai.expect;
 
@@ -75,7 +76,7 @@ function watchIterator(ref: Ref, opts: Option) {
 class TestGenerateAsyncGenerator {
     @test public async "happy path"() {
         const ref: Ref = { isDisposed: false, result: [], watchStarted: false };
-        const it = watchIterator(ref, { times: 5 });
+        const it: EventIterator<number> = watchIterator(ref, { times: 5 });
         try {
             for await (const v of it) {
                 ref.result.push(v);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acb3364</samp>

Use `EventIterator` type for better async iterator testing in `generate-async-generator.spec.ts`

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
