### PR TITLE
[ws-manager-mk2] Add node utilization metrics

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -304,6 +304,7 @@ func (m *controllerMetrics) Describe(ch chan<- *prometheus.Desc) {
 
 	m.workspacePhases.Describe(ch)
 	m.timeoutSettings.Describe(ch)
+	m.workspaceNodeCapacity.Describe(ch)
 }
 
 // Collect implements Collector.
@@ -321,6 +322,7 @@ func (m *controllerMetrics) Collect(ch chan<- prometheus.Metric) {
 
 	m.workspacePhases.Collect(ch)
 	m.timeoutSettings.Collect(ch)
+	m.workspaceNodeCapacity.Collect(ch)
 }
 
 // phaseTotalVec returns a gauge vector counting the workspaces per phase
@@ -515,7 +517,13 @@ func (n *nodeCapacityVec) Collect(ch chan<- prometheus.Metric) {
 		// Record node total capacity.
 		for _, resource := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 			capacity := node.Status.Capacity[resource]
-			metric, err := prometheus.NewConstMetric(n.desc, prometheus.GaugeValue, float64(capacity.Value()), node.Name, resource.String(), "total")
+			var value int64
+			if resource == corev1.ResourceCPU {
+				value = capacity.MilliValue()
+			} else {
+				value = capacity.Value()
+			}
+			metric, err := prometheus.NewConstMetric(n.desc, prometheus.GaugeValue, float64(value), node.Name, resource.String(), "total")
 			if err != nil {
 				log.FromContext(ctx).Error(err, "cannot create node capacity metric", "node", node.Name, "resource", resource.String(), "metric", "total")
 				continue
@@ -543,7 +551,7 @@ func (n *nodeCapacityVec) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 
-		if ws.Status.Phase != workspacev1.WorkspacePhaseStopped {
+		if ws.Status.Phase == workspacev1.WorkspacePhaseStopped {
 			// Stopped, no longer consuming resources on the node.
 			continue
 		}
@@ -567,7 +575,7 @@ func (n *nodeCapacityVec) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 
-		nodeCapacity[nodeName][corev1.ResourceCPU] += requests.Cpu().Value()
+		nodeCapacity[nodeName][corev1.ResourceCPU] += requests.Cpu().MilliValue()
 		nodeCapacity[nodeName][corev1.ResourceMemory] += requests.Memory().Value()
 	}
 

--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -15,7 +15,9 @@ import (
 	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -29,6 +31,7 @@ const (
 	workspaceBackupFailuresTotal  string = "workspace_backups_failure_total"
 	workspaceRestoresTotal        string = "workspace_restores_total"
 	workspaceRestoresFailureTotal string = "workspace_restores_failure_total"
+	workspaceNodeCapacity         string = "workspace_node_capacity"
 )
 
 type StopReason string
@@ -57,6 +60,8 @@ type controllerMetrics struct {
 
 	workspacePhases *phaseTotalVec
 	timeoutSettings *timeoutSettingsVec
+
+	workspaceNodeCapacity *nodeCapacityVec
 
 	// used to prevent recording metrics multiple times
 	cache *lru.Cache
@@ -127,9 +132,10 @@ func newControllerMetrics(r *WorkspaceReconciler) (*controllerMetrics, error) {
 			Help:      "total number of workspace restore failures",
 		}, []string{"type", "class"}),
 
-		workspacePhases: newPhaseTotalVec(r),
-		timeoutSettings: newTimeoutSettingsVec(r),
-		cache:           cache,
+		workspacePhases:       newPhaseTotalVec(r),
+		timeoutSettings:       newTimeoutSettingsVec(r),
+		workspaceNodeCapacity: newNodeCapacityVec(r),
+		cache:                 cache,
 	}, nil
 }
 
@@ -457,4 +463,123 @@ func (m *maintenanceEnabledGauge) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	ch <- metric
+}
+
+type nodeCapacityVec struct {
+	name       string
+	desc       *prometheus.Desc
+	reconciler *WorkspaceReconciler
+}
+
+func newNodeCapacityVec(r *WorkspaceReconciler) *nodeCapacityVec {
+	name := prometheus.BuildFQName(metricsNamespace, metricsWorkspaceSubsystem, workspaceNodeCapacity)
+	desc := prometheus.NewDesc(
+		name,
+		"Amount of resource capacity on the node (cpu/memory, metric for `total` on the node vs `requested` by workspaces)",
+		[]string{"node", "resource", "metric"},
+		prometheus.Labels(map[string]string{}),
+	)
+	return &nodeCapacityVec{
+		name:       name,
+		reconciler: r,
+		desc:       desc,
+	}
+}
+
+// Describe implements Collector. It will send exactly one Desc to the provided channel.
+func (n *nodeCapacityVec) Describe(ch chan<- *prometheus.Desc) {
+	ch <- n.desc
+}
+
+// Collect implements Collector.
+func (n *nodeCapacityVec) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetesOperationTimeout)
+	defer cancel()
+
+	var nodes corev1.NodeList
+	err := n.reconciler.List(ctx, &nodes)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "cannot list nodes for node capacity metric")
+		return
+	}
+
+	nodeMap := make(map[string]corev1.Node)
+	for _, node := range nodes.Items {
+		// Only collect metrics for workspace nodes.
+		if node.Labels["gitpod.io/workload_workspace_regular"] != "true" && node.Labels["gitpod.io/workload_workspace_headless"] != "true" {
+			continue
+		}
+
+		nodeMap[node.Name] = node
+
+		// Record node total capacity.
+		for _, resource := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			capacity := node.Status.Capacity[resource]
+			metric, err := prometheus.NewConstMetric(n.desc, prometheus.GaugeValue, float64(capacity.Value()), node.Name, resource.String(), "total")
+			if err != nil {
+				log.FromContext(ctx).Error(err, "cannot create node capacity metric", "node", node.Name, "resource", resource.String(), "metric", "total")
+				continue
+			}
+
+			ch <- metric
+		}
+	}
+
+	var workspaces workspacev1.WorkspaceList
+	if err = n.reconciler.List(ctx, &workspaces, client.InNamespace(n.reconciler.Config.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "cannot list workspaces for node capacity metric")
+		return
+	}
+
+	// we're only interested in the total capacity of the node
+	nodeCapacity := make(map[string]map[corev1.ResourceName]int64)
+	for _, ws := range workspaces.Items {
+		if ws.Status.Runtime == nil {
+			continue
+		}
+		nodeName := ws.Status.Runtime.NodeName
+		if nodeName == "" {
+			// Not yet scheduled.
+			continue
+		}
+
+		if ws.Status.Phase != workspacev1.WorkspacePhaseStopped {
+			// Stopped, no longer consuming resources on the node.
+			continue
+		}
+
+		if _, ok := nodeCapacity[nodeName]; !ok {
+			nodeCapacity[nodeName] = map[corev1.ResourceName]int64{
+				corev1.ResourceCPU:    0,
+				corev1.ResourceMemory: 0,
+			}
+		}
+
+		class, ok := n.reconciler.Config.WorkspaceClasses[ws.Spec.Class]
+		if !ok {
+			log.FromContext(ctx).Error(err, "cannot find workspace class for node capacity metric", "class", ws.Spec.Class)
+			continue
+		}
+
+		requests, err := class.Container.Requests.ResourceList()
+		if err != nil {
+			log.FromContext(ctx).Error(err, "cannot get resource requests for node capacity metric", "class", ws.Spec.Class)
+			continue
+		}
+
+		nodeCapacity[nodeName][corev1.ResourceCPU] += requests.Cpu().Value()
+		nodeCapacity[nodeName][corev1.ResourceMemory] += requests.Memory().Value()
+	}
+
+	for nodeName, metrics := range nodeCapacity {
+		for resource, value := range metrics {
+			metric, err := prometheus.NewConstMetric(n.desc, prometheus.GaugeValue, float64(value), nodeName, resource.String(), "requested")
+			if err != nil {
+				log.FromContext(ctx).Error(err, "cannot create node capacity metric", "node", nodeName, "resource", resource.String(), "metric", "requested")
+				continue
+			}
+
+			ch <- metric
+		}
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds node utilization metrics, reporting per node how much cpu/memory is requested by workspaces (using the resource request values of their workspace class).

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04b9fbb</samp>

Added a new metric to measure workspace resource requests per node. This metric, `workspaceNodeUtilization`, is collected and exposed by the ws-manager-mk2 controller using a custom type `nodeUtilizationVec`. This can help monitor and optimize the node allocation and utilization of workspaces.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of ENG-1071

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
