### PR TITLE
[server] fix listAuthProviderDescriptions if unauthenticated

### DIFF
--- a/components/server/src/api/auth-provider-service-api.ts
+++ b/components/server/src/api/auth-provider-service-api.ts
@@ -27,7 +27,7 @@ import { AuthProviderEntry, AuthProviderInfo, User } from "@gitpod/gitpod-protoc
 import { Unauthenticated } from "./unauthenticated";
 import { validate as uuidValidate } from "uuid";
 import { selectPage } from "./pagination";
-import { ctxUserId } from "../util/request-context";
+import { ctxTrySubjectId, ctxUserId } from "../util/request-context";
 import { UserService } from "../user/user-service";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
@@ -120,7 +120,7 @@ export class AuthProviderServiceAPI implements ServiceImpl<typeof AuthProviderSe
         request: ListAuthProviderDescriptionsRequest,
         _: HandlerContext,
     ): Promise<ListAuthProviderDescriptionsResponse> {
-        const userId = ctxUserId();
+        const userId = ctxTrySubjectId()?.userId();
         let user: User | undefined = undefined;
         if (userId) {
             user = await this.userService.findUserById(userId, userId);


### PR DESCRIPTION
## Description
This is a follow-up from https://github.com/gitpod-io/gitpod/pull/19023/files#r1399425814

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 84116e8</samp>

Add authorization checks to auth provider service API. Use `request-context` module to get caller identity and context.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
* enable FF for gRPC in server
* see that the Login page is rendered properly

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-fix-lis0f3e653d7b</li>
	<li><b>🔗 URL</b> - <a href="https://at-fix-lis0f3e653d7b.preview.gitpod-dev.com/workspaces" target="_blank">at-fix-lis0f3e653d7b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-fix-list-providers-unauthenticated-gha.20417</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-fix-lis0f3e653d7b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
