### PR TITLE
[dashboard] retry the context resolution

### DIFF
--- a/components/dashboard/src/data/workspaces/resolve-context-query.ts
+++ b/components/dashboard/src/data/workspaces/resolve-context-query.ts
@@ -10,17 +10,11 @@ import { getGitpodService } from "../../service/service";
 import { StartWorkspaceError } from "../../start/StartPage";
 
 export function useWorkspaceContext(contextUrl?: string) {
-    const query = useQuery<WorkspaceContext | null, StartWorkspaceError>(
-        ["workspace-context", contextUrl],
-        () => {
-            if (!contextUrl) {
-                return null;
-            }
-            return getGitpodService().server.resolveContext(contextUrl);
-        },
-        {
-            retry: false,
-        },
-    );
+    const query = useQuery<WorkspaceContext | null, StartWorkspaceError>(["workspace-context", contextUrl], () => {
+        if (!contextUrl) {
+            return null;
+        }
+        return getGitpodService().server.resolveContext(contextUrl);
+    });
     return query;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Retry resolving the context if it failed

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b89550</samp>

Removed `retry` option from `useQuery` hook for resolving workspace context. This avoids unnecessary retries and improves dashboard UX and performance.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-907

## How to test
<!-- Provide steps to test this PR -->

go to create workspace page and wait for the suggested repos to be populated.
- disconnect from the internet
- select an arbitrary reopository
- wait a minute for a timeout
- reconnect
- works now

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-fix-query-caching</li>
	<li><b>🔗 URL</b> - <a href="https://se-fix-query-caching.preview.gitpod-dev.com/workspaces" target="_blank">se-fix-query-caching.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-fix-query-caching-gha.19756</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-fix-query-caching%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
