### PR TITLE
[dashboard/server] app error conversion based on error details

### DIFF
--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -10,7 +10,7 @@ import Alert from "./Alert";
 import Modal from "./Modal";
 import { Heading2 } from "./typography/headings";
 
-export function UsageLimitReachedModal(p: { hints: any; onClose?: () => void }) {
+export function UsageLimitReachedModal(p: { onClose?: () => void }) {
     const currentOrg = useCurrentOrg();
 
     const orgName = currentOrg.data?.name;

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -111,9 +111,7 @@ export function StartPage(props: StartPageProps) {
                     <ProgressBar phase={phase} error={!!error} />
                 )}
                 {error && error.code === ErrorCodes.NEEDS_VERIFICATION && <VerifyModal />}
-                {error && error.code === ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED && (
-                    <UsageLimitReachedModal hints={error?.data} />
-                )}
+                {error && error.code === ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED && <UsageLimitReachedModal />}
                 {error && <StartError error={error} />}
                 {props.children}
                 <WarningView

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -522,7 +522,7 @@ const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({ error, reset, setS
         case ErrorCodes.INVALID_COST_CENTER:
             return <RepositoryInputError title={`The organization '${error.data}' is not valid.`} />;
         case ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED:
-            return <UsageLimitReachedModal onClose={reset} hints={error?.data} />;
+            return <UsageLimitReachedModal onClose={reset} />;
         case ErrorCodes.NEEDS_VERIFICATION:
             return <VerifyModal />;
         default:

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -5,9 +5,15 @@
  */
 
 import { scrubber } from "../util/scrubbing";
+import { PlainMessage } from "@bufbuild/protobuf";
+import {
+    InvalidGitpodYMLError as InvalidGitpodYMLErrorData,
+    RepositoryNotFoundError as RepositoryNotFoundErrorData,
+    RepositoryUnauthorizedError as RepositoryUnauthorizedErrorData,
+} from "@gitpod/public-api/lib/gitpod/v1/error_pb";
 
 export class ApplicationError extends Error {
-    constructor(public readonly code: ErrorCode, message: string, public readonly data?: any) {
+    constructor(readonly code: ErrorCode, readonly message: string, readonly data?: any) {
         super(message);
         this.data = scrubber.scrub(this.data, true);
     }
@@ -18,6 +24,25 @@ export class ApplicationError extends Error {
             message: this.message,
             data: this.data,
         };
+    }
+}
+
+export class RepositoryNotFoundError extends ApplicationError {
+    constructor(readonly info: PlainMessage<RepositoryNotFoundErrorData>) {
+        // on gRPC we remap to PRECONDITION_FAILED, all error code for backwards compatibility with the dashboard
+        super(ErrorCodes.NOT_FOUND, "Repository not found.", info);
+    }
+}
+export class UnauthorizedRepositoryAccessError extends ApplicationError {
+    constructor(readonly info: PlainMessage<RepositoryUnauthorizedErrorData>) {
+        // on gRPC we remap to PRECONDITION_FAILED, all error code for backwards compatibility with the dashboard
+        super(ErrorCodes.NOT_AUTHENTICATED, "Repository unauthorized.", info);
+    }
+}
+export class InvalidGitpodYMLError extends ApplicationError {
+    constructor(readonly info: PlainMessage<InvalidGitpodYMLErrorData>) {
+        // on gRPC we remap to PRECONDITION_FAILED, all error code for backwards compatibility with the dashboard
+        super(ErrorCodes.INVALID_GITPOD_YML, "Invalid gitpod.yml: " + info.violations.join(","), info);
     }
 }
 

--- a/components/gitpod-protocol/src/public-api-converter.spec.ts
+++ b/components/gitpod-protocol/src/public-api-converter.spec.ts
@@ -5,7 +5,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Timestamp } from "@bufbuild/protobuf";
+import { Timestamp, toPlainMessage } from "@bufbuild/protobuf";
 import {
     AdmissionLevel,
     WorkspaceEnvironmentVariable,
@@ -41,6 +41,27 @@ import {
     EnvironmentVariableAdmission,
     UserEnvironmentVariable,
 } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import {
+    ApplicationError,
+    ErrorCodes,
+    InvalidGitpodYMLError,
+    RepositoryNotFoundError,
+    UnauthorizedRepositoryAccessError,
+} from "./messaging/error";
+import { Code, ConnectError } from "@connectrpc/connect";
+import {
+    FailedPreconditionDetails,
+    NeedsVerificationError,
+    PermissionDeniedDetails,
+    UserBlockedError,
+    InvalidGitpodYMLError as InvalidGitpodYMLErrorData,
+    RepositoryNotFoundError as RepositoryNotFoundErrorData,
+    RepositoryUnauthorizedError as RepositoryUnauthorizedErrorData,
+    PaymentSpendingLimitReachedError,
+    InvalidCostCenterError,
+    ImageBuildLogsNotYetAvailableError,
+    TooManyRunningWorkspacesError,
+} from "@gitpod/public-api/lib/gitpod/v1/error_pb";
 
 describe("PublicAPIConverter", () => {
     const converter = new PublicAPIConverter();
@@ -996,6 +1017,333 @@ describe("PublicAPIConverter", () => {
                 configurationName: "Gitpod",
                 repoName: "gitpod",
             });
+        });
+    });
+
+    describe("errors", () => {
+        it("USER_BLOCKED", () => {
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.USER_BLOCKED, "user blocked"));
+            expect(connectError.code).to.equal(Code.PermissionDenied);
+            expect(connectError.rawMessage).to.equal("user blocked");
+
+            const details = connectError.findDetails(PermissionDeniedDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("userBlocked");
+            expect(details?.reason?.value).to.be.instanceOf(UserBlockedError);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.USER_BLOCKED);
+            expect(appError.message).to.equal("user blocked");
+        });
+
+        it("NEEDS_VERIFICATION", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.NEEDS_VERIFICATION, "needs verification"),
+            );
+            expect(connectError.code).to.equal(Code.PermissionDenied);
+            expect(connectError.rawMessage).to.equal("needs verification");
+
+            const details = connectError.findDetails(PermissionDeniedDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("needsVerification");
+            expect(details?.reason?.value).to.be.instanceOf(NeedsVerificationError);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.NEEDS_VERIFICATION);
+            expect(appError.message).to.equal("needs verification");
+        });
+
+        it("INVALID_GITPOD_YML", () => {
+            const connectError = converter.toError(
+                new InvalidGitpodYMLError({
+                    violations: ['Invalid value: "": must not be empty'],
+                }),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal('Invalid gitpod.yml: Invalid value: "": must not be empty');
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("invalidGitpodYml");
+            expect(details?.reason?.value).to.be.instanceOf(InvalidGitpodYMLErrorData);
+
+            let violations = (details?.reason?.value as InvalidGitpodYMLErrorData).violations;
+            expect(violations).to.deep.equal(['Invalid value: "": must not be empty']);
+
+            const appError = converter.fromError(connectError);
+            expect(appError).to.be.instanceOf(InvalidGitpodYMLError);
+            expect(appError.code).to.equal(ErrorCodes.INVALID_GITPOD_YML);
+            expect(appError.message).to.equal('Invalid gitpod.yml: Invalid value: "": must not be empty');
+
+            violations = (appError as InvalidGitpodYMLError).info.violations;
+            expect(violations).to.deep.equal(['Invalid value: "": must not be empty']);
+        });
+
+        it("RepositoryNotFoundError", () => {
+            const connectError = converter.toError(
+                new RepositoryNotFoundError({
+                    host: "github.com",
+                    lastUpdate: "2021-06-28T10:48:28Z",
+                    owner: "akosyakov",
+                    userIsOwner: true,
+                    userScopes: ["repo"],
+                }),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("Repository not found.");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("repositoryNotFound");
+            expect(details?.reason?.value).to.be.instanceOf(RepositoryNotFoundErrorData);
+
+            let data = toPlainMessage(details?.reason?.value as RepositoryNotFoundErrorData);
+            expect(data.host).to.equal("github.com");
+            expect(data.lastUpdate).to.equal("2021-06-28T10:48:28Z");
+            expect(data.owner).to.equal("akosyakov");
+            expect(data.userIsOwner).to.equal(true);
+            expect(data.userScopes).to.deep.equal(["repo"]);
+
+            const appError = converter.fromError(connectError);
+            expect(appError).to.be.instanceOf(RepositoryNotFoundError);
+            expect(appError.code).to.equal(ErrorCodes.NOT_FOUND);
+            expect(appError.message).to.equal("Repository not found.");
+
+            data = (appError as RepositoryNotFoundError).info;
+            expect(data.host).to.equal("github.com");
+            expect(data.lastUpdate).to.equal("2021-06-28T10:48:28Z");
+            expect(data.owner).to.equal("akosyakov");
+            expect(data.userIsOwner).to.equal(true);
+            expect(data.userScopes).to.deep.equal(["repo"]);
+        });
+
+        it("UnauthorizedRepositoryAccessError", () => {
+            const connectError = converter.toError(
+                new UnauthorizedRepositoryAccessError({
+                    host: "github.com",
+                    scopes: ["repo"],
+                }),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("Repository unauthorized.");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("repositoryUnauthorized");
+            expect(details?.reason?.value).to.be.instanceOf(RepositoryUnauthorizedErrorData);
+
+            let data = toPlainMessage(details?.reason?.value as RepositoryUnauthorizedErrorData);
+            expect(data.host).to.equal("github.com");
+            expect(data.scopes).to.deep.equal(["repo"]);
+
+            const appError = converter.fromError(connectError);
+            expect(appError).to.be.instanceOf(UnauthorizedRepositoryAccessError);
+            expect(appError.code).to.equal(ErrorCodes.NOT_AUTHENTICATED);
+            expect(appError.message).to.equal("Repository unauthorized.");
+
+            data = (appError as UnauthorizedRepositoryAccessError).info;
+            expect(data.host).to.equal("github.com");
+            expect(data.scopes).to.deep.equal(["repo"]);
+        });
+
+        it("PAYMENT_SPENDING_LIMIT_REACHED", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED, "payment spending limit reached"),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("payment spending limit reached");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("paymentSpendingLimitReached");
+            expect(details?.reason?.value).to.be.instanceOf(PaymentSpendingLimitReachedError);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED);
+            expect(appError.message).to.equal("payment spending limit reached");
+        });
+
+        it("INVALID_COST_CENTER", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.INVALID_COST_CENTER, "invalid cost center", {
+                    attributionId: 12345,
+                }),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("invalid cost center");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("invalidCostCenter");
+            expect(details?.reason?.value).to.be.instanceOf(InvalidCostCenterError);
+
+            let data = toPlainMessage(details?.reason?.value as InvalidCostCenterError);
+            expect(data.attributionId).to.equal(12345);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.INVALID_COST_CENTER);
+            expect(appError.message).to.equal("invalid cost center");
+
+            data = appError.data;
+            expect(data.attributionId).to.equal(12345);
+        });
+
+        it("HEADLESS_LOG_NOT_YET_AVAILABLE", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE, "image build log not yet available"),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("image build log not yet available");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("imageBuildLogsNotYetAvailable");
+            expect(details?.reason?.value).to.be.instanceOf(ImageBuildLogsNotYetAvailableError);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE);
+            expect(appError.message).to.equal("image build log not yet available");
+        });
+
+        it("TOO_MANY_RUNNING_WORKSPACES", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.TOO_MANY_RUNNING_WORKSPACES, "too many running workspaces"),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("too many running workspaces");
+
+            const details = connectError.findDetails(FailedPreconditionDetails)[0];
+            expect(details).to.not.be.undefined;
+            expect(details?.reason?.case).to.equal("tooManyRunningWorkspaces");
+            expect(details?.reason?.value).to.be.instanceOf(TooManyRunningWorkspacesError);
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.TOO_MANY_RUNNING_WORKSPACES);
+            expect(appError.message).to.equal("too many running workspaces");
+        });
+
+        it("NOT_FOUND", () => {
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.NOT_FOUND, "not found"));
+            expect(connectError.code).to.equal(Code.NotFound);
+            expect(connectError.rawMessage).to.equal("not found");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.NOT_FOUND);
+            expect(appError.message).to.equal("not found");
+        });
+
+        it("NOT_AUTHENTICATED", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, "not authenticated"),
+            );
+            expect(connectError.code).to.equal(Code.Unauthenticated);
+            expect(connectError.rawMessage).to.equal("not authenticated");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.NOT_AUTHENTICATED);
+            expect(appError.message).to.equal("not authenticated");
+        });
+
+        it("PERMISSION_DENIED", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.PERMISSION_DENIED, "permission denied"),
+            );
+            expect(connectError.code).to.equal(Code.PermissionDenied);
+            expect(connectError.rawMessage).to.equal("permission denied");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.PERMISSION_DENIED);
+            expect(appError.message).to.equal("permission denied");
+        });
+
+        it("CONFLICT", () => {
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.CONFLICT, "conflict"));
+            expect(connectError.code).to.equal(Code.AlreadyExists);
+            expect(connectError.rawMessage).to.equal("conflict");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.CONFLICT);
+            expect(appError.message).to.equal("conflict");
+        });
+
+        it("PRECONDITION_FAILED", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.PRECONDITION_FAILED, "precondition failed"),
+            );
+            expect(connectError.code).to.equal(Code.FailedPrecondition);
+            expect(connectError.rawMessage).to.equal("precondition failed");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.PRECONDITION_FAILED);
+            expect(appError.message).to.equal("precondition failed");
+        });
+
+        it("TOO_MANY_REQUESTS", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.TOO_MANY_REQUESTS, "too many requests"),
+            );
+            expect(connectError.code).to.equal(Code.ResourceExhausted);
+            expect(connectError.rawMessage).to.equal("too many requests");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.TOO_MANY_REQUESTS);
+            expect(appError.message).to.equal("too many requests");
+        });
+
+        it("CANCELLED", () => {
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.CANCELLED, "cancelled"));
+            expect(connectError.code).to.equal(Code.Canceled);
+            expect(connectError.rawMessage).to.equal("cancelled");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.CANCELLED);
+            expect(appError.message).to.equal("cancelled");
+        });
+
+        it("INTERNAL_SERVER_ERROR", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "internal server error"),
+            );
+            expect(connectError.code).to.equal(Code.Internal);
+            expect(connectError.rawMessage).to.equal("internal server error");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
+            expect(appError.message).to.equal("internal server error");
+        });
+
+        it("UNKNOWN", () => {
+            // some errors are not really used by clients we turn them to unknown on API interface
+            // and then to internal on the dashboard
+            // we monitor such occurences via tests and observability and replace them with stanard codes or get rid of them
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.EE_FEATURE, "unknown"));
+            expect(connectError.code).to.equal(Code.Unknown);
+            expect(connectError.rawMessage).to.equal("unknown");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
+            expect(appError.message).to.equal("unknown");
+        });
+
+        it("ConnectError", () => {
+            const connectError = new ConnectError("already exists", Code.AlreadyExists);
+            const error = converter.toError(connectError);
+            expect(error).to.equal(connectError, "preserved on API");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.CONFLICT, "app error on dashboard");
+            expect(appError.message).to.equal("already exists");
+        });
+
+        it("Any other error is internal", () => {
+            const error = new Error("unknown");
+            const connectError = converter.toError(error);
+            expect(connectError.code).to.equal(Code.Internal);
+            expect(connectError.rawMessage).to.equal("unknown");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
+            expect(appError.message).to.equal("unknown");
         });
     });
 });

--- a/components/gitpod-protocol/src/public-api-converter.ts
+++ b/components/gitpod-protocol/src/public-api-converter.ts
@@ -4,8 +4,21 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Timestamp } from "@bufbuild/protobuf";
+import { Timestamp, toPlainMessage } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
+import {
+    FailedPreconditionDetails,
+    ImageBuildLogsNotYetAvailableError,
+    InvalidCostCenterError as InvalidCostCenterErrorData,
+    InvalidGitpodYMLError as InvalidGitpodYMLErrorData,
+    NeedsVerificationError,
+    PaymentSpendingLimitReachedError,
+    PermissionDeniedDetails,
+    RepositoryNotFoundError as RepositoryNotFoundErrorData,
+    RepositoryUnauthorizedError as RepositoryUnauthorizedErrorData,
+    TooManyRunningWorkspacesError,
+    UserBlockedError,
+} from "@gitpod/public-api/lib/gitpod/v1/error_pb";
 import {
     AuthProvider,
     AuthProviderDescription,
@@ -51,7 +64,13 @@ import {
     PrebuildPhase,
     PrebuildPhase_Phase,
 } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
-import { ApplicationError, ErrorCode, ErrorCodes } from "./messaging/error";
+import {
+    ApplicationError,
+    ErrorCodes,
+    InvalidGitpodYMLError,
+    RepositoryNotFoundError,
+    UnauthorizedRepositoryAccessError,
+} from "./messaging/error";
 import {
     AuthProviderEntry as AuthProviderProtocol,
     AuthProviderInfo,
@@ -79,7 +98,6 @@ import {
     Project,
     Organization as ProtocolOrganization,
 } from "./teams-projects-protocol";
-import { TrustedValue } from "./util/scrubbing";
 import {
     ConfigurationIdeConfig,
     PortProtocol,
@@ -91,9 +109,6 @@ import { Author, Commit } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 import type { DeepPartial } from "./util/deep-partial";
 
 export type PartialConfiguration = DeepPartial<Configuration> & Pick<Configuration, "id">;
-
-const applicationErrorCode = "application-error-code";
-const applicationErrorData = "application-error-data";
 
 /**
  * Converter between gRPC and JSON-RPC types.
@@ -199,57 +214,240 @@ export class PublicAPIConverter {
             return reason;
         }
         if (reason instanceof ApplicationError) {
-            const metadata: HeadersInit = {};
-            metadata[applicationErrorCode] = String(reason.code);
-            if (reason.data) {
-                metadata[applicationErrorData] = JSON.stringify(reason.data);
+            if (reason.code === ErrorCodes.USER_BLOCKED) {
+                return new ConnectError(
+                    reason.message,
+                    Code.PermissionDenied,
+                    undefined,
+                    [
+                        new PermissionDeniedDetails({
+                            reason: {
+                                case: "userBlocked",
+                                value: new UserBlockedError(),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason.code === ErrorCodes.NEEDS_VERIFICATION) {
+                return new ConnectError(
+                    reason.message,
+                    Code.PermissionDenied,
+                    undefined,
+                    [
+                        new PermissionDeniedDetails({
+                            reason: {
+                                case: "needsVerification",
+                                value: new NeedsVerificationError(),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason instanceof InvalidGitpodYMLError) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "invalidGitpodYml",
+                                value: new InvalidGitpodYMLErrorData(reason.info),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason instanceof RepositoryNotFoundError) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "repositoryNotFound",
+                                value: new RepositoryNotFoundErrorData(reason.info),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason instanceof UnauthorizedRepositoryAccessError) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "repositoryUnauthorized",
+                                value: new RepositoryUnauthorizedErrorData(reason.info),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason.code === ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "paymentSpendingLimitReached",
+                                value: new PaymentSpendingLimitReachedError(),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason.code === ErrorCodes.INVALID_COST_CENTER) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "invalidCostCenter",
+                                value: new InvalidCostCenterErrorData({
+                                    attributionId: reason.data.attributionId,
+                                }),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason.code === ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "imageBuildLogsNotYetAvailable",
+                                value: new ImageBuildLogsNotYetAvailableError(),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
+            }
+            if (reason.code === ErrorCodes.TOO_MANY_RUNNING_WORKSPACES) {
+                return new ConnectError(
+                    reason.message,
+                    Code.FailedPrecondition,
+                    undefined,
+                    [
+                        new FailedPreconditionDetails({
+                            reason: {
+                                case: "tooManyRunningWorkspaces",
+                                value: new TooManyRunningWorkspacesError(),
+                            },
+                        }),
+                    ],
+                    reason,
+                );
             }
             if (reason.code === ErrorCodes.NOT_FOUND) {
-                return new ConnectError(reason.message, Code.NotFound, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.NotFound, undefined, undefined, reason);
             }
             if (reason.code === ErrorCodes.NOT_AUTHENTICATED) {
-                return new ConnectError(reason.message, Code.Unauthenticated, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.Unauthenticated, undefined, undefined, reason);
             }
-            if (reason.code === ErrorCodes.PERMISSION_DENIED || reason.code === ErrorCodes.USER_BLOCKED) {
-                return new ConnectError(reason.message, Code.PermissionDenied, metadata, undefined, reason);
+            if (reason.code === ErrorCodes.PERMISSION_DENIED) {
+                return new ConnectError(reason.message, Code.PermissionDenied, undefined, undefined, reason);
             }
             if (reason.code === ErrorCodes.CONFLICT) {
-                return new ConnectError(reason.message, Code.AlreadyExists, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.AlreadyExists, undefined, undefined, reason);
             }
             if (reason.code === ErrorCodes.PRECONDITION_FAILED) {
-                return new ConnectError(reason.message, Code.FailedPrecondition, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.FailedPrecondition, undefined, undefined, reason);
             }
             if (reason.code === ErrorCodes.TOO_MANY_REQUESTS) {
-                return new ConnectError(reason.message, Code.ResourceExhausted, metadata, undefined, reason);
-            }
-            if (reason.code === ErrorCodes.INTERNAL_SERVER_ERROR) {
-                return new ConnectError(reason.message, Code.Internal, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.ResourceExhausted, undefined, undefined, reason);
             }
             if (reason.code === ErrorCodes.CANCELLED) {
-                return new ConnectError(reason.message, Code.DeadlineExceeded, metadata, undefined, reason);
+                return new ConnectError(reason.message, Code.Canceled, undefined, undefined, reason);
             }
-            return new ConnectError(reason.message, Code.InvalidArgument, metadata, undefined, reason);
+            if (reason.code === ErrorCodes.INTERNAL_SERVER_ERROR) {
+                return new ConnectError(reason.message, Code.Internal, undefined, undefined, reason);
+            }
+            return new ConnectError(reason.message, Code.Unknown, undefined, undefined, reason);
         }
         return ConnectError.from(reason, Code.Internal);
     }
 
-    fromError(reason: ConnectError): Error {
-        const codeMetadata = reason.metadata?.get(applicationErrorCode);
-        if (!codeMetadata) {
-            return reason;
+    fromError(reason: ConnectError): ApplicationError {
+        if (reason.code === Code.NotFound) {
+            return new ApplicationError(ErrorCodes.NOT_FOUND, reason.rawMessage);
         }
-        const code = Number(codeMetadata) as ErrorCode;
-        const dataMetadata = reason.metadata?.get(applicationErrorData);
-        let data = undefined;
-        if (dataMetadata) {
-            try {
-                data = JSON.parse(dataMetadata);
-            } catch (e) {
-                console.error("failed to parse application error data", e);
+        if (reason.code === Code.Unauthenticated) {
+            return new ApplicationError(ErrorCodes.NOT_AUTHENTICATED, reason.rawMessage);
+        }
+        if (reason.code === Code.PermissionDenied) {
+            const details = reason.findDetails(PermissionDeniedDetails)[0];
+            switch (details?.reason?.case) {
+                case "userBlocked":
+                    return new ApplicationError(ErrorCodes.USER_BLOCKED, reason.rawMessage);
+                case "needsVerification":
+                    return new ApplicationError(ErrorCodes.NEEDS_VERIFICATION, reason.rawMessage);
             }
+            return new ApplicationError(ErrorCodes.PERMISSION_DENIED, reason.rawMessage);
         }
-        // data is trusted here, since it was scrubbed before on the server
-        return new ApplicationError(code, reason.message, new TrustedValue(data));
+        if (reason.code === Code.AlreadyExists) {
+            return new ApplicationError(ErrorCodes.CONFLICT, reason.rawMessage);
+        }
+        if (reason.code === Code.FailedPrecondition) {
+            const details = reason.findDetails(FailedPreconditionDetails)[0];
+            switch (details?.reason?.case) {
+                case "invalidGitpodYml":
+                    const invalidGitpodYmlInfo = toPlainMessage(details.reason.value);
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                    return new InvalidGitpodYMLError(invalidGitpodYmlInfo);
+                case "repositoryNotFound":
+                    const repositoryNotFoundInfo = toPlainMessage(details.reason.value);
+                    return new RepositoryNotFoundError(repositoryNotFoundInfo);
+                case "repositoryUnauthorized":
+                    const repositoryUnauthorizedInfo = toPlainMessage(details.reason.value);
+                    return new UnauthorizedRepositoryAccessError(repositoryUnauthorizedInfo);
+                case "paymentSpendingLimitReached":
+                    return new ApplicationError(ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED, reason.rawMessage);
+                case "invalidCostCenter":
+                    const invalidCostCenterInfo = toPlainMessage(details.reason.value);
+                    return new ApplicationError(
+                        ErrorCodes.INVALID_COST_CENTER,
+                        reason.rawMessage,
+                        invalidCostCenterInfo,
+                    );
+                case "imageBuildLogsNotYetAvailable":
+                    return new ApplicationError(ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE, reason.rawMessage);
+                case "tooManyRunningWorkspaces":
+                    return new ApplicationError(ErrorCodes.TOO_MANY_RUNNING_WORKSPACES, reason.rawMessage);
+            }
+            return new ApplicationError(ErrorCodes.PRECONDITION_FAILED, reason.rawMessage);
+        }
+        if (reason.code === Code.ResourceExhausted) {
+            return new ApplicationError(ErrorCodes.TOO_MANY_REQUESTS, reason.rawMessage);
+        }
+        if (reason.code === Code.Canceled) {
+            return new ApplicationError(ErrorCodes.CANCELLED, reason.rawMessage);
+        }
+        if (reason.code === Code.Internal) {
+            return new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, reason.rawMessage);
+        }
+        return new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, reason.rawMessage);
     }
 
     toWorkspaceEnvironmentVariables(context: WorkspaceContext): WorkspaceEnvironmentVariable[] {

--- a/components/server/src/auth/errors.ts
+++ b/components/server/src/auth/errors.ts
@@ -4,20 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Identity } from "@gitpod/gitpod-protocol";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
-
-export interface TosNotAcceptedYetException extends Error {
-    readonly identity: Identity;
-}
-export namespace TosNotAcceptedYetException {
-    export function create(identity: Identity) {
-        return Object.assign(new Error("TosNotAcceptedYetException"), { identity });
-    }
-    export function is(error: any): error is TosNotAcceptedYetException {
-        return !!error && error.message === "TosNotAcceptedYetException";
-    }
-}
 
 export interface AuthException extends Error {
     readonly payload: any;

--- a/components/server/src/errors/index.ts
+++ b/components/server/src/errors/index.ts
@@ -5,62 +5,38 @@
  */
 
 import { User, Token } from "@gitpod/gitpod-protocol";
+import {
+    RepositoryNotFoundError,
+    UnauthorizedRepositoryAccessError,
+} from "@gitpod/gitpod-protocol/lib/messaging/error";
 
-export interface NotFoundError extends Error {
-    readonly data: NotFoundError.Data;
-}
 export namespace NotFoundError {
-    export interface Data {
-        readonly host: string;
-        readonly owner: string;
-        readonly repoName: string;
-        readonly userScopes?: string[];
-        readonly lastUpdate?: string;
-    }
     export async function create(token: Token | undefined, user: User, host: string, owner: string, repoName: string) {
-        const lastUpdate = token && token.updateDate;
+        const lastUpdate = (token && token.updateDate) || "";
         const userScopes = token ? [...token.scopes] : [];
 
         const userIsOwner = owner == user.name; // TODO: shouldn't this be a comparison with `identity.authName`?
-        const data = <NotFoundError.Data>{ host, owner, repoName, userIsOwner, userScopes, lastUpdate };
-        const error = Object.assign(new Error("NotFoundError"), { data });
-        return error;
+        return new RepositoryNotFoundError({
+            host,
+            owner,
+            userIsOwner,
+            userScopes,
+            lastUpdate,
+        });
     }
-    export function is(error: any): error is NotFoundError {
-        return (
-            !!error &&
-            !!error.data &&
-            !!error.data.host &&
-            !!error.data.owner &&
-            !!error.data.repoName &&
-            error.message === "NotFoundError"
-        );
+    export function is(error: any): error is RepositoryNotFoundError {
+        return error instanceof RepositoryNotFoundError;
     }
 }
 
-export interface UnauthorizedError extends Error {
-    readonly data: UnauthorizedError.Data;
-}
 export namespace UnauthorizedError {
-    export interface Data {
-        readonly host: string;
-        readonly scopes: string[];
-        readonly messageHint: string;
-    }
-    const message = "UnauthorizedError";
     export function create(host: string, scopes: string[], messageHint?: string) {
-        const data = <UnauthorizedError.Data>{ host, scopes, messageHint: messageHint || "unauthorized" };
-        const error = Object.assign(new Error(message), { data });
-        return error;
+        return new UnauthorizedRepositoryAccessError({
+            host,
+            scopes,
+        });
     }
-    export function is(error: any): error is UnauthorizedError {
-        return (
-            !!error &&
-            !!error.data &&
-            !!error.data.host &&
-            !!error.data.scopes &&
-            !!error.data.messageHint &&
-            error.message === message
-        );
+    export function is(error: any): error is UnauthorizedRepositoryAccessError {
+        return error instanceof UnauthorizedRepositoryAccessError;
     }
 }

--- a/components/server/src/workspace/context-parser-service.ts
+++ b/components/server/src/workspace/context-parser-service.ts
@@ -9,7 +9,8 @@ import { injectable, multiInject, inject } from "inversify";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { IPrefixContextParser, IContextParser } from "./context-parser";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { ConfigProvider, InvalidGitpodYMLError } from "./config-provider";
+import { ConfigProvider } from "./config-provider";
+import { InvalidGitpodYMLError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class ContextParser {
@@ -128,9 +129,9 @@ export class ContextParser {
                     config.config.mainConfiguration,
                 );
                 if (!CommitContext.is(mainRepoContext)) {
-                    throw new InvalidGitpodYMLError([
-                        `Cannot find main repository '${config.config.mainConfiguration}'.`,
-                    ]);
+                    throw new InvalidGitpodYMLError({
+                        violations: [`Cannot find main repository '${config.config.mainConfiguration}'.`],
+                    });
                 }
                 // Note: we only care about repo related stuff in this function.
                 // Fields like `config.image` will not be exposed, so we don't pass organizationId here
@@ -146,7 +147,9 @@ export class ContextParser {
                         subRepo.url,
                     )) as CommitContext;
                     if (!CommitContext.is(subContext)) {
-                        throw new InvalidGitpodYMLError([`Cannot find sub-repository '${subRepo.url}'.`]);
+                        throw new InvalidGitpodYMLError({
+                            violations: [`Cannot find sub-repository '${subRepo.url}'.`],
+                        });
                     }
                     if (context.repository.cloneUrl === subContext.repository.cloneUrl) {
                         // if it's the repo from the original context we want to use that commit.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR:
- unifies API errors on server by consistently using ApplicationError
- drops http headers to encode/decode errors instead use gRPC error details
- delete dead errors and code

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9e624aa</samp>

Refactored and improved the error handling logic in the server and dashboard components, using new subclasses of `ApplicationError` with protobuf messages and predefined error codes. Removed unused code and props related to errors.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Test that unified errors are working with preview envs:
  - [x] invalid yaml - try to start a workspace on https://github.com/akosyakov/parcel-demo/tree/invalid_gitpod_yml
  - [x] repo unauthorized - https://github.com/foo/parcel-demo/tree/invalid_gitpod_yml
  - [x] repo not found - https://github.com/akosyakov/bar/tree/invalid_gitpod_yml + press grant access
- Review conversions for gRPC and their tests (they should pass on CI too)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ak-app-errd866363f8b</li>
	<li><b>🔗 URL</b> - <a href="https://ak-app-errd866363f8b.preview.gitpod-dev.com/workspaces" target="_blank">ak-app-errd866363f8b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ak-app_error_conversion-gha.20480</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ak-app-errd866363f8b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
