### PR TITLE
Update repo config detail pages to use nested router

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -78,12 +78,8 @@ const Usage = React.lazy(() => import(/* webpackPrefetch: true */ "../Usage"));
 const ConfigurationListPage = React.lazy(
     () => import(/* webpackPrefetch: true */ "../repositories/list/RepositoryList"),
 );
-const ConfigurationGeneral = React.lazy(
-    () => import(/* webpackPrefetch: true */ "../repositories/detail/ConfigurationDetailGeneral"),
-);
-
-const ConfigurationWorkspaces = React.lazy(
-    () => import(/* webpackPrefetch: true */ "../repositories/detail/ConfigurationDetailWorkspaces"),
+const ConfigurationDetailPage = React.lazy(
+    () => import(/* webpackPrefetch: true */ "../repositories/detail/ConfigurationDetailPage"),
 );
 
 export const AppRoutes = () => {
@@ -221,8 +217,8 @@ export const AppRoutes = () => {
                     {repoConfigListAndDetail && (
                         <>
                             <Route exact path="/repositories" component={ConfigurationListPage} />
-                            <Route exact path="/repositories/:id" component={ConfigurationGeneral} />
-                            <Route exact path="/repositories/:id/workspaces" component={ConfigurationWorkspaces} />
+                            {/* Handles all /repositories/:id/* routes in a nested router */}
+                            <Route path="/repositories/:id" component={ConfigurationDetailPage} />
                         </>
                     )}
                     {/* basic redirect for old team slugs */}

--- a/components/dashboard/src/components/WidePageWithSubmenu.tsx
+++ b/components/dashboard/src/components/WidePageWithSubmenu.tsx
@@ -29,7 +29,7 @@ export function WidePageWithSubMenu(p: PageWithSubMenuProps) {
                             // Handle flipping between row and column layout
                             "flex flex-row md:flex-col items-center",
                             "w-full md:w-52 overflow-auto md:overflow-visible",
-                            "pt-4 pb-4 md:pb-0",
+                            "pt-4 pb-4 md:pt-0 md:pb-0",
                             "space-x-2 md:space-x-0 md:space-y-2",
                             "tracking-wide text-gray-500",
                         )}
@@ -39,6 +39,7 @@ export function WidePageWithSubMenu(p: PageWithSubMenuProps) {
                         })}
                     </ul>
                 </nav>
+                {/* TODO: see if we want the content w/ top padding and not aligned on purpose */}
                 <div className="md:ml-4 w-full pt-1 mb-40">
                     <Separator className="md:hidden" />
                     <div className="pt-4 md:pt-0">{p.children}</div>

--- a/components/dashboard/src/components/forms/InputField.tsx
+++ b/components/dashboard/src/components/forms/InputField.tsx
@@ -4,9 +4,9 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import classNames from "classnames";
 import { FunctionComponent, memo, ReactNode } from "react";
 import { InputFieldHint } from "./InputFieldHint";
+import { cn } from "@podkit/lib/cn";
 
 type Props = {
     label?: ReactNode;
@@ -21,10 +21,10 @@ type Props = {
 export const InputField: FunctionComponent<Props> = memo(
     ({ label, id, hint, error, topMargin = true, className, children, disabled = false }) => {
         return (
-            <div className={classNames("flex flex-col space-y-2", { "mt-4": topMargin }, className)}>
+            <div className={cn("flex flex-col space-y-2", { "mt-4": topMargin }, className)}>
                 {label && (
                     <label
-                        className={classNames(
+                        className={cn(
                             "text-md font-semibold",
                             disabled
                                 ? "text-gray-400 dark:text-gray-400"

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailGeneral.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailGeneral.tsx
@@ -5,29 +5,19 @@
  */
 
 import { FC } from "react";
-import { useParams } from "react-router";
 import { ConfigurationNameForm } from "./general/ConfigurationName";
-import { ConfigurationDetailPage } from "./ConfigurationDetailPage";
-import { useConfiguration } from "../../data/configurations/configuration-queries";
 import { RemoveConfiguration } from "./general/RemoveConfiguration";
+import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 
-type PageRouteParams = {
-    id: string;
+type Props = {
+    configuration: Configuration;
 };
-const ConfigurationDetailGeneral: FC = () => {
-    const { id } = useParams<PageRouteParams>();
-    const configurationQuery = useConfiguration(id);
-    const { data } = configurationQuery;
-
+export const ConfigurationDetailGeneral: FC<Props> = ({ configuration }) => {
     return (
-        <ConfigurationDetailPage configurationQuery={configurationQuery} id={id}>
-            {data && (
-                <>
-                    <ConfigurationNameForm configuration={data} />
-                    <RemoveConfiguration configuration={data} />
-                </>
-            )}
-        </ConfigurationDetailPage>
+        <>
+            <ConfigurationNameForm configuration={configuration} />
+            <RemoveConfiguration configuration={configuration} />
+        </>
     );
 };
 

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailGeneral.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailGeneral.tsx
@@ -20,5 +20,3 @@ export const ConfigurationDetailGeneral: FC<Props> = ({ configuration }) => {
         </>
     );
 };
-
-export default ConfigurationDetailGeneral;

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -13,8 +13,9 @@ import { WidePageWithSubMenu } from "../../components/WidePageWithSubmenu";
 import type { SubmenuItemProps } from "../../components/PageWithSubMenu";
 import { Route, Switch, useParams, useRouteMatch } from "react-router";
 import { useConfiguration } from "../../data/configurations/configuration-queries";
-import ConfigurationDetailGeneral from "./ConfigurationDetailGeneral";
-import ConfigurationDetailWorkspaces from "./ConfigurationDetailWorkspaces";
+import { ConfigurationDetailGeneral } from "./ConfigurationDetailGeneral";
+import { ConfigurationDetailWorkspaces } from "./ConfigurationDetailWorkspaces";
+import { ConfigurationDetailPrebuilds } from "./ConfigurationDetailPrebuilds";
 
 type PageRouteParams = {
     id: string;
@@ -79,14 +80,19 @@ const ConfigurationDetailPage: FC = () => {
                         // TODO: add a better not-found UI w/ link back to repositories
                         <div>Sorry, we couldn't find that repository configuration.</div>
                     ) : (
-                        <Switch>
-                            <Route exact path={path}>
-                                <ConfigurationDetailGeneral configuration={data} />
-                            </Route>
-                            <Route exact path={`${path}/workspaces`}>
-                                <ConfigurationDetailWorkspaces configuration={data} />
-                            </Route>
-                        </Switch>
+                        <div className="flex flex-col gap-4">
+                            <Switch>
+                                <Route exact path={path}>
+                                    <ConfigurationDetailGeneral configuration={data} />
+                                </Route>
+                                <Route exact path={`${path}/workspaces`}>
+                                    <ConfigurationDetailWorkspaces configuration={data} />
+                                </Route>
+                                <Route exact path={`${path}/prebuilds`}>
+                                    <ConfigurationDetailPrebuilds configuration={data} />
+                                </Route>
+                            </Switch>
+                        </div>
                     ))
                 )}
             </WidePageWithSubMenu>

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -4,28 +4,50 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { BreadcrumbNav } from "@podkit/breadcrumbs/BreadcrumbNav";
 import { Button } from "@podkit/buttons/Button";
-import type { UseQueryResult } from "@tanstack/react-query";
-import { AlertTriangle, HelpCircle, Loader2 } from "lucide-react";
-import { useMemo } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { FC, useMemo } from "react";
 import Alert from "../../components/Alert";
 import { WidePageWithSubMenu } from "../../components/WidePageWithSubmenu";
 import type { SubmenuItemProps } from "../../components/PageWithSubMenu";
+import { Route, Switch, useParams, useRouteMatch } from "react-router";
+import { useConfiguration } from "../../data/configurations/configuration-queries";
+import ConfigurationDetailGeneral from "./ConfigurationDetailGeneral";
+import ConfigurationDetailWorkspaces from "./ConfigurationDetailWorkspaces";
 
-export interface PageWithAdminSubMenuProps {
-    children: React.ReactNode;
-    configurationQuery: UseQueryResult<Configuration | undefined, Error>;
+type PageRouteParams = {
     id: string;
-}
+};
 
-export function ConfigurationDetailPage({ children, configurationQuery, id }: PageWithAdminSubMenuProps) {
-    const { data, error, isLoading, refetch } = configurationQuery;
+const ConfigurationDetailPage: FC = () => {
+    const { id } = useParams<PageRouteParams>();
+    let { path, url } = useRouteMatch();
+
+    const { data, error, isLoading, refetch } = useConfiguration(id);
 
     const settingsMenu = useMemo(() => {
-        return getConfigurationsMenu(id);
-    }, [id]);
+        const menu: SubmenuItemProps[] = [
+            {
+                title: "General",
+                link: [url],
+            },
+            {
+                title: "Prebuilds",
+                link: [`${url}/prebuilds`],
+                icon: <AlertTriangle size={20} />,
+            },
+            {
+                title: "Environment variables",
+                link: [`${url}/variables`],
+            },
+            {
+                title: "Workspace defaults",
+                link: [`${url}/workspaces`],
+            },
+        ];
+        return menu;
+    }, [url]);
 
     return (
         <div className="w-full">
@@ -57,38 +79,19 @@ export function ConfigurationDetailPage({ children, configurationQuery, id }: Pa
                         // TODO: add a better not-found UI w/ link back to repositories
                         <div>Sorry, we couldn't find that repository configuration.</div>
                     ) : (
-                        children
+                        <Switch>
+                            <Route exact path={path}>
+                                <ConfigurationDetailGeneral configuration={data} />
+                            </Route>
+                            <Route exact path={`${path}/workspaces`}>
+                                <ConfigurationDetailWorkspaces configuration={data} />
+                            </Route>
+                        </Switch>
                     ))
                 )}
             </WidePageWithSubMenu>
         </div>
     );
-}
+};
 
-function getConfigurationsMenu(id: string): SubmenuItemProps[] {
-    const base = `/repositories/${id}`;
-    return [
-        {
-            title: "General",
-            link: [base],
-        },
-        {
-            title: "Gitpod YAML",
-            link: [`${base}/configuration`],
-            icon: <HelpCircle size={20} />,
-        },
-        {
-            title: "Prebuilds",
-            link: [`${base}/prebuilds`],
-            icon: <AlertTriangle size={20} />,
-        },
-        {
-            title: "Environment variables",
-            link: [`${base}/variables`],
-        },
-        {
-            title: "Workspace defaults",
-            link: [`${base}/workspaces`],
-        },
-    ];
-}
+export default ConfigurationDetailPage;

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
@@ -17,7 +17,7 @@ export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
         <>
             <ConfigurationSettingsField>
                 <Heading3>Prebuilds</Heading3>
-                <Subheading>
+                <Subheading className="max-w-lg">
                     Prebuilds reduce wait time for new workspaces. Enabling requires permissions to configure repository
                     webhooks.{" "}
                     <a href="/docs/configure/projects/prebuilds" className="gp-link">

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { ConfigurationSettingsField } from "./ConfigurationSettingsField";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
+
+type Props = {
+    configuration: Configuration;
+};
+export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
+    return (
+        <>
+            <ConfigurationSettingsField>
+                <Heading3>Prebuilds</Heading3>
+                <Subheading>
+                    Prebuilds reduce wait time for new workspaces. Enabling requires permissions to configure repository
+                    webhooks.{" "}
+                    <a href="/docs/configure/projects/prebuilds" className="gp-link">
+                        Learn more
+                    </a>
+                    .
+                </Subheading>
+            </ConfigurationSettingsField>
+        </>
+    );
+};

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
@@ -11,8 +11,6 @@ import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb
 type Props = {
     configuration: Configuration;
 };
-const ConfigurationDetailWorkspaces: FC<Props> = ({ configuration }) => {
+export const ConfigurationDetailWorkspaces: FC<Props> = ({ configuration }) => {
     return <ConfigurationWorkspaceSizeOptions configuration={configuration} />;
 };
-
-export default ConfigurationDetailWorkspaces;

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
@@ -5,24 +5,14 @@
  */
 
 import { FC } from "react";
-import { useParams } from "react-router";
-import { ConfigurationDetailPage } from "./ConfigurationDetailPage";
-import { useConfiguration } from "../../data/configurations/configuration-queries";
 import { ConfigurationWorkspaceSizeOptions } from "./workspaces/WorkpaceSizeOptions";
+import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 
-type PageRouteParams = {
-    id: string;
+type Props = {
+    configuration: Configuration;
 };
-const ConfigurationDetailWorkspaces: FC = () => {
-    const { id } = useParams<PageRouteParams>();
-    const configurationQuery = useConfiguration(id);
-    const { data } = configurationQuery;
-
-    return (
-        <ConfigurationDetailPage configurationQuery={configurationQuery} id={id}>
-            {data && <ConfigurationWorkspaceSizeOptions configuration={data} />}
-        </ConfigurationDetailPage>
-    );
+const ConfigurationDetailWorkspaces: FC<Props> = ({ configuration }) => {
+    return <ConfigurationWorkspaceSizeOptions configuration={configuration} />;
 };
 
 export default ConfigurationDetailWorkspaces;

--- a/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
@@ -13,8 +13,6 @@ interface Props {
 
 export const ConfigurationSettingsField = ({ children, className }: Props) => {
     return (
-        <div className={cn("border border-gray-300 dark:border-gray-700 rounded-xl p-4 my-4", className)}>
-            {children}
-        </div>
+        <div className={cn("border border-gray-300 dark:border-gray-700 rounded-xl p-6", className)}>{children}</div>
     );
 };

--- a/components/dashboard/src/repositories/detail/general/ConfigurationName.tsx
+++ b/components/dashboard/src/repositories/detail/general/ConfigurationName.tsx
@@ -60,6 +60,7 @@ export const ConfigurationNameForm: FC<Props> = ({ configuration }) => {
                 <TextInputField
                     label="Configuration name"
                     hint={`The name can be up to ${MAX_LENGTH} characters long.`}
+                    containerClassName="mt-0"
                     value={configurationName}
                     error={nameError.message}
                     onChange={setConfigurationName}

--- a/components/dashboard/src/repositories/detail/general/RemoveConfiguration.tsx
+++ b/components/dashboard/src/repositories/detail/general/RemoveConfiguration.tsx
@@ -4,13 +4,13 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Heading2, Subheading } from "@podkit/typography/Headings";
-import { Button } from "../../../components/Button";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { RemoveConfigurationModal } from "./RemoveConfigurationModal";
 import { useHistory } from "react-router";
 import { useCallback, useState } from "react";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
+import { Button } from "@podkit/buttons/Button";
 
 interface Props {
     configuration: Configuration;
@@ -27,12 +27,13 @@ export const RemoveConfiguration = ({ configuration }: Props) => {
     return (
         <>
             <ConfigurationSettingsField>
-                <Heading2>Remove this Configuration</Heading2>
-                <Subheading className="pb-4 max-w-md dark:text-gray-400">
+                <Heading3>Remove this Configuration</Heading3>
+                <Subheading className="max-w-lg">
                     This will delete the project and all project-level environment variables you've set for this
                     project. It will not delete the repository.
                 </Subheading>
-                <Button type={"danger.secondary"} onClick={() => setShowRemoveModal(true)}>
+
+                <Button variant="destructive" className="mt-4" onClick={() => setShowRemoveModal(true)}>
                     Remove Configuration
                 </Button>
             </ConfigurationSettingsField>

--- a/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
+++ b/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
@@ -9,8 +9,7 @@ import React, { useCallback, useState } from "react";
 import { useWorkspaceClasses } from "../../../data/workspaces/workspace-classes-query";
 import { Label } from "@podkit/forms/Label";
 import { RadioGroup, RadioGroupItem } from "@podkit/forms/RadioListField";
-import { TextMuted } from "@podkit/typography/TextMuted";
-import { Heading2 } from "@podkit/typography/Headings";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
 import { useToast } from "../../../components/toasts/Toasts";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
@@ -66,13 +65,12 @@ export const ConfigurationWorkspaceSizeOptions = ({ configuration }: Props) => {
     }
 
     return (
-        <ConfigurationSettingsField className="px-8 py-6">
+        <ConfigurationSettingsField>
             <form onSubmit={setWorkspaceClass}>
-                <div className="mb-4">
-                    <Heading2 className="text-base">Workspace Size Options</Heading2>
-                    <TextMuted>Choose the size of your workspace based on the resources you need.</TextMuted>
-                </div>
-                <RadioGroup value={selectedValue} onValueChange={setSelectedValue}>
+                <Heading3>Workspace Size Options</Heading3>
+                <Subheading>Choose the size of your workspace based on the resources you need.</Subheading>
+
+                <RadioGroup value={selectedValue} onValueChange={setSelectedValue} className="mt-4">
                     {classes.map((wsClass) => (
                         <Label className="flex items-start space-x-2 my-2">
                             <RadioGroupItem value={wsClass.id} />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I started out working on the Prebuilds settings page, but decided to just stub it out and scope this PR to the following change:

To make handling data loading, error handling and passing data into the various repo config detail pages I've refactored the setup to use a single top level route in `AppRoutes` and a nested router for the sub-pages. The top level route looks like:

```tsx
<Route path="/repositories/:id" component={ConfigurationDetail} />
```

This catches all routes that start w/ that prefix since it doesn't have `exact` set. Then inside of `ConfigurationDetailPage` we can do all of the data loading and error handling and use a nested router for the sub-pages. This lets us pass the loaded configuration as a prop and avoid the backwardzy way we had it previously.

```tsx
!data ? (
    // TODO: add a better not-found UI w/ link back to repositories
    <div>Sorry, we couldn't find that repository configuration.</div>
) : (
    <Switch>
        <Route exact path={path}>
            <ConfigurationDetailGeneral configuration={data} />
        </Route>
        <Route exact path={`${path}/workspaces`}>
            <ConfigurationDetailWorkspaces configuration={data} />
        </Route>
    </Switch>
);
```

A few nice properties of this approach of using nested routers in cases like this:

* Make loading dependent data and error handling for it easier/consolidated
* Avoids re-rendering the full page as you navigate to different sub-pages which avoids some flashing content. Only the nested route has to re-render.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7c12df1</samp>

Refactor the dashboard UI for repository configuration pages to use nested routing and props. This reduces code duplication, simplifies the components, and improves reusability. The affected files are `AppRoutes.tsx`, `ConfigurationDetailPage.tsx`, `ConfigurationDetailGeneral.tsx`, and `ConfigurationDetailWorkspaces.tsx`.

</details>

## How to test
<!-- Provide steps to test this PR -->
* Test importing a repo and navigating the different pages from the sidebar.
* Prebuilds should have a placeholder heading
* Env Vars doesn't rendering anything atm (that work is in flight so didn't want to mess with it)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-confidc3b0cecc1</li>
	<li><b>🔗 URL</b> - <a href="https://brad-confidc3b0cecc1.preview.gitpod-dev.com/workspaces" target="_blank">brad-confidc3b0cecc1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-config-prebuild-settings-gha.21011</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-confidc3b0cecc1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
