### PR TITLE
[build] update leeway

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     outputs:
       previewctl_hash: ${{ steps.build.outputs.previewctl_hash }}
     steps:
@@ -161,7 +161,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
       env:
         DB_HOST: "mysql"
         DB_PORT: "23306"
@@ -401,7 +401,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -101,7 +101,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [configuration,create-runner]
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     steps:
       # Most of this is taken over from the Build workflow/preview-env-check-regressions workflow
       - uses: actions/checkout@v4

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -86,7 +86,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -136,7 +136,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     steps:
       - uses: actions/checkout@v4
       - id: auth
@@ -167,7 +167,7 @@ jobs:
     if: inputs.skip_delete != 'true' && always()
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
     steps:
       - uses: actions/checkout@v4
       - name: Delete preview environment

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,88 +2,91 @@ image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
-    - port: 1337
-      onOpen: open-preview
-    - port: 3000
-      onOpen: ignore
-    - port: 3001
-      onOpen: ignore
-    - port: 3306
-      onOpen: ignore
-    - port: 4000
-      onOpen: ignore
-    # VNC
-    - port: 5900
-      onOpen: ignore
-    # noVNC
-    - port: 6080
-      onOpen: ignore
-    # Werft
-    - port: 7777
-      onOpen: ignore
-    - port: 9229
-      onOpen: ignore
-    # Go proxy
-    - port: 9999
-      onOpen: ignore
-    - port: 13001
-      onOpen: ignore
-    # Dev Theia
-    - port: 13444
-    # Used when using port-forwarding to SSH to preview environment VMs
-    - port: 8022
-      onOpen: ignore
+  - port: 1337
+    onOpen: open-preview
+  - port: 3000
+    onOpen: ignore
+  - port: 3001
+    onOpen: ignore
+  - port: 3306
+    onOpen: ignore
+  - port: 4000
+    onOpen: ignore
+  # VNC
+  - port: 5900
+    onOpen: ignore
+  # noVNC
+  - port: 6080
+    onOpen: ignore
+  # Werft
+  - port: 7777
+    onOpen: ignore
+  - port: 9229
+    onOpen: ignore
+  # Go proxy
+  - port: 9999
+    onOpen: ignore
+  - port: 13001
+    onOpen: ignore
+  # Dev Theia
+  - port: 13444
+  # Used when using port-forwarding to SSH to preview environment VMs
+  - port: 8022
+    onOpen: ignore
 tasks:
-    - name: Remove GCP_ADC_FILE
-      command: |
-          if [[ -n "${GCP_ADC_FILE}" ]]; then
-            echo "$GCP_ADC_FILE" > "/home/gitpod/.config/gcloud/application_default_credentials.json"
-            yes | gcloud auth application-default revoke
-            gp env -u GCP_ADC_FILE
-          fi
-          exit 0
-    - name: Install `gitpod` CLI
-      command: |
-        leeway run components/local-app:install-cli
-        leeway run components/local-app:cli-completion
-        exit 0
-    # This task takes care of configuring your workspace so it can manage and interact
-    # with preview environments.
-    - name: Preview environment configuration
-      init: leeway run dev/preview/previewctl:install
-      command: INSTALL_CONTEXT=true leeway run dev/preview:configure-workspace
-    - name: Installer dependencies
-      init: |
-          (cd install/installer && make deps)
-          exit 0
-    - name: Java
-      init: |
-          leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib --cache-key gradle_build -- ./gradlew build
-          leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel --cache-key gradle_buildPlugin -- ./gradlew buildPlugin
-    - name: TypeScript
-      init: yarn --network-timeout 100000 && yarn build
-    - name: Go
-      before: pre-commit install --install-hooks
-      init: |
-          ./components/gitpod-protocol/go/scripts/generate-config.sh
-          leeway exec --filter-type go -v -- go mod verify
+  - name: Remove GCP_ADC_FILE
+    command: |
+      if [[ -n "${GCP_ADC_FILE}" ]]; then
+        echo "$GCP_ADC_FILE" > "/home/gitpod/.config/gcloud/application_default_credentials.json"
+        yes | gcloud auth application-default revoke
+        gp env -u GCP_ADC_FILE
+      fi
+      exit 0
+  - name: Install `gitpod` CLI
+    command: |
+      leeway run components/local-app:install-cli
+      leeway run components/local-app:cli-completion
+      exit 0
+  # This task takes care of configuring your workspace so it can manage and interact
+  # with preview environments.
+  - name: Preview environment configuration
+    init: leeway run dev/preview/previewctl:install
+    command: INSTALL_CONTEXT=true leeway run dev/preview:configure-workspace
+  - name: Installer dependencies
+    init: |
+      (cd install/installer && make deps)
+      exit 0
+  - name: Java
+    command: |
+      if [ -z "$RUN_GRADLE_TASK" ]; then
+        read -r -p "Press enter to continue Java gradle task"
+      fi
+      leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
+      leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
+  - name: TypeScript
+    init: yarn --network-timeout 100000 && yarn build
+  - name: Go
+    before: pre-commit install --install-hooks
+    init: |
+      ./components/gitpod-protocol/go/scripts/generate-config.sh
+      leeway exec --filter-type go -v -- go mod verify
 vscode:
-    extensions:
-        - EditorConfig.EditorConfig
-        - golang.go
-        - hashicorp.terraform
-        - ms-azuretools.vscode-docker
-        - ms-kubernetes-tools.vscode-kubernetes-tools
-        - stkb.rewrap
-        - zxh404.vscode-proto3
-        - matthewpi.caddyfile-support
-        - heptio.jsonnet
-        - timonwong.shellcheck
-        - fwcd.kotlin
-        - dbaeumer.vscode-eslint
-        - esbenp.prettier-vscode
-        - akosyakov.gitpod-monitor
-        - hbenl.vscode-mocha-test-adapter
+  extensions:
+    - EditorConfig.EditorConfig
+    - golang.go
+    - hashicorp.terraform
+    - ms-azuretools.vscode-docker
+    - ms-kubernetes-tools.vscode-kubernetes-tools
+    - stkb.rewrap
+    - zxh404.vscode-proto3
+    - matthewpi.caddyfile-support
+    - heptio.jsonnet
+    - timonwong.shellcheck
+    - fwcd.kotlin
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode
+    - akosyakov.gitpod-monitor
+    - hbenl.vscode-mocha-test-adapter
 jetbrains:
   intellij:
     vmoptions: -Xmx4g

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-leeway-pigz-gha.18593
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:se-update-leeway-gha.20594
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -57,12 +57,9 @@ tasks:
           (cd install/installer && make deps)
           exit 0
     - name: Java
-      command: |
-          if [ -z "$RUN_GRADLE_TASK" ]; then
-            read -r -p "Press enter to continue Java gradle task"
-          fi
-          leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
-          leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
+      init: |
+          leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib --cache-key gradle_build -- ./gradlew build
+          leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel --cache-key gradle_buildPlugin -- ./gradlew buildPlugin
     - name: TypeScript
       init: yarn --network-timeout 100000 && yarn build
     - name: Go

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -99,7 +99,6 @@ import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 import { Disposable, CancellationToken } from "vscode-jsonrpc";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { AuthProviderService } from "../auth/auth-provider-service";
-import { HostContextProvider } from "../auth/host-context-provider";
 import { GuardedResource, ResourceAccessGuard, ResourceAccessOp } from "../auth/resource-access";
 import { Config } from "../config";
 import { NotFoundError, UnauthorizedError } from "../errors";
@@ -179,7 +178,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         @inject(Config) private readonly config: Config,
         @inject(TracedWorkspaceDB) private readonly workspaceDb: DBWithTracing<WorkspaceDB>,
         @inject(ContextParser) private contextParser: ContextParser,
-        @inject(HostContextProvider) private readonly hostContextProvider: HostContextProvider,
 
         @inject(PrebuildManager) private readonly prebuildManager: PrebuildManager,
         @inject(IncrementalWorkspaceService) private readonly incrementalPrebuildsService: IncrementalWorkspaceService,

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -48,12 +48,12 @@ RUN cd /usr/bin && curl -fsSL https://github.com/cert-manager/cert-manager/relea
 RUN cd /usr/bin && curl -fsSL https://github.com/praetorian-inc/gokart/releases/download/v0.4.0/gokart_0.4.0_linux_x86_64.tar.gz | tar xzv --no-anchored gokart
 
 # leeway
-ARG LEEWAY_VERSION=0.7.9
+ARG LEEWAY_VERSION=0.8.0
 ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
 ENV LEEWAY_WORKSPACE_ROOT=/workspace/gitpod
 ENV LEEWAY_REMOTE_CACHE_BUCKET=gitpod-core-leeway-cache-branch
-ENV LEEWAY_CACHE_DIR=/var/tmp/cache
-ENV LEEWAY_BUILD_DIR=/var/tmp/build
+ENV LEEWAY_CACHE_DIR=/workspace/.leeway/cache
+ENV LEEWAY_BUILD_DIR=/workspace/.leeway/build
 RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v${LEEWAY_VERSION}/leeway_${LEEWAY_VERSION}_Linux_x86_64.tar.gz | tar xz
 
 # evans (gRPC client)

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
         "typescript": "~4.4.4"
     },
     "scripts": {
-        "build": "leeway exec --filter-type yarn --components -- yarn build",
+        "build": "leeway exec --filter-type yarn --cache-key yarn_build -- yarn build",
         "watch": "leeway exec --package components:all --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
-        "clean": "leeway exec --filter-type yarn --components -- yarn clean && rm -rf node_modules"
+        "clean": "leeway exec --filter-type yarn -- yarn clean && rm -rf node_modules"
     },
     "workspaces": {
         "packages": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change updates the development container to use the latest version of leeway, which gained support for caching when using `leeway exec`.

It makes use of this in our root `yarn build` script, so that rerunning this script (as we do on every workspace start) no longer takes 80 secs, but more like 4sec.

This change also moves the leeway cache below `/workspace`

<img width="858" alt="Screenshot 2023-11-22 at 18 13 51" src="https://github.com/gitpod-io/gitpod/assets/372735/3a253f08-6552-4298-8bf7-b3ceba1db007">

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e759747</samp>

This pull request optimizes the Gitpod development environment and workflow by using the `--cache-key` option of leeway for Java and yarn build tasks. It also removes unused code related to `HostContextProvider` from the `gitpod-server-impl.ts` file.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a workspace on this PR and try yarn build in the root folder.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
