### PR TITLE
Reduce job log verbosity

### DIFF
--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -89,7 +89,7 @@ export class JobRunner {
                     subjectId: SYSTEM_USER,
                 };
                 await runWithRequestContext(ctx, async () => {
-                    log.info(`Acquired lock for job ${job.name}.`, logCtx);
+                    log.debug(`Acquired lock for job ${job.name}.`, logCtx);
                     // we want to hold the lock for the entire duration of the job, so we return earliest after frequencyMs
                     const timeout = new Promise<void>((resolve) => setTimeout(resolve, job.frequencyMs));
                     const timer = jobsDurationSeconds.startTimer({ name: job.name });
@@ -97,7 +97,7 @@ export class JobRunner {
                     const now = new Date().getTime();
                     try {
                         await job.run();
-                        log.info(`Successfully finished job ${job.name}`, {
+                        log.debug(`Successfully finished job ${job.name}`, {
                             ...logCtx,
                             jobTookSec: `${(new Date().getTime() - now) / 1000}s`,
                         });


### PR DESCRIPTION
## Description

Trying to read server logs in a cell I find out the amount of logs for Jobs is more than 50%

```
$ cat 000000 |wc -l
10317
$ cat 000000 |grep "Acquired lock for job workspace-start-controller."|wc -l
2985
$ cat 000000 |grep "Successfully finished job workspace-start-controller"|wc -l
2985
```

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5dda1a6</samp>

Lowered log verbosity for job runner module. This reduces noise and overhead in the `components/server/src/jobs/runner.ts` file.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
