### PR TITLE
[configcat] ensure that browser updates the cache

### DIFF
--- a/components/proxy/plugins/configcat/configcat.go
+++ b/components/proxy/plugins/configcat/configcat.go
@@ -93,6 +93,9 @@ func (c *ConfigCat) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	arr := strings.Split(r.URL.Path, "/")
 	configVersion := arr[len(arr)-1]
 
+	// ensure that the browser must revalidate it, but still cache it
+	w.Header().Set("Cache-Control", "no-cache")
+
 	if c.configCatConfigDir != "" {
 		c.ServeFromFile(w, r, configVersion)
 		return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

it is a req to guruantee that ETag works: https://stackoverflow.com/a/68407563

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2efa84</samp>

Set `Cache-Control` header to `no-cache` for proxy responses with feature flags. This prevents the browser from using stale feature flags that may not match the TTL set by the ConfigCat service.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

fix EXP-979

## How to test
<!-- Provide steps to test this PR -->

Deploy to dogfood, toggle FF, check that it is updated on Dashboard.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://ak-proxy-c63f583f0d1.preview.gitpod-dev.com/workspaces

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
