### PR TITLE
[ts] Add metric gitpod_logs_total(level) for TS components

### DIFF
--- a/components/gitpod-protocol/src/util/logging-node.ts
+++ b/components/gitpod-protocol/src/util/logging-node.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as prometheusClient from "prom-client";
+import { LogHook } from "./logging";
+
+const logsCounter = new prometheusClient.Counter({
+    name: "gitpod_logs_total",
+    help: "Total number of logs by level",
+    labelNames: ["level"],
+    registers: [prometheusClient.register],
+});
+
+export function reportLogCount(level: string) {
+    logsCounter.inc({ level });
+}
+
+export function installLogCountMetric() {
+    LogHook.setHook((item) => {
+        reportLogCount((item.severity || "").toLowerCase());
+    });
+}

--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -55,6 +55,7 @@ import express from "express";
 import { Container } from "inversify";
 import { Server } from "./server";
 import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { installLogCountMetric } from "@gitpod/gitpod-protocol/lib/util/logging-node";
 import { TracingManager } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { TypeORM } from "@gitpod/gitpod-db/lib";
 import { dbConnectionsEnqueued, dbConnectionsFree, dbConnectionsTotal } from "./prometheus-metrics";
@@ -66,6 +67,7 @@ if (process.env.NODE_ENV === "development") {
 
 log.enableJSONLogging("server", process.env.VERSION, LogrusLogLevel.getFromEnv());
 installCtxLogAugmenter();
+installLogCountMetric();
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {

--- a/components/ws-manager-bridge/src/main.ts
+++ b/components/ws-manager-bridge/src/main.ts
@@ -8,6 +8,7 @@ import { Container } from "inversify";
 import * as express from "express";
 import * as prometheusClient from "prom-client";
 import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { installLogCountMetric } from "@gitpod/gitpod-protocol/lib/util/logging-node";
 import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
 import { TypeORM } from "@gitpod/gitpod-db/lib/typeorm/typeorm";
 import { TracingManager } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -17,6 +18,7 @@ import { AppClusterWorkspaceInstancesController } from "./app-cluster-instance-c
 import { redisMetricsRegistry } from "@gitpod/gitpod-db/lib";
 
 log.enableJSONLogging("ws-manager-bridge", undefined, LogrusLogLevel.getFromEnv());
+installLogCountMetric();
 
 export const start = async (container: Container) => {
     process.on("uncaughtException", function (err) {


### PR DESCRIPTION
## Description
Based on: https://github.com/gitpod-io/gitpod/pull/19063

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at caf9b1a</samp>

This pull request improves the logging functionality and adds log count reporting to the server and ws-manager-bridge components. It introduces a new file `logging-backend.ts` that defines a function to report log counts to Prometheus, and uses this function in the `init.ts` and `main.ts` files of the respective components.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-349

## How to test
 - `kubectl port-forward deployment/server 9500 &`
 - `curl localhost:9500/metrics | grep logs_total`
 - interact with the system, and repeat the query to see the metrics increasing :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-ts-log-metrics</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-ts-log-metrics.preview.gitpod-dev.com/workspaces" target="_blank">gpl-ts-log-metrics.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-ts-log-metrics-gha.20374</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-ts-log-metrics%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
