### PR TITLE
don't use project name if excludeProjects is true

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -100,7 +100,7 @@ export default function RepositoryFinder({
             const result = repos.map((repo) => {
                 return {
                     id: repo.projectId || repo.url,
-                    element: <SuggestedRepositoryOption repo={repo} />,
+                    element: <SuggestedRepositoryOption repo={repo} useProjectNameIfAvailable={!excludeProjects} />,
                     isSelectable: true,
                 } as ComboboxElement;
             });
@@ -148,7 +148,7 @@ export default function RepositoryFinder({
             }
             return result;
         },
-        [repos, hasMore, authProviders.data],
+        [repos, hasMore, authProviders.data, excludeProjects],
     );
 
     return (
@@ -189,9 +189,11 @@ export default function RepositoryFinder({
 
 type SuggestedRepositoryOptionProps = {
     repo: SuggestedRepository;
+    useProjectNameIfAvailable?: boolean;
 };
-const SuggestedRepositoryOption: FC<SuggestedRepositoryOptionProps> = ({ repo }) => {
-    const name = repo.projectName || repo.repositoryName;
+const SuggestedRepositoryOption: FC<SuggestedRepositoryOptionProps> = ({ repo, useProjectNameIfAvailable = true }) => {
+    // use the project name if it's available and not explicitly disabed via prop, otherwise use the repo name
+    const name = useProjectNameIfAvailable && repo.projectName ? repo.projectName : repo.repositoryName;
     const repoPath = stripOffProtocol(repo.url);
 
     return (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In the Import Repository flow we don't want to use the project name for listed repos, just the url. This fixes that, but still uses project name on the new workspace page.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 013a686</samp>

Add a prop to show project or repository name in `RepositoryFinder`. This improves the user experience when selecting a repository for a new project.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-proje3e56cc5142</li>
	<li><b>🔗 URL</b> - <a href="https://brad-proje3e56cc5142.preview.gitpod-dev.com/workspaces" target="_blank">brad-proje3e56cc5142.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-project-name-repo-finder-gha.20528</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-proje3e56cc5142%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
