### PR TITLE
[common-go] reduce configcat info log

### DIFF
--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -69,7 +69,7 @@ func NewClient(opts ...ClientOpt) Client {
 		return NewAlwaysReturningDefaultValueClient()
 	}
 	logger := log.Log.Dup()
-	logger.Level = logrus.ErrorLevel
+	logger.Logger.SetLevel(logrus.ErrorLevel)
 	return newConfigCatClient(configcat.Config{
 		SDKKey:       opt.sdkKey,
 		BaseURL:      opt.baseURL,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[common-go] reduce configcat info log, we have too many useless logs for configcat

![image](https://github.com/gitpod-io/gitpod/assets/8299500/e72f2cdf-d6c8-4feb-9ba7-a9fa126dbde3)


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ca7d85</samp>

Update common-go dependencies and logging. Use `SetLevel` instead of `Level` for `logrus.Logger` in `experiments/types.go`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
