### PR TITLE
[dashboard] enable grpc migration per service

### DIFF
--- a/components/gitpod-protocol/src/generate-async-generator.ts
+++ b/components/gitpod-protocol/src/generate-async-generator.ts
@@ -21,7 +21,7 @@ import { ApplicationError, ErrorCodes } from "./messaging/error";
 export function generateAsyncGenerator<T>(
     setup: (queue: Queue<T>) => (() => void) | void,
     opts: { signal: AbortSignal },
-) {
+): AsyncIterable<T> {
     return new EventIterator<T>((queue) => {
         opts.signal.addEventListener("abort", () => {
             queue.fail(new ApplicationError(ErrorCodes.CANCELLED, "cancelled"));

--- a/components/server/src/api/prebuild-service-api.ts
+++ b/components/server/src/api/prebuild-service-api.ts
@@ -24,7 +24,7 @@ import { ProjectsService } from "../projects/projects-service";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
 import { validate as uuidValidate } from "uuid";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ctxUserId } from "../util/request-context";
+import { ctxSignal, ctxUserId } from "../util/request-context";
 import { UserService } from "../user/user-service";
 
 @injectable()
@@ -120,7 +120,9 @@ export class PrebuildServiceAPI implements ServiceImpl<typeof PrebuildServiceInt
             });
             configurationId = resp.prebuild!.configurationId;
         }
-        const it = this.prebuildManager.watchPrebuildStatus(ctxUserId(), configurationId);
+        const it = await this.prebuildManager.watchPrebuildStatus(ctxUserId(), configurationId, {
+            signal: ctxSignal(),
+        });
         for await (const pb of it) {
             if (request.scope.case === "prebuildId") {
                 if (pb.info.id !== request.scope.value) {

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -55,6 +55,8 @@ import { BearerAuth } from "../auth/bearer-authenticator";
 import { ScmServiceAPI } from "./scm-service-api";
 import { SCMService } from "@gitpod/public-api/lib/gitpod/v1/scm_connect";
 import { SSHService } from "@gitpod/public-api/lib/gitpod/v1/ssh_connect";
+import { PrebuildServiceAPI } from "./prebuild-service-api";
+import { PrebuildService } from "@gitpod/public-api/lib/gitpod/v1/prebuild_connect";
 
 decorate(injectable(), PublicAPIConverter);
 
@@ -81,6 +83,7 @@ export class API {
     @inject(Config) private readonly config: Config;
     @inject(UserService) private readonly userService: UserService;
     @inject(BearerAuth) private readonly bearerAuthenticator: BearerAuth;
+    @inject(PrebuildServiceAPI) private readonly prebuildServiceApi: PrebuildServiceAPI;
 
     listenPrivate(): http.Server {
         const app = express();
@@ -129,6 +132,7 @@ export class API {
                         service(EnvironmentVariableService, this.envvarServiceApi),
                         service(SCMService, this.scmServiceAPI),
                         service(SSHService, this.sshServiceApi),
+                        service(PrebuildService, this.prebuildServiceApi),
                     ]) {
                         router.service(type, new Proxy(impl, this.interceptService(type)));
                     }
@@ -384,6 +388,7 @@ export class API {
         bind(ScmServiceAPI).toSelf().inSingletonScope();
         bind(SSHServiceAPI).toSelf().inSingletonScope();
         bind(StatsServiceAPI).toSelf().inSingletonScope();
+        bind(PrebuildServiceAPI).toSelf().inSingletonScope();
         bind(API).toSelf().inSingletonScope();
     }
 }

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -33,6 +33,7 @@ import { ScmService } from "../scm/scm-service";
 import { ContextService } from "../workspace/context-service";
 import { ContextParser } from "../workspace/context-parser-service";
 import { SSHKeyService } from "../user/sshkey-service";
+import { PrebuildManager } from "../prebuilds/prebuild-manager";
 
 const expect = chai.expect;
 
@@ -63,6 +64,7 @@ export class APITeamsServiceSpec {
         this.container.bind(ContextService).toConstantValue({} as ContextService);
         this.container.bind(ContextParser).toConstantValue({} as ContextParser);
         this.container.bind(SSHKeyService).toConstantValue({} as SSHKeyService);
+        this.container.bind(PrebuildManager).toConstantValue({} as PrebuildManager);
 
         // Clean-up database
         const typeorm = testContainer.get<TypeORM>(TypeORM);

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -6,7 +6,6 @@
 
 import { inject, injectable } from "inversify";
 import * as grpc from "@grpc/grpc-js";
-import { EventIterator } from "event-iterator";
 import { RedisPublisher, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import {
     GetWorkspaceTimeoutResult,
@@ -757,7 +756,7 @@ export class WorkspaceService {
         return urls;
     }
 
-    public watchWorkspaceStatus(userId: string, opts: { signal: AbortSignal }): EventIterator<WorkspaceInstance> {
+    public watchWorkspaceStatus(userId: string, opts: { signal: AbortSignal }): AsyncIterable<WorkspaceInstance> {
         return generateAsyncGenerator<WorkspaceInstance>((sink) => {
             try {
                 const dispose = this.subscriber.listenForWorkspaceInstanceUpdates(userId, (_ctx, instance) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Enables gRPC traffic shift on the dashboard per a service. We are going to enable all of them first on Dogfood and if it is alright there for a day or two start traffic shift on Cloud. We won't do it yet for the workspace service, since it is not completed.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5251f80</samp>

Refactor dashboard public API to use JSON-RPC and improve service client logic. Deprecate `oidcService` and fix a bug in `resolveClient`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Smoke tests all services in https://ak-grpc-service-ff.preview.gitpod-dev.com/workspaces:
- [x] workspace - create/start
- [x] authprovider - should be able to login
- [x] org - update settings, membership
- [x] prebuild - create a project, enable prebuilds, run a prebuild
- [x] ssh - follow docs and create ssh keys, check that you can see and delete them
- [x] scm -  change git scopes, check that saved
- [x] envvar - add user and project env vars, try to change them, check that you can see them in a workspace 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://ak-grpc-service-ff.preview.gitpod-dev.com/workspaces

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
