### PR TITLE
Fix some log statements and a minor in pre-commit settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,5 +79,6 @@ repos:
         entry: leeway run components/dashboard:lint
         language: system
         pass_filenames: false
+        files: ^components/dashboard/
 
 exclude: ^install/installer/.*/.*\.golden$

--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -180,7 +180,7 @@ export class BitbucketApp {
                         });
                     }
                 } catch (error) {
-                    log.error("Error processing Bitbucket Server webhook event", error);
+                    log.error("Error processing Bitbucket webhook event", error);
                 }
             }
         } catch (e) {

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -353,7 +353,7 @@ export class GithubApp {
                             });
                         });
                 } catch (error) {
-                    log.error("Error processing Bitbucket Server webhook event", error);
+                    log.error("Error processing GitHub webhook event", error);
                 }
             }
         } catch (e) {

--- a/components/server/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/src/prebuilds/github-enterprise-app.ts
@@ -205,7 +205,7 @@ export class GitHubEnterpriseApp {
                         });
                     }
                 } catch (error) {
-                    log.error("Error processing Bitbucket Server webhook event", error);
+                    log.error("Error processing GitHub webhook event", error);
                 }
             }
         } catch (e) {

--- a/components/server/src/prebuilds/gitlab-app.ts
+++ b/components/server/src/prebuilds/gitlab-app.ts
@@ -193,7 +193,7 @@ export class GitLabApp {
                         prebuildId: ws.prebuildId,
                     });
                 } catch (error) {
-                    log.error("Error processing Bitbucket Server webhook event", error);
+                    log.error("Error processing GitLab webhook event", error);
                 }
             }
         } catch (e) {


### PR DESCRIPTION
* Fix misleading log statement
* Also make `git commit` work even if `yarn install` isn't finished


<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ce3364</samp>

This pull request applies code formatting to the dashboard component and fixes some typos in the log messages of the prebuild classes for different git providers.

</details>




## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
