### PR TITLE
[dev] Add "previewctl get url"

### DIFF
--- a/dev/preview/previewctl/cmd/get.go
+++ b/dev/preview/previewctl/cmd/get.go
@@ -28,6 +28,7 @@ func newGetCmd(logger *logrus.Logger) *cobra.Command {
 	cmd.AddCommand(
 		newGetNameSubCmd(),
 		newGetActiveCmd(logger),
+		newGetUrlSubCmd(),
 	)
 
 	return cmd
@@ -44,6 +45,26 @@ func newGetNameSubCmd() *cobra.Command {
 			}
 
 			fmt.Println(previewName)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newGetUrlSubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "url",
+		Short: "",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			previewName, err := preview.GetName(branch)
+			if err != nil {
+				return err
+			}
+
+			previewUrl := fmt.Sprintf("https://%s.preview.gitpod-dev.com", previewName)
+			fmt.Println(previewUrl)
 
 			return nil
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e3f7a66</samp>

Add a new subcommand to `previewctl` for getting preview URLs. This allows users to easily find the preview URL of a branch without opening the Gitpod dashboard.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
