### PR TITLE
[dashboard] Use SCM Service (gRPC)

### DIFF
--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -5,10 +5,10 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { getGitpodService } from "../../service/service";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { useDebounce } from "../../hooks/use-debounce";
 import { useFeatureFlag } from "../featureflag-query";
+import { scmClient } from "../../service/public-api";
 
 export const useSearchRepositories = ({ searchString, limit }: { searchString: string; limit: number }) => {
     // This disables the search behavior when flag is disabled
@@ -19,11 +19,11 @@ export const useSearchRepositories = ({ searchString, limit }: { searchString: s
     return useQuery(
         ["search-repositories", { organizationId: org?.id || "", searchString: debouncedSearchString, limit }],
         async () => {
-            return await getGitpodService().server.searchRepositories({
+            const { repositories } = await scmClient.searchRepositories({
                 searchString,
-                organizationId: org?.id ?? "",
                 limit,
             });
+            return repositories;
         },
         {
             enabled: repositoryFinderSearchEnabled && !!org && debouncedSearchString.length >= 3,

--- a/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/suggested-repositories-query.ts
@@ -6,7 +6,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentOrg } from "../organizations/orgs-query";
-import { getGitpodService } from "../../service/service";
+import { scmClient } from "../../service/public-api";
 
 export const useSuggestedRepositories = () => {
     const { data: org } = useCurrentOrg();
@@ -18,7 +18,8 @@ export const useSuggestedRepositories = () => {
                 throw new Error("No org selected");
             }
 
-            return await getGitpodService().server.getSuggestedRepositories(org.id);
+            const { repositories } = await scmClient.listSuggestedRepositories({ organizationId: org.id });
+            return repositories;
         },
         {
             // Keeps data in cache for 7 days - will still refresh though

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -29,7 +29,7 @@ import * as SCMClasses from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 // This is used to version the cache
 // If data we cache changes in a non-backwards compatible way, increment this version
 // That will bust any previous cache versions a client may have stored
-const CACHE_VERSION = "7";
+const CACHE_VERSION = "8";
 
 export function noPersistence(queryKey: QueryKey): QueryKey {
     return [...queryKey, "no-persistence"];

--- a/components/dashboard/src/service/json-rpc-scm-client.ts
+++ b/components/dashboard/src/service/json-rpc-scm-client.ts
@@ -27,13 +27,9 @@ export class JsonRpcScmClient implements PromiseClient<typeof SCMService> {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "host is required");
         }
         const response = new SearchSCMTokensResponse();
-        try {
-            const token = await getGitpodService().server.getToken({ host });
-            if (token) {
-                response.tokens.push(converter.toSCMToken(token));
-            }
-        } catch (error) {
-            throw new ApplicationError(ErrorCodes.NOT_FOUND, "token not found");
+        const token = await getGitpodService().server.getToken({ host });
+        if (token) {
+            response.tokens.push(converter.toSCMToken(token));
         }
         return response;
     }
@@ -53,7 +49,7 @@ export class JsonRpcScmClient implements PromiseClient<typeof SCMService> {
         });
         return new GuessTokenScopesResponse({
             message: response.message,
-            scopes: response.scopes,
+            scopes: response.scopes || [],
         });
     }
 

--- a/components/dashboard/src/service/json-rpc-scm-client.ts
+++ b/components/dashboard/src/service/json-rpc-scm-client.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { PartialMessage } from "@bufbuild/protobuf";
+import { PromiseClient } from "@connectrpc/connect";
+import { SCMService } from "@gitpod/public-api/lib/gitpod/v1/scm_connect";
+import { converter } from "./public-api";
+import { getGitpodService } from "./service";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import {
+    SearchSCMTokensRequest,
+    SearchSCMTokensResponse,
+    GuessTokenScopesRequest,
+    SearchRepositoriesRequest,
+    ListSuggestedRepositoriesRequest,
+    ListSuggestedRepositoriesResponse,
+    SearchRepositoriesResponse,
+    GuessTokenScopesResponse,
+} from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
+
+export class JsonRpcScmClient implements PromiseClient<typeof SCMService> {
+    async searchSCMTokens({ host }: PartialMessage<SearchSCMTokensRequest>): Promise<SearchSCMTokensResponse> {
+        if (!host) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "host is required");
+        }
+        const response = new SearchSCMTokensResponse();
+        try {
+            const token = await getGitpodService().server.getToken({ host });
+            if (token) {
+                response.tokens.push(converter.toSCMToken(token));
+            }
+        } catch (error) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, "token not found");
+        }
+        return response;
+    }
+
+    async guessTokenScopes({
+        gitCommand,
+        host,
+        repoUrl,
+    }: PartialMessage<GuessTokenScopesRequest>): Promise<GuessTokenScopesResponse> {
+        if (!host) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "host is required");
+        }
+        const response = await getGitpodService().server.guessGitTokenScopes({
+            gitCommand: gitCommand || "",
+            host,
+            repoUrl: repoUrl || "",
+        });
+        return new GuessTokenScopesResponse({
+            message: response.message,
+            scopes: response.scopes,
+        });
+    }
+
+    async searchRepositories(request: PartialMessage<SearchRepositoriesRequest>): Promise<SearchRepositoriesResponse> {
+        const { limit, searchString } = request;
+        if (!searchString) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "searchString is required");
+        }
+        const repos = await getGitpodService().server.searchRepositories({ searchString, limit });
+        return new SearchRepositoriesResponse({
+            repositories: repos.map((r) => converter.toSuggestedRepository(r)),
+        });
+    }
+
+    async listSuggestedRepositories(
+        request: PartialMessage<ListSuggestedRepositoriesRequest>,
+    ): Promise<ListSuggestedRepositoriesResponse> {
+        const { organizationId } = request;
+        if (!organizationId) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
+        }
+        const repos = await getGitpodService().server.getSuggestedRepositories(organizationId);
+        return new SearchRepositoriesResponse({
+            repositories: repos.map((r) => converter.toSuggestedRepository(r)),
+        });
+    }
+}

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -32,6 +32,8 @@ import { JsonRpcEnvvarClient } from "./json-rpc-envvar-client";
 import { Prebuild, WatchPrebuildRequest, WatchPrebuildResponse } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { JsonRpcPrebuildClient } from "./json-rpc-prebuild-client";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { JsonRpcScmClient } from "./json-rpc-scm-client";
+import { SCMService } from "@gitpod/public-api/lib/gitpod/v1/scm_connect";
 
 const transport = createConnectTransport({
     baseUrl: `${window.location.protocol}//${window.location.host}/public-api`,
@@ -60,6 +62,8 @@ export const configurationClient = createServiceClient(ConfigurationService);
 export const prebuildClient = createServiceClient(PrebuildService, new JsonRpcPrebuildClient());
 
 export const authProviderClient = createServiceClient(AuthProviderService, new JsonRpcAuthProviderClient());
+
+export const scmClient = createServiceClient(SCMService, new JsonRpcScmClient());
 
 export const envVarClient = createServiceClient(EnvironmentVariableService, new JsonRpcEnvvarClient());
 

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -35,7 +35,7 @@ import {
     AuthProviderDescription,
     AuthProviderType,
 } from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
-import { authProviderClient } from "../service/public-api";
+import { authProviderClient, scmClient } from "../service/public-api";
 import { useCreateUserAuthProviderMutation } from "../data/auth-providers/create-user-auth-provider-mutation";
 import { useUpdateUserAuthProviderMutation } from "../data/auth-providers/update-user-auth-provider-mutation";
 import { useDeleteUserAuthProviderMutation } from "../data/auth-providers/delete-user-auth-provider-mutation";
@@ -77,7 +77,7 @@ function GitProviders() {
                 if (!provider) {
                     continue;
                 }
-                const token = await getGitpodService().server.getToken({ host: provider.host });
+                const token = (await scmClient.searchSCMTokens({ host: provider.host })).tokens[0];
                 scopesByProvider.set(provider.id, token?.scopes?.slice() || []);
             }
             setAllScopes(scopesByProvider);
@@ -182,7 +182,7 @@ function GitProviders() {
     const startEditPermissions = async (provider: AuthProviderDescription) => {
         // todo: add spinner
 
-        const token = await getGitpodService().server.getToken({ host: provider.host });
+        const token = (await scmClient.searchSCMTokens({ host: provider.host })).tokens[0];
         if (token) {
             setEditModal({ provider, prevScopes: new Set(token.scopes), nextScopes: new Set(token.scopes) });
         }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -325,7 +325,8 @@ export interface GetProviderRepositoriesParams {
     maxPages?: number;
 }
 export interface SearchRepositoriesParams {
-    organizationId: string;
+    /** @deprecated unused */
+    organizationId?: string;
     searchString: string;
     limit?: number; // defaults to 30
 }


### PR DESCRIPTION
## Description
Based on https://github.com/gitpod-io/gitpod/pull/19098

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b92b9a9</samp>

Refactored the dashboard and the server to use a new `SCMService` interface for SCM-related operations instead of the `GitpodServer` interface. Added Protobuf, gRPC, and Connect definitions and implementations for the `SCMService` interface. Removed unused or deprecated parameters and interfaces from the `GitpodServer` interface.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
⚠️ Test with FF disabled ⚠️ 

UIs affected by this PR, but we need to verify that they continue working as usual.
* Git Integrations, as we're reading the scopes of the current token
* New Workspace modal
* New Project modal

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-scm-serc5fcb94ce8</li>
	<li><b>🔗 URL</b> - <a href="https://at-scm-serc5fcb94ce8.preview.gitpod-dev.com/workspaces" target="_blank">at-scm-serc5fcb94ce8.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-scm-service-dashboard-gha.20481</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-scm-serc5fcb94ce8%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
