### PR TITLE
Support disabling preemptible preview VMs

### DIFF
--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -29,6 +29,7 @@ TF_VAR_preview_name="$(previewctl get-name --branch "${INPUT_NAME}")"
 export TF_VAR_preview_name
 export TF_VAR_infra_provider="${INPUT_INFRASTRUCTURE_PROVIDER}"
 export TF_VAR_with_large_vm="${INPUT_LARGE_VM}"
+export TF_VAR_gce_use_spot="${INPUT_PREEMPTIBLE}"
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true
 leeway run dev/preview:create-preview

--- a/.github/actions/preview-create/metadata.yml
+++ b/.github/actions/preview-create/metadata.yml
@@ -11,6 +11,10 @@ inputs:
         description: "Whether to use a larger VM for the env"
         required: true
         default: false
+    preemptible:
+        description: "Whether to use preemptible VMs for the env"
+        required: true
+        default: true
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,6 +66,8 @@ gitpod:summary
 - [ ] /werft with-large-vm
 - [x] /werft with-gce-vm
       If enabled this will create the environment on GCE infra
+- [x] /werft preemptible
+      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
 - [ ] with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
 - [ ] with-monitoring

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       with_large_vm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft with-large-vm') || (steps.output.outputs.with_integration_tests != '') }}
       publish_to_npm: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-npm') }}
       publish_to_jbmp: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft publish-to-jb-marketplace') }}
+      with_preemptible: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft preemptible') }}
       with_dedicated_emulation: ${{ contains( steps.pr-details.outputs.pr_body, '[X] with-dedicated-emulation') }}
       analytics: ${{ steps.output.outputs.analytics }}
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
@@ -135,6 +136,7 @@ jobs:
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
           large_vm: ${{ needs.configuration.outputs.with_large_vm }}
+          preemptible: ${{ needs.configuration.outputs.with_preemptible }}
           recreate_vm: ${{ inputs.recreate_vm }}
 
   build-gitpod:


### PR DESCRIPTION
## Description
This PR adds support for disabling preemptible preview VMs. Doing so increases the cost for our preview environments, but buys us stability and a better developer experience.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 263b1cc</samp>

This pull request adds an option to use preemptible VMs for preview environments, which can reduce costs but also increase the risk of termination. It modifies the `.github/workflows/build.yml`, `.github/actions/preview-create/entrypoint.sh`, `.github/actions/preview-create/metadata.yml`, and `.github/pull_request_template.md` files to implement this option.

</details>

## How to test
- Untick the preemptible checkbox below
- Recreate the preview env using the GH action

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
