### PR TITLE
[common-go] fix incorrect log level

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -106,6 +106,10 @@ func (l *configCatLogger) GetLevel() configcat.LogLevel {
 	return configcat.LogLevelError
 }
 
+func (l *configCatLogger) Debugf(format string, args ...interface{}) {}
+func (l *configCatLogger) Infof(format string, args ...interface{})  {}
+func (l *configCatLogger) Warnf(format string, args ...interface{})  {}
+
 func logField(experimentName, value interface{}) logrus.Fields {
 	return logrus.Fields{
 		fmt.Sprintf("experiments.%s", experimentName): value,

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -12,7 +12,6 @@ import (
 
 	configcat "github.com/configcat/go-sdk/v7"
 	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/sirupsen/logrus"
 )
 
 type Client interface {
@@ -90,13 +89,11 @@ func NewClient(opts ...ClientOpt) Client {
 		}
 		return NewAlwaysReturningDefaultValueClient()
 	}
-	logger := log.Log.Dup()
-	logger.Logger.SetLevel(logrus.ErrorLevel)
 	return newConfigCatClient(configcat.Config{
 		SDKKey:       opt.sdkKey,
 		BaseURL:      opt.baseURL,
 		PollInterval: opt.pollInterval,
 		HTTPTimeout:  3 * time.Second,
-		Logger:       &configCatLogger{logger},
+		Logger:       &configCatLogger{log.Log},
 	})
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

https://github.com/gitpod-io/gitpod/pull/19060 This PR will affect all log levels, because log.Log.Dup itself only duplicates the entry and does not duplicate the logger. Therefore, setting the log level on the logger will lead to an impact on the entire logic of logging.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 64f1c5a</samp>

Simplify logging code in `experiments` package and suppress configcat SDK messages.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
