### PR TITLE
[bridge] sync ws status updates

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -36,6 +36,22 @@ import { WorkspaceInstanceController } from "./workspace-instance-controller";
 import { PrebuildUpdater } from "./prebuild-updater";
 import { RedisPublisher } from "@gitpod/gitpod-db/lib";
 
+/**
+ * TODO(se) use a proper distributed lock here
+ * This only works for a single instance of bridge, but that's fine as we run only one instance of ws-manager-bridge
+ * Ideally we'd use a redis-based distributed lock here, but that's not available in this component (only server)
+ */
+class PoorMensSyncer {
+    private readonly queues = new Map<string, Queue>();
+
+    public sync<T>(key: string, cb: () => Promise<T>): Promise<T> {
+        const q = this.queues.get(key) || new Queue();
+        const result = q.enqueue(cb);
+        this.queues.set(key, q);
+        return result;
+    }
+}
+
 export const WorkspaceManagerBridgeFactory = Symbol("WorkspaceManagerBridgeFactory");
 
 function toBool(b: WorkspaceConditionBool | undefined): boolean | undefined {
@@ -50,6 +66,7 @@ export type WorkspaceClusterInfo = Pick<WorkspaceCluster, "name" | "url">;
 
 @injectable()
 export class WorkspaceManagerBridge implements Disposable {
+    private readonly syncer = new PoorMensSyncer();
     constructor(
         @inject(WorkspaceClusterDB) private readonly clusterDB: WorkspaceClusterDB,
         @inject(TracedWorkspaceDB) private readonly workspaceDB: DBWithTracing<WorkspaceDB>,
@@ -235,152 +252,158 @@ export class WorkspaceManagerBridge implements Disposable {
                 workspaceId,
             };
 
-            const instance = await this.workspaceDB.trace({ span }).findInstanceById(instanceId);
-            if (instance) {
-                this.metrics.statusUpdateReceived(this.cluster.name, true);
-            } else {
-                // This scenario happens when the update for a WorkspaceInstance is picked up by a ws-manager-bridge in a different region,
-                // before periodic deleter finished running. This is because all ws-manager-bridge instances receive updates from all WorkspaceClusters.
-                // We ignore this update because we do not have anything to reconcile this update against, but also because we assume it is handled
-                // by another instance of ws-manager-bridge that is in the region where the WorkspaceInstance record was created.
-                this.metrics.statusUpdateReceived(this.cluster.name, false);
-                return;
-            }
+            await this.syncer.sync(instanceId, async () => {
+                // this is only to treat the typeschecker
+                if (!status.spec || !status.metadata || !status.conditions) {
+                    return;
+                }
+                const instance = await this.workspaceDB.trace({ span }).findInstanceById(instanceId);
+                if (instance) {
+                    this.metrics.statusUpdateReceived(this.cluster.name, true);
+                } else {
+                    // This scenario happens when the update for a WorkspaceInstance is picked up by a ws-manager-bridge in a different region,
+                    // before periodic deleter finished running. This is because all ws-manager-bridge instances receive updates from all WorkspaceClusters.
+                    // We ignore this update because we do not have anything to reconcile this update against, but also because we assume it is handled
+                    // by another instance of ws-manager-bridge that is in the region where the WorkspaceInstance record was created.
+                    this.metrics.statusUpdateReceived(this.cluster.name, false);
+                    return;
+                }
 
-            const currentStatusVersion = instance.status.version || 0;
-            if (currentStatusVersion > 0 && currentStatusVersion >= status.statusVersion) {
-                // We've gotten an event which is older than one we've already processed. We shouldn't process the stale one.
-                span.setTag("statusUpdate.staleEvent", true);
-                this.metrics.recordStaleStatusUpdate();
-                log.debug(ctx, "Stale status update received, skipping.");
-            }
+                const currentStatusVersion = instance.status.version || 0;
+                if (currentStatusVersion > 0 && currentStatusVersion >= status.statusVersion) {
+                    // We've gotten an event which is older than one we've already processed. We shouldn't process the stale one.
+                    span.setTag("statusUpdate.staleEvent", true);
+                    this.metrics.recordStaleStatusUpdate();
+                    log.debug(ctx, "Stale status update received, skipping.");
+                }
 
-            if (!!status.spec.exposedPortsList) {
-                instance.status.exposedPorts = status.spec.exposedPortsList.map((p) => {
-                    return <WorkspaceInstancePort>{
-                        port: p.port,
-                        visibility: mapPortVisibility(p.visibility),
-                        protocol: mapPortProtocol(p.protocol),
-                        url: p.url,
-                    };
-                });
-            }
+                if (!!status.spec.exposedPortsList) {
+                    instance.status.exposedPorts = status.spec.exposedPortsList.map((p) => {
+                        return <WorkspaceInstancePort>{
+                            port: p.port,
+                            visibility: mapPortVisibility(p.visibility),
+                            protocol: mapPortProtocol(p.protocol),
+                            url: p.url,
+                        };
+                    });
+                }
 
-            if (!instance.status.conditions.firstUserActivity && status.conditions.firstUserActivity) {
-                // Only report this when it's observed the first time
-                const firstUserActivity = mapFirstUserActivity(rawStatus.getConditions()!.getFirstUserActivity())!;
-                this.metrics.observeFirstUserActivity(instance, firstUserActivity);
-            }
+                if (!instance.status.conditions.firstUserActivity && status.conditions.firstUserActivity) {
+                    // Only report this when it's observed the first time
+                    const firstUserActivity = mapFirstUserActivity(rawStatus.getConditions()!.getFirstUserActivity())!;
+                    this.metrics.observeFirstUserActivity(instance, firstUserActivity);
+                }
 
-            instance.ideUrl = status.spec.url!;
-            instance.status.version = status.statusVersion;
-            instance.status.timeout = status.spec.timeout;
-            if (!!instance.status.conditions.failed && !status.conditions.failed) {
-                // We already have a "failed" condition, and received an empty one: This is a bug, "failed" conditions are terminal per definition.
-                // Do not override!
-                log.error(logContext, 'We received an empty "failed" condition overriding an existing one!', {
-                    current: instance.status.conditions.failed,
-                });
+                instance.ideUrl = status.spec.url!;
+                instance.status.version = status.statusVersion;
+                instance.status.timeout = status.spec.timeout;
+                if (!!instance.status.conditions.failed && !status.conditions.failed) {
+                    // We already have a "failed" condition, and received an empty one: This is a bug, "failed" conditions are terminal per definition.
+                    // Do not override!
+                    log.error(logContext, 'We received an empty "failed" condition overriding an existing one!', {
+                        current: instance.status.conditions.failed,
+                    });
 
-                // TODO(gpl) To make ensure we do not break anything big time we keep the unconditional override for now, and observe for some time.
-                instance.status.conditions.failed = status.conditions.failed;
-            } else {
-                instance.status.conditions.failed = status.conditions.failed;
-            }
-            instance.status.conditions.pullingImages = toBool(status.conditions.pullingImages!);
-            instance.status.conditions.deployed = toBool(status.conditions.deployed);
-            instance.status.conditions.timeout = status.conditions.timeout;
-            instance.status.conditions.firstUserActivity = mapFirstUserActivity(
-                rawStatus.getConditions()!.getFirstUserActivity(),
-            );
-            instance.status.conditions.headlessTaskFailed = status.conditions.headlessTaskFailed;
-            instance.status.conditions.stoppedByRequest = toBool(status.conditions.stoppedByRequest);
-            instance.status.message = status.message;
-            instance.status.nodeName = instance.status.nodeName || status.runtime?.nodeName;
-            instance.status.podName = instance.status.podName || status.runtime?.podName;
-            instance.status.nodeIp = instance.status.nodeIp || status.runtime?.nodeIp;
-            instance.status.ownerToken = status.auth!.ownerToken;
+                    // TODO(gpl) To make ensure we do not break anything big time we keep the unconditional override for now, and observe for some time.
+                    instance.status.conditions.failed = status.conditions.failed;
+                } else {
+                    instance.status.conditions.failed = status.conditions.failed;
+                }
+                instance.status.conditions.pullingImages = toBool(status.conditions.pullingImages!);
+                instance.status.conditions.deployed = toBool(status.conditions.deployed);
+                instance.status.conditions.timeout = status.conditions.timeout;
+                instance.status.conditions.firstUserActivity = mapFirstUserActivity(
+                    rawStatus.getConditions()!.getFirstUserActivity(),
+                );
+                instance.status.conditions.headlessTaskFailed = status.conditions.headlessTaskFailed;
+                instance.status.conditions.stoppedByRequest = toBool(status.conditions.stoppedByRequest);
+                instance.status.message = status.message;
+                instance.status.nodeName = instance.status.nodeName || status.runtime?.nodeName;
+                instance.status.podName = instance.status.podName || status.runtime?.podName;
+                instance.status.nodeIp = instance.status.nodeIp || status.runtime?.nodeIp;
+                instance.status.ownerToken = status.auth!.ownerToken;
 
-            let lifecycleHandler: (() => Promise<void>) | undefined;
-            switch (status.phase) {
-                case WorkspacePhase.PENDING:
-                    instance.status.phase = "pending";
-                    break;
-                case WorkspacePhase.CREATING:
-                    instance.status.phase = "creating";
-                    break;
-                case WorkspacePhase.INITIALIZING:
-                    instance.status.phase = "initializing";
-                    break;
-                case WorkspacePhase.RUNNING:
-                    if (!instance.startedTime) {
-                        instance.startedTime = new Date().toISOString();
-                        this.metrics.observeWorkspaceStartupTime(instance);
-                        this.analytics.track({
-                            event: "workspace_running",
-                            messageId: `bridge-wsrun-${instance.id}`,
-                            properties: { instanceId: instance.id, workspaceId: workspaceId },
-                            userId,
-                            timestamp: new Date(instance.startedTime),
-                        });
-                    }
-
-                    instance.status.phase = "running";
-                    // let's check if the state is inconsistent and be loud if it is.
-                    if (instance.stoppedTime || instance.stoppingTime) {
-                        log.error("Resetting already stopped workspace to running.", {
-                            instanceId: instance.id,
-                            stoppedTime: instance.stoppedTime,
-                        });
-                        instance.stoppedTime = undefined;
-                        instance.stoppingTime = undefined;
-                    }
-                    break;
-                case WorkspacePhase.INTERRUPTED:
-                    instance.status.phase = "interrupted";
-                    break;
-                case WorkspacePhase.STOPPING:
-                    if (instance.status.phase != "stopped") {
-                        instance.status.phase = "stopping";
-                        if (!instance.stoppingTime) {
-                            // The first time a workspace enters stopping we record that as it's stoppingTime time.
-                            // This way we don't take the time a workspace requires to stop into account when
-                            // computing the time a workspace instance was running.
-                            instance.stoppingTime = new Date().toISOString();
+                let lifecycleHandler: (() => Promise<void>) | undefined;
+                switch (status.phase) {
+                    case WorkspacePhase.PENDING:
+                        instance.status.phase = "pending";
+                        break;
+                    case WorkspacePhase.CREATING:
+                        instance.status.phase = "creating";
+                        break;
+                    case WorkspacePhase.INITIALIZING:
+                        instance.status.phase = "initializing";
+                        break;
+                    case WorkspacePhase.RUNNING:
+                        if (!instance.startedTime) {
+                            instance.startedTime = new Date().toISOString();
+                            this.metrics.observeWorkspaceStartupTime(instance);
+                            this.analytics.track({
+                                event: "workspace_running",
+                                messageId: `bridge-wsrun-${instance.id}`,
+                                properties: { instanceId: instance.id, workspaceId: workspaceId },
+                                userId,
+                                timestamp: new Date(instance.startedTime),
+                            });
                         }
-                    } else {
-                        log.warn(logContext, "Got a stopping event for an already stopped workspace.", instance);
-                    }
-                    break;
-                case WorkspacePhase.STOPPED:
-                    const now = new Date().toISOString();
-                    instance.stoppedTime = now;
-                    instance.status.phase = "stopped";
-                    if (!instance.stoppingTime) {
-                        // It's possible we've never seen a stopping update, hence have not set the `stoppingTime`
-                        // yet. Just for this case we need to set it now.
-                        instance.stoppingTime = now;
-                    }
-                    lifecycleHandler = () => this.workspaceInstanceController.onStopped({ span }, userId, instance);
-                    break;
-            }
 
-            span.setTag("after", JSON.stringify(instance));
+                        instance.status.phase = "running";
+                        // let's check if the state is inconsistent and be loud if it is.
+                        if (instance.stoppedTime || instance.stoppingTime) {
+                            log.error("Resetting already stopped workspace to running.", {
+                                instanceId: instance.id,
+                                stoppedTime: instance.stoppedTime,
+                            });
+                            instance.stoppedTime = undefined;
+                            instance.stoppingTime = undefined;
+                        }
+                        break;
+                    case WorkspacePhase.INTERRUPTED:
+                        instance.status.phase = "interrupted";
+                        break;
+                    case WorkspacePhase.STOPPING:
+                        if (instance.status.phase != "stopped") {
+                            instance.status.phase = "stopping";
+                            if (!instance.stoppingTime) {
+                                // The first time a workspace enters stopping we record that as it's stoppingTime time.
+                                // This way we don't take the time a workspace requires to stop into account when
+                                // computing the time a workspace instance was running.
+                                instance.stoppingTime = new Date().toISOString();
+                            }
+                        } else {
+                            log.warn(logContext, "Got a stopping event for an already stopped workspace.", instance);
+                        }
+                        break;
+                    case WorkspacePhase.STOPPED:
+                        const now = new Date().toISOString();
+                        instance.stoppedTime = now;
+                        instance.status.phase = "stopped";
+                        if (!instance.stoppingTime) {
+                            // It's possible we've never seen a stopping update, hence have not set the `stoppingTime`
+                            // yet. Just for this case we need to set it now.
+                            instance.stoppingTime = now;
+                        }
+                        lifecycleHandler = () => this.workspaceInstanceController.onStopped({ span }, userId, instance);
+                        break;
+                }
 
-            // now notify all prebuild listeners about updates - and update DB if needed
-            await this.prebuildUpdater.updatePrebuiltWorkspace({ span }, userId, status);
+                span.setTag("after", JSON.stringify(instance));
 
-            await this.workspaceDB.trace(ctx).storeInstance(instance);
+                // now notify all prebuild listeners about updates - and update DB if needed
+                await this.prebuildUpdater.updatePrebuiltWorkspace({ span }, userId, status);
 
-            // cleanup
-            // important: call this after the DB update
-            if (!!lifecycleHandler) {
-                await lifecycleHandler();
-            }
-            await this.publisher.publishInstanceUpdate({
-                ownerID: userId,
-                instanceID: instance.id,
-                workspaceID: instance.workspaceId,
+                await this.workspaceDB.trace(ctx).storeInstance(instance);
+
+                // cleanup
+                // important: call this after the DB update
+                if (!!lifecycleHandler) {
+                    await lifecycleHandler();
+                }
+                await this.publisher.publishInstanceUpdate({
+                    ownerID: userId,
+                    instanceID: instance.id,
+                    workspaceID: instance.workspaceId,
+                });
             });
         } catch (e) {
             TraceContext.setError({ span }, e);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Syncs the workspace instance updates so that we don't accidentally overwrite state when there is a race between looking up the object from db and storing it again.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 603fdb1</samp>

This pull request introduces a new way of synchronizing workspace status updates between the ws-manager and the ws-manager-bridge components. It uses a queue-based approach that avoids race conditions and improves performance. The new logic is implemented in the `PoorMensSyncer` class and used by the `WorkspaceManagerBridge` class in `bridge.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
