### PR TITLE
[dashboard] Fix Repository Finder after switch to SCM Service

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
@@ -4,23 +4,23 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { SuggestedRepository } from "@gitpod/gitpod-protocol";
+import { SuggestedRepository } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 import { deduplicateAndFilterRepositories } from "./unified-repositories-search-query";
 
 function repo(name: string, project?: string): SuggestedRepository {
-    return {
+    return new SuggestedRepository({
         url: `http://github.com/efu3he4rf/${name}`,
-        repositoryName: name,
-        projectName: project,
-        projectId: project,
-    };
+        repoName: name,
+        configurationName: project,
+        configurationId: project,
+    });
 }
 
 test("it should deduplicate non-project entries", () => {
     const suggestedRepos: SuggestedRepository[] = [repo("foo"), repo("foo2"), repo("foo", "project-foo")];
     const deduplicated = deduplicateAndFilterRepositories("foo", false, suggestedRepos);
     expect(deduplicated.length).toEqual(2);
-    expect(deduplicated[1].projectName).toEqual("project-foo");
+    expect(deduplicated[1].configurationName).toEqual("project-foo");
 });
 
 test("it should not deduplicate project entries", () => {
@@ -41,8 +41,8 @@ test("it should exclude project entries", () => {
     ];
     const deduplicated = deduplicateAndFilterRepositories("foo", true, suggestedRepos);
     expect(deduplicated.length).toEqual(2);
-    expect(deduplicated[0].repositoryName).toEqual("foo");
-    expect(deduplicated[1].repositoryName).toEqual("foo2");
+    expect(deduplicated[0].repoName).toEqual("foo");
+    expect(deduplicated[1].repoName).toEqual("foo2");
 });
 
 test("it should match entries in url as well as poject name", () => {
@@ -72,10 +72,10 @@ test("it keeps the order", () => {
         repo("bar", "FOOtest"),
     ];
     const deduplicated = deduplicateAndFilterRepositories("foot", false, suggestedRepos);
-    expect(deduplicated[0].repositoryName).toEqual("somefOOtest");
-    expect(deduplicated[1].repositoryName).toEqual("Footest");
-    expect(deduplicated[2].projectName).toEqual("someFootest");
-    expect(deduplicated[3].projectName).toEqual("FOOtest");
+    expect(deduplicated[0].repoName).toEqual("somefOOtest");
+    expect(deduplicated[1].repoName).toEqual("Footest");
+    expect(deduplicated[2].configurationName).toEqual("someFootest");
+    expect(deduplicated[3].configurationName).toEqual("FOOtest");
 });
 
 test("it should return all repositories without duplicates when excludeProjects is true", () => {
@@ -88,6 +88,6 @@ test("it should return all repositories without duplicates when excludeProjects 
     ];
     const deduplicated = deduplicateAndFilterRepositories("foo", true, suggestedRepos);
     expect(deduplicated.length).toEqual(2);
-    expect(deduplicated[0].repositoryName).toEqual("foo");
-    expect(deduplicated[1].repositoryName).toEqual("bar");
+    expect(deduplicated[0].repoName).toEqual("foo");
+    expect(deduplicated[1].repoName).toEqual("bar");
 });

--- a/components/dashboard/src/projects/create-project-modal/CreateProjectModal.tsx
+++ b/components/dashboard/src/projects/create-project-modal/CreateProjectModal.tsx
@@ -8,11 +8,12 @@ import { FC, useCallback, useState } from "react";
 import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
 import { Button } from "../../components/Button";
 import { CreateProjectArgs, useCreateProject } from "../../data/projects/create-project-mutation";
-import { Project, SuggestedRepository } from "@gitpod/gitpod-protocol";
+import { Project } from "@gitpod/gitpod-protocol";
 import RepositoryFinder from "../../components/RepositoryFinder";
 import { InputField } from "../../components/forms/InputField";
 import { AuthorizeGit, useNeedsGitAuthorization } from "../../components/AuthorizeGit";
 import { useTemporaryState } from "../../hooks/use-temporary-value";
+import { SuggestedRepository } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 
 type Props = {
     onCreated: (project: Project) => void;
@@ -61,7 +62,7 @@ export const CreateProjectModal: FC<Props> = ({ onClose, onCreated }) => {
                             <InputField label="Repository" className="mb-8 w-full">
                                 <RepositoryFinder
                                     selectedContextURL={selectedRepo?.url}
-                                    selectedProjectID={selectedRepo?.projectId}
+                                    selectedConfigurationId={selectedRepo?.configurationId}
                                     onChange={setSelectedRepo}
                                     excludeProjects
                                 />

--- a/components/dashboard/src/repositories/create/ImportRepositoryModal.tsx
+++ b/components/dashboard/src/repositories/create/ImportRepositoryModal.tsx
@@ -61,7 +61,7 @@ export const ImportRepositoryModal: FC<Props> = ({ onClose, onCreated }) => {
                             <InputField className="mb-8 w-full">
                                 <RepositoryFinder
                                     selectedContextURL={selectedRepo?.url}
-                                    selectedProjectID={selectedRepo?.projectId}
+                                    selectedConfigurationId={selectedRepo?.projectId}
                                     onChange={setSelectedRepo}
                                     excludeProjects
                                 />

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -393,7 +393,7 @@ export function CreateWorkspacePage() {
                         <RepositoryFinder
                             onChange={handleContextURLChange}
                             selectedContextURL={contextURL}
-                            selectedProjectID={selectedProjectID}
+                            selectedConfigurationId={selectedProjectID}
                             expanded={!contextURL}
                             disabled={createWorkspaceMutation.isStarting}
                         />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 115cda8</samp>

This pull request updates the dashboard components and modules that use the `RepositoryFinder` component to work with the new `SuggestedRepository` type from the public API, which has different fields for project-related information. This affects the `CreateProjectModal`, `ImportRepositoryModal`, `CreateWorkspacePage`, and the related types, tests, and logic.

</details>


## How to test
Verify that repo names and project names are shown in Repository Finder instances (thus are New Workspace & New Project modals.)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-fix-repo-finder</li>
	<li><b>🔗 URL</b> - <a href="https://at-fix-repo-finder.preview.gitpod-dev.com/workspaces" target="_blank">at-fix-repo-finder.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-fix-repo-finder-gha.20877</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-fix-repo-finder%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
