### PR TITLE
[service-waiter] use ide proxy for metric report

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -535,7 +535,7 @@ func componentWaiterContainer(ctx *RenderContext, component, labels, image strin
 			"--gitpod-host",
 			ctx.Config.Domain,
 			"--ide-metrics-host",
-			"http://" + IDEMetricsComponent + ":" + strconv.Itoa(IDEMetricsPort),
+			ClusterURL("http", IDEProxyComponent, ctx.Namespace, IDEProxyPort),
 			"--namespace",
 			ctx.Namespace,
 			"--component",

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -6,7 +6,6 @@ package common_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -59,8 +58,8 @@ func TestPublicApiServerComponentWaiterContainer(t *testing.T) {
 	container := common.PublicApiServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.PublicApiComponent)
 	require.Equal(t, labels, "app=gitpod,component=public-api-server")
-	ideMetricsHost := "http://" + common.IDEMetricsComponent + ":" + strconv.Itoa(common.IDEMetricsPort)
-	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideMetricsHost, "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
+	ideProxyHost := common.ClusterURL("http", common.IDEProxyComponent, ctx.Namespace, common.IDEProxyPort)
+	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideProxyHost, "--namespace", "test_namespace", "--component", common.PublicApiComponent, "--labels", labels, "--image", ctx.Config.Repository + "/public-api-server:" + "happy_path_papi_image"}, container.Args)
 }
 
 func TestServerComponentWaiterContainer(t *testing.T) {
@@ -73,6 +72,6 @@ func TestServerComponentWaiterContainer(t *testing.T) {
 	container := common.ServerComponentWaiterContainer(ctx)
 	labels := common.DefaultLabelSelector(common.ServerComponent)
 	require.Equal(t, labels, "app=gitpod,component=server")
-	ideMetricsHost := "http://" + common.IDEMetricsComponent + ":" + strconv.Itoa(common.IDEMetricsPort)
-	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideMetricsHost, "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
+	ideProxyHost := common.ClusterURL("http", common.IDEProxyComponent, ctx.Namespace, common.IDEProxyPort)
+	require.Equal(t, []string{"-v", "component", "--gitpod-host", ctx.Config.Domain, "--ide-metrics-host", ideProxyHost, "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
 }

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -65,6 +65,8 @@ const (
 	DashboardComponent          = "dashboard"
 	IDEMetricsComponent         = "ide-metrics"
 	IDEMetricsPort              = 3000
+	IDEProxyComponent           = "ide-proxy"
+	IDEProxyPort                = 80
 )
 
 var (

--- a/install/installer/pkg/components/ide-proxy/constants.go
+++ b/install/installer/pkg/components/ide-proxy/constants.go
@@ -4,10 +4,12 @@
 
 package ide_proxy
 
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
 const (
-	Component     = "ide-proxy"
-	ContainerPort = 80
+	Component     = common.IDEProxyComponent
+	ContainerPort = common.IDEProxyPort
 	PortName      = "http"
-	ServicePort   = 80
+	ServicePort   = common.IDEProxyPort
 	ReadinessPort = 8080
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 71cb23d</samp>

This pull request refactors the ide-metrics-host argument for some components to use a common function and constants, and updates the corresponding tests and constants files. This improves the code quality and maintainability.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1701067409899119?thread_ts=1699547477.092979&cid=C05H5UQBW6Q)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-wai165b81fbbb</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-wai165b81fbbb.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-wai165b81fbbb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-waiter-error-report-gha.20813</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-wai165b81fbbb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
