### PR TITLE
Imported repos list empty state updates

### DIFF
--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -8,7 +8,7 @@ import { useLocation } from "react-router";
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { Separator } from "./Separator";
 import TabMenuItem from "./TabMenuItem";
-import { Heading1, Subheading } from "./typography/headings";
+import { Heading1, Subheading } from "@podkit/typography/Headings";
 
 export interface HeaderProps {
     title: string;

--- a/components/dashboard/src/components/podkit/typography/Headings.tsx
+++ b/components/dashboard/src/components/podkit/typography/Headings.tsx
@@ -57,7 +57,7 @@ export const Heading3: FC<HeadingProps> = ({ id, color, tracking, className, chi
  */
 export const Subheading: FC<HeadingProps> = ({ id, tracking, className, children }) => {
     return (
-        <p id={id} className={cn("text-base text-gray-500 dark:text-gray-500", getTracking(tracking), className)}>
+        <p id={id} className={cn("text-base text-gray-500 dark:text-gray-400", getTracking(tracking), className)}>
             {children}
         </p>
     );

--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -8,8 +8,6 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tansta
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { configurationClient } from "../../service/public-api";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
-import { useStateWithDebounce } from "../../hooks/use-state-with-debounce";
-import { useEffect } from "react";
 
 const BASE_KEY = "configurations";
 
@@ -21,15 +19,8 @@ type ListConfigurationsArgs = {
 export const useListConfigurations = ({ searchTerm = "", pageSize }: ListConfigurationsArgs) => {
     const { data: org } = useCurrentOrg();
 
-    // Debounce searchTerm for query
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_, setSearchTerm, debouncedSearchTerm] = useStateWithDebounce(searchTerm);
-    useEffect(() => {
-        setSearchTerm(searchTerm);
-    }, [searchTerm, setSearchTerm]);
-
     return useInfiniteQuery(
-        getListConfigurationsQueryKey(org?.id || "", { searchTerm: debouncedSearchTerm, pageSize }),
+        getListConfigurationsQueryKey(org?.id || "", { searchTerm, pageSize }),
         // QueryFn receives the past page's pageParam as it's argument
         async ({ pageParam: nextToken }) => {
             if (!org) {
@@ -38,7 +29,7 @@ export const useListConfigurations = ({ searchTerm = "", pageSize }: ListConfigu
 
             const { configurations, pagination } = await configurationClient.listConfigurations({
                 organizationId: org.id,
-                searchTerm: debouncedSearchTerm,
+                searchTerm,
                 pagination: { pageSize, token: nextToken },
             });
 

--- a/components/dashboard/src/repositories/list/RepoListEmptyState.tsx
+++ b/components/dashboard/src/repositories/list/RepoListEmptyState.tsx
@@ -16,7 +16,7 @@ export const RepoListEmptyState: FC<Props> = ({ onImport }) => {
     return (
         <div className={cn("w-full flex justify-center mt-2 rounded-xl bg-gray-100 dark:bg-gray-800 px-4 py-20")}>
             <div className="flex flex-col justify-center items-center text-center space-y-4">
-                <Heading2>No repositories yet</Heading2>
+                <Heading2>No imported repositories yet</Heading2>
                 <Subheading className="max-w-md">
                     Importing and configuring repositories allows your team members to be coding at the click of a
                     button.

--- a/components/dashboard/src/repositories/list/RepoListEmptyState.tsx
+++ b/components/dashboard/src/repositories/list/RepoListEmptyState.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Heading2, Subheading } from "@podkit/typography/Headings";
+import { Button } from "@podkit/buttons/Button";
+import { cn } from "@podkit/lib/cn";
+
+type Props = {
+    onImport: () => void;
+};
+export const RepoListEmptyState: FC<Props> = ({ onImport }) => {
+    return (
+        <div className={cn("w-full flex justify-center mt-2 rounded-xl bg-gray-100 dark:bg-gray-800 px-4 py-20")}>
+            <div className="flex flex-col justify-center items-center text-center space-y-4">
+                <Heading2>No repositories yet</Heading2>
+                <Subheading className="max-w-md">
+                    Importing and configuring repositories allows your team members to be coding at the click of a
+                    button.
+                </Subheading>
+                <Button onClick={onImport}>Import a Repository</Button>
+            </div>
+        </div>
+    );
+};

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -4,40 +4,38 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useState } from "react";
-import { LoaderIcon } from "lucide-react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { RepositoryListItem } from "./RepoListItem";
 import { useListConfigurations } from "../../data/configurations/configuration-queries";
-import { TextInput } from "../../components/forms/TextInputField";
 import { PageHeading } from "@podkit/layout/PageHeading";
 import { Button } from "@podkit/buttons/Button";
 import { useDocumentTitle } from "../../hooks/use-document-title";
-import { Table, TableBody, TableHead, TableHeader, TableRow } from "@podkit/tables/Table";
 import { ImportRepositoryModal } from "../create/ImportRepositoryModal";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
-import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { useQueryParams } from "../../hooks/use-query-params";
+import { RepoListEmptyState } from "./RepoListEmptyState";
+import { useStateWithDebounce } from "../../hooks/use-state-with-debounce";
+import { RepositoryTable } from "./RepositoryTable";
+import { LoadingState } from "@podkit/loading/LoadingState";
 
 const RepositoryListPage: FC = () => {
     useDocumentTitle("Imported repositories");
 
     const history = useHistory();
 
-    // Search/Filter params tracked in url query params
     const params = useQueryParams();
-    const searchTerm = params.get("search") || "";
-    const updateSearchTerm = useCallback(
-        (val: string) => {
-            history.replace({ search: `?search=${encodeURIComponent(val)}` });
-        },
-        [history],
-    );
-
-    const { data, isFetching, isFetchingNextPage, isPreviousData, hasNextPage, fetchNextPage } = useListConfigurations({
-        searchTerm,
-    });
+    const [searchTerm, setSearchTerm, searchTermDebounced] = useStateWithDebounce(params.get("search") || "");
     const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);
+
+    // Search/Filter params tracked in url query params
+    useEffect(() => {
+        history.replace({ search: `?search=${encodeURIComponent(searchTermDebounced)}` });
+    }, [history, searchTermDebounced]);
+
+    const { data, isLoading, isFetching, isFetchingNextPage, isPreviousData, hasNextPage, fetchNextPage } =
+        useListConfigurations({
+            searchTerm: searchTermDebounced,
+        });
 
     const handleRepoImported = useCallback(
         (configuration: Configuration) => {
@@ -46,78 +44,43 @@ const RepositoryListPage: FC = () => {
         [history],
     );
 
+    const configurations = useMemo(() => {
+        return data?.pages.map((page) => page.configurations).flat() ?? [];
+    }, [data?.pages]);
+
+    // This tracks any filters/search params applied
+    const hasFilters = !!searchTermDebounced;
+
+    // Show the table once we're done loading and either have results, or have filters applied
+    const showTable = !isLoading && (configurations.length > 0 || hasFilters);
+
     return (
         <>
             <div className="app-container mb-8">
                 <PageHeading
                     title="Imported repositories"
                     subtitle="Configure and refine the experience of working with a repository in Gitpod"
-                    action={<Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>}
+                    action={
+                        showTable && <Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>
+                    }
                 />
 
-                {/* Search/Filter bar */}
-                <div className="flex flex-row flex-wrap justify-between items-center">
-                    <div className="flex flex-row flex-wrap gap-2 items-center">
-                        {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
-                        <TextInput
-                            className="w-80"
-                            value={searchTerm}
-                            onChange={updateSearchTerm}
-                            placeholder="Search imported repositories"
-                        />
-                        {/* TODO: Add prebuild status filter dropdown */}
-                    </div>
-                    {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
-                </div>
+                {isLoading && <LoadingState />}
 
-                <div className="relative w-full overflow-auto mt-2">
-                    <Table>
-                        {/* TODO: Add sorting controls */}
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead className="w-52">Name</TableHead>
-                                <TableHead hideOnSmallScreen>Repository</TableHead>
-                                <TableHead className="w-32" hideOnSmallScreen>
-                                    Created
-                                </TableHead>
-                                <TableHead className="w-24" hideOnSmallScreen>
-                                    Prebuilds
-                                </TableHead>
-                                {/* Action column, loading status in header */}
-                                <TableHead className="w-24 text-right">
-                                    {isFetching && isPreviousData && (
-                                        <div className="flex flex-right justify-end items-center">
-                                            {/* TODO: Make a LoadingIcon component */}
-                                            <LoaderIcon
-                                                className="animate-spin text-gray-500 dark:text-gray-300"
-                                                size={20}
-                                            />
-                                        </div>
-                                    )}
-                                </TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {data?.pages.map((page) => {
-                                return page.configurations.map((configuration) => {
-                                    return <RepositoryListItem key={configuration.id} configuration={configuration} />;
-                                });
-                            })}
-                        </TableBody>
-                    </Table>
+                {showTable && (
+                    <RepositoryTable
+                        searchTerm={searchTerm}
+                        configurations={configurations}
+                        // we check isPreviousData too so we don't show spinner if it's a background refresh
+                        isSearching={isFetching && isPreviousData}
+                        isFetchingNextPage={isFetchingNextPage}
+                        hasNextPage={!!hasNextPage}
+                        onLoadNextPage={() => fetchNextPage()}
+                        onSearchTermChange={setSearchTerm}
+                    />
+                )}
 
-                    {hasNextPage && (
-                        <div className="my-4 flex flex-row justify-center">
-                            <LoadingButton
-                                variant="secondary"
-                                onClick={() => fetchNextPage()}
-                                loading={isFetchingNextPage}
-                            >
-                                Load more
-                            </LoadingButton>
-                        </div>
-                    )}
-                </div>
+                {!showTable && !isLoading && <RepoListEmptyState onImport={() => setShowCreateProjectModal(true)} />}
             </div>
 
             {showCreateProjectModal && (

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -29,7 +29,8 @@ const RepositoryListPage: FC = () => {
 
     // Search/Filter params tracked in url query params
     useEffect(() => {
-        history.replace({ search: `?search=${encodeURIComponent(searchTermDebounced)}` });
+        const params = searchTermDebounced ? `?search=${encodeURIComponent(searchTermDebounced)}` : "";
+        history.replace({ search: params });
     }, [history, searchTermDebounced]);
 
     const { data, isLoading, isFetching, isFetchingNextPage, isPreviousData, hasNextPage, fetchNextPage } =
@@ -47,6 +48,8 @@ const RepositoryListPage: FC = () => {
     const configurations = useMemo(() => {
         return data?.pages.map((page) => page.configurations).flat() ?? [];
     }, [data?.pages]);
+
+    const hasMoreThanOnePage = (data?.pages.length ?? 0) > 1;
 
     // This tracks any filters/search params applied
     const hasFilters = !!searchTermDebounced;
@@ -75,6 +78,7 @@ const RepositoryListPage: FC = () => {
                         isSearching={isFetching && isPreviousData}
                         isFetchingNextPage={isFetchingNextPage}
                         hasNextPage={!!hasNextPage}
+                        hasMoreThanOnePage={hasMoreThanOnePage}
                         onLoadNextPage={() => fetchNextPage()}
                         onSearchTermChange={setSearchTerm}
                     />

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -11,11 +11,15 @@ import { LoaderIcon } from "lucide-react";
 import { RepositoryListItem } from "./RepoListItem";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { TextMuted } from "@podkit/typography/TextMuted";
+import { Subheading } from "@podkit/typography/Headings";
+import { cn } from "@podkit/lib/cn";
 
 type Props = {
     configurations: Configuration[];
     searchTerm: string;
     hasNextPage: boolean;
+    hasMoreThanOnePage: boolean;
     isSearching: boolean;
     isFetchingNextPage: boolean;
     onSearchTermChange: (val: string) => void;
@@ -26,6 +30,7 @@ export const RepositoryTable: FC<Props> = ({
     searchTerm,
     configurations,
     hasNextPage,
+    hasMoreThanOnePage,
     isSearching,
     isFetchingNextPage,
     onSearchTermChange,
@@ -45,52 +50,58 @@ export const RepositoryTable: FC<Props> = ({
                     />
                     {/* TODO: Add prebuild status filter dropdown */}
                 </div>
-                {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
             </div>
             <div className="relative w-full overflow-auto mt-2">
-                <Table>
-                    {/* TODO: Add sorting controls */}
-                    <TableHeader>
-                        <TableRow>
-                            <TableHead className="w-52">Name</TableHead>
-                            <TableHead hideOnSmallScreen>Repository</TableHead>
-                            <TableHead className="w-32" hideOnSmallScreen>
-                                Created
-                            </TableHead>
-                            <TableHead className="w-24" hideOnSmallScreen>
-                                Prebuilds
-                            </TableHead>
-                            {/* Action column, loading status in header */}
-                            <TableHead className="w-24 text-right">
-                                {isSearching && (
-                                    <div className="flex flex-right justify-end items-center">
-                                        {/* TODO: Make a LoadingIcon component */}
-                                        <LoaderIcon
-                                            className="animate-spin text-gray-500 dark:text-gray-300"
-                                            size={20}
-                                        />
-                                    </div>
-                                )}
-                            </TableHead>
-                        </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                        {configurations.map((configuration) => {
-                            return <RepositoryListItem key={configuration.id} configuration={configuration} />;
-                        })}
-                    </TableBody>
-                </Table>
+                {configurations.length > 0 ? (
+                    <Table>
+                        {/* TODO: Add sorting controls */}
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-52">Name</TableHead>
+                                <TableHead hideOnSmallScreen>Repository</TableHead>
+                                <TableHead className="w-32" hideOnSmallScreen>
+                                    Created
+                                </TableHead>
+                                <TableHead className="w-24" hideOnSmallScreen>
+                                    Prebuilds
+                                </TableHead>
+                                {/* Action column, loading status in header */}
+                                <TableHead className="w-24 text-right">
+                                    {isSearching && (
+                                        <div className="flex flex-right justify-end items-center">
+                                            {/* TODO: Make a LoadingIcon component */}
+                                            <LoaderIcon
+                                                className="animate-spin text-gray-500 dark:text-gray-300"
+                                                size={20}
+                                            />
+                                        </div>
+                                    )}
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {configurations.map((configuration) => {
+                                return <RepositoryListItem key={configuration.id} configuration={configuration} />;
+                            })}
+                        </TableBody>
+                    </Table>
+                ) : (
+                    <div
+                        className={cn(
+                            "w-full flex justify-center rounded-xl bg-gray-100 dark:bg-gray-800 px-4 py-10 animate-fade-in-fast",
+                        )}
+                    >
+                        <Subheading className="max-w-md">No results found. Try adjusting your search terms.</Subheading>
+                    </div>
+                )}
 
-                {configurations.length === 0 && <div className="flex flex-row justify-center my-4">No results</div>}
-
-                <div className="my-4 flex flex-row justify-center">
+                <div className="mt-4 mb-8 flex flex-row justify-center">
                     {hasNextPage ? (
                         <LoadingButton variant="secondary" onClick={onLoadNextPage} loading={isFetchingNextPage}>
                             Load more
                         </LoadingButton>
                     ) : (
-                        // TODO: get the actual copy from Cory
-                        <span>That's all folks</span>
+                        hasMoreThanOnePage && <TextMuted>All repositories are loaded</TextMuted>
                     )}
                 </div>
             </div>

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { TextInput } from "../../components/forms/TextInputField";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@podkit/tables/Table";
+import { LoaderIcon } from "lucide-react";
+import { RepositoryListItem } from "./RepoListItem";
+import { LoadingButton } from "@podkit/buttons/LoadingButton";
+import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+
+type Props = {
+    configurations: Configuration[];
+    searchTerm: string;
+    hasNextPage: boolean;
+    isSearching: boolean;
+    isFetchingNextPage: boolean;
+    onSearchTermChange: (val: string) => void;
+    onLoadNextPage: () => void;
+};
+
+export const RepositoryTable: FC<Props> = ({
+    searchTerm,
+    configurations,
+    hasNextPage,
+    isSearching,
+    isFetchingNextPage,
+    onSearchTermChange,
+    onLoadNextPage,
+}) => {
+    return (
+        <>
+            {/* Search/Filter bar */}
+            <div className="flex flex-row flex-wrap justify-between items-center">
+                <div className="flex flex-row flex-wrap gap-2 items-center">
+                    {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
+                    <TextInput
+                        className="w-80"
+                        value={searchTerm}
+                        onChange={onSearchTermChange}
+                        placeholder="Search imported repositories"
+                    />
+                    {/* TODO: Add prebuild status filter dropdown */}
+                </div>
+                {/* Account for variation of message when totalRows is greater than smallest page size option (20?) */}
+            </div>
+            <div className="relative w-full overflow-auto mt-2">
+                <Table>
+                    {/* TODO: Add sorting controls */}
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-52">Name</TableHead>
+                            <TableHead hideOnSmallScreen>Repository</TableHead>
+                            <TableHead className="w-32" hideOnSmallScreen>
+                                Created
+                            </TableHead>
+                            <TableHead className="w-24" hideOnSmallScreen>
+                                Prebuilds
+                            </TableHead>
+                            {/* Action column, loading status in header */}
+                            <TableHead className="w-24 text-right">
+                                {isSearching && (
+                                    <div className="flex flex-right justify-end items-center">
+                                        {/* TODO: Make a LoadingIcon component */}
+                                        <LoaderIcon
+                                            className="animate-spin text-gray-500 dark:text-gray-300"
+                                            size={20}
+                                        />
+                                    </div>
+                                )}
+                            </TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {configurations.map((configuration) => {
+                            return <RepositoryListItem key={configuration.id} configuration={configuration} />;
+                        })}
+                    </TableBody>
+                </Table>
+
+                {configurations.length === 0 && <div className="flex flex-row justify-center my-4">No results</div>}
+
+                <div className="my-4 flex flex-row justify-center">
+                    {hasNextPage ? (
+                        <LoadingButton variant="secondary" onClick={onLoadNextPage} loading={isFetchingNextPage}>
+                            Load more
+                        </LoadingButton>
+                    ) : (
+                        // TODO: get the actual copy from Cory
+                        <span>That's all folks</span>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+};


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This makes some updates to the empty states of the Imported Repos list.

| No imported repos | No matches | Loaded all results |
|--------|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/9ac729f7-7669-44bd-87d8-e7701424708a) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/24d0808f-f4f4-4a72-86fd-bb3f1f9cb7c9) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/4777db42-2361-4f86-97f6-410d85537eb9) | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1260de</samp>

Refactored the repository list page and its components to improve the search and filter functionality, the code structure, and the user interface. Extracted the `RepositoryTable` and `RepoListEmptyState` components to separate files and simplified the `useListConfigurations` hook.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-932

## How to test
<!-- Provide steps to test this PR -->
* You can [join my org](https://brad-confif73281ba8d.preview.gitpod-dev.com/orgs/join?inviteId=246eef97-0fa0-45d9-b9a3-4aacd08fd2ae) to have > 1 page of results.
* Test loading more. You should see the all results loaded message after you've loaded them all instead the load more button.
* Try searching for `asdf` - you should see the no matching results message
* Check the repo list for your org when there are no imported repos and you should see the empty state.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-confif73281ba8d</li>
	<li><b>🔗 URL</b> - <a href="https://brad-confif73281ba8d.preview.gitpod-dev.com/workspaces" target="_blank">brad-confif73281ba8d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-configs-empty-state-gha.20403</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-confif73281ba8d%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
