### PR TITLE
[gRPC] Enable PATs to be used for authorizing with the gRPC API

### DIFF
--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -27,6 +27,7 @@ import { Config } from "../config";
 import { OrganizationService } from "../orgs/organization-service";
 import { ProjectsService } from "../projects/projects-service";
 import { AuthProviderService } from "../auth/auth-provider-service";
+import { BearerAuth } from "../auth/bearer-authenticator";
 
 const expect = chai.expect;
 
@@ -45,6 +46,7 @@ export class APITeamsServiceSpec {
         this.container.bind(WorkspaceService).toConstantValue({} as WorkspaceService);
         this.container.bind(OrganizationService).toConstantValue({} as OrganizationService);
         this.container.bind(UserAuthentication).toConstantValue({} as UserAuthentication);
+        this.container.bind(BearerAuth).toConstantValue({} as BearerAuth);
         this.container.bind(SessionHandler).toConstantValue({} as SessionHandler);
         this.container.bind(Config).toConstantValue({} as Config);
         this.container.bind(Redis).toConstantValue({} as Redis);

--- a/components/server/src/auth/bearer-authenticator.spec.db.ts
+++ b/components/server/src/auth/bearer-authenticator.spec.db.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM, resetDB } from "@gitpod/gitpod-db/lib";
+import { BearerAuth, PersonalAccessToken } from "./bearer-authenticator";
+import { expect } from "chai";
+import { describe } from "mocha";
+import { Container } from "inversify";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { UserService } from "../user/user-service";
+import { User } from "@gitpod/gitpod-protocol";
+import { Config } from "../config";
+import { Request } from "express";
+import { WithResourceAccessGuard } from "./resource-access";
+import { WithFunctionAccessGuard } from "./function-access";
+import { fail } from "assert";
+import { SubjectId } from "./subject-id";
+
+function toDateTime(date: Date): string {
+    return date.toISOString().replace("T", " ").replace("Z", "");
+}
+
+describe("BearerAuth", () => {
+    let container: Container;
+    let bearerAuth: BearerAuth;
+    let userService: UserService;
+    let typeORM: TypeORM;
+    let testUser: User;
+
+    async function insertPat(userId: string, patId: string, scopes: string[] = ["function:*"]): Promise<string> {
+        const patValue = "someValue";
+        const signature = "V7BsZVjpMQRaWxS5XJE9r-Ovpxk2xT_bfFSmic4yW6g"; // depends on the value
+        const pat = new PersonalAccessToken("doesnotmatter", patValue);
+
+        const conn = await typeORM.getConnection();
+        await conn.query(
+            "INSERT d_b_personal_access_token (id, userId, hash, name, scopes, expirationTime, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [patId, userId, pat.hash(), patId, scopes, toDateTime(new Date("2030")), toDateTime(new Date())],
+        );
+        return `gitpod_pat_${signature}.${patValue}`;
+    }
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+        });
+        const oldConfig = container.get<Config>(Config);
+        container.rebind(Config).toDynamicValue((ctx) => {
+            return {
+                ...oldConfig,
+                patSigningKey: "super-duper-secret-pat-signing-key",
+            };
+        });
+        bearerAuth = container.get(BearerAuth);
+        userService = container.get<UserService>(UserService);
+        typeORM = container.get<TypeORM>(TypeORM);
+
+        testUser = await userService.createUser({
+            identity: {
+                authId: "gh-user-1",
+                authName: "testUser",
+                authProviderId: "public-github",
+            },
+        });
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+    });
+
+    it("authExpressRequest should successfully authenticate BearerToken (PAT)", async () => {
+        const pat1 = await insertPat(testUser.id, "pat-1");
+
+        const req = {
+            headers: {
+                authorization: `Bearer ${pat1}`,
+            },
+        } as Request;
+        await bearerAuth.authExpressRequest(req);
+
+        expect(req.user?.id).to.equal(testUser.id);
+        expect((req as WithResourceAccessGuard).resourceGuard).to.not.be.undefined;
+        expect((req as WithFunctionAccessGuard).functionGuard).to.not.be.undefined;
+    });
+
+    it("authExpressRequest should fail to authenticate with missing BearerToken in header", async () => {
+        await insertPat(testUser.id, "pat-1");
+
+        const req = {
+            headers: {
+                authorization: `Bearer `, // missing
+            },
+        } as Request;
+        await expectError(async () => bearerAuth.authExpressRequest(req), "missing bearer token header");
+    });
+
+    it("authExpressRequest should fail to authenticate with missing BearerToken from DB (PAT)", async () => {
+        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4";
+
+        const req = {
+            headers: {
+                authorization: `Bearer ${patNotStored}`,
+            },
+        } as Request;
+        await expectError(async () => bearerAuth.authExpressRequest(req), "cannot find token");
+    });
+
+    it("tryAuthFromHeaders should successfully authenticate BearerToken (PAT)", async () => {
+        const pat1 = await insertPat(testUser.id, "pat-1");
+
+        const headers = new Headers();
+        headers.set("authorization", `Bearer ${pat1}`);
+        const subjectId = await bearerAuth.tryAuthFromHeaders(headers);
+
+        expect(subjectId?.toString()).to.equal(SubjectId.fromUserId(testUser.id).toString());
+    });
+
+    it("tryAuthFromHeaders should return undefined with missing BearerToken in header", async () => {
+        await insertPat(testUser.id, "pat-1");
+
+        const headers = new Headers();
+        headers.set("authorization", `Bearer `); // missing
+        expect(await bearerAuth.tryAuthFromHeaders(headers)).to.be.undefined;
+    });
+
+    it("tryAuthFromHeaders should fail to authenticate with missing BearerToken from DB (PAT)", async () => {
+        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4";
+
+        const headers = new Headers();
+        headers.set("authorization", `Bearer ${patNotStored}`);
+        await expectError(async () => bearerAuth.tryAuthFromHeaders(headers), "cannot find token");
+    });
+
+    async function expectError(fun: () => Promise<any>, message: string) {
+        try {
+            await fun();
+            fail(`Expected error: ${message}`);
+        } catch (err) {}
+    }
+});

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -9,20 +9,24 @@ import { GitpodTokenType, User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as crypto from "crypto";
 import express from "express";
-import { IncomingHttpHeaders } from "http";
 import { inject, injectable } from "inversify";
 import { Config } from "../config";
-import { AllAccessFunctionGuard, ExplicitFunctionAccessGuard, WithFunctionAccessGuard } from "./function-access";
+import {
+    AllAccessFunctionGuard,
+    ExplicitFunctionAccessGuard,
+    FunctionAccessGuard,
+    WithFunctionAccessGuard,
+} from "./function-access";
 import { TokenResourceGuard, WithResourceAccessGuard } from "./resource-access";
 import { UserService } from "../user/user-service";
+import { SubjectId } from "./subject-id";
 
-export function getBearerToken(headers: IncomingHttpHeaders): string | undefined {
-    const authorizationHeader = headers["authorization"];
+export function getBearerToken(authorizationHeader: string | undefined | null): string | undefined {
     if (!authorizationHeader || !(typeof authorizationHeader === "string")) {
-        return;
+        return undefined;
     }
     if (!authorizationHeader.startsWith("Bearer ")) {
-        return;
+        return undefined;
     }
 
     return authorizationHeader.substring("Bearer ".length);
@@ -51,7 +55,7 @@ export class BearerAuth {
     get restHandler(): express.RequestHandler {
         return async (req, res, next) => {
             try {
-                await this.auth(req);
+                await this.authExpressRequest(req);
             } catch (e) {
                 if (isBearerAuthError(e)) {
                     // (AT) while investigating https://github.com/gitpod-io/gitpod/issues/8703 we
@@ -71,7 +75,7 @@ export class BearerAuth {
     get restHandlerOptionally(): express.RequestHandler {
         return async (req, res, next) => {
             try {
-                await this.auth(req);
+                await this.authExpressRequest(req);
             } catch (e) {
                 // don't error the request, we just have not bearer authentication token
             }
@@ -79,8 +83,8 @@ export class BearerAuth {
         };
     }
 
-    async auth(req: express.Request): Promise<void> {
-        const token = getBearerToken(req.headers);
+    async authExpressRequest(req: express.Request): Promise<void> {
+        const token = getBearerToken(req.headers["authorization"]);
         if (!token) {
             throw createBearerAuthError("missing Bearer token");
         }
@@ -90,10 +94,8 @@ export class BearerAuth {
         const resourceGuard = new TokenResourceGuard(user.id, scopes);
         (req as WithResourceAccessGuard).resourceGuard = resourceGuard;
 
-        const functionScopes = scopes
-            .filter((s) => s.startsWith("function:"))
-            .map((s) => s.substring("function:".length));
-        if (functionScopes.length === 1 && functionScopes[0] === "*") {
+        const { isAllAccessFunctionGuard, functionScopes } = FunctionAccessGuard.extractFunctionScopes(scopes);
+        if (isAllAccessFunctionGuard) {
             (req as WithFunctionAccessGuard).functionGuard = new AllAccessFunctionGuard();
         } else {
             // We always install a function access guard. If the token has no scopes, it's not allowed to do anything.
@@ -101,6 +103,22 @@ export class BearerAuth {
         }
 
         req.user = user;
+    }
+
+    async tryAuthFromHeaders(headers: Headers): Promise<SubjectId | undefined> {
+        const token = getBearerToken(headers.get("authorization"));
+        if (!token) {
+            return undefined;
+        }
+        const { user, scopes } = await this.userAndScopesFromToken(token);
+
+        // gpl: Once we move PAT to FGA-backed scopes, this special case will go away, and covered by a different SubjectIdKind.
+        const { isAllAccessFunctionGuard } = FunctionAccessGuard.extractFunctionScopes(scopes);
+        if (!isAllAccessFunctionGuard) {
+            return undefined;
+        }
+
+        return SubjectId.fromUserId(user.id);
     }
 
     private async userAndScopesFromToken(token: string): Promise<{ user: User; scopes: string[] }> {

--- a/components/server/src/auth/function-access.ts
+++ b/components/server/src/auth/function-access.ts
@@ -10,6 +10,19 @@ export interface FunctionAccessGuard {
     canAccess(name: string): boolean;
 }
 
+export namespace FunctionAccessGuard {
+    export function extractFunctionScopes(scopes: string[]): {
+        functionScopes: string[];
+        isAllAccessFunctionGuard: boolean;
+    } {
+        const functionScopes = scopes
+            .filter((s) => s.startsWith("function:"))
+            .map((s) => s.substring("function:".length));
+        const isAllAccessFunctionGuard = functionScopes.length === 1 && functionScopes[0] === "*";
+        return { functionScopes, isAllAccessFunctionGuard };
+    }
+}
+
 export interface WithFunctionAccessGuard {
     functionGuard?: FunctionAccessGuard;
 }

--- a/components/server/src/auth/personal-access-token.spec.ts
+++ b/components/server/src/auth/personal-access-token.spec.ts
@@ -4,23 +4,20 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { suite, test } from "@testdeck/mocha";
 import { PersonalAccessToken } from "./bearer-authenticator";
 import { expect } from "chai";
+import { describe } from "mocha";
 
-@suite()
-class TestPersonalAccessToken {
-    @test
-    test_parse_token_ok() {
+describe("PersonalAccessToken", () => {
+    it("should parse token successfully", () => {
         const token = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4." + "test".repeat(10);
 
         const parsed = PersonalAccessToken.parse(token);
         const expected = new PersonalAccessToken("GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4", "test".repeat(10));
         expect(parsed).to.deep.equal(expected);
-    }
+    });
 
-    @test
-    test_parse_token_throws() {
+    it("should parse token and throw an error", () => {
         const tokens = [
             "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4.", // no value
             `gitpod_pat_.${"test".repeat(10)}`, // no signature
@@ -30,7 +27,5 @@ class TestPersonalAccessToken {
         tokens.forEach((token) => {
             expect(() => PersonalAccessToken.parse(token)).to.throw();
         });
-    }
-}
-
-module.exports = new TestPersonalAccessToken();
+    });
+});

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -503,11 +503,13 @@ export class Authorizer {
     }
 }
 
-export async function isFgaChecksEnabled(userId: string): Promise<boolean> {
+export async function isFgaChecksEnabled(userId: string | undefined): Promise<boolean> {
     return getExperimentsClientForBackend().getValueAsync("centralizedPermissions", false, {
-        user: {
-            id: userId,
-        },
+        user: userId
+            ? {
+                  id: userId,
+              }
+            : undefined,
     });
 }
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -191,7 +191,7 @@ export class Server {
                     }
 
                     try {
-                        await this.bearerAuth.auth(info.req as express.Request);
+                        await this.bearerAuth.authExpressRequest(info.req as express.Request);
                         authenticatedUsingBearerToken = true;
                     } catch (e) {
                         if (isBearerAuthError(e)) {

--- a/dev/gpctl/cmd/public-api-workspace.go
+++ b/dev/gpctl/cmd/public-api-workspace.go
@@ -9,8 +9,9 @@ import (
 )
 
 var publicApiWorkspacesCmd = &cobra.Command{
-	Use:   "workspaces",
-	Short: "Interact with workspaces through the public-API",
+	Use:     "workspaces",
+	Aliases: []string{"ws"},
+	Short:   "Interact with workspaces through the public-API",
 }
 
 func init() {

--- a/dev/gpctl/cmd/public-api-workspaces-list.go
+++ b/dev/gpctl/cmd/public-api-workspaces-list.go
@@ -6,30 +6,36 @@ package cmd
 
 import (
 	"github.com/gitpod-io/gitpod/common-go/log"
-	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/v1"
+	v1connect "github.com/gitpod-io/gitpod/components/public-api/go/v1/v1connect"
 	"github.com/spf13/cobra"
 )
 
 var publicApiWorkspacesListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List your workspaces",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List your workspaces",
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		conn, err := newPublicAPIConn()
+		organizationID := args[0]
+
+		httpClient, address, opts, err := newConnectHttpClient()
 		if err != nil {
 			log.Log.WithError(err).Fatal()
 		}
 
-		service := v1.NewWorkspacesServiceClient(conn)
+		service := v1connect.NewWorkspaceServiceClient(httpClient, address, opts...)
 
-		resp, err := service.ListWorkspaces(cmd.Context(), &v1.ListWorkspacesRequest{})
+		cResp, err := service.ListWorkspaces(cmd.Context(), wrapReq(&v1.ListWorkspacesRequest{OrganizationId: organizationID}))
 		if err != nil {
 			log.WithError(err).Fatal("failed to retrieve workspace list")
 			return
 		}
+		resp := cResp.Msg
 
-		tpl := `ID	Owner	ContextURL	InstanceID	InstanceStatus
-{{- range .Result }}
-{{ .WorkspaceId }}	{{ .OwnerId }}	{{ .Context.ContextUrl }}	{{ .Status.Instance.InstanceId}}	{{ .Status.Instance.Status.Phase}}
+		tpl := `ID	OrganizationID	ContextURL	InstanceID	InstanceStatus
+{{- range .Workspaces }}
+{{ .Id }}	{{ .OrganizationId }}	{{ .ContextUrl }}	{{ .Status.InstanceId }}	{{ .Status.Phase.Name }}
 {{ end }}
 `
 		err = getOutputFormat(tpl, "{..id}").Print(resp)

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -27,6 +27,8 @@ require (
 	k8s.io/client-go v0.27.3
 )
 
+require github.com/bufbuild/connect-go v1.10.0
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect

--- a/dev/gpctl/go.sum
+++ b/dev/gpctl/go.sum
@@ -13,6 +13,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bufbuild/connect-go v1.10.0 h1:QAJ3G9A1OYQW2Jbk3DeoJbkCxuKArrvZgDt47mjdTbg=
+github.com/bufbuild/connect-go v1.10.0/go.mod h1:CAIePUgkDR5pAFaylSMtNK45ANQjp9JvpluG20rhpV8=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
## Description
~Blocked by/based on: https://github.com/gitpod-io/gitpod/pull/19023~

Adds the ability to call the gRPC API with a PAT token. This works because PATs at the moment only supporting two "scopes":
  - all functions
  - nothing

Only if the "all functions" are allowed, we accept it for the gRPC API.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a29e3ea</samp>

This pull request enhances the bearer token authentication and authorization logic for different kinds of subjects, such as users and tokens. It adds a new SubjectId class to represent subjects, a new extractFunctionScopes method to handle function scopes, and a new authExpressRequest method to authenticate express requests. It also renames and refactors some existing methods and functions for clarity and consistency. The affected files are `server.ts`, `bearer-authenticator.ts`, `function-access.ts`, and `authorizer.ts`.

</details>

## Related Issue(s)
Fixes EXP-897

## How to test
 - login
 - create a PAT token
 - open a workspace on this PR
 - `dev/gpctl`
 - `export GPCTL_PUBLICAPI_TOKEN=<your pat>`
 - `go run main.go api ws ls <an org id> --address gpl-897-pat-api.preview.gitpod-dev.com` :heavy_check_mark: 
 - `go run main.go api ws get <ws id> --address gpl-897-pat-api.preview.gitpod-dev.com` :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-897-pat-api</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-897-pat-api.preview.gitpod-dev.com/workspaces" target="_blank">gpl-897-pat-api.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-897-pat-api-gha.20224</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-897-pat-api%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
