### PR TITLE
Add pin command to CLI

### DIFF
--- a/components/gitpod-cli/cmd/pin.go
+++ b/components/gitpod-cli/cmd/pin.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/spf13/cobra"
+)
+
+var pinCmd = &cobra.Command{
+	Use:   "pin",
+	Short: "Toggle pinning of the current workspace",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			cancel()
+		}()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			return err
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:updateWorkspaceUserPin",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			return err
+		}
+		action := protocol.PinActionToggle
+		err = client.UpdateWorkspaceUserPin(ctx, wsInfo.WorkspaceId, &action)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pinCmd)
+}

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1583,6 +1583,7 @@ export class WorkspaceStarter {
             // Without this scope the workspace cannot produce ID tokens.
             "function:getIDToken",
             "function:getDefaultWorkspaceImage",
+            "function:updateWorkspaceUserPin",
 
             "resource:" +
                 ScopedResourceGuard.marshalResourceScope({


### PR DESCRIPTION
## Description

This adds a pin command to the CLI, which allows you to toggle the pinned state of the current workspace.

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13297

Related to #6226

## How to test
<!-- Provide steps to test this PR -->

1. In the Gitpod CLI, run: `gp pin`
2. Go to the workspace list in your org
3. See that the current workspace has been pinned

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
