### PR TITLE
[public-api] Migrate envvarService

### DIFF
--- a/components/dashboard/src/data/projects/set-project-env-var-mutation.ts
+++ b/components/dashboard/src/data/projects/set-project-env-var-mutation.ts
@@ -5,16 +5,22 @@
  */
 
 import { useMutation } from "@tanstack/react-query";
-import { getGitpodService } from "../../service/service";
+import { envVarClient } from "../../service/public-api";
+import { EnvironmentVariableAdmission } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 
 type SetProjectEnvVarArgs = {
     projectId: string;
     name: string;
     value: string;
-    censored: boolean;
+    admission: EnvironmentVariableAdmission;
 };
 export const useSetProjectEnvVar = () => {
-    return useMutation<void, Error, SetProjectEnvVarArgs>(async ({ projectId, name, value, censored }) => {
-        return getGitpodService().server.setProjectEnvironmentVariable(projectId, name, value, censored);
+    return useMutation<void, Error, SetProjectEnvVarArgs>(async ({ projectId, name, value, admission }) => {
+        await envVarClient.createConfigurationEnvironmentVariable({
+            name,
+            value,
+            configurationId: projectId,
+            admission,
+        });
     });
 };

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -22,11 +22,12 @@ import * as WorkspaceClasses from "@gitpod/public-api/lib/gitpod/v1/workspace_pb
 import * as PaginationClasses from "@gitpod/public-api/lib/gitpod/v1/pagination_pb";
 import * as ConfigurationClasses from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import * as AuthProviderClasses from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
+import * as EnvVarClasses from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 
 // This is used to version the cache
 // If data we cache changes in a non-backwards compatible way, increment this version
 // That will bust any previous cache versions a client may have stored
-const CACHE_VERSION = "5";
+const CACHE_VERSION = "6";
 
 export function noPersistence(queryKey: QueryKey): QueryKey {
     return [...queryKey, "no-persistence"];
@@ -145,6 +146,7 @@ function initializeMessages() {
         ...Object.values(PaginationClasses),
         ...Object.values(ConfigurationClasses),
         ...Object.values(AuthProviderClasses),
+        ...Object.values(EnvVarClasses),
     ];
     for (const c of constr) {
         if ((c as any).prototype instanceof Message) {

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Code, ConnectError, PromiseClient } from "@connectrpc/connect";
+import { PartialMessage } from "@bufbuild/protobuf";
+import { EnvironmentVariableService } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
+import {
+    CreateConfigurationEnvironmentVariableRequest,
+    CreateConfigurationEnvironmentVariableResponse,
+    CreateUserEnvironmentVariableRequest,
+    CreateUserEnvironmentVariableResponse,
+    DeleteConfigurationEnvironmentVariableRequest,
+    DeleteConfigurationEnvironmentVariableResponse,
+    DeleteUserEnvironmentVariableRequest,
+    DeleteUserEnvironmentVariableResponse,
+    EnvironmentVariableAdmission,
+    ListConfigurationEnvironmentVariablesRequest,
+    ListConfigurationEnvironmentVariablesResponse,
+    ListUserEnvironmentVariablesRequest,
+    ListUserEnvironmentVariablesResponse,
+    ResolveWorkspaceEnvironmentVariablesRequest,
+    ResolveWorkspaceEnvironmentVariablesResponse,
+    UpdateConfigurationEnvironmentVariableRequest,
+    UpdateConfigurationEnvironmentVariableResponse,
+    UpdateUserEnvironmentVariableRequest,
+    UpdateUserEnvironmentVariableResponse,
+} from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import { converter } from "./public-api";
+import { getGitpodService } from "./service";
+import { UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
+
+export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVariableService> {
+    async listUserEnvironmentVariables(
+        req: PartialMessage<ListUserEnvironmentVariablesRequest>,
+    ): Promise<ListUserEnvironmentVariablesResponse> {
+        const result = new ListUserEnvironmentVariablesResponse();
+        const userEnvVars = await getGitpodService().server.getAllEnvVars();
+        result.environmentVariables = userEnvVars.map((i) => converter.toUserEnvironmentVariable(i));
+
+        return result;
+    }
+
+    async updateUserEnvironmentVariable(
+        req: PartialMessage<UpdateUserEnvironmentVariableRequest>,
+    ): Promise<UpdateUserEnvironmentVariableResponse> {
+        if (!req.envVarId) {
+            throw new ConnectError("id is not set", Code.InvalidArgument);
+        }
+
+        const response = new UpdateUserEnvironmentVariableResponse();
+
+        const userEnvVars = await getGitpodService().server.getAllEnvVars();
+        const userEnvVarfound = userEnvVars.find((i) => i.id === req.envVarId);
+        if (userEnvVarfound) {
+            const variable: UserEnvVarValue = {
+                name: req.name ?? userEnvVarfound.name,
+                value: req.value ?? userEnvVarfound.value,
+                repositoryPattern: req.repositoryPattern ?? userEnvVarfound.repositoryPattern,
+            };
+            variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
+
+            await getGitpodService().server.setEnvVar(variable);
+
+            const updatedUserEnvVars = await getGitpodService().server.getAllEnvVars();
+            const updatedUserEnvVar = updatedUserEnvVars.find((i) => i.id === req.envVarId);
+            if (!updatedUserEnvVar) {
+                throw new ConnectError("could not update env variable", Code.Internal);
+            }
+
+            response.environmentVariable = converter.toUserEnvironmentVariable(updatedUserEnvVar);
+            return response;
+        }
+
+        throw new ConnectError("env variable not found", Code.InvalidArgument);
+    }
+
+    async createUserEnvironmentVariable(
+        req: PartialMessage<CreateUserEnvironmentVariableRequest>,
+    ): Promise<CreateUserEnvironmentVariableResponse> {
+        if (!req.name || !req.value || !req.repositoryPattern) {
+            throw new ConnectError("invalid argument", Code.InvalidArgument);
+        }
+
+        const response = new CreateUserEnvironmentVariableResponse();
+
+        const variable: UserEnvVarValue = {
+            name: req.name,
+            value: req.value,
+            repositoryPattern: req.repositoryPattern,
+        };
+        variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
+
+        await getGitpodService().server.setEnvVar(variable);
+
+        const updatedUserEnvVars = await getGitpodService().server.getAllEnvVars();
+        const updatedUserEnvVar = updatedUserEnvVars.find(
+            (v) => v.name === variable.name && v.repositoryPattern === variable.repositoryPattern,
+        );
+        if (!updatedUserEnvVar) {
+            throw new ConnectError("could not update env variable", Code.Internal);
+        }
+
+        response.environmentVariable = converter.toUserEnvironmentVariable(updatedUserEnvVar);
+
+        return response;
+    }
+
+    async deleteUserEnvironmentVariable(
+        req: PartialMessage<DeleteUserEnvironmentVariableRequest>,
+    ): Promise<DeleteUserEnvironmentVariableResponse> {
+        if (!req.envVarId) {
+            throw new ConnectError("invalid argument", Code.InvalidArgument);
+        }
+
+        const variable: UserEnvVarValue = {
+            id: req.envVarId,
+            name: "",
+            value: "",
+            repositoryPattern: "",
+        };
+
+        await getGitpodService().server.deleteEnvVar(variable);
+
+        const response = new DeleteUserEnvironmentVariableResponse();
+        return response;
+    }
+
+    async listConfigurationEnvironmentVariables(
+        req: PartialMessage<ListConfigurationEnvironmentVariablesRequest>,
+    ): Promise<ListConfigurationEnvironmentVariablesResponse> {
+        if (!req.configurationId) {
+            throw new ConnectError("configurationId is not set", Code.InvalidArgument);
+        }
+
+        const result = new ListConfigurationEnvironmentVariablesResponse();
+        const projectEnvVars = await getGitpodService().server.getProjectEnvironmentVariables(req.configurationId);
+        result.environmentVariables = projectEnvVars.map((i) => converter.toConfigurationEnvironmentVariable(i));
+
+        return result;
+    }
+
+    async updateConfigurationEnvironmentVariable(
+        req: PartialMessage<UpdateConfigurationEnvironmentVariableRequest>,
+    ): Promise<UpdateConfigurationEnvironmentVariableResponse> {
+        if (!req.envVarId) {
+            throw new ConnectError("envVarId is not set", Code.InvalidArgument);
+        }
+        if (!req.configurationId) {
+            throw new ConnectError("configurationId is not set", Code.InvalidArgument);
+        }
+
+        const response = new UpdateConfigurationEnvironmentVariableResponse();
+
+        const projectEnvVars = await getGitpodService().server.getProjectEnvironmentVariables(req.configurationId);
+        const projectEnvVarfound = projectEnvVars.find((i) => i.id === req.envVarId);
+        if (projectEnvVarfound) {
+            await getGitpodService().server.setProjectEnvironmentVariable(
+                req.configurationId,
+                req.name ?? projectEnvVarfound.name,
+                req.value ?? "",
+                (req.admission === EnvironmentVariableAdmission.PREBUILD ? true : false) ?? projectEnvVarfound.censored,
+            );
+
+            const updatedProjectEnvVars = await getGitpodService().server.getProjectEnvironmentVariables(
+                req.configurationId,
+            );
+            const updatedProjectEnvVar = updatedProjectEnvVars.find((i) => i.id === req.envVarId);
+            if (!updatedProjectEnvVar) {
+                throw new ConnectError("could not update env variable", Code.Internal);
+            }
+
+            response.environmentVariable = converter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
+            return response;
+        }
+
+        throw new ConnectError("env variable not found", Code.InvalidArgument);
+    }
+
+    async createConfigurationEnvironmentVariable(
+        req: PartialMessage<CreateConfigurationEnvironmentVariableRequest>,
+    ): Promise<CreateConfigurationEnvironmentVariableResponse> {
+        if (!req.configurationId || !req.name || !req.value) {
+            throw new ConnectError("invalid argument", Code.InvalidArgument);
+        }
+
+        const response = new CreateConfigurationEnvironmentVariableResponse();
+
+        await getGitpodService().server.setProjectEnvironmentVariable(
+            req.configurationId,
+            req.name,
+            req.value,
+            req.admission === EnvironmentVariableAdmission.PREBUILD ? true : false,
+        );
+
+        const updatedProjectEnvVars = await getGitpodService().server.getProjectEnvironmentVariables(
+            req.configurationId,
+        );
+        const updatedProjectEnvVar = updatedProjectEnvVars.find((v) => v.name === req.name);
+        if (!updatedProjectEnvVar) {
+            throw new ConnectError("could not create env variable", Code.Internal);
+        }
+
+        response.environmentVariable = converter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
+
+        return response;
+    }
+
+    async deleteConfigurationEnvironmentVariable(
+        req: PartialMessage<DeleteConfigurationEnvironmentVariableRequest>,
+    ): Promise<DeleteConfigurationEnvironmentVariableResponse> {
+        if (!req.envVarId) {
+            throw new ConnectError("invalid argument", Code.InvalidArgument);
+        }
+
+        await getGitpodService().server.deleteProjectEnvironmentVariable(req.envVarId);
+
+        const response = new DeleteConfigurationEnvironmentVariableResponse();
+        return response;
+    }
+
+    async resolveWorkspaceEnvironmentVariables(
+        req: PartialMessage<ResolveWorkspaceEnvironmentVariablesRequest>,
+    ): Promise<ResolveWorkspaceEnvironmentVariablesResponse> {
+        throw new Error("Not implemented");
+    }
+}

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -75,7 +75,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.InvalidArgument);
+        throw new ConnectError("env variable not found", Code.NotFound);
     }
 
     async createUserEnvironmentVariable(
@@ -177,7 +177,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.InvalidArgument);
+        throw new ConnectError("env variable not found", Code.NotFound);
     }
 
     async createConfigurationEnvironmentVariable(

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -224,6 +224,6 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
     async resolveWorkspaceEnvironmentVariables(
         req: PartialMessage<ResolveWorkspaceEnvironmentVariablesRequest>,
     ): Promise<ResolveWorkspaceEnvironmentVariablesResponse> {
-        throw new Error("Not implemented");
+        throw new ConnectError("Unimplemented", Code.Unimplemented);
     }
 }

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Code, ConnectError, PromiseClient } from "@connectrpc/connect";
+import { PromiseClient } from "@connectrpc/connect";
 import { PartialMessage } from "@bufbuild/protobuf";
 import { EnvironmentVariableService } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
 import {
@@ -31,6 +31,7 @@ import {
 import { converter } from "./public-api";
 import { getGitpodService } from "./service";
 import { UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVariableService> {
     async listUserEnvironmentVariables(
@@ -47,7 +48,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<UpdateUserEnvironmentVariableRequest>,
     ): Promise<UpdateUserEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         const response = new UpdateUserEnvironmentVariableResponse();
@@ -68,21 +69,21 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
             const updatedUserEnvVars = await getGitpodService().server.getAllEnvVars();
             const updatedUserEnvVar = updatedUserEnvVars.find((i) => i.id === req.envVarId);
             if (!updatedUserEnvVar) {
-                throw new ConnectError("could not update env variable", Code.Internal);
+                throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "could not update env variable");
             }
 
             response.environmentVariable = converter.toUserEnvironmentVariable(updatedUserEnvVar);
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.NotFound);
+        throw new ApplicationError(ErrorCodes.NOT_FOUND, "env variable not found");
     }
 
     async createUserEnvironmentVariable(
         req: PartialMessage<CreateUserEnvironmentVariableRequest>,
     ): Promise<CreateUserEnvironmentVariableResponse> {
         if (!req.name || !req.value || !req.repositoryPattern) {
-            throw new ConnectError("name, value and repositoryPattern are required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "name, value and repositoryPattern are required");
         }
 
         const response = new CreateUserEnvironmentVariableResponse();
@@ -101,7 +102,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
             (v) => v.name === variable.name && v.repositoryPattern === variable.repositoryPattern,
         );
         if (!updatedUserEnvVar) {
-            throw new ConnectError("could not update env variable", Code.Internal);
+            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "could not update env variable");
         }
 
         response.environmentVariable = converter.toUserEnvironmentVariable(updatedUserEnvVar);
@@ -113,7 +114,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<DeleteUserEnvironmentVariableRequest>,
     ): Promise<DeleteUserEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         const variable: UserEnvVarValue = {
@@ -133,7 +134,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<ListConfigurationEnvironmentVariablesRequest>,
     ): Promise<ListConfigurationEnvironmentVariablesResponse> {
         if (!req.configurationId) {
-            throw new ConnectError("configurationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "configurationId is required");
         }
 
         const result = new ListConfigurationEnvironmentVariablesResponse();
@@ -147,10 +148,10 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<UpdateConfigurationEnvironmentVariableRequest>,
     ): Promise<UpdateConfigurationEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
         if (!req.configurationId) {
-            throw new ConnectError("configurationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "configurationId is required");
         }
 
         const response = new UpdateConfigurationEnvironmentVariableResponse();
@@ -170,21 +171,21 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
             );
             const updatedProjectEnvVar = updatedProjectEnvVars.find((i) => i.id === req.envVarId);
             if (!updatedProjectEnvVar) {
-                throw new ConnectError("could not update env variable", Code.Internal);
+                throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "could not update env variable");
             }
 
             response.environmentVariable = converter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.NotFound);
+        throw new ApplicationError(ErrorCodes.NOT_FOUND, "env variable not found");
     }
 
     async createConfigurationEnvironmentVariable(
         req: PartialMessage<CreateConfigurationEnvironmentVariableRequest>,
     ): Promise<CreateConfigurationEnvironmentVariableResponse> {
         if (!req.configurationId || !req.name || !req.value) {
-            throw new ConnectError("configurationId, name and value are required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "configurationId, name and value are required");
         }
 
         const response = new CreateConfigurationEnvironmentVariableResponse();
@@ -201,7 +202,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         );
         const updatedProjectEnvVar = updatedProjectEnvVars.find((v) => v.name === req.name);
         if (!updatedProjectEnvVar) {
-            throw new ConnectError("could not create env variable", Code.Internal);
+            throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "could not create env variable");
         }
 
         response.environmentVariable = converter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
@@ -213,7 +214,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<DeleteConfigurationEnvironmentVariableRequest>,
     ): Promise<DeleteConfigurationEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         await getGitpodService().server.deleteProjectEnvironmentVariable(req.envVarId);
@@ -225,6 +226,6 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
     async resolveWorkspaceEnvironmentVariables(
         req: PartialMessage<ResolveWorkspaceEnvironmentVariablesRequest>,
     ): Promise<ResolveWorkspaceEnvironmentVariablesResponse> {
-        throw new ConnectError("Unimplemented", Code.Unimplemented);
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unimplemented");
     }
 }

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -56,6 +56,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         const userEnvVarfound = userEnvVars.find((i) => i.id === req.envVarId);
         if (userEnvVarfound) {
             const variable: UserEnvVarValue = {
+                id: req.envVarId,
                 name: req.name ?? userEnvVarfound.name,
                 value: req.value ?? userEnvVarfound.value,
                 repositoryPattern: req.repositoryPattern ?? userEnvVarfound.repositoryPattern,

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -47,7 +47,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<UpdateUserEnvironmentVariableRequest>,
     ): Promise<UpdateUserEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("id is not set", Code.InvalidArgument);
+            throw new ConnectError("envVarId is required", Code.InvalidArgument);
         }
 
         const response = new UpdateUserEnvironmentVariableResponse();
@@ -81,7 +81,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<CreateUserEnvironmentVariableRequest>,
     ): Promise<CreateUserEnvironmentVariableResponse> {
         if (!req.name || !req.value || !req.repositoryPattern) {
-            throw new ConnectError("invalid argument", Code.InvalidArgument);
+            throw new ConnectError("name, value and repositoryPattern are required", Code.InvalidArgument);
         }
 
         const response = new CreateUserEnvironmentVariableResponse();
@@ -112,7 +112,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<DeleteUserEnvironmentVariableRequest>,
     ): Promise<DeleteUserEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("invalid argument", Code.InvalidArgument);
+            throw new ConnectError("envVarId is required", Code.InvalidArgument);
         }
 
         const variable: UserEnvVarValue = {
@@ -132,7 +132,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<ListConfigurationEnvironmentVariablesRequest>,
     ): Promise<ListConfigurationEnvironmentVariablesResponse> {
         if (!req.configurationId) {
-            throw new ConnectError("configurationId is not set", Code.InvalidArgument);
+            throw new ConnectError("configurationId is required", Code.InvalidArgument);
         }
 
         const result = new ListConfigurationEnvironmentVariablesResponse();
@@ -146,10 +146,10 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<UpdateConfigurationEnvironmentVariableRequest>,
     ): Promise<UpdateConfigurationEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("envVarId is not set", Code.InvalidArgument);
+            throw new ConnectError("envVarId is required", Code.InvalidArgument);
         }
         if (!req.configurationId) {
-            throw new ConnectError("configurationId is not set", Code.InvalidArgument);
+            throw new ConnectError("configurationId is required", Code.InvalidArgument);
         }
 
         const response = new UpdateConfigurationEnvironmentVariableResponse();
@@ -183,7 +183,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<CreateConfigurationEnvironmentVariableRequest>,
     ): Promise<CreateConfigurationEnvironmentVariableResponse> {
         if (!req.configurationId || !req.name || !req.value) {
-            throw new ConnectError("invalid argument", Code.InvalidArgument);
+            throw new ConnectError("configurationId, name and value are required", Code.InvalidArgument);
         }
 
         const response = new CreateConfigurationEnvironmentVariableResponse();
@@ -212,7 +212,7 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
         req: PartialMessage<DeleteConfigurationEnvironmentVariableRequest>,
     ): Promise<DeleteConfigurationEnvironmentVariableResponse> {
         if (!req.envVarId) {
-            throw new ConnectError("invalid argument", Code.InvalidArgument);
+            throw new ConnectError("envVarId is required", Code.InvalidArgument);
         }
 
         await getGitpodService().server.deleteProjectEnvironmentVariable(req.envVarId);

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -25,6 +25,8 @@ import { JsonRpcOrganizationClient } from "./json-rpc-organization-client";
 import { JsonRpcWorkspaceClient } from "./json-rpc-workspace-client";
 import { JsonRpcAuthProviderClient } from "./json-rpc-authprovider-client";
 import { AuthProviderService } from "@gitpod/public-api/lib/gitpod/v1/authprovider_connect";
+import { EnvironmentVariableService } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
+import { JsonRpcEnvvarClient } from "./json-rpc-envvar-client";
 
 const transport = createConnectTransport({
     baseUrl: `${window.location.protocol}//${window.location.host}/public-api`,
@@ -52,6 +54,8 @@ export const organizationClient = createServiceClient(
 export const configurationClient = createServiceClient(ConfigurationService);
 
 export const authProviderClient = createServiceClient(AuthProviderService, new JsonRpcAuthProviderClient());
+
+export const envVarClient = createServiceClient(EnvironmentVariableService, new JsonRpcEnvvarClient());
 
 export async function listAllProjects(opts: { orgId: string }): Promise<ProtocolProject[]> {
     let pagination = {

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -9,11 +9,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { Item, ItemField, ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
-import { getGitpodService } from "../service/service";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { EnvironmentVariableEntry } from "./EnvironmentVariableEntry";
 import { Button } from "../components/Button";
 import { Heading2, Subheading } from "../components/typography/headings";
+import { envVarClient } from "../service/public-api";
+import { UserEnvironmentVariable } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -133,7 +134,7 @@ function DeleteEnvVarModal(p: { variable: UserEnvVarValue; deleteVariable: () =>
     );
 }
 
-function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
+function sortEnvVars(a: UserEnvironmentVariable, b: UserEnvironmentVariable) {
     if (a.name === b.name) {
         return a.repositoryPattern > b.repositoryPattern ? 1 : -1;
     }
@@ -143,6 +144,7 @@ function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
 export default function EnvVars() {
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
     const [currentEnvVar, setCurrentEnvVar] = useState({
+        id: undefined,
         name: "",
         value: "",
         repositoryPattern: "",
@@ -150,9 +152,16 @@ export default function EnvVars() {
     const [isAddEnvVarModalVisible, setAddEnvVarModalVisible] = useState(false);
     const [isDeleteEnvVarModalVisible, setDeleteEnvVarModalVisible] = useState(false);
     const update = async () => {
-        await getGitpodService()
-            .server.getAllEnvVars()
-            .then((r) => setEnvVars(r.sort(sortEnvVars)));
+        await envVarClient.listUserEnvironmentVariables({}).then((r) =>
+            setEnvVars(
+                r.environmentVariables.sort(sortEnvVars).map((e) => ({
+                    id: e.id,
+                    name: e.name,
+                    value: e.value,
+                    repositoryPattern: e.repositoryPattern,
+                })),
+            ),
+        );
     };
 
     useEffect(() => {
@@ -160,7 +169,7 @@ export default function EnvVars() {
     }, []);
 
     const add = () => {
-        setCurrentEnvVar({ name: "", value: "", repositoryPattern: "" });
+        setCurrentEnvVar({ id: undefined, name: "", value: "", repositoryPattern: "" });
         setAddEnvVarModalVisible(true);
         setDeleteEnvVarModalVisible(false);
     };
@@ -178,12 +187,28 @@ export default function EnvVars() {
     };
 
     const save = async (variable: UserEnvVarValue) => {
-        await getGitpodService().server.setEnvVar(variable);
+        if (variable.id) {
+            await envVarClient.updateUserEnvironmentVariable({
+                envVarId: variable.id,
+                name: variable.name,
+                value: variable.value,
+                repositoryPattern: variable.repositoryPattern,
+            });
+        } else {
+            await envVarClient.createUserEnvironmentVariable({
+                name: variable.name,
+                value: variable.value,
+                repositoryPattern: variable.repositoryPattern,
+            });
+        }
+
         await update();
     };
 
     const deleteVariable = async (variable: UserEnvVarValue) => {
-        await getGitpodService().server.deleteEnvVar(variable);
+        await envVarClient.deleteUserEnvironmentVariable({
+            envVarId: variable.id,
+        });
         await update();
     };
 

--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -20,8 +20,11 @@ export interface ProjectDB extends TransactionalDB<ProjectDB> {
         projectId: string,
         envVar: ProjectEnvVarWithValue,
     ): Promise<ProjectEnvVar | undefined>;
-    addProjectEnvironmentVariable(projectId: string, envVar: ProjectEnvVarWithValue): Promise<void>;
-    updateProjectEnvironmentVariable(projectId: string, envVar: Required<ProjectEnvVarWithValue>): Promise<void>;
+    addProjectEnvironmentVariable(projectId: string, envVar: ProjectEnvVarWithValue): Promise<ProjectEnvVar>;
+    updateProjectEnvironmentVariable(
+        projectId: string,
+        envVar: Partial<ProjectEnvVarWithValue>,
+    ): Promise<ProjectEnvVar | undefined>;
     getProjectEnvironmentVariables(projectId: string): Promise<ProjectEnvVar[]>;
     getProjectEnvironmentVariableById(variableId: string): Promise<ProjectEnvVar | undefined>;
     deleteProjectEnvironmentVariable(variableId: string): Promise<void>;

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -16,6 +16,8 @@ import { DBProjectInfo } from "./entity/db-project-info";
 import { DBProjectUsage } from "./entity/db-project-usage";
 import { TransactionalDBImpl } from "./transactional-db-impl";
 import { TypeORM } from "./typeorm";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { filter } from "../utils";
 
 function toProjectEnvVar(envVarWithValue: DBProjectEnvVar): ProjectEnvVar {
     const envVar = { ...envVarWithValue };
@@ -145,9 +147,12 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
         return envVarRepo.findOne({ projectId, name: envVar.name, deleted: false });
     }
 
-    public async addProjectEnvironmentVariable(projectId: string, envVar: ProjectEnvVarWithValue): Promise<void> {
+    public async addProjectEnvironmentVariable(
+        projectId: string,
+        envVar: ProjectEnvVarWithValue,
+    ): Promise<ProjectEnvVar> {
         const envVarRepo = await this.getProjectEnvVarRepo();
-        await envVarRepo.save({
+        const insertedEnvVar = await envVarRepo.save({
             id: uuidv4(),
             projectId,
             name: envVar.name,
@@ -156,14 +161,31 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
             creationTime: new Date().toISOString(),
             deleted: false,
         });
+        return toProjectEnvVar(insertedEnvVar);
     }
 
     public async updateProjectEnvironmentVariable(
         projectId: string,
-        envVar: Required<ProjectEnvVarWithValue>,
-    ): Promise<void> {
-        const envVarRepo = await this.getProjectEnvVarRepo();
-        await envVarRepo.update({ id: envVar.id, projectId }, { value: envVar.value, censored: envVar.censored });
+        envVar: Partial<ProjectEnvVarWithValue>,
+    ): Promise<ProjectEnvVar | undefined> {
+        if (!envVar.id) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "An environment variable with this ID could not be found");
+        }
+
+        return await this.transaction(async (_, ctx) => {
+            const envVarRepo = ctx.entityManager.getRepository<DBProjectEnvVar>(DBProjectEnvVar);
+
+            await envVarRepo.update(
+                { id: envVar.id, projectId },
+                filter(envVar, (_, v) => v !== null && v !== undefined),
+            );
+
+            const found = await envVarRepo.findOne({ id: envVar.id, projectId, deleted: false });
+            if (!found) {
+                return;
+            }
+            return toProjectEnvVar(found);
+        });
     }
 
     public async getProjectEnvironmentVariables(projectId: string): Promise<ProjectEnvVar[]> {

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -416,7 +416,7 @@ export class TypeORMUserDBImpl extends TransactionalDBImpl<UserDB> implements Us
             const envVarRepo = ctx.entityManager.getRepository<DBUserEnvVar>(DBUserEnvVar);
 
             await envVarRepo.update(
-                { id: envVar.id, userId },
+                { id: envVar.id, userId, deleted: false },
                 filter(envVar, (_, v) => v !== null && v !== undefined),
             );
 

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -114,8 +114,8 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository, Trans
     findUsersByEmail(email: string): Promise<User[]>;
 
     findEnvVar(userId: string, envVar: UserEnvVarValue): Promise<UserEnvVar | undefined>;
-    addEnvVar(userId: string, envVar: UserEnvVarValue): Promise<void>;
-    updateEnvVar(userId: string, envVar: UserEnvVarValue): Promise<void>;
+    addEnvVar(userId: string, envVar: UserEnvVarValue): Promise<UserEnvVar>;
+    updateEnvVar(userId: string, envVar: Partial<UserEnvVarValue>): Promise<UserEnvVar | undefined>;
     deleteEnvVar(envVar: UserEnvVar): Promise<void>;
     getEnvVars(userId: string): Promise<UserEnvVar[]>;
 

--- a/components/gitpod-db/src/utils.ts
+++ b/components/gitpod-db/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */

--- a/components/gitpod-db/src/utils.ts
+++ b/components/gitpod-db/src/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export function filter(
+    obj: { [key: string]: any },
+    predicate: (key: string, value: any) => boolean,
+): { [key: string]: any } {
+    const result = Object.create(null);
+    for (const [key, value] of Object.entries(obj)) {
+        if (predicate(key, value)) {
+            result[key] = value;
+        }
+    }
+    return result;
+}

--- a/components/gitpod-db/src/utils.ts
+++ b/components/gitpod-db/src/utils.ts
@@ -8,7 +8,7 @@ export function filter(
     obj: { [key: string]: any },
     predicate: (key: string, value: any) => boolean,
 ): { [key: string]: any } {
-    const result = Object.create(null);
+    const result = Object.create({}); // typeorm doesn't like Object.create(null)
     for (const [key, value] of Object.entries(obj)) {
         if (predicate(key, value)) {
             result[key] = value;

--- a/components/gitpod-protocol/src/public-api-converter.spec.ts
+++ b/components/gitpod-protocol/src/public-api-converter.spec.ts
@@ -8,6 +8,7 @@
 import { Timestamp } from "@bufbuild/protobuf";
 import {
     AdmissionLevel,
+    WorkspaceEnvironmentVariable,
     WorkspacePhase_Phase,
     WorkspacePort_Policy,
     WorkspacePort_Protocol,
@@ -21,12 +22,17 @@ import {
     PrebuildSettings,
     WorkspaceSettings,
 } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
-import { AuthProviderEntry, AuthProviderInfo } from "./protocol";
+import { AuthProviderEntry, AuthProviderInfo, ProjectEnvVar, UserEnvVarValue, WithEnvvarsContext } from "./protocol";
 import {
     AuthProvider,
     AuthProviderDescription,
     AuthProviderType,
 } from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
+import {
+    ConfigurationEnvironmentVariable,
+    EnvironmentVariableAdmission,
+    UserEnvironmentVariable,
+} from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 
 describe("PublicAPIConverter", () => {
     const converter = new PublicAPIConverter();
@@ -806,6 +812,61 @@ describe("PublicAPIConverter", () => {
                 const result = converter.toAuthProviderType(k);
                 expect(result).to.deep.equal(mapping[k]);
             }
+        });
+    });
+
+    describe("toWorkspaceEnvironmentVariables", () => {
+        const wsCtx: WithEnvvarsContext = {
+            title: "title",
+            envvars: [
+                {
+                    name: "FOO",
+                    value: "bar",
+                },
+            ],
+        };
+        const envVars = [new WorkspaceEnvironmentVariable({ name: "FOO", value: "bar" })];
+        it("should convert workspace environment variable types", () => {
+            const result = converter.toWorkspaceEnvironmentVariables(wsCtx);
+            expect(result).to.deep.equal(envVars);
+        });
+    });
+
+    describe("toUserEnvironmentVariable", () => {
+        const envVar: UserEnvVarValue = {
+            id: "1",
+            name: "FOO",
+            value: "bar",
+            repositoryPattern: "*/*",
+        };
+        const userEnvVar = new UserEnvironmentVariable({
+            id: "1",
+            name: "FOO",
+            value: "bar",
+            repositoryPattern: "*/*",
+        });
+        it("should convert user environment variable types", () => {
+            const result = converter.toUserEnvironmentVariable(envVar);
+            expect(result).to.deep.equal(userEnvVar);
+        });
+    });
+
+    describe("toConfigurationEnvironmentVariable", () => {
+        const envVar: ProjectEnvVar = {
+            id: "1",
+            name: "FOO",
+            censored: true,
+            projectId: "1",
+        };
+        const userEnvVar = new ConfigurationEnvironmentVariable({
+            id: "1",
+            name: "FOO",
+            admission: EnvironmentVariableAdmission.PREBUILD,
+            configurationId: "1",
+        });
+        it("should convert configuration environment variable types", () => {
+            const result = converter.toConfigurationEnvironmentVariable(envVar);
+            expect(result).to.deep.equal(userEnvVar);
         });
     });
 });

--- a/components/gitpod-protocol/src/public-api-converter.ts
+++ b/components/gitpod-protocol/src/public-api-converter.ts
@@ -38,6 +38,11 @@ import {
     WorkspacePort_Protocol,
     WorkspaceStatus,
 } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import {
+    ConfigurationEnvironmentVariable,
+    EnvironmentVariableAdmission,
+    UserEnvironmentVariable,
+} from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 import { ContextURL } from "./context-url";
 import { ApplicationError, ErrorCode, ErrorCodes } from "./messaging/error";
 import {
@@ -50,6 +55,8 @@ import {
     WithPrebuild,
     WorkspaceContext,
     WorkspaceInfo,
+    UserEnvVarValue,
+    ProjectEnvVar,
 } from "./protocol";
 import {
     OrgMemberInfo,
@@ -104,7 +111,7 @@ export class PublicAPIConverter {
             status.admission = this.toAdmission(arg.workspace.shareable);
             status.gitStatus = this.toGitStatus(arg.workspace);
             workspace.status = status;
-            workspace.additionalEnvironmentVariables = this.toEnvironmentVariables(arg.workspace.context);
+            workspace.additionalEnvironmentVariables = this.toWorkspaceEnvironmentVariables(arg.workspace.context);
 
             if (arg.latestInstance) {
                 return this.toWorkspace(arg.latestInstance, workspace);
@@ -228,17 +235,37 @@ export class PublicAPIConverter {
         return new ApplicationError(code, reason.message, new TrustedValue(data));
     }
 
-    toEnvironmentVariables(context: WorkspaceContext): WorkspaceEnvironmentVariable[] {
+    toWorkspaceEnvironmentVariables(context: WorkspaceContext): WorkspaceEnvironmentVariable[] {
         if (WithEnvvarsContext.is(context)) {
-            return context.envvars.map((envvar) => this.toEnvironmentVariable(envvar));
+            return context.envvars.map((envvar) => this.toWorkspaceEnvironmentVariable(envvar));
         }
         return [];
     }
 
-    toEnvironmentVariable(envVar: EnvVarWithValue): WorkspaceEnvironmentVariable {
+    toWorkspaceEnvironmentVariable(envVar: EnvVarWithValue): WorkspaceEnvironmentVariable {
         const result = new WorkspaceEnvironmentVariable();
         result.name = envVar.name;
-        envVar.value = envVar.value;
+        result.value = envVar.value;
+        return result;
+    }
+
+    toUserEnvironmentVariable(envVar: UserEnvVarValue): UserEnvironmentVariable {
+        const result = new UserEnvironmentVariable();
+        result.id = envVar.id || "";
+        result.name = envVar.name;
+        result.value = envVar.value;
+        result.repositoryPattern = envVar.repositoryPattern;
+        return result;
+    }
+
+    toConfigurationEnvironmentVariable(envVar: ProjectEnvVar): ConfigurationEnvironmentVariable {
+        const result = new ConfigurationEnvironmentVariable();
+        result.id = envVar.id || "";
+        result.name = envVar.name;
+        result.configurationId = envVar.projectId;
+        result.admission = envVar.censored
+            ? EnvironmentVariableAdmission.PREBUILD
+            : EnvironmentVariableAdmission.EVERYWHERE;
         return result;
     }
 

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -84,7 +84,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.InvalidArgument);
+        throw new ConnectError("env variable not found", Code.NotFound);
     }
 
     async createUserEnvironmentVariable(

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Code, ConnectError, HandlerContext, ServiceImpl } from "@connectrpc/connect";
+import { EnvironmentVariableService as EnvironmentVariableServiceInterface } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
+import {
+    ListUserEnvironmentVariablesRequest,
+    ListUserEnvironmentVariablesResponse,
+    UpdateUserEnvironmentVariableRequest,
+    UpdateUserEnvironmentVariableResponse,
+    DeleteUserEnvironmentVariableRequest,
+    DeleteUserEnvironmentVariableResponse,
+    CreateUserEnvironmentVariableRequest,
+    CreateUserEnvironmentVariableResponse,
+    ListConfigurationEnvironmentVariablesRequest,
+    ListConfigurationEnvironmentVariablesResponse,
+    UpdateConfigurationEnvironmentVariableRequest,
+    UpdateConfigurationEnvironmentVariableResponse,
+    EnvironmentVariableAdmission,
+    CreateConfigurationEnvironmentVariableRequest,
+    CreateConfigurationEnvironmentVariableResponse,
+    DeleteConfigurationEnvironmentVariableRequest,
+    DeleteConfigurationEnvironmentVariableResponse,
+    ResolveWorkspaceEnvironmentVariablesResponse,
+    ResolveWorkspaceEnvironmentVariablesRequest,
+    ResolveWorkspaceEnvironmentVariablesResponse_EnvironmentVariable,
+} from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import { inject, injectable } from "inversify";
+import { EnvVarService } from "../user/env-var-service";
+import { PublicAPIConverter } from "@gitpod/gitpod-protocol/lib/public-api-converter";
+import { ProjectEnvVarWithValue, UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
+import { WorkspaceService } from "../workspace/workspace-service";
+
+@injectable()
+export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof EnvironmentVariableServiceInterface> {
+    @inject(EnvVarService)
+    private readonly envVarService: EnvVarService;
+
+    @inject(WorkspaceService)
+    private readonly workspaceService: WorkspaceService;
+
+    @inject(PublicAPIConverter)
+    private readonly apiConverter: PublicAPIConverter;
+
+    async listUserEnvironmentVariables(
+        req: ListUserEnvironmentVariablesRequest,
+        context: HandlerContext,
+    ): Promise<ListUserEnvironmentVariablesResponse> {
+        const response = new ListUserEnvironmentVariablesResponse();
+        const userEnvVars = await this.envVarService.listUserEnvVars(context.user.id, context.user.id);
+        response.environmentVariables = userEnvVars.map((i) => this.apiConverter.toUserEnvironmentVariable(i));
+
+        return response;
+    }
+
+    async updateUserEnvironmentVariable(
+        req: UpdateUserEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<UpdateUserEnvironmentVariableResponse> {
+        if (!req.envVarId) {
+            throw new ConnectError("envVarId is not set", Code.InvalidArgument);
+        }
+
+        const response = new UpdateUserEnvironmentVariableResponse();
+
+        const userEnvVars = await this.envVarService.listUserEnvVars(context.user.id, context.user.id);
+        const userEnvVarfound = userEnvVars.find((i) => i.id === req.envVarId);
+        if (userEnvVarfound) {
+            const variable: UserEnvVarValue = {
+                name: req.name ?? userEnvVarfound.name,
+                value: req.value ?? userEnvVarfound.value,
+                repositoryPattern: req.repositoryPattern ?? userEnvVarfound.repositoryPattern,
+            };
+            variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
+
+            await this.envVarService.updateUserEnvVar(context.user.id, context.user.id, variable);
+
+            const updatedUserEnvVars = await this.envVarService.listUserEnvVars(context.user.id, context.user.id);
+            const updatedUserEnvVar = updatedUserEnvVars.find((i) => i.id === req.envVarId);
+            if (!updatedUserEnvVar) {
+                throw new ConnectError("could not update env variable", Code.Internal);
+            }
+
+            response.environmentVariable = this.apiConverter.toUserEnvironmentVariable(updatedUserEnvVar);
+            return response;
+        }
+
+        throw new ConnectError("env variable not found", Code.InvalidArgument);
+    }
+
+    async createUserEnvironmentVariable(
+        req: CreateUserEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<CreateUserEnvironmentVariableResponse> {
+        const response = new CreateUserEnvironmentVariableResponse();
+
+        const variable: UserEnvVarValue = {
+            name: req.name,
+            value: req.value,
+            repositoryPattern: req.repositoryPattern,
+        };
+        variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
+
+        await this.envVarService.addUserEnvVar(context.user.id, context.user.id, variable);
+
+        const updatedUserEnvVars = await this.envVarService.listUserEnvVars(context.user.id, context.user.id);
+        const updatedUserEnvVar = updatedUserEnvVars.find(
+            (v) => v.name === variable.name && v.repositoryPattern === variable.repositoryPattern,
+        );
+        if (!updatedUserEnvVar) {
+            throw new ConnectError("could not create env variable", Code.Internal);
+        }
+
+        response.environmentVariable = this.apiConverter.toUserEnvironmentVariable(updatedUserEnvVar);
+
+        return response;
+    }
+
+    async deleteUserEnvironmentVariable(
+        req: DeleteUserEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<DeleteUserEnvironmentVariableResponse> {
+        const variable: UserEnvVarValue = {
+            id: req.envVarId,
+            name: "",
+            value: "",
+            repositoryPattern: "",
+        };
+
+        await this.envVarService.deleteUserEnvVar(context.user.id, context.user.id, variable);
+
+        const response = new DeleteUserEnvironmentVariableResponse();
+        return response;
+    }
+
+    async listConfigurationEnvironmentVariables(
+        req: ListConfigurationEnvironmentVariablesRequest,
+        context: HandlerContext,
+    ): Promise<ListConfigurationEnvironmentVariablesResponse> {
+        const response = new ListConfigurationEnvironmentVariablesResponse();
+        const projectEnvVars = await this.envVarService.listProjectEnvVars(context.user.id, req.configurationId);
+        response.environmentVariables = projectEnvVars.map((i) =>
+            this.apiConverter.toConfigurationEnvironmentVariable(i),
+        );
+
+        return response;
+    }
+
+    async updateConfigurationEnvironmentVariable(
+        req: UpdateConfigurationEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<UpdateConfigurationEnvironmentVariableResponse> {
+        const response = new UpdateConfigurationEnvironmentVariableResponse();
+
+        const projectEnvVars = await this.envVarService.listProjectEnvVars(context.user.id, req.configurationId);
+        const projectEnvVarfound = projectEnvVars.find((i) => i.id === req.envVarId);
+        if (projectEnvVarfound) {
+            const variable: ProjectEnvVarWithValue = {
+                name: req.name ?? projectEnvVarfound.name,
+                value: "",
+                censored:
+                    (req.admission === EnvironmentVariableAdmission.PREBUILD ? true : false) ??
+                    projectEnvVarfound.censored,
+            };
+
+            await this.envVarService.updateProjectEnvVar(context.user.id, req.configurationId, variable);
+
+            const updatedProjectEnvVars = await this.envVarService.listProjectEnvVars(
+                context.user.id,
+                req.configurationId,
+            );
+            const updatedProjectEnvVar = updatedProjectEnvVars.find((i) => i.id === req.envVarId);
+            if (!updatedProjectEnvVar) {
+                throw new ConnectError("could not update env variable", Code.Internal);
+            }
+
+            response.environmentVariable = this.apiConverter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
+            return response;
+        }
+
+        throw new ConnectError("env variable not found", Code.InvalidArgument);
+    }
+
+    async createConfigurationEnvironmentVariable(
+        req: CreateConfigurationEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<CreateConfigurationEnvironmentVariableResponse> {
+        const response = new CreateConfigurationEnvironmentVariableResponse();
+
+        const variable: ProjectEnvVarWithValue = {
+            name: req.name,
+            value: req.value,
+            censored: req.admission === EnvironmentVariableAdmission.PREBUILD ? true : false,
+        };
+
+        await this.envVarService.addProjectEnvVar(context.user.id, req.configurationId, variable);
+
+        const updatedProjectEnvVars = await this.envVarService.listProjectEnvVars(context.user.id, req.configurationId);
+        const updatedProjectEnvVar = updatedProjectEnvVars.find((v) => v.name === variable.name);
+        if (!updatedProjectEnvVar) {
+            throw new ConnectError("could not create env variable", Code.Internal);
+        }
+
+        response.environmentVariable = this.apiConverter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
+
+        return response;
+    }
+
+    async deleteConfigurationEnvironmentVariable(
+        req: DeleteConfigurationEnvironmentVariableRequest,
+        context: HandlerContext,
+    ): Promise<DeleteConfigurationEnvironmentVariableResponse> {
+        await this.envVarService.deleteProjectEnvVar(context.user.id, req.envVarId);
+
+        const response = new DeleteConfigurationEnvironmentVariableResponse();
+        return response;
+    }
+
+    async resolveWorkspaceEnvironmentVariables(
+        req: ResolveWorkspaceEnvironmentVariablesRequest,
+        context: HandlerContext,
+    ): Promise<ResolveWorkspaceEnvironmentVariablesResponse> {
+        const response = new ResolveWorkspaceEnvironmentVariablesResponse();
+
+        const { workspace } = await this.workspaceService.getWorkspace(context.user.id, req.workspaceId);
+        const envVars = await this.envVarService.resolveEnvVariables(
+            workspace.ownerId,
+            workspace.projectId,
+            workspace.type,
+            workspace.context,
+        );
+
+        response.environmentVariables = envVars.workspace.map(
+            (i) =>
+                new ResolveWorkspaceEnvironmentVariablesResponse_EnvironmentVariable({ name: i.name, value: i.value }),
+        );
+
+        return response;
+    }
+}

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -72,6 +72,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         const userEnvVarfound = userEnvVars.find((i) => i.id === req.envVarId);
         if (userEnvVarfound) {
             const variable: UserEnvVarValue = {
+                id: req.envVarId,
                 name: req.name ?? userEnvVarfound.name,
                 value: req.value ?? userEnvVarfound.value,
                 repositoryPattern: req.repositoryPattern ?? userEnvVarfound.repositoryPattern,

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Code, ConnectError, HandlerContext, ServiceImpl } from "@connectrpc/connect";
+import { HandlerContext, ServiceImpl } from "@connectrpc/connect";
 import { EnvironmentVariableService as EnvironmentVariableServiceInterface } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
 import {
     ListUserEnvironmentVariablesRequest,
@@ -35,6 +35,7 @@ import { ProjectEnvVarWithValue, UserEnvVarValue } from "@gitpod/gitpod-protocol
 import { WorkspaceService } from "../workspace/workspace-service";
 import { ctxUserId } from "../util/request-context";
 import { validate as uuidValidate } from "uuid";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof EnvironmentVariableServiceInterface> {
@@ -63,7 +64,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         _: HandlerContext,
     ): Promise<UpdateUserEnvironmentVariableResponse> {
         if (!uuidValidate(req.envVarId)) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         const response = new UpdateUserEnvironmentVariableResponse();
@@ -84,7 +85,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
             return response;
         }
 
-        throw new ConnectError("env variable not found", Code.NotFound);
+        throw new ApplicationError(ErrorCodes.NOT_FOUND, "env variable not found");
     }
 
     async createUserEnvironmentVariable(
@@ -110,7 +111,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         _: HandlerContext,
     ): Promise<DeleteUserEnvironmentVariableResponse> {
         if (!uuidValidate(req.envVarId)) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         const variable: UserEnvVarValue = {
@@ -131,7 +132,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         _: HandlerContext,
     ): Promise<ListConfigurationEnvironmentVariablesResponse> {
         if (!uuidValidate(req.configurationId)) {
-            throw new ConnectError("configurationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "configurationId is required");
         }
 
         const response = new ListConfigurationEnvironmentVariablesResponse();
@@ -148,10 +149,10 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         _: HandlerContext,
     ): Promise<UpdateConfigurationEnvironmentVariableResponse> {
         if (!uuidValidate(req.configurationId)) {
-            throw new ConnectError("configurationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "configurationId is required");
         }
         if (!uuidValidate(req.envVarId)) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         const updatedProjectEnvVar = await this.envVarService.updateProjectEnvVar(ctxUserId(), req.configurationId, {
@@ -190,7 +191,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         _: HandlerContext,
     ): Promise<DeleteConfigurationEnvironmentVariableResponse> {
         if (!uuidValidate(req.envVarId)) {
-            throw new ConnectError("envVarId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "envVarId is required");
         }
 
         await this.envVarService.deleteProjectEnvVar(ctxUserId(), req.envVarId);

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -31,7 +31,7 @@ import {
 import { inject, injectable } from "inversify";
 import { EnvVarService } from "../user/env-var-service";
 import { PublicAPIConverter } from "@gitpod/gitpod-protocol/lib/public-api-converter";
-import { ProjectEnvVarWithValue, UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
+import { ProjectEnvVarWithValue, UserEnvVarValue } from "@gitpod/gitpod-protocol";
 import { WorkspaceService } from "../workspace/workspace-service";
 import { ctxUserId } from "../util/request-context";
 import { validate as uuidValidate } from "uuid";
@@ -97,7 +97,6 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
             value: req.value,
             repositoryPattern: req.repositoryPattern,
         };
-        variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
 
         const result = await this.envVarService.addUserEnvVar(ctxUserId(), ctxUserId(), variable);
         response.environmentVariable = this.apiConverter.toUserEnvironmentVariable(result);
@@ -154,8 +153,6 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
             throw new ConnectError("envVarId is required", Code.InvalidArgument);
         }
 
-        const response = new UpdateConfigurationEnvironmentVariableResponse();
-
         const updatedProjectEnvVar = await this.envVarService.updateProjectEnvVar(ctxUserId(), req.configurationId, {
             id: req.envVarId,
             censored: req.admission
@@ -165,6 +162,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
                 : undefined,
         });
 
+        const response = new UpdateConfigurationEnvironmentVariableResponse();
         response.environmentVariable = this.apiConverter.toConfigurationEnvironmentVariable(updatedProjectEnvVar);
         return response;
     }
@@ -173,8 +171,6 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         req: CreateConfigurationEnvironmentVariableRequest,
         _: HandlerContext,
     ): Promise<CreateConfigurationEnvironmentVariableResponse> {
-        const response = new CreateConfigurationEnvironmentVariableResponse();
-
         const variable: ProjectEnvVarWithValue = {
             name: req.name,
             value: req.value,
@@ -182,8 +178,9 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         };
 
         const result = await this.envVarService.addProjectEnvVar(ctxUserId(), req.configurationId, variable);
-        response.environmentVariable = this.apiConverter.toConfigurationEnvironmentVariable(result);
 
+        const response = new CreateConfigurationEnvironmentVariableResponse();
+        response.environmentVariable = this.apiConverter.toConfigurationEnvironmentVariable(result);
         return response;
     }
 

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -18,6 +18,7 @@ import { OrganizationService } from "@gitpod/public-api/lib/gitpod/v1/organizati
 import { WorkspaceService } from "@gitpod/public-api/lib/gitpod/v1/workspace_connect";
 import { ConfigurationService } from "@gitpod/public-api/lib/gitpod/v1/configuration_connect";
 import { AuthProviderService } from "@gitpod/public-api/lib/gitpod/v1/authprovider_connect";
+import { EnvironmentVariableService } from "@gitpod/public-api/lib/gitpod/v1/envvar_connect";
 import express from "express";
 import * as http from "http";
 import { decorate, inject, injectable, interfaces } from "inversify";
@@ -46,6 +47,7 @@ import { APIUserService as UserServiceAPI } from "./user";
 import { WorkspaceServiceAPI } from "./workspace-service-api";
 import { ConfigurationServiceAPI } from "./configuration-service-api";
 import { AuthProviderServiceAPI } from "./auth-provider-service-api";
+import { EnvironmentVariableServiceAPI } from "./envvar-service-api";
 import { Unauthenticated } from "./unauthenticated";
 import { SubjectId } from "../auth/subject-id";
 import { BearerAuth } from "../auth/bearer-authenticator";
@@ -64,6 +66,7 @@ export class API {
     @inject(OrganizationServiceAPI) private readonly organizationServiceApi: OrganizationServiceAPI;
     @inject(ConfigurationServiceAPI) private readonly configurationServiceApi: ConfigurationServiceAPI;
     @inject(AuthProviderServiceAPI) private readonly authProviderServiceApi: AuthProviderServiceAPI;
+    @inject(EnvironmentVariableServiceAPI) private readonly envvarServiceApi: EnvironmentVariableServiceAPI;
     @inject(StatsServiceAPI) private readonly tatsServiceApi: StatsServiceAPI;
     @inject(HelloServiceAPI) private readonly helloServiceApi: HelloServiceAPI;
     @inject(SessionHandler) private readonly sessionHandler: SessionHandler;
@@ -117,6 +120,7 @@ export class API {
                         service(OrganizationService, this.organizationServiceApi),
                         service(ConfigurationService, this.configurationServiceApi),
                         service(AuthProviderService, this.authProviderServiceApi),
+                        service(EnvironmentVariableService, this.envvarServiceApi),
                     ]) {
                         router.service(type, new Proxy(impl, this.interceptService(type)));
                     }
@@ -367,6 +371,7 @@ export class API {
         bind(OrganizationServiceAPI).toSelf().inSingletonScope();
         bind(ConfigurationServiceAPI).toSelf().inSingletonScope();
         bind(AuthProviderServiceAPI).toSelf().inSingletonScope();
+        bind(EnvironmentVariableServiceAPI).toSelf().inSingletonScope();
         bind(StatsServiceAPI).toSelf().inSingletonScope();
         bind(API).toSelf().inSingletonScope();
     }

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -28,6 +28,7 @@ import { OrganizationService } from "../orgs/organization-service";
 import { ProjectsService } from "../projects/projects-service";
 import { AuthProviderService } from "../auth/auth-provider-service";
 import { BearerAuth } from "../auth/bearer-authenticator";
+import { EnvVarService } from "../user/env-var-service";
 
 const expect = chai.expect;
 
@@ -53,6 +54,7 @@ export class APITeamsServiceSpec {
         this.container.bind(UserService).toConstantValue({} as UserService);
         this.container.bind(ProjectsService).toConstantValue({} as ProjectsService);
         this.container.bind(AuthProviderService).toConstantValue({} as AuthProviderService);
+        this.container.bind(EnvVarService).toConstantValue({} as EnvVarService);
 
         // Clean-up database
         const typeorm = testContainer.get<TypeORM>(TypeORM);

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -142,7 +142,11 @@ describe("EnvVarService", async () => {
         const resp1 = await es.listUserEnvVars(member.id, member.id);
         expect(resp1.length).to.equal(0);
 
-        await es.addUserEnvVar(member.id, member.id, { name: "var1", value: "foo", repositoryPattern: "*/*" });
+        const added1 = await es.addUserEnvVar(member.id, member.id, {
+            name: "var1",
+            value: "foo",
+            repositoryPattern: "*/*",
+        });
 
         const resp2 = await es.listUserEnvVars(member.id, member.id);
         expect(resp2.length).to.equal(1);
@@ -152,14 +156,23 @@ describe("EnvVarService", async () => {
             es.addUserEnvVar(member.id, member.id, { name: "var1", value: "foo2", repositoryPattern: "*/*" }),
         );
 
-        await es.updateUserEnvVar(member.id, member.id, { name: "var1", value: "foo2", repositoryPattern: "*/*" });
+        await es.updateUserEnvVar(member.id, member.id, {
+            ...added1,
+            name: "var1",
+            value: "foo2",
+            repositoryPattern: "*/*",
+        });
 
         const resp3 = await es.listUserEnvVars(member.id, member.id);
         expect(resp3.length).to.equal(1);
 
         await expectError(
-            ErrorCodes.BAD_REQUEST,
-            es.updateUserEnvVar(member.id, member.id, { name: "var2", value: "foo2", repositoryPattern: "*/*" }),
+            ErrorCodes.NOT_FOUND,
+            es.updateUserEnvVar(member.id, member.id, {
+                name: "var2",
+                value: "foo2",
+                repositoryPattern: "*/*",
+            }),
         );
 
         await expectError(ErrorCodes.NOT_FOUND, es.listUserEnvVars(stranger.id, member.id));
@@ -197,15 +210,15 @@ describe("EnvVarService", async () => {
     });
 
     it("should let owners create, update, delete and get project env vars", async () => {
-        await es.addProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR", censored: false });
+        const added1 = await es.addProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR", censored: false });
         await expectError(
             ErrorCodes.BAD_REQUEST,
             es.addProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR2", censored: false }),
         );
 
-        await es.updateProjectEnvVar(owner.id, project.id, { name: "FOO", value: "BAR2", censored: false });
+        await es.updateProjectEnvVar(owner.id, project.id, { ...added1, name: "FOO", value: "BAR2", censored: false });
         await expectError(
-            ErrorCodes.BAD_REQUEST,
+            ErrorCodes.NOT_FOUND,
             es.updateProjectEnvVar(owner.id, project.id, { name: "FOO2", value: "BAR", censored: false }),
         );
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1830,11 +1830,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkAndBlockUser("setEnvVar");
         const userEnvVars = await this.envVarService.listUserEnvVars(user.id, user.id);
         if (userEnvVars.find((v) => v.name == variable.name && v.repositoryPattern == variable.repositoryPattern)) {
-            return this.envVarService.updateUserEnvVar(user.id, user.id, variable, (envvar: UserEnvVar) => {
+            await this.envVarService.updateUserEnvVar(user.id, user.id, variable, (envvar: UserEnvVar) => {
                 return this.guardAccess({ kind: "envVar", subject: envvar }, "update");
             });
         } else {
-            return this.envVarService.addUserEnvVar(user.id, user.id, variable, (envvar: UserEnvVar) => {
+            await this.envVarService.addUserEnvVar(user.id, user.id, variable, (envvar: UserEnvVar) => {
                 return this.guardAccess({ kind: "envVar", subject: envvar }, "create");
             });
         }
@@ -1882,9 +1882,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         await this.guardProjectOperation(user, projectId, "update");
         const envVars = await this.envVarService.listProjectEnvVars(user.id, projectId);
         if (envVars.find((v) => v.name === name)) {
-            return this.envVarService.updateProjectEnvVar(user.id, projectId, { name, value, censored });
+            await this.envVarService.updateProjectEnvVar(user.id, projectId, { name, value, censored });
         } else {
-            return this.envVarService.addProjectEnvVar(user.id, projectId, { name, value, censored });
+            await this.envVarService.addProjectEnvVar(user.id, projectId, { name, value, censored });
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d8b9cb</samp>

This pull request adds a new public API service for managing user environment variables for workspaces. It defines the service and its messages using Protobuf, generates client and server code for gRPC and Connect in Go and TypeScript, and implements the service handler and client in the server and dashboard components. It also refactors the dashboard component for environment variables to use the new public API service.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- It should be able to CRUD env in `org`, `configuration` and `user` level
- Start workspace in `org`, envs in `org` + `user` should be in workspace
- Start workspace in `org` + `configuration`, envs in `org` + `configuration` + `user` should be in workspace
- Create a new `org`, there should only have `user` envs in workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-practical-guppy</li>
	<li><b>🔗 URL</b> - <a href="https://jp-practical-guppy.preview.gitpod-dev.com/workspaces" target="_blank">jp-practical-guppy.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-practical-guppy-gha.20044</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-practical-guppy%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
