### PR TITLE
Fix logic that hydrates protobuf msgs and add test

### DIFF
--- a/components/dashboard/src/data/setup.test.ts
+++ b/components/dashboard/src/data/setup.test.ts
@@ -22,6 +22,21 @@ test("set and get proto message", async () => {
     expect(rehydrate({ foo: org }).foo.creationTime!.toDate()).toStrictEqual(now);
 });
 
+test("set and get proto message that include | in the message value", async () => {
+    const now = new Date();
+    const org = new Organization({
+        creationTime: Timestamp.fromDate(now),
+        id: "test-id",
+        name: "test-name|more",
+        slug: "test-slug",
+    });
+
+    expect(rehydrate(org).creationTime!.toDate()).toStrictEqual(now);
+    expect(rehydrate([org])[0].creationTime!.toDate()).toStrictEqual(now);
+    expect(rehydrate({ foo: org }).foo.creationTime!.toDate()).toStrictEqual(now);
+    expect(rehydrate(org).name).toStrictEqual("test-name|more");
+});
+
 function rehydrate<T>(obj: T): T {
     const dehydrated = dehydrate(obj);
     const str = JSON.stringify(dehydrated);

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -183,14 +183,19 @@ export function dehydrate(message: any): any {
     return message;
 }
 
+// This is used to hydrate protobuf messages from the cache
+// Serialized protobuf messages follow the format: |messageName|jsonstring
 export function hydrate(value: any): any {
     if (value instanceof Array) {
         return value.map(hydrate);
     }
     if (typeof value === "string" && value.startsWith("|") && value.lastIndexOf("|") > 1) {
-        const separatorIdx = value.lastIndexOf("|");
-        const messageName = value.substring(1, separatorIdx);
-        const json = value.substring(separatorIdx + 1);
+        // Remove the leading |
+        const trimmedVal = value.substring(1);
+        // Find the first | after the leading | to get the message name
+        const separatorIdx = trimmedVal.indexOf("|");
+        const messageName = trimmedVal.substring(0, separatorIdx);
+        const json = trimmedVal.substring(separatorIdx + 1);
         const constructor = supportedMessages.get(messageName);
         if (!constructor) {
             console.error("unsupported message type", messageName);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix issue with protobuf messages that include a `|` character in their json value. Fixed the logic we use to parse these special messages in our cache and added a test to ensure it's not a problem in the future.

[Slack thread](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1701205754045279) w/ more context.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3c605d8</samp>

This pull request enhances the serialization and deserialization of protobuf messages in the dashboard component. It improves the documentation, fixes a bug with `|` characters, and adds a test case for the `hydrate` function in `setup.tsx`.

</details>


## How to test
<!-- Provide steps to test this PR -->

* Start a new workspace
* Rename the workspace to include a `|` character
* Reload your page and it shouldn't blow up as described in the Slack thread.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-fix-p7e8fd4e432</li>
	<li><b>🔗 URL</b> - <a href="https://brad-fix-p7e8fd4e432.preview.gitpod-dev.com/workspaces" target="_blank">brad-fix-p7e8fd4e432.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-fix-protobuf-msg-client-cache-gha.21004</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-fix-p7e8fd4e432%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
