### PR TITLE
adding import repo modal

### DIFF
--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -88,3 +88,35 @@ export const getConfigurationQueryKey = (configurationId: string) => {
 
     return key;
 };
+
+export type CreateConfigurationArgs = {
+    name: string;
+    cloneUrl: string;
+};
+
+export const useCreateConfiguration = () => {
+    const { data: org } = useCurrentOrg();
+
+    return useMutation<Configuration, Error, CreateConfigurationArgs>({
+        mutationFn: async ({ name, cloneUrl }) => {
+            if (!org) {
+                throw new Error("No org currently selected");
+            }
+
+            // TODO: Should we push this into the api?
+            // ensure a .git suffix
+            const normalizedCloneURL = cloneUrl.endsWith(".git") ? cloneUrl : `${cloneUrl}.git`;
+
+            const response = await configurationClient.createConfiguration({
+                name,
+                cloneUrl: normalizedCloneURL,
+                organizationId: org.id,
+            });
+            if (!response.configuration) {
+                throw new Error("Failed to create configuration");
+            }
+
+            return response.configuration;
+        },
+    });
+};

--- a/components/dashboard/src/repositories/create/ImportRepositoryModal.tsx
+++ b/components/dashboard/src/repositories/create/ImportRepositoryModal.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC, useCallback, useState } from "react";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
+import { Button } from "../../components/Button";
+import { SuggestedRepository } from "@gitpod/gitpod-protocol";
+import RepositoryFinder from "../../components/RepositoryFinder";
+import { InputField } from "../../components/forms/InputField";
+import { AuthorizeGit, useNeedsGitAuthorization } from "../../components/AuthorizeGit";
+import { useTemporaryState } from "../../hooks/use-temporary-value";
+import { CreateConfigurationArgs, useCreateConfiguration } from "../../data/configurations/configuration-queries";
+import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+
+type Props = {
+    onCreated: (configuration: Configuration) => void;
+    onClose: () => void;
+};
+
+export const ImportRepositoryModal: FC<Props> = ({ onClose, onCreated }) => {
+    const needsGitAuth = useNeedsGitAuthorization();
+    const [selectedRepo, setSelectedRepo] = useState<SuggestedRepository>();
+    const createConfiguration = useCreateConfiguration();
+    const [createErrorMsg, setCreateErrorMsg] = useTemporaryState("", 3000);
+
+    const handleSubmit = useCallback(() => {
+        if (!selectedRepo) {
+            setCreateErrorMsg("Please select a repository");
+            return;
+        }
+
+        const newProjectArgs: CreateConfigurationArgs = {
+            // leave the name empty to let the backend generate the name
+            name: "",
+            cloneUrl: selectedRepo.url,
+        };
+
+        createConfiguration.mutate(newProjectArgs, {
+            onSuccess: onCreated,
+        });
+    }, [createConfiguration, onCreated, selectedRepo, setCreateErrorMsg]);
+
+    const errorMessage =
+        createErrorMsg ||
+        (createConfiguration.isError &&
+            (createConfiguration.error?.message ?? "There was a problem importing your repository"));
+
+    return (
+        <Modal visible onClose={onClose} onSubmit={handleSubmit}>
+            <ModalHeader>New Project</ModalHeader>
+            <ModalBody>
+                <div className="w-112 max-w-full">
+                    {needsGitAuth ? (
+                        <AuthorizeGit />
+                    ) : (
+                        <>
+                            <InputField label="Repository" className="mb-8 w-full">
+                                <RepositoryFinder
+                                    selectedContextURL={selectedRepo?.url}
+                                    selectedProjectID={selectedRepo?.projectId}
+                                    onChange={setSelectedRepo}
+                                    excludeProjects
+                                />
+                            </InputField>
+                        </>
+                    )}
+                </div>
+            </ModalBody>
+            <ModalFooter
+                alert={
+                    errorMessage && (
+                        <ModalFooterAlert type="danger" onClose={() => setCreateErrorMsg("")}>
+                            {errorMessage}
+                        </ModalFooterAlert>
+                    )
+                }
+            >
+                <Button type="secondary" onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button htmlType="submit" loading={createConfiguration.isLoading}>
+                    Create
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+};

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -7,8 +7,6 @@
 import { FC, useCallback, useEffect, useState } from "react";
 import { LoaderIcon } from "lucide-react";
 import { useHistory } from "react-router-dom";
-import { Project } from "@gitpod/gitpod-protocol";
-import { CreateProjectModal } from "../../projects/create-project-modal/CreateProjectModal";
 import { RepositoryListItem } from "./RepoListItem";
 import { useListConfigurations } from "../../data/configurations/configuration-queries";
 import { useStateWithDebounce } from "../../hooks/use-state-with-debounce";
@@ -19,6 +17,8 @@ import { Button } from "@podkit/buttons/Button";
 import { useDocumentTitle } from "../../hooks/use-document-title";
 import { PaginationControls, PaginationCountText } from "./PaginationControls";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@podkit/tables/Table";
+import { ImportRepositoryModal } from "../create/ImportRepositoryModal";
+import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 
 const RepositoryListPage: FC = () => {
     useDocumentTitle("Imported repositories");
@@ -51,9 +51,9 @@ const RepositoryListPage: FC = () => {
     const totalRows = data?.pagination?.total ?? 0;
     const totalPages = Math.ceil(totalRows / pageSize);
 
-    const handleProjectCreated = useCallback(
-        (project: Project) => {
-            history.push(`/repositories/${project.id}`);
+    const handleRepoImported = useCallback(
+        (configuration: Configuration) => {
+            history.push(`/repositories/${configuration.id}`);
         },
         [history],
     );
@@ -145,7 +145,10 @@ const RepositoryListPage: FC = () => {
             </div>
 
             {showCreateProjectModal && (
-                <CreateProjectModal onClose={() => setShowCreateProjectModal(false)} onCreated={handleProjectCreated} />
+                <ImportRepositoryModal
+                    onClose={() => setShowCreateProjectModal(false)}
+                    onCreated={handleRepoImported}
+                />
             )}
         </>
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This updates the import repository modal to diverge a bit from the existing new project modal so we can avoid having to evolve both at the same time. The new project modal will go away once we release the new configuration UIs.

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-880

## How to test
<!-- Provide steps to test this PR -->
* Navigation the Repositories under the org menu
* Click Import Repository
* Pick a rep and import
* Make sure it lands you on the General Settings page for the imported repo.
* Go back to the Imported repositories list and ensure it shows up there.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
