### PR TITLE
Add GitpodWorkspaceHighStartFailureRate alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -28,6 +28,18 @@ spec:
           gitpod_ws_manager_mk2_workspace_phase_total{type="Regular", phase="Stopping", cluster!~"ephemeral.*"}
         ) without(phase) > 15
 
+    - alert: GitpodWorkspaceHighStartFailureRate
+      labels:
+        severity: critical
+        dedicated: included
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceHighFailureRate.md
+        summary: Workspaces are failing to start in cluster {{ $labels.cluster }}.
+        description: For the last 15 minutes more than 20% of hew workspaces have failed to start
+      for: 15m
+      expr: |
+          sum(increase(gitpod_ws_manager_mk2_workspace_starts_failure_total{type="Regular", cluster!~"ephemeral.*"}[5m])) by (cluster) / sum(increase(gitpod_ws_manager_mk2_workspace_starts_total{type="Regular", cluster!~"ephemeral.*"}[5m])) by (cluster) > 0.2
+
     - alert: GitpodWorkspaceHighFailureRateMk2
       labels:
         severity: critical


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds an alert which would have triggered for the incident inc-2023-11-20-workspace-start-failures-on-gitpod-cloud.

![Screenshot 2023-11-21 at 12 51 19](https://github.com/gitpod-io/gitpod/assets/83561/88a23326-82b1-494c-837c-de067c16fa45)

By having the alert use `for: 15m` we ensure it doesn't get triggered by smaller spikes. Such smaller spikes will be picked up by our SLO error budget instead.

This alert uses an existing runbook which we improved to cover this case as well in https://github.com/gitpod-io/runbooks/pull/422

Paired with @WVerlaek 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3d1220f</samp>

Add a new alert rule for high workspace start failure rate in `workspaces.yaml`. This rule helps to monitor and troubleshoot Gitpod workspaces reliability.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of follow-ups of inc-2023-11-20-workspace-start-failures-on-gitpod-cloud

## How to test
<!-- Provide steps to test this PR -->

N/A

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

N/A
