### PR TITLE
[server/dashboard] use ApplicationError

### DIFF
--- a/components/dashboard/src/service/json-rpc-authprovider-client.ts
+++ b/components/dashboard/src/service/json-rpc-authprovider-client.ts
@@ -5,7 +5,7 @@
  */
 
 import { PartialMessage } from "@bufbuild/protobuf";
-import { Code, ConnectError, PromiseClient } from "@connectrpc/connect";
+import { PromiseClient } from "@connectrpc/connect";
 import { AuthProviderService } from "@gitpod/public-api/lib/gitpod/v1/authprovider_connect";
 import {
     CreateAuthProviderRequest,
@@ -23,6 +23,7 @@ import {
 } from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
 import { converter } from "./public-api";
 import { getGitpodService } from "./service";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProviderService> {
     async createAuthProvider(request: PartialMessage<CreateAuthProviderRequest>): Promise<CreateAuthProviderResponse> {
@@ -30,13 +31,13 @@ export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProvi
         const organizationId = request.owner?.case === "organizationId" ? request.owner.value : undefined;
 
         if (!organizationId && !ownerId) {
-            throw new ConnectError("organizationId or ownerId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId or ownerId is required");
         }
         if (!request.type) {
-            throw new ConnectError("type is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "type is required");
         }
         if (!request.host) {
-            throw new ConnectError("host is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "host is required");
         }
 
         if (organizationId) {
@@ -64,12 +65,12 @@ export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProvi
             return new CreateAuthProviderResponse({ authProvider: converter.toAuthProvider(result) });
         }
 
-        throw new ConnectError("organizationId or ownerId is required", Code.InvalidArgument);
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId or ownerId is required");
     }
 
     async getAuthProvider(request: PartialMessage<GetAuthProviderRequest>): Promise<GetAuthProviderResponse> {
         if (!request.authProviderId) {
-            throw new ConnectError("authProviderId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "authProviderId is required");
         }
 
         const provider = await getGitpodService().server.getAuthProvider(request.authProviderId);
@@ -80,13 +81,13 @@ export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProvi
 
     async listAuthProviders(request: PartialMessage<ListAuthProvidersRequest>): Promise<ListAuthProvidersResponse> {
         if (!request.id?.case) {
-            throw new ConnectError("id is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "id is required");
         }
         const organizationId = request.id.case === "organizationId" ? request.id.value : undefined;
         const userId = request.id.case === "userId" ? request.id.value : undefined;
 
         if (!organizationId && !userId) {
-            throw new ConnectError("organizationId or userId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId or userId is required");
         }
 
         const authProviders = !!organizationId
@@ -111,12 +112,12 @@ export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProvi
 
     async updateAuthProvider(request: PartialMessage<UpdateAuthProviderRequest>): Promise<UpdateAuthProviderResponse> {
         if (!request.authProviderId) {
-            throw new ConnectError("authProviderId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "authProviderId is required");
         }
         const clientId = request?.clientId || "";
         const clientSecret = request?.clientSecret || "";
         if (!clientId && !clientSecret) {
-            throw new ConnectError("clientId or clientSecret are required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "clientId or clientSecret are required");
         }
 
         const entry = await getGitpodService().server.updateAuthProvider(request.authProviderId, {
@@ -130,7 +131,7 @@ export class JsonRpcAuthProviderClient implements PromiseClient<typeof AuthProvi
 
     async deleteAuthProvider(request: PartialMessage<DeleteAuthProviderRequest>): Promise<DeleteAuthProviderResponse> {
         if (!request.authProviderId) {
-            throw new ConnectError("authProviderId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "authProviderId is required");
         }
         await getGitpodService().server.deleteAuthProvider(request.authProviderId);
         return new DeleteAuthProviderResponse();

--- a/components/dashboard/src/service/json-rpc-organization-client.ts
+++ b/components/dashboard/src/service/json-rpc-organization-client.ts
@@ -5,7 +5,7 @@
  */
 
 import { PartialMessage } from "@bufbuild/protobuf";
-import { CallOptions, Code, ConnectError, PromiseClient } from "@connectrpc/connect";
+import { CallOptions, PromiseClient } from "@connectrpc/connect";
 import { OrganizationService } from "@gitpod/public-api/lib/gitpod/v1/organization_connect";
 import {
     CreateOrganizationRequest,
@@ -37,6 +37,7 @@ import {
 } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
 import { getGitpodService } from "./service";
 import { converter } from "./public-api";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export class JsonRpcOrganizationClient implements PromiseClient<typeof OrganizationService> {
     async createOrganization(
@@ -44,7 +45,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<CreateOrganizationResponse> {
         if (!request.name) {
-            throw new ConnectError("name is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "name is required");
         }
         const result = await getGitpodService().server.createTeam(request.name);
         return new CreateOrganizationResponse({
@@ -57,7 +58,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<GetOrganizationResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("id is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "id is required");
         }
         const result = await getGitpodService().server.getTeam(request.organizationId);
 
@@ -71,10 +72,10 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<UpdateOrganizationResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (!request.name) {
-            throw new ConnectError("name is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "name is required");
         }
         await getGitpodService().server.updateTeam(request.organizationId, {
             name: request.name,
@@ -97,7 +98,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<DeleteOrganizationResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         await getGitpodService().server.deleteTeam(request.organizationId);
         return new DeleteOrganizationResponse();
@@ -108,7 +109,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<GetOrganizationInvitationResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         const result = await getGitpodService().server.getGenericInvite(request.organizationId);
         return new GetOrganizationInvitationResponse({
@@ -121,7 +122,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<JoinOrganizationResponse> {
         if (!request.invitationId) {
-            throw new ConnectError("invitationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "invitationId is required");
         }
         const result = await getGitpodService().server.joinTeam(request.invitationId);
         return new JoinOrganizationResponse({
@@ -134,7 +135,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<ResetOrganizationInvitationResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         const newInvite = await getGitpodService().server.resetGenericInvite(request.organizationId);
         return new ResetOrganizationInvitationResponse({
@@ -147,7 +148,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<ListOrganizationMembersResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         const result = await getGitpodService().server.getTeamMembers(request.organizationId);
         return new ListOrganizationMembersResponse({
@@ -160,13 +161,13 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<UpdateOrganizationMemberResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (!request.userId) {
-            throw new ConnectError("userId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "userId is required");
         }
         if (!request.role) {
-            throw new ConnectError("role is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "role is required");
         }
         await getGitpodService().server.setTeamMemberRole(
             request.organizationId,
@@ -181,10 +182,10 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<DeleteOrganizationMemberResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (!request.userId) {
-            throw new ConnectError("userId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "userId is required");
         }
         await getGitpodService().server.removeTeamMember(request.organizationId, request.userId);
         return new DeleteOrganizationMemberResponse();
@@ -195,7 +196,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<GetOrganizationSettingsResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         const result = await getGitpodService().server.getOrgSettings(request.organizationId);
         return new GetOrganizationSettingsResponse({
@@ -208,7 +209,7 @@ export class JsonRpcOrganizationClient implements PromiseClient<typeof Organizat
         options?: CallOptions | undefined,
     ): Promise<UpdateOrganizationSettingsResponse> {
         if (!request.organizationId) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         await getGitpodService().server.updateOrgSettings(request.organizationId, {
             workspaceSharingDisabled: request?.workspaceSharingDisabled,

--- a/components/dashboard/src/service/json-rpc-workspace-client.ts
+++ b/components/dashboard/src/service/json-rpc-workspace-client.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { CallOptions, Code, ConnectError, PromiseClient } from "@connectrpc/connect";
+import { CallOptions, PromiseClient } from "@connectrpc/connect";
 import { PartialMessage } from "@bufbuild/protobuf";
 import { WorkspaceService } from "@gitpod/public-api/lib/gitpod/v1/workspace_connect";
 import {
@@ -22,11 +22,12 @@ import { generateAsyncGenerator } from "@gitpod/gitpod-protocol/lib/generate-asy
 import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { parsePagination } from "@gitpod/gitpod-protocol/lib/public-api-pagination";
 import { validate as uuidValidate } from "uuid";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export class JsonRpcWorkspaceClient implements PromiseClient<typeof WorkspaceService> {
     async getWorkspace(request: PartialMessage<GetWorkspaceRequest>): Promise<GetWorkspaceResponse> {
         if (!request.workspaceId) {
-            throw new ConnectError("workspaceId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
         }
         const info = await getGitpodService().server.getWorkspace(request.workspaceId);
         const workspace = converter.toWorkspace(info);
@@ -40,7 +41,7 @@ export class JsonRpcWorkspaceClient implements PromiseClient<typeof WorkspaceSer
         options?: CallOptions,
     ): AsyncIterable<WatchWorkspaceStatusResponse> {
         if (!options?.signal) {
-            throw new ConnectError("signal is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "signal is required");
         }
         if (request.workspaceId) {
             const resp = await this.getWorkspace({ workspaceId: request.workspaceId });
@@ -91,7 +92,7 @@ export class JsonRpcWorkspaceClient implements PromiseClient<typeof WorkspaceSer
         _options?: CallOptions,
     ): Promise<ListWorkspacesResponse> {
         if (!request.organizationId || !uuidValidate(request.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         const { limit } = parsePagination(request.pagination, 50);
         let resultTotal = 0;

--- a/components/server/src/api/organization-service-api.ts
+++ b/components/server/src/api/organization-service-api.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Code, ConnectError, HandlerContext, ServiceImpl } from "@connectrpc/connect";
+import { HandlerContext, ServiceImpl } from "@connectrpc/connect";
 import { inject, injectable } from "inversify";
 import { OrganizationService as OrganizationServiceInterface } from "@gitpod/public-api/lib/gitpod/v1/organization_connect";
 import {
@@ -67,7 +67,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
 
     async getOrganization(req: GetOrganizationRequest, _: HandlerContext): Promise<GetOrganizationResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const org = await this.orgService.getOrganization(ctxUserId(), req.organizationId);
@@ -78,10 +78,10 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
 
     async updateOrganization(req: UpdateOrganizationRequest, _: HandlerContext): Promise<UpdateOrganizationResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (typeof req.name !== "string") {
-            throw new ConnectError("nothing to update", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "nothing to update");
         }
 
         const org = await this.orgService.updateOrganization(ctxUserId(), req.organizationId, {
@@ -110,7 +110,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
 
     async deleteOrganization(req: DeleteOrganizationRequest, _: HandlerContext): Promise<DeleteOrganizationResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         await this.orgService.deleteOrganization(ctxUserId(), req.organizationId);
@@ -122,7 +122,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<GetOrganizationInvitationResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const invitation = await this.orgService.getOrCreateInvite(ctxUserId(), req.organizationId);
@@ -133,7 +133,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
 
     async joinOrganization(req: JoinOrganizationRequest, _: HandlerContext): Promise<JoinOrganizationResponse> {
         if (!uuidValidate(req.invitationId)) {
-            throw new ConnectError("invitationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "invitationId is required");
         }
 
         const orgId = await this.orgService.joinOrganization(ctxUserId(), req.invitationId);
@@ -147,7 +147,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<ResetOrganizationInvitationResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const inviteId = await this.orgService.resetInvite(ctxUserId(), req.organizationId);
@@ -161,7 +161,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<ListOrganizationMembersResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const members = await this.orgService.listMembers(ctxUserId(), req.organizationId);
@@ -178,13 +178,13 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<UpdateOrganizationMemberResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (!uuidValidate(req.userId)) {
-            throw new ConnectError("userId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "userId is required");
         }
         if (req.role === undefined) {
-            throw new ConnectError("nothing to update", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "nothing to update");
         }
 
         await this.orgService.addOrUpdateMember(
@@ -206,10 +206,10 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<DeleteOrganizationMemberResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
         if (!uuidValidate(req.userId)) {
-            throw new ConnectError("userId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "userId is required");
         }
 
         await this.orgService.removeOrganizationMember(ctxUserId(), req.organizationId, req.userId);
@@ -221,7 +221,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<GetOrganizationSettingsResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const settings = await this.orgService.getSettings(ctxUserId(), req.organizationId);
@@ -235,7 +235,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         _: HandlerContext,
     ): Promise<UpdateOrganizationSettingsResponse> {
         if (!uuidValidate(req.organizationId)) {
-            throw new ConnectError("organizationId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
         }
 
         const update: Partial<ProtocolOrganizationSettings> = {};
@@ -247,7 +247,7 @@ export class OrganizationServiceAPI implements ServiceImpl<typeof OrganizationSe
         }
 
         if (Object.keys(update).length === 0) {
-            throw new ConnectError("nothing to update", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "nothing to update");
         }
 
         const settings = await this.orgService.updateSettings(ctxUserId(), req.organizationId, update);

--- a/components/server/src/api/workspace-service-api.ts
+++ b/components/server/src/api/workspace-service-api.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Code, ConnectError, HandlerContext, ServiceImpl } from "@connectrpc/connect";
+import { HandlerContext, ServiceImpl } from "@connectrpc/connect";
 import { WorkspaceService as WorkspaceServiceInterface } from "@gitpod/public-api/lib/gitpod/v1/workspace_connect";
 import {
     GetWorkspaceRequest,
@@ -33,7 +33,7 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
 
     async getWorkspace(req: GetWorkspaceRequest, _: HandlerContext): Promise<GetWorkspaceResponse> {
         if (!req.workspaceId) {
-            throw new ConnectError("workspaceId is required", Code.InvalidArgument);
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
         }
         const info = await this.workspaceService.getWorkspace(ctxUserId(), req.workspaceId);
         const response = new GetWorkspaceResponse();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Align to use AppliationError for backward compatibility, and encapsulate ConnectError conversions in one place.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 20c34fb</samp>

Updated error handling in dashboard and server components to use `ApplicationError` and `ErrorCodes` from the public API. This makes the code more consistent, readable, and compatible with the `@connectrpc/connect` library.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Smoke test the dashboard a bit.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-use-app-errors</li>
	<li><b>🔗 URL</b> - <a href="https://ak-use-app-errors.preview.gitpod-dev.com/workspaces" target="_blank">ak-use-app-errors.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-use_app_errors-gha.20337</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-use-app-errors%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
