### PR TITLE
SubjectId: Address mismatch (I)

### DIFF
--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -21,6 +21,7 @@ import { URL } from "url";
 import { ProjectsService } from "../projects/projects-service";
 import { SubjectId } from "../auth/subject-id";
 import { runWithSubjectId } from "../util/request-context";
+import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 
 @injectable()
 export class BitbucketApp {
@@ -122,7 +123,9 @@ export class BitbucketApp {
         const span = TraceContext.startSpan("Bitbucket.handlePushHook", ctx);
         try {
             const cloneURL = data.gitCloneUrl;
-            const projects = await this.projectService.findProjectsByCloneUrl(user.id, cloneURL);
+            const projects = await runWithSubjectId(SYSTEM_USER, () =>
+                this.projectService.findProjectsByCloneUrl(SYSTEM_USER_ID, cloneURL),
+            );
             for (const project of projects) {
                 try {
                     const projectOwner = await this.findProjectOwner(project, user);

--- a/components/server/src/prebuilds/bitbucket-app.ts
+++ b/components/server/src/prebuilds/bitbucket-app.ts
@@ -19,6 +19,8 @@ import { UserService } from "../user/user-service";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { URL } from "url";
 import { ProjectsService } from "../projects/projects-service";
+import { SubjectId } from "../auth/subject-id";
+import { runWithSubjectId } from "../util/request-context";
 
 @injectable()
 export class BitbucketApp {
@@ -151,34 +153,36 @@ export class BitbucketApp {
                         continue;
                     }
 
-                    log.info("Starting prebuild.", { contextURL });
-                    const { host, owner, repo } = RepoURL.parseRepoUrl(data.repoUrl)!;
-                    const hostCtx = this.hostCtxProvider.get(host);
-                    let commitInfo: CommitInfo | undefined;
-                    if (hostCtx?.services?.repositoryProvider) {
-                        commitInfo = await hostCtx.services.repositoryProvider.getCommitInfo(
-                            user,
-                            owner,
-                            repo,
-                            data.commitHash,
+                    await runWithSubjectId(SubjectId.fromUserId(projectOwner.id), async () => {
+                        log.info("Starting prebuild.", { contextURL });
+                        const { host, owner, repo } = RepoURL.parseRepoUrl(data.repoUrl)!;
+                        const hostCtx = this.hostCtxProvider.get(host);
+                        let commitInfo: CommitInfo | undefined;
+                        if (hostCtx?.services?.repositoryProvider) {
+                            commitInfo = await hostCtx.services.repositoryProvider.getCommitInfo(
+                                user,
+                                owner,
+                                repo,
+                                data.commitHash,
+                            );
+                        }
+                        const ws = await this.prebuildManager.startPrebuild(
+                            { span },
+                            {
+                                user: projectOwner,
+                                project,
+                                context,
+                                commitInfo,
+                            },
                         );
-                    }
-                    const ws = await this.prebuildManager.startPrebuild(
-                        { span },
-                        {
-                            user: projectOwner,
-                            project,
-                            context,
-                            commitInfo,
-                        },
-                    );
-                    if (!ws.done) {
-                        await this.webhookEvents.updateEvent(event.id, {
-                            prebuildStatus: "prebuild_triggered",
-                            status: "processed",
-                            prebuildId: ws.prebuildId,
-                        });
-                    }
+                        if (!ws.done) {
+                            await this.webhookEvents.updateEvent(event.id, {
+                                prebuildStatus: "prebuild_triggered",
+                                status: "processed",
+                                prebuildId: ws.prebuildId,
+                            });
+                        }
+                    });
                 } catch (error) {
                     log.error("Error processing Bitbucket Server webhook event", error);
                 }
@@ -218,7 +222,9 @@ export class BitbucketApp {
             const hostContext = this.hostCtxProvider.get(new URL(project.cloneUrl).host);
             const authProviderId = hostContext?.authProvider.authProviderId;
             for (const teamMember of teamMembers) {
-                const user = await this.userService.findUserById(teamMember.userId, teamMember.userId);
+                const user = await runWithSubjectId(SubjectId.fromUserId(teamMember.userId), () =>
+                    this.userService.findUserById(teamMember.userId, teamMember.userId),
+                );
                 if (user && user.identities.some((i) => i.authProviderId === authProviderId)) {
                     return user;
                 }

--- a/components/server/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/src/prebuilds/bitbucket-server-app.ts
@@ -21,6 +21,7 @@ import { URL } from "url";
 import { ProjectsService } from "../projects/projects-service";
 import { SubjectId } from "../auth/subject-id";
 import { runWithSubjectId } from "../util/request-context";
+import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 
 @injectable()
 export class BitbucketServerApp {
@@ -119,7 +120,9 @@ export class BitbucketServerApp {
         const span = TraceContext.startSpan("Bitbucket.handlePushHook", ctx);
         try {
             const cloneURL = this.getCloneUrl(payload);
-            const projects = await this.projectService.findProjectsByCloneUrl(user.id, cloneURL);
+            const projects = await runWithSubjectId(SYSTEM_USER, () =>
+                this.projectService.findProjectsByCloneUrl(SYSTEM_USER_ID, cloneURL),
+            );
             for (const project of projects) {
                 try {
                     const projectOwner = await this.findProjectOwner(project, user);

--- a/components/server/src/prebuilds/github-app.ts
+++ b/components/server/src/prebuilds/github-app.ts
@@ -34,7 +34,7 @@ import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { PrebuildManager } from "./prebuild-manager";
 import { PrebuildStatusMaintainer } from "./prebuilt-status-maintainer";
 import { Options, ApplicationFunctionOptions } from "probot/lib/types";
-import { asyncHandler, toHeaders } from "../express-util";
+import { asyncHandler } from "../express-util";
 import { ContextParser } from "../workspace/context-parser-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { RepoURL } from "../repohost";
@@ -114,90 +114,70 @@ export class GithubApp {
                     res.redirect(301, this.getBadgeImageURL());
                 });
 
-        // Use RequestContext
-        options.getRouter &&
-            options.getRouter("/*").use((req, res, next) => {
-                runWithRequestContext(
-                    {
-                        requestKind: "probot",
-                        requestMethod: req.path,
-                        signal: new AbortController().signal,
-                        headers: toHeaders(req.headers),
-                    },
-                    () => next(),
-                );
-            });
-
         app.on("installation.created", (ctx: Context<"installation.created">) => {
-            catchError(
-                (async () => {
-                    const targetAccountName = `${ctx.payload.installation.account.login}`;
-                    const installationId = `${ctx.payload.installation.id}`;
+            handleEvent(ctx.name, async () => {
+                const targetAccountName = `${ctx.payload.installation.account.login}`;
+                const installationId = `${ctx.payload.installation.id}`;
 
-                    // cf. https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
-                    const authId = `${ctx.payload.sender.id}`;
+                // cf. https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#installation
+                const authId = `${ctx.payload.sender.id}`;
 
-                    const user = await this.userDB.findUserByIdentity({
-                        authProviderId: this.config.githubApp?.authProviderId || "unknown",
-                        authId,
-                    });
-                    const userId = user ? user.id : undefined;
-                    await this.appInstallationDB.recordNewInstallation(
-                        "github",
-                        "platform",
-                        installationId,
-                        userId,
-                        authId,
-                    );
-                    log.debug({ userId }, "New installation recorded", { userId, authId, targetAccountName });
-                })(),
-            );
+                const user = await this.userDB.findUserByIdentity({
+                    authProviderId: this.config.githubApp?.authProviderId || "unknown",
+                    authId,
+                });
+                const userId = user ? user.id : undefined;
+                await this.appInstallationDB.recordNewInstallation(
+                    "github",
+                    "platform",
+                    installationId,
+                    userId,
+                    authId,
+                );
+                log.debug({ userId }, "New installation recorded", { userId, authId, targetAccountName });
+            });
         });
         app.on("installation.deleted", (ctx: Context<"installation.deleted">) => {
-            catchError(
-                (async () => {
-                    const installationId = `${ctx.payload.installation.id}`;
-                    await this.appInstallationDB.recordUninstallation("github", "platform", installationId);
-                })(),
-            );
+            handleEvent(ctx.name, async () => {
+                const installationId = `${ctx.payload.installation.id}`;
+                await this.appInstallationDB.recordUninstallation("github", "platform", installationId);
+            });
         });
 
         app.on("repository.renamed", (ctx: Context<"repository.renamed">) => {
-            catchError(
-                (async () => {
-                    const { action, repository, installation } = ctx.payload;
-                    if (!installation) {
-                        return;
-                    }
-                    if (action === "renamed") {
-                        // HINT(AT): This is undocumented, but the event payload contains something like
-                        // "changes": { "repository": { "name": { "from": "test-repo-123" } } }
-                        // To implement this in a more robust way, we'd need to store `repository.id` with the project, next to the cloneUrl.
-                        const oldName = (ctx.payload as any)?.changes?.repository?.name?.from;
-                        if (oldName) {
-                            const projects = await runWithSubjectId(SYSTEM_USER, async () =>
-                                this.projectService.findProjectsByCloneUrl(
-                                    SYSTEM_USER_ID,
-                                    `https://github.com/${repository.owner.login}/${oldName}.git`,
-                                ),
-                            );
-                            for (const project of projects) {
-                                project.cloneUrl = repository.clone_url;
-                                await this.projectDB.storeProject(project);
-                            }
+            handleEvent(ctx.name, async () => {
+                const { action, repository, installation } = ctx.payload;
+                if (!installation) {
+                    return;
+                }
+                if (action === "renamed") {
+                    // HINT(AT): This is undocumented, but the event payload contains something like
+                    // "changes": { "repository": { "name": { "from": "test-repo-123" } } }
+                    // To implement this in a more robust way, we'd need to store `repository.id` with the project, next to the cloneUrl.
+                    const oldName = (ctx.payload as any)?.changes?.repository?.name?.from;
+                    if (oldName) {
+                        const projects = await runWithSubjectId(SYSTEM_USER, async () =>
+                            this.projectService.findProjectsByCloneUrl(
+                                SYSTEM_USER_ID,
+                                `https://github.com/${repository.owner.login}/${oldName}.git`,
+                            ),
+                        );
+                        for (const project of projects) {
+                            project.cloneUrl = repository.clone_url;
+                            await this.projectDB.storeProject(project);
                         }
                     }
-                })(),
-            );
+                }
+            });
             // TODO(at): handle deleted as well
         });
 
         app.on("push", (ctx: Context<"push">) => {
-            catchError(this.handlePushEvent(ctx));
+            handleEvent(ctx.name, () => this.handlePushEvent(ctx));
         });
 
         app.on(["pull_request.opened", "pull_request.synchronize", "pull_request.reopened"], (ctx) => {
-            catchError(this.handlePullRequest(ctx));
+            handleEvent(ctx.name, () => this.handlePullRequest(ctx));
         });
 
         options.getRouter &&
@@ -427,9 +407,8 @@ export class GithubApp {
             }
             const context = (await this.contextParser.handle({ span }, installationOwner, contextURL)) as CommitContext;
 
-            const projects = await this.projectService.findProjectsByCloneUrl(
-                installationOwner.id,
-                context.repository.cloneUrl,
+            const projects = await runWithSubjectId(SubjectId.fromUserId(installationOwner.id), () =>
+                this.projectService.findProjectsByCloneUrl(installationOwner.id, context.repository.cloneUrl),
             );
             for (const project of projects) {
                 const user = await this.findProjectOwner(project, installationOwner);
@@ -685,15 +664,24 @@ export class GithubApp {
     }
 }
 
-function catchError<R>(p: Promise<R>): void {
-    p.catch((err) => {
-        let logger = log.error;
-        if (ApplicationError.hasErrorCode(err)) {
-            logger = ErrorCode.isUserError(err.code) ? log.info : log.error;
-        }
+function handleEvent(eventName: string, p: () => Promise<any>): void {
+    runWithRequestContext(
+        {
+            requestKind: "probot",
+            requestMethod: eventName,
+            signal: new AbortController().signal,
+        },
+        () => {
+            p().catch((err) => {
+                let logger = log.error;
+                if (ApplicationError.hasErrorCode(err)) {
+                    logger = ErrorCode.isUserError(err.code) ? log.info : log.error;
+                }
 
-        logger("Failed to handle github event", err);
-    });
+                logger("Failed to handle github event", err);
+            });
+        },
+    );
 }
 
 export namespace GithubApp {

--- a/components/server/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/src/prebuilds/github-enterprise-app.ts
@@ -154,7 +154,9 @@ export class GitHubEnterpriseApp {
             const cloneURL = payload.repository.clone_url;
             const contextURL = this.createContextUrl(payload);
             const context = (await this.contextParser.handle({ span }, user, contextURL)) as CommitContext;
-            const projects = await this.projectService.findProjectsByCloneUrl(user.id, context.repository.cloneUrl);
+            const projects = await runWithSubjectId(SYSTEM_USER, () =>
+                this.projectService.findProjectsByCloneUrl(SYSTEM_USER_ID, context.repository.cloneUrl),
+            );
             span.setTag("contextURL", contextURL);
             for (const project of projects) {
                 try {

--- a/components/server/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/src/prebuilds/github-enterprise-app.ts
@@ -24,6 +24,7 @@ import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messag
 import { ProjectsService } from "../projects/projects-service";
 import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 import { runWithSubjectId } from "../util/request-context";
+import { SubjectId } from "../auth/subject-id";
 
 @injectable()
 export class GitHubEnterpriseApp {
@@ -187,23 +188,25 @@ export class GitHubEnterpriseApp {
 
                     log.debug("GitHub Enterprise push event: Starting prebuild.", { contextURL });
 
-                    const commitInfo = await this.getCommitInfo(user, payload.repository.url, payload.after);
-                    const ws = await this.prebuildManager.startPrebuild(
-                        { span },
-                        {
-                            context,
-                            user: projectOwner,
-                            project: project,
-                            commitInfo,
-                        },
-                    );
-                    if (!ws.done) {
-                        await this.webhookEvents.updateEvent(event.id, {
-                            prebuildStatus: "prebuild_triggered",
-                            status: "processed",
-                            prebuildId: ws.prebuildId,
-                        });
-                    }
+                    await runWithSubjectId(SubjectId.fromUserId(projectOwner.id), async () => {
+                        const commitInfo = await this.getCommitInfo(user, payload.repository.url, payload.after);
+                        const ws = await this.prebuildManager.startPrebuild(
+                            { span },
+                            {
+                                context,
+                                user: projectOwner,
+                                project: project,
+                                commitInfo,
+                            },
+                        );
+                        if (!ws.done) {
+                            await this.webhookEvents.updateEvent(event.id, {
+                                prebuildStatus: "prebuild_triggered",
+                                status: "processed",
+                                prebuildId: ws.prebuildId,
+                            });
+                        }
+                    });
                 } catch (error) {
                     log.error("Error processing Bitbucket Server webhook event", error);
                 }
@@ -246,7 +249,9 @@ export class GitHubEnterpriseApp {
             const hostContext = this.hostContextProvider.get(new URL(project.cloneUrl).host);
             const authProviderId = hostContext?.authProvider.authProviderId;
             for (const teamMember of teamMembers) {
-                const user = await this.userService.findUserById(webhookInstaller.id, teamMember.userId);
+                const user = await runWithSubjectId(SubjectId.fromUserId(webhookInstaller.id), () =>
+                    this.userService.findUserById(webhookInstaller.id, teamMember.userId),
+                );
                 if (user && user.identities.some((i) => i.authProviderId === authProviderId)) {
                     return user;
                 }
@@ -271,7 +276,9 @@ export class GitHubEnterpriseApp {
                 const hostContext = this.hostContextProvider.get(new URL(cloneURL).host);
                 const authProviderId = hostContext?.authProvider.authProviderId;
                 for (const teamMember of owners) {
-                    const user = await this.userService.findUserById(teamMember.userId, teamMember.userId);
+                    const user = await runWithSubjectId(SubjectId.fromUserId(teamMember.userId), () =>
+                        this.userService.findUserById(teamMember.userId, teamMember.userId),
+                    );
                     if (user && user.identities.some((i) => i.authProviderId === authProviderId)) {
                         users.push(user);
                     }

--- a/components/server/src/prebuilds/gitlab-app.ts
+++ b/components/server/src/prebuilds/gitlab-app.ts
@@ -21,6 +21,7 @@ import { UserService } from "../user/user-service";
 import { ProjectsService } from "../projects/projects-service";
 import { runWithSubjectId } from "../util/request-context";
 import { SubjectId } from "../auth/subject-id";
+import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 
 @injectable()
 export class GitLabApp {
@@ -143,7 +144,9 @@ export class GitLabApp {
         const span = TraceContext.startSpan("GitLapApp.handlePushHook", ctx);
         try {
             const cloneUrl = this.getCloneUrl(body);
-            const projects = await this.projectService.findProjectsByCloneUrl(user.id, cloneUrl);
+            const projects = await runWithSubjectId(SYSTEM_USER, () =>
+                this.projectService.findProjectsByCloneUrl(SYSTEM_USER_ID, cloneUrl),
+            );
             for (const project of projects) {
                 try {
                     const projectOwner = await this.findProjectOwner(project, user);

--- a/components/server/src/prebuilds/gitlab-app.ts
+++ b/components/server/src/prebuilds/gitlab-app.ts
@@ -19,6 +19,8 @@ import { RepoURL } from "../repohost";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { UserService } from "../user/user-service";
 import { ProjectsService } from "../projects/projects-service";
+import { runWithSubjectId } from "../util/request-context";
+import { SubjectId } from "../auth/subject-id";
 
 @injectable()
 export class GitLabApp {
@@ -177,20 +179,23 @@ export class GitLabApp {
 
                     log.debug({ userId: user.id }, "GitLab push event: Starting prebuild", { body, contextURL });
 
-                    const commitInfo = await this.getCommitInfo(user, body.repository.git_http_url, body.after);
-                    const ws = await this.prebuildManager.startPrebuild(
-                        { span },
-                        {
-                            user: projectOwner || user,
-                            project: project,
-                            context,
-                            commitInfo,
-                        },
-                    );
-                    await this.webhookEvents.updateEvent(event.id, {
-                        prebuildStatus: "prebuild_triggered",
-                        status: "processed",
-                        prebuildId: ws.prebuildId,
+                    const workspaceUser = projectOwner || user;
+                    await runWithSubjectId(SubjectId.fromUserId(workspaceUser.id), async () => {
+                        const commitInfo = await this.getCommitInfo(user, body.repository.git_http_url, body.after);
+                        const ws = await this.prebuildManager.startPrebuild(
+                            { span },
+                            {
+                                user: workspaceUser,
+                                project: project,
+                                context,
+                                commitInfo,
+                            },
+                        );
+                        await this.webhookEvents.updateEvent(event.id, {
+                            prebuildStatus: "prebuild_triggered",
+                            status: "processed",
+                            prebuildId: ws.prebuildId,
+                        });
                     });
                 } catch (error) {
                     log.error("Error processing Bitbucket Server webhook event", error);
@@ -243,7 +248,9 @@ export class GitLabApp {
                 return webhookInstaller;
             }
             for (const teamMember of teamMembers) {
-                const user = await this.userService.findUserById(teamMember.userId, teamMember.userId);
+                const user = await runWithSubjectId(SubjectId.fromUserId(teamMember.userId), () =>
+                    this.userService.findUserById(teamMember.userId, teamMember.userId),
+                );
                 if (user && user.identities.some((i) => i.authProviderId === "Public-GitLab")) {
                     return user;
                 }

--- a/components/server/src/util/request-context.ts
+++ b/components/server/src/util/request-context.ts
@@ -125,6 +125,14 @@ export function ctxCheckAborted() {
 }
 
 /**
+ * @throws If there is no context available
+ * @returns Whether the request has been aborted
+ */
+export function ctxIsAborted(): boolean {
+    return ctxGet().signal.aborted;
+}
+
+/**
  * @returns The AbortSignal associated with the current request.
  */
 export function ctxSignal() {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -132,7 +132,8 @@ import { RedlockAbortSignal } from "redlock";
 import { ConfigProvider } from "./config-provider";
 import { isGrpcError } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { runWithSubjectId } from "../util/request-context";
+import { ctxIsAborted, runWithRequestContext, runWithSubjectId } from "../util/request-context";
+import { SubjectId } from "../auth/subject-id";
 
 export interface StartWorkspaceOptions extends GitpodServer.StartWorkspaceOptions {
     excludeFeatureFlags?: NamedWorkspaceFeatureFlag[];
@@ -348,39 +349,49 @@ export class WorkspaceStarter {
         const ctx = TraceContext.childContext("reconcileWorkspaceStart", _ctx);
 
         const doReconcileWorkspaceStart = async (abortSignal: RedlockAbortSignal) => {
-            try {
-                // Fetch a fresh instance to check it's phase
-                const instance = await this.workspaceDb.trace({}).findInstanceById(instanceId);
-                if (!instance) {
-                    ctx.span.finish();
-                    throw new Error("cannot find workspace for instance");
-                }
-                if (!WorkspaceStarter.STARTING_PHASES.includes(instance.status.phase)) {
-                    log.debug(
-                        { instanceId, workspaceId: instance.workspaceId, userId: user.id },
-                        "can't start workspace instance in this phase",
-                        { phase: instance.status.phase },
-                    );
-                    return;
-                }
+            await runWithRequestContext(
+                {
+                    requestKind: "workspace-start",
+                    requestMethod: "reconcileWorkspaceStart",
+                    signal: abortSignal,
+                    subjectId: SubjectId.fromUserId(user.id),
+                },
+                async () => {
+                    try {
+                        // Fetch a fresh instance to check it's phase
+                        const instance = await this.workspaceDb.trace({}).findInstanceById(instanceId);
+                        if (!instance) {
+                            ctx.span.finish();
+                            throw new Error("cannot find workspace for instance");
+                        }
+                        if (!WorkspaceStarter.STARTING_PHASES.includes(instance.status.phase)) {
+                            log.debug(
+                                { instanceId, workspaceId: instance.workspaceId, userId: user.id },
+                                "can't start workspace instance in this phase",
+                                { phase: instance.status.phase },
+                            );
+                            return;
+                        }
 
-                const envVars = await this.envVarService.resolveEnvVariables(
-                    user.id,
-                    workspace.projectId,
-                    workspace.type,
-                    workspace.context,
-                );
+                        const envVars = await this.envVarService.resolveEnvVariables(
+                            user.id,
+                            workspace.projectId,
+                            workspace.type,
+                            workspace.context,
+                        );
 
-                await this.actuallyStartWorkspace(ctx, instance, workspace, user, envVars, abortSignal);
-            } catch (err) {
-                this.logAndTraceStartWorkspaceError(
-                    ctx,
-                    { userId: user.id, workspaceId: workspace.id, instanceId },
-                    err,
-                );
-            } finally {
-                ctx.span.finish();
-            }
+                        await this.actuallyStartWorkspace(ctx, instance, workspace, user, envVars);
+                    } catch (err) {
+                        this.logAndTraceStartWorkspaceError(
+                            ctx,
+                            { userId: user.id, workspaceId: workspace.id, instanceId },
+                            err,
+                        );
+                    } finally {
+                        ctx.span.finish();
+                    }
+                },
+            );
         };
 
         // We try to acquire a mutex here, which we intend to hold until the workspace start request is sent to ws-manager.
@@ -507,7 +518,6 @@ export class WorkspaceStarter {
         workspace: Workspace,
         user: User,
         envVars: ResolvedEnvVars,
-        abortSignal: RedlockAbortSignal,
     ): Promise<void> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
         const region = instance.configuration.regionPreference;
@@ -534,7 +544,6 @@ export class WorkspaceStarter {
                 additionalAuth,
                 forceRebuild,
                 forceRebuild,
-                abortSignal,
                 region,
             );
 
@@ -573,18 +582,10 @@ export class WorkspaceStarter {
                 }
 
                 for (; retries < MAX_INSTANCE_START_RETRIES; retries++) {
-                    if (abortSignal.aborted) {
+                    if (ctxIsAborted()) {
                         return;
                     }
-                    resp = await this.tryStartOnCluster(
-                        { span },
-                        startRequest,
-                        user,
-                        workspace,
-                        instance,
-                        abortSignal,
-                        region,
-                    );
+                    resp = await this.tryStartOnCluster({ span }, startRequest, user, workspace, instance, region);
                     if (resp) {
                         break;
                     }
@@ -601,13 +602,13 @@ export class WorkspaceStarter {
                         "We're in the middle of an update. We'll be back to normal soon. Please try again in a few minutes.",
                     );
                 }
-                await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
+                await this.failInstanceStart({ span }, err, workspace, instance);
                 throw new StartInstanceError(reason, err);
             }
 
             if (!resp) {
                 const err = new Error("cannot start a workspace because no workspace clusters are available");
-                await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
+                await this.failInstanceStart({ span }, err, workspace, instance);
                 throw new StartInstanceError("clusterSelectionFailed", err);
             }
             increaseSuccessfulInstanceStartCounter(retries);
@@ -640,13 +641,13 @@ export class WorkspaceStarter {
                 log.warn(logCtx, "cannot start workspace instance due to temporary error", err);
             } else if (!(err instanceof StartInstanceError)) {
                 // fallback in case we did not already handle this error
-                await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
+                await this.failInstanceStart({ span }, err, workspace, instance);
                 err = new StartInstanceError("other", err); // don't throw because there's nobody catching it. We just want to log/trace it.
             }
 
             this.logAndTraceStartWorkspaceError({ span }, logCtx, err);
         } finally {
-            if (abortSignal.aborted) {
+            if (ctxIsAborted()) {
                 ctx.span?.setTag("aborted", true);
             }
             span.finish();
@@ -685,7 +686,6 @@ export class WorkspaceStarter {
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
-        abortSignal: RedlockAbortSignal,
         region?: WorkspaceRegion,
     ): Promise<StartWorkspaceResponse.AsObject | undefined> {
         const constrainOnWorkspaceClassSupport = await isWorkspaceClassDiscoveryEnabled(user);
@@ -699,7 +699,7 @@ export class WorkspaceStarter {
             constrainOnWorkspaceClassSupport,
         );
         for await (const cluster of clusters) {
-            if (abortSignal.aborted) {
+            if (ctxIsAborted()) {
                 return;
             }
             try {
@@ -788,14 +788,8 @@ export class WorkspaceStarter {
      * failInstanceStart properly fails a workspace instance if something goes wrong before the instance ever reaches
      * workspace manager. In this case we need to make sure we also fulfil the tasks of the bridge (e.g. for prebulds).
      */
-    private async failInstanceStart(
-        ctx: TraceContext,
-        err: any,
-        workspace: Workspace,
-        instance: WorkspaceInstance,
-        abortSignal: RedlockAbortSignal,
-    ) {
-        if (abortSignal.aborted) {
+    private async failInstanceStart(ctx: TraceContext, err: any, workspace: Workspace, instance: WorkspaceInstance) {
+        if (ctxIsAborted()) {
             return;
         }
 
@@ -1140,7 +1134,6 @@ export class WorkspaceStarter {
         additionalAuth: Map<string, string>,
         ignoreBaseImageresolvedAndRebuildBase: boolean = false,
         forceRebuild: boolean = false,
-        abortSignal: RedlockAbortSignal,
         region?: WorkspaceRegion,
     ): Promise<WorkspaceInstance> {
         const span = TraceContext.startSpan("buildWorkspaceImage", ctx);
@@ -1247,7 +1240,6 @@ export class WorkspaceStarter {
                         additionalAuth,
                         true,
                         forceRebuild,
-                        abortSignal,
                         region,
                     );
                 } else {
@@ -1284,7 +1276,7 @@ export class WorkspaceStarter {
             }
 
             // This instance's image build "failed" as well, so mark it as such.
-            await this.failInstanceStart({ span }, err, workspace, instance, abortSignal);
+            await this.failInstanceStart({ span }, err, workspace, instance);
 
             const looksLikeUserError = (msg: string): boolean => {
                 return (


### PR DESCRIPTION
## Description
Addresses all occasions where this alarm :bell: triggered: [source](https://github.com/gitpod-io/gitpod/blob/b6fa451a947ee219ad90702594f166c9cf36b6e5/components/server/src/authorization/authorizer.ts#L535-L544)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8412f8</samp>

This pull request adds support for tracing and logging user context in prebuild operations for various git providers. It also simplifies the request handling and cancellation logic in the workspace starter module. It modifies the files `bitbucket-app.ts`, `bitbucket-server-app.ts`, `github-app.ts`, `github-enterprise-app.ts`, `gitlab-app.ts`, `workspace-starter.ts`, and `request-context.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-918

## How to test
 - login
 - start a workspace on this branch
 - trigger a workspace start with an image build, and `kubectl rollout restart deployment/server` shortly after:
   - notice how workspace-start-controller picks up again after restart
   - no "SubjectId mismatch" log messages :heavy_check_mark: 
 - trigger a prebuild (create a project, expand GitHub token scopes, enable prebuilds, commit)
   - notice no "SubjectId mismatch" log messages :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-918-mismatch-1</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-918-mismatch-1.preview.gitpod-dev.com/workspaces" target="_blank">gpl-918-mismatch-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-918-mismatch-1-gha.20841</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-918-mismatch-1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
