### PR TITLE
[server] Removes unused RepositoryService.canInstall

### DIFF
--- a/components/server/src/prebuilds/bitbucket-server-service.spec.ts
+++ b/components/server/src/prebuilds/bitbucket-server-service.spec.ts
@@ -89,38 +89,6 @@ class TestBitbucketServerService {
         };
     }
 
-    @test async test_canInstallAutomatedPrebuilds_unauthorized() {
-        const result = await this.service.canInstallAutomatedPrebuilds(
-            this.user,
-            "https://bitbucket.gitpod-self-hosted.com/users/jldec/repos/test-repo",
-        );
-        expect(result).to.be.false;
-    }
-
-    @test async test_canInstallAutomatedPrebuilds_in_project_ok() {
-        const result = await this.service.canInstallAutomatedPrebuilds(
-            this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/jldec/repos/jldec-repo-march-30",
-        );
-        expect(result).to.be.true;
-    }
-
-    @test async test_canInstallAutomatedPrebuilds_ok() {
-        const result = await this.service.canInstallAutomatedPrebuilds(
-            this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
-        );
-        expect(result).to.be.true;
-    }
-
-    @test async test_canInstallAutomatedPrebuilds_users_project_ok() {
-        const result = await this.service.canInstallAutomatedPrebuilds(
-            this.user,
-            "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/yolo.git",
-        );
-        expect(result).to.be.true;
-    }
-
     @test async test_installAutomatedPrebuilds_ok() {
         try {
             await this.service.installAutomatedPrebuilds(

--- a/components/server/src/prebuilds/bitbucket-service.ts
+++ b/components/server/src/prebuilds/bitbucket-service.ts
@@ -8,7 +8,6 @@ import { RepositoryService } from "../repohost/repo-service";
 import { User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from "inversify";
 import { BitbucketApiFactory } from "../bitbucket/bitbucket-api-factory";
-import { AuthProviderParams } from "../auth/auth-provider";
 import { BitbucketApp } from "./bitbucket-app";
 import { Config } from "../config";
 import { TokenService } from "../user/token-service";
@@ -18,24 +17,13 @@ import { BitbucketContextParser } from "../bitbucket/bitbucket-context-parser";
 export class BitbucketService extends RepositoryService {
     static PREBUILD_TOKEN_SCOPE = "prebuilds";
 
-    @inject(BitbucketApiFactory) protected api: BitbucketApiFactory;
-    @inject(Config) protected readonly config: Config;
-    @inject(AuthProviderParams) protected authProviderConfig: AuthProviderParams;
-    @inject(TokenService) protected tokenService: TokenService;
-    @inject(BitbucketContextParser) protected bitbucketContextParser: BitbucketContextParser;
-
-    async canInstallAutomatedPrebuilds(user: User, cloneUrl: string): Promise<boolean> {
-        const { host, owner, repoName } = await this.bitbucketContextParser.parseURL(user, cloneUrl);
-        if (host !== this.authProviderConfig.host) {
-            return false;
-        }
-
-        // only admins may install webhooks on repositories
-        const api = await this.api.create(user);
-        const response = await api.user.listPermissionsForRepos({
-            q: `repository.full_name="${owner}/${repoName}"`,
-        });
-        return !!response.data?.values && response.data.values[0]?.permission === "admin";
+    constructor(
+        @inject(BitbucketApiFactory) private readonly api: BitbucketApiFactory,
+        @inject(Config) private readonly config: Config,
+        @inject(TokenService) private readonly tokenService: TokenService,
+        @inject(BitbucketContextParser) private readonly bitbucketContextParser: BitbucketContextParser,
+    ) {
+        super();
     }
 
     async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {

--- a/components/server/src/repohost/repo-service.ts
+++ b/components/server/src/repohost/repo-service.ts
@@ -17,10 +17,6 @@ export class RepositoryService {
         return [];
     }
 
-    async canInstallAutomatedPrebuilds(user: User, cloneUrl: string): Promise<boolean> {
-        return false;
-    }
-
     async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {
         throw new Error("unsupported");
     }

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -110,9 +110,6 @@ const mockApplyingContainerModule = new ContainerModule((bind, unbound, isbound,
                         installAutomatedPrebuilds: async (user: any, cloneUrl: string) => {
                             webhooks.add(cloneUrl);
                         },
-                        canInstallAutomatedPrebuilds: async () => {
-                            throw "not expected to be called";
-                        },
                     },
                     repositoryProvider: {
                         hasReadAccess: async (user: any, owner: string, repo: string) => {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -29,7 +29,6 @@ import {
     PrebuiltWorkspace,
     PrebuiltWorkspaceContext,
     SetWorkspaceTimeoutResult,
-    StartPrebuildContext,
     StartWorkspaceResult,
     Token,
     User,
@@ -96,7 +95,6 @@ import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-c
 import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import { StopWorkspacePolicy, TakeSnapshotRequest } from "@gitpod/ws-manager/lib/core_pb";
 import { inject, injectable } from "inversify";
-import { URL } from "url";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 import { Disposable, CancellationToken } from "vscode-jsonrpc";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
@@ -1120,30 +1118,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             // if we're forced to use the default config, mark the context as such
             if (!!options.forceDefaultConfig) {
                 context = WithDefaultConfig.mark(context);
-            }
-
-            // if this is an explicit prebuild, check if the user wants to install an app.
-            if (
-                StartPrebuildContext.is(context) &&
-                CommitContext.is(context.actual) &&
-                context.actual.repository.cloneUrl
-            ) {
-                const cloneUrl = context.actual.repository.cloneUrl;
-                const host = new URL(cloneUrl).hostname;
-                const hostContext = this.hostContextProvider.get(host);
-                const services = hostContext && hostContext.services;
-                if (!hostContext || !services) {
-                    console.error("Unknown host: " + host);
-                } else {
-                    // on purpose to not await on that installation process, because it‘s not required of workspace start
-                    // See https://github.com/gitpod-io/gitpod/pull/6420#issuecomment-953499632 for more detail
-                    (async () => {
-                        if (await services.repositoryService.canInstallAutomatedPrebuilds(user, cloneUrl)) {
-                            console.log("Installing automated prebuilds for " + cloneUrl);
-                            await services.repositoryService.installAutomatedPrebuilds(user, cloneUrl);
-                        }
-                    })().catch((e) => console.error("Install automated prebuilds failed", e));
-                }
             }
 
             if (!options.ignoreRunningWorkspaceOnSameCommit && !context.forceCreateNewWorkspace) {


### PR DESCRIPTION
## Description
PR to remove unused code.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac7fe43</samp>

This pull request simplifies and cleans up the code of various classes and files related to prebuilds and repository services. It removes unused dependencies, methods, imports, and tests, and refactors some constructors and helper methods. The overall purpose is to improve code quality, consistency, and performance.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
* See you can create a workspace in preview environment w/o issues.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-remove-f7bcae44fe</li>
	<li><b>🔗 URL</b> - <a href="https://at-remove-f7bcae44fe.preview.gitpod-dev.com/workspaces" target="_blank">at-remove-f7bcae44fe.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-remove-unused-caninstall-gha.20553</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-remove-f7bcae44fe%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
