### PR TITLE
[proxy] Expose v1 api on api. subdomain

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -127,7 +127,6 @@
 }
 
 (server_public_api) {
-	# TODO(ak) verify that it only enabled for json content-type, not grpc
 	import compression
 
 	reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3001 {

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -127,7 +127,6 @@
 }
 
 (server_public_api) {
-	uri strip_prefix /public-api
 	# TODO(ak) verify that it only enabled for json content-type, not grpc
 	import compression
 
@@ -174,6 +173,10 @@ api.{$GITPOD_DOMAIN} {
 		allowed_origins https://{$GITPOD_DOMAIN}
 	}
 
+	handle /gitpod.v1.* {
+		import server_public_api
+	}
+
 	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 }
 
@@ -212,11 +215,15 @@ https://{$GITPOD_DOMAIN} {
 
 	@proxy_server_public_api path /public-api/gitpod.experimental.v1.HelloService*
 	handle @proxy_server_public_api {
+		uri strip_prefix /public-api
+
 		import server_public_api
 	}
 
 	@proxy_server_public_api_2 path /public-api/gitpod.v1.*
 	handle @proxy_server_public_api_2 {
+		uri strip_prefix /public-api
+
 		import server_public_api
 	}
 

--- a/dev/gpctl/cmd/public-api-workspaces-get.go
+++ b/dev/gpctl/cmd/public-api-workspaces-get.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/v1"
-	v1connect "github.com/gitpod-io/gitpod/components/public-api/go/v1/v1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -18,20 +17,19 @@ var publicApiWorkspacesGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		workspaceID := args[0]
 
-		httpClient, address, opts, err := newConnectHttpClient()
+		conn, err := newPublicAPIConn()
 		if err != nil {
 			log.Log.WithError(err).Fatal()
 		}
 
-		service := v1connect.NewWorkspaceServiceClient(httpClient, address, opts...)
+		service := v1.NewWorkspaceServiceClient(conn)
 
 		log.Log.Debugf("Retrieving workspace ID: %s", workspaceID)
-		cResp, err := service.GetWorkspace(cmd.Context(), wrapReq(&v1.GetWorkspaceRequest{WorkspaceId: workspaceID}))
+		resp, err := service.GetWorkspace(cmd.Context(), &v1.GetWorkspaceRequest{WorkspaceId: workspaceID})
 		if err != nil {
 			log.WithError(err).Fatalf("failed to retrieve workspace (ID: %s)", workspaceID)
 			return
 		}
-		resp := cResp.Msg
 
 		tpl := `ID:	{{ .Workspace.Id }}
 OrganizationID:	{{ .Workspace.OrganizationId }}

--- a/dev/gpctl/cmd/public-api-workspaces-list.go
+++ b/dev/gpctl/cmd/public-api-workspaces-list.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/v1"
-	v1connect "github.com/gitpod-io/gitpod/components/public-api/go/v1/v1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -19,19 +18,18 @@ var publicApiWorkspacesListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		organizationID := args[0]
 
-		httpClient, address, opts, err := newConnectHttpClient()
+		conn, err := newPublicAPIConn()
 		if err != nil {
 			log.Log.WithError(err).Fatal()
 		}
 
-		service := v1connect.NewWorkspaceServiceClient(httpClient, address, opts...)
+		service := v1.NewWorkspaceServiceClient(conn)
 
-		cResp, err := service.ListWorkspaces(cmd.Context(), wrapReq(&v1.ListWorkspacesRequest{OrganizationId: organizationID}))
+		resp, err := service.ListWorkspaces(cmd.Context(), &v1.ListWorkspacesRequest{OrganizationId: organizationID})
 		if err != nil {
 			log.WithError(err).Fatal("failed to retrieve workspace list")
 			return
 		}
-		resp := cResp.Msg
 
 		tpl := `ID	OrganizationID	ContextURL	InstanceID	InstanceStatus
 {{- range .Workspaces }}

--- a/dev/gpctl/cmd/public-api.go
+++ b/dev/gpctl/cmd/public-api.go
@@ -8,11 +8,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"net/http"
 	"os"
-	"strings"
 
-	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -71,37 +68,4 @@ func newPublicAPIConn() (*grpc.ClientConn, error) {
 	}
 
 	return conn, nil
-}
-
-type connectHttpTransport struct {
-	token string
-}
-
-func (t *connectHttpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Path = "/public-api" + req.URL.Path
-	req.Header.Add("authorization", fmt.Sprintf("Bearer %s", t.token))
-	return http.DefaultTransport.RoundTrip(req)
-}
-
-func newConnectHttpClient() (client connect.HTTPClient, address string, opts []connect.ClientOption, err error) {
-	if publicApiCmdOpts.address == "" {
-		return nil, "", nil, fmt.Errorf("empty connection address")
-	}
-	address = publicApiCmdOpts.address
-	if !strings.Contains(publicApiCmdOpts.address, "://") {
-		address = "https://" + address
-	}
-
-	if publicApiCmdOpts.token == "" {
-		return nil, "", nil, fmt.Errorf("empty connection token. Use --token or GPCTL_PUBLICAPI_TOKEN to provide one.")
-	}
-	opts = []connect.ClientOption{
-		connect.WithProtoJSON(),
-	}
-	client = &http.Client{Transport: &connectHttpTransport{token: publicApiCmdOpts.token}}
-	return client, address, opts, nil
-}
-
-func wrapReq[T any](req *T) *connect.Request[T] {
-	return &connect.Request[T]{Msg: req}
 }


### PR DESCRIPTION
## Description
Exposes the `v1` API on `api.gitpod.io`. This allows regular gRPC clients to access it, because it's serve on the root. The old route at `gitpod.io/public-api` is kept for now as well.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d3254de</samp>

This pull request improves the proxy configuration for the Gitpod API and supervisor frontend. It adds support for `new-api` and `supervisor` prefixes and simplifies the `Caddyfile`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-940

## How to test
 - login
 - create a PAT
 - start a workspace (so we see sth on the API)
 - open workspace on this branch
 - `cd dev/gpctl`
```
go run main.go api ws ls <your orgId> --address api.gpl-940-grpc.preview.gitpod-dev.com:443 --token <your token>
ID        OrganizationID        ContextURL        InstanceID        InstanceStatus
```
:heavy_check_mark: 
```
go run main.go api ws get <workspaceId> -
-address api.gpl-940-grpc.preview.gitpod-dev.com:443 --token <your token>
```
:heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-940-grpc</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-940-grpc.preview.gitpod-dev.com/workspaces" target="_blank">gpl-940-grpc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-940-grpc-gha.20323</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-940-grpc%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
