### PR TITLE
Repo List - Style updates 

### DIFF
--- a/components/dashboard/src/components/Button.tsx
+++ b/components/dashboard/src/components/Button.tsx
@@ -52,7 +52,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                 className={classNames(
                     "cursor-pointer my-auto",
                     "text-sm font-medium whitespace-nowrap",
-                    "rounded-xl focus:outline-none focus:ring transition ease-in-out",
+                    "rounded-lg focus:outline-none focus:ring transition ease-in-out",
                     spacing === "compact" ? ["px-1 py-1"] : null,
                     spacing === "default" ? ["px-4 py-2"] : null,
                     type === "primary"

--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -8,11 +8,10 @@ import { useLocation } from "react-router";
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { Separator } from "./Separator";
 import TabMenuItem from "./TabMenuItem";
-import { Heading1, Subheading } from "@podkit/typography/Headings";
+import { PageHeading } from "@podkit/layout/PageHeading";
 
 export interface HeaderProps {
     title: string;
-    complexTitle?: React.ReactElement;
     subtitle: string | React.ReactElement;
     tabs?: TabEntry[];
 }
@@ -28,16 +27,8 @@ export default function Header(p: HeaderProps) {
     useDocumentTitle(`${p.title}`);
     return (
         <div className="app-container border-gray-200 dark:border-gray-800">
-            <div className="flex pb-8 pt-6">
-                <div className="w-full">
-                    {p.complexTitle ? p.complexTitle : <Heading1 tracking="tight">{p.title}</Heading1>}
-                    {typeof p.subtitle === "string" ? (
-                        <Subheading tracking="wide">{p.subtitle}</Subheading>
-                    ) : (
-                        p.subtitle
-                    )}
-                </div>
-            </div>
+            <PageHeading title={p.title} subtitle={p.subtitle} />
+
             <nav className="flex">
                 {p.tabs?.map((entry) => (
                     <TabMenuItem

--- a/components/dashboard/src/components/forms/SelectInputField.tsx
+++ b/components/dashboard/src/components/forms/SelectInputField.tsx
@@ -90,7 +90,7 @@ export const SelectInput: FunctionComponent<SelectInputProps> = memo(
         return (
             <select
                 id={id}
-                className={classNames("w-full max-w-lg", className)}
+                className={classNames("w-full max-w-lg text-sm", className)}
                 value={value}
                 disabled={disabled}
                 required={required}

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -97,8 +97,8 @@ export const TextInput: FunctionComponent<TextInputProps> = memo(
         return (
             <input
                 id={id}
-                // 5px top/bottom padding ensures height matches buttons (36px)
-                className={cn("py-[5px] w-full max-w-lg rounded-lg dark:text-[#A8A29E]", className)}
+                // 7px top/bottom padding ensures height matches buttons (36px)
+                className={cn("py-[7px] w-full max-w-lg rounded-lg dark:text-[#A8A29E]", "text-sm", className)}
                 value={value}
                 type={type}
                 placeholder={placeholder}

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -97,7 +97,8 @@ export const TextInput: FunctionComponent<TextInputProps> = memo(
         return (
             <input
                 id={id}
-                className={cn("w-full max-w-lg dark:text-[#A8A29E]", className)}
+                // 5px top/bottom padding ensures height matches buttons (36px)
+                className={cn("py-[5px] w-full max-w-lg rounded-lg dark:text-[#A8A29E]", className)}
                 value={value}
                 type={type}
                 placeholder={placeholder}

--- a/components/dashboard/src/components/podkit/buttons/Button.tsx
+++ b/components/dashboard/src/components/podkit/buttons/Button.tsx
@@ -10,7 +10,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@podkit/lib/cn";
 
 export const buttonVariants = cva(
-    "inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+    "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
     {
         variants: {
             variant: {

--- a/components/dashboard/src/components/podkit/layout/PageHeading.tsx
+++ b/components/dashboard/src/components/podkit/layout/PageHeading.tsx
@@ -8,18 +8,16 @@ import { Heading1, Subheading } from "@podkit/typography/Headings";
 import { FC, ReactNode } from "react";
 
 type PageHeadingProps = {
-    title: string;
-    subtitle?: string;
-    action?: ReactNode;
+    title: ReactNode;
+    subtitle?: ReactNode;
 };
-export const PageHeading: FC<PageHeadingProps> = ({ title, subtitle, action }) => {
+export const PageHeading: FC<PageHeadingProps> = ({ title, subtitle }) => {
     return (
         <div className="flex flex-row flex-wrap justify-between py-8 gap-2">
             <div>
                 <Heading1>{title}</Heading1>
                 {subtitle && <Subheading>{subtitle}</Subheading>}
             </div>
-            {action && action}
         </div>
     );
 };

--- a/components/dashboard/src/components/podkit/loading/LoadingState.tsx
+++ b/components/dashboard/src/components/podkit/loading/LoadingState.tsx
@@ -9,10 +9,11 @@ import { Delayed } from "./Delayed";
 import { FC } from "react";
 
 type Props = {
+    size?: number;
     delay?: boolean;
 };
-export const LoadingState: FC<Props> = ({ delay = true }) => {
-    const loader = <Loader2 className="animate-spin" />;
+export const LoadingState: FC<Props> = ({ delay = true, size = 24 }) => {
+    const loader = <Loader2 className="animate-spin" size={size} />;
 
     if (!delay) {
         return loader;

--- a/components/dashboard/src/components/podkit/tables/SortableTable.tsx
+++ b/components/dashboard/src/components/podkit/tables/SortableTable.tsx
@@ -31,11 +31,15 @@ export const SortableTableHead = React.forwardRef<
             {...props}
             aria-sort={sortOrder === "asc" ? "ascending" : sortOrder === "desc" ? "descending" : "none"}
         >
-            <Button variant="ghost" onClick={handleClick} className="flex flex-row items-center gap-1 font-semibold">
+            <Button
+                variant="ghost"
+                onClick={handleClick}
+                className="flex flex-row items-center gap-1 font-semibold p-0 -h-9"
+            >
                 {children}
                 {/* keep element in dom to preserve space */}
                 <span className={cn(!sortOrder && "invisible")}>
-                    {sortOrder === "asc" ? <ChevronUpIcon size={20} /> : <ChevronDownIcon size={20} />}
+                    {sortOrder === "asc" ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}
                 </span>
             </Button>
         </TableHead>

--- a/components/dashboard/src/components/podkit/tables/SortableTable.tsx
+++ b/components/dashboard/src/components/podkit/tables/SortableTable.tsx
@@ -31,7 +31,7 @@ export const SortableTableHead = React.forwardRef<
             {...props}
             aria-sort={sortOrder === "asc" ? "ascending" : sortOrder === "desc" ? "descending" : "none"}
         >
-            <Button variant="ghost" onClick={handleClick} className="flex flex-row items-center gap-1">
+            <Button variant="ghost" onClick={handleClick} className="flex flex-row items-center gap-1 font-semibold">
                 {children}
                 {/* keep element in dom to preserve space */}
                 <span className={cn(!sortOrder && "invisible")}>

--- a/components/dashboard/src/components/podkit/tables/SortableTable.tsx
+++ b/components/dashboard/src/components/podkit/tables/SortableTable.tsx
@@ -39,7 +39,7 @@ export const SortableTableHead = React.forwardRef<
                 {children}
                 {/* keep element in dom to preserve space */}
                 <span className={cn(!sortOrder && "invisible")}>
-                    {sortOrder === "asc" ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}
+                    {sortOrder === "asc" ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
                 </span>
             </Button>
         </TableHead>

--- a/components/dashboard/src/components/podkit/tables/Table.tsx
+++ b/components/dashboard/src/components/podkit/tables/Table.tsx
@@ -27,7 +27,7 @@ export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLA
         return (
             <thead
                 ref={ref}
-                className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th]:font-semibold dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md"
+                className="[&_th]:py-2 [&_th]:px-4 [&_th]:bg-gray-100 [&_th]:font-semibold dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md"
                 {...props}
             />
         );
@@ -53,7 +53,11 @@ TableHead.displayName = "TableHead";
 export const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
     ({ className, ...props }, ref) => {
         return (
-            <tbody ref={ref} className="[&_td]:p-3 [&_td:last-child]:text-right [&_tr]:hover:bg-muted/5" {...props} />
+            <tbody
+                ref={ref}
+                className="[&_td]:py-3 [&_td]:px-4 [&_td:last-child]:text-right [&_tr]:hover:bg-muted/5"
+                {...props}
+            />
         );
     },
 );

--- a/components/dashboard/src/components/podkit/tables/Table.tsx
+++ b/components/dashboard/src/components/podkit/tables/Table.tsx
@@ -27,7 +27,7 @@ export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLA
         return (
             <thead
                 ref={ref}
-                className="[&_th]:p-3 [&_th]:bg-gray-100 dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md text-semibold"
+                className="[&_th]:p-3 [&_th]:bg-gray-100 [&_th]:font-semibold dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md"
                 {...props}
             />
         );

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -69,7 +69,7 @@
     input[type="email"],
     input[type="url"],
     select {
-        @apply block w-56 text-gray-600 dark:text-gray-400 dark:bg-gray-800 bg-white rounded-md border border-gray-300 dark:border-gray-500 focus:border-gray-400 dark:focus:border-gray-400 focus:ring-0;
+        @apply block w-56 text-gray-600 dark:text-gray-400 dark:bg-gray-800 bg-white rounded-lg border border-gray-300 dark:border-gray-500 focus:border-gray-400 dark:focus:border-gray-400 focus:ring-0;
     }
     textarea::placeholder,
     input[type="text"]::placeholder,
@@ -102,7 +102,7 @@
 
     /* Search */
     input[type="search"] {
-        @apply border-0 dark:bg-gray-800 bg-gray-50 text-gray-600 dark:text-gray-400 rounded-md focus:border-gray-400 dark:focus:border-gray-400 focus:outline-none focus:ring ring-0 focus:ring-blue-400 dark:focus:ring-blue-500 transition ease-in-out;
+        @apply border-0 dark:bg-gray-800 bg-gray-50 text-gray-600 dark:text-gray-400 rounded-lg focus:border-gray-400 dark:focus:border-gray-400 focus:outline-none focus:ring ring-0 focus:ring-blue-400 dark:focus:ring-blue-500 transition ease-in-out;
     }
     input[type="checkbox"] {
         @apply disabled:opacity-50;

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -26,6 +26,7 @@ const ConfigurationDetailPage: FC = () => {
     let { path, url } = useRouteMatch();
 
     const { data, error, isLoading, refetch } = useConfiguration(id);
+    const prebuildsEnabled = !!data?.prebuildSettings?.enabled;
 
     const settingsMenu = useMemo(() => {
         const menu: SubmenuItemProps[] = [
@@ -36,7 +37,7 @@ const ConfigurationDetailPage: FC = () => {
             {
                 title: "Prebuilds",
                 link: [`${url}/prebuilds`],
-                icon: <AlertTriangle size={20} />,
+                icon: !prebuildsEnabled ? <AlertTriangle size={20} /> : undefined,
             },
             {
                 title: "Environment variables",
@@ -48,7 +49,7 @@ const ConfigurationDetailPage: FC = () => {
             },
         ];
         return menu;
-    }, [url]);
+    }, [prebuildsEnabled, url]);
 
     return (
         <div className="w-full">

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -35,7 +35,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
             </TableCell>
 
             <TableCell hideOnSmallScreen>
-                <TextMuted className="text-sm">{url}</TextMuted>
+                <TextMuted className="text-sm break-all">{url}</TextMuted>
             </TableCell>
 
             <TableCell hideOnSmallScreen>{created}</TableCell>

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -30,7 +30,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
                 <div className="flex flex-col gap-1">
                     <Text className="font-semibold">{configuration.name}</Text>
                     {/* We show the url on a 2nd line for smaller screens since we hide the column */}
-                    <TextMuted className="inline md:hidden text-sm">{url}</TextMuted>
+                    <TextMuted className="inline md:hidden text-sm break-all">{url}</TextMuted>
                 </div>
             </TableCell>
 

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -10,7 +10,6 @@ import { TextMuted } from "@podkit/typography/TextMuted";
 import { Text } from "@podkit/typography/Text";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
-import { cn } from "@podkit/lib/cn";
 import { AlertTriangleIcon, CheckCircle2Icon } from "lucide-react";
 import { TableCell, TableRow } from "@podkit/tables/Table";
 
@@ -46,12 +45,10 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
                     {prebuildsEnabled ? (
                         <CheckCircle2Icon size={20} className="text-green-500" />
                     ) : (
-                        <AlertTriangleIcon size={20} className="text-red-500" />
+                        <AlertTriangleIcon size={20} className="text-kumquat-base" />
                     )}
 
-                    <TextMuted className={cn(!prebuildsEnabled && "text-red-500 dark:text-red-500")}>
-                        {prebuildsEnabled ? "Enabled" : "Disabled"}
-                    </TextMuted>
+                    <TextMuted>{prebuildsEnabled ? "Enabled" : "Disabled"}</TextMuted>
                 </div>
             </TableCell>
 

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -8,7 +8,6 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useListConfigurations } from "../../data/configurations/configuration-queries";
 import { PageHeading } from "@podkit/layout/PageHeading";
-import { Button } from "@podkit/buttons/Button";
 import { useDocumentTitle } from "../../hooks/use-document-title";
 import { ImportRepositoryModal } from "../create/ImportRepositoryModal";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
@@ -88,9 +87,6 @@ const RepositoryListPage: FC = () => {
                 <PageHeading
                     title="Imported repositories"
                     subtitle="Configure and refine the experience of working with a repository in Gitpod"
-                    action={
-                        showTable && <Button onClick={() => setShowCreateProjectModal(true)}>Import Repository</Button>
-                    }
                 />
 
                 {isLoading && <LoadingState />}
@@ -106,6 +102,7 @@ const RepositoryListPage: FC = () => {
                         isFetchingNextPage={isFetchingNextPage}
                         hasNextPage={!!hasNextPage}
                         hasMoreThanOnePage={hasMoreThanOnePage}
+                        onImport={() => setShowCreateProjectModal(true)}
                         onLoadNextPage={() => fetchNextPage()}
                         onSearchTermChange={setSearchTerm}
                         onSort={handleSort}

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -49,11 +49,11 @@ export const RepositoryTable: FC<Props> = ({
     return (
         <>
             {/* Search/Filter bar */}
-            <div className="flex flex-row flex-wrap justify-between items-center">
-                <div className="flex flex-row flex-wrap items-center">
+            <div className="flex flex-col-reverse md:flex-row flex-wrap justify-between items-center gap-2">
+                <div className="flex flex-row flex-wrap items-center w-full md:w-auto">
                     {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
                     <TextInput
-                        className="w-80"
+                        className="w-full max-w-none md:w-80"
                         value={searchTerm}
                         onChange={onSearchTermChange}
                         placeholder="Search imported repositories"
@@ -61,7 +61,10 @@ export const RepositoryTable: FC<Props> = ({
                     {/* TODO: Add prebuild status filter dropdown */}
                 </div>
 
-                <Button onClick={onImport}>Import Repository</Button>
+                {/* TODO: Consider making all podkit buttons behave this way, full width on small screen */}
+                <Button className="w-full md:w-auto" onClick={onImport}>
+                    Import Repository
+                </Button>
             </div>
             <div className="relative w-full overflow-auto mt-4">
                 {configurations.length > 0 ? (

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -15,6 +15,7 @@ import { Subheading } from "@podkit/typography/Headings";
 import { cn } from "@podkit/lib/cn";
 import { SortableTableHead, TableSortOrder } from "@podkit/tables/SortableTable";
 import { LoadingState } from "@podkit/loading/LoadingState";
+import { Button } from "@podkit/buttons/Button";
 
 type Props = {
     configurations: Configuration[];
@@ -25,6 +26,7 @@ type Props = {
     hasMoreThanOnePage: boolean;
     isSearching: boolean;
     isFetchingNextPage: boolean;
+    onImport: () => void;
     onSearchTermChange: (val: string) => void;
     onLoadNextPage: () => void;
     onSort: (columnName: string, direction: TableSortOrder) => void;
@@ -39,6 +41,7 @@ export const RepositoryTable: FC<Props> = ({
     hasMoreThanOnePage,
     isSearching,
     isFetchingNextPage,
+    onImport,
     onSearchTermChange,
     onLoadNextPage,
     onSort,
@@ -47,7 +50,7 @@ export const RepositoryTable: FC<Props> = ({
         <>
             {/* Search/Filter bar */}
             <div className="flex flex-row flex-wrap justify-between items-center">
-                <div className="flex flex-row flex-wrap gap-2 items-center">
+                <div className="flex flex-row flex-wrap items-center">
                     {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
                     <TextInput
                         className="w-80"
@@ -57,8 +60,10 @@ export const RepositoryTable: FC<Props> = ({
                     />
                     {/* TODO: Add prebuild status filter dropdown */}
                 </div>
+
+                <Button onClick={onImport}>Import Repository</Button>
             </div>
-            <div className="relative w-full overflow-auto mt-2">
+            <div className="relative w-full overflow-auto mt-4">
                 {configurations.length > 0 ? (
                     <Table>
                         <TableHeader>

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -51,7 +51,7 @@ export const RepositoryTable: FC<Props> = ({
             {/* Search/Filter bar */}
             <div className="flex flex-col-reverse md:flex-row flex-wrap justify-between items-center gap-2">
                 <div className="flex flex-row flex-wrap items-center w-full md:w-auto">
-                    {/* TODO: Add search icon on left and decide on pulling Inputs into podkit */}
+                    {/* TODO: Add search icon on left - need to revisit TextInputs for podkit - and remove global styles */}
                     <TextInput
                         className="w-full max-w-none md:w-80"
                         value={searchTerm}

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -96,7 +96,7 @@ export const RepositoryTable: FC<Props> = ({
                                 <TableHead className="w-24 text-right">
                                     {isSearching && (
                                         <div className="flex flex-right justify-end items-center">
-                                            <LoadingState delay={false} />
+                                            <LoadingState delay={false} size={16} />
                                         </div>
                                     )}
                                 </TableHead>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes a couple small styling issues on the repo list page.

* Tone down the prebuilds disabled icon & text
* Fix table headings to all be semibold.
* Adjust input and button heights/rounding to match each-other (reviewed this w/ Cory and did this to help push towards in flight design changes)

| Header | Header |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/906b067b-4590-4de7-bdea-bfc10938d191) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/9731493c-39e4-43e8-9849-cc8e8d4c4931) | 

* I also updated the sidebar for the repo config detail pages to remove Gitpod YAML for now (we cut it from initial scope) and hide the prebuild warning icon if prebuilds are enabled.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 70eb648</samp>

Updated the styling and font weights of some dashboard components to improve consistency and readability. Changed the alert icon color in `RepoListItem.tsx`, and applied `font-semibold` to the button and header text in `SortableTable.tsx` and `Table.tsx`.

</details>


## How to test
<!-- Provide steps to test this PR -->
* Navigate to the Repositories menu item from the org menu
* Import a repo
* Navigate back to the list
* Verify the prebuilds disabled looks like the updated version in screenshot above
* Verify all of the table headers are the same font weight (semibold).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-repo-ea93d142e6</li>
	<li><b>🔗 URL</b> - <a href="https://brad-repo-ea93d142e6.preview.gitpod-dev.com/workspaces" target="_blank">brad-repo-ea93d142e6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-repo-list-style-updates-gha.20965</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-repo-ea93d142e6%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
