### PR TITLE
Frontend development: redirect instead of proxy

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -268,7 +268,7 @@ scripts:
         echo "No input."
       else
         echo "User: $user"
-        query="update d_b_user set rolesOrPermissions = '[\"admin\"]', fgaRelationshipsVersion=0 where name=\"$user\";"
+        query="update d_b_user set rolesOrPermissions = '[\"admin\", \"admin-permissions\"]', fgaRelationshipsVersion=0 where name=\"$user\";"
         mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
       fi
       kill $PID || true

--- a/components/dashboard/README.md
+++ b/components/dashboard/README.md
@@ -36,9 +36,26 @@ After creating a new component, run the following to update the license header:
 
 ## How to develop in gitpod.io
 
+### Against any* Gitpod installation
+
+Gitpod installations have a feature that - if you are authorized - allow different versions of the dashboard. This allows for front-end development with live data and super-quick turnarounds.
+
+**Preconditions**
+ 1. logged in user on the respective Gitpod installation (e.g. gitpod.example.org)
+ 1. user has the `"developer"` role
+
+**Steps**
+ 1. Start a workspace (on any installation), and start the dev-server with `yarn start-local`
+ 1. Configure your browser to always send header `X-Frontend-Dev-URL` with value set to the result of `gp url 3000` to the Gitpod installation you want to modify (gitpod.example.org)
+ 1. Visit https://gitpod.example.org, start modifying your `dashboard` in your workspace, and experience the effect live (incl. hot reloading)
+
+*: This feature is _not_ enabled on all installations, and requires special user privileges.
+
+### Outdated, in-workspace (?)
+
 All the commands in this section are meant to be executed from the `components/dashboard` directory.
 
-### 1. Environment variables
+#### 1. Environment variables
 
 Set the following 2 [environment variables](https://www.gitpod.io/docs/environment-variables) either [via your account settings](https://gitpod.io/variables) or [via the command line](https://www.gitpod.io/docs/environment-variables#using-the-command-line-gp-env).
 
@@ -63,7 +80,7 @@ Replace `AUTHENTICATION_COOKIE_VALUE` with the value of your auth cookie taken f
 | -------------------------------------------------------------------------- |
 | ![Where to get the auth cookie name and value from](how-to-get-cookie.png) |
 
-### 2. Start the dashboard app
+#### 2. Start the dashboard app
 
 🚀 After following the above steps, run `yarn run start` to start developing.
 You can view the dashboard at https://`PORT_NUMBER`-`GITPOD_WORKSPACE_URL` (`PORT_NUMBER` is usually `3000`).

--- a/components/dashboard/craco.config.js
+++ b/components/dashboard/craco.config.js
@@ -7,6 +7,10 @@ const { when } = require("@craco/craco");
 const path = require("path");
 const webpack = require("webpack");
 
+function withEndingSlash(str) {
+    return str.endsWith("/") ? str : str + "/";
+}
+
 module.exports = {
     style: {
         postcss: {
@@ -49,6 +53,16 @@ module.exports = {
                     Buffer: ["buffer", "Buffer"],
                 }),
             ],
+            // If ASSET_PATH is set, we imply that we also want a statically named main.js, so we can reference it from the outside
+            output: !!process.env.ASSET_PATH
+                ? {
+                      ...(webpack?.configure?.output || {}),
+                      filename: (pathData) => {
+                          return pathData.chunk.name === "main" ? "static/js/main.js" : undefined;
+                      },
+                      publicPath: withEndingSlash(process.env.ASSET_PATH),
+                  }
+                : undefined,
         },
     },
     devServer: {

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -95,7 +95,7 @@
   },
   "scripts": {
     "start": "BROWSER=none HMR_HOST=`gp url 3001` craco start",
-    "start-local": "BROWSER=none HMR_HOST=`gp url 3000` ASSET_PATH=`gp url 3000` craco start",
+    "start-local": "gp ports visibility 3000:public; BROWSER=none HMR_HOST=`gp url 3000` ASSET_PATH=`gp url 3000` craco start",
     "build": "craco build --verbose",
     "lint": "eslint --max-warnings=0 --ext=.jsx,.js,.tsx,.ts ./src",
     "test": "yarn test:unit",

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -95,7 +95,7 @@
   },
   "scripts": {
     "start": "BROWSER=none HMR_HOST=`gp url 3001` craco start",
-    "start-local": "BROWSER=none HMR_HOST=`gp url 3000` craco start",
+    "start-local": "BROWSER=none HMR_HOST=`gp url 3000` ASSET_PATH=`gp url 3000` craco start",
     "build": "craco build --verbose",
     "lint": "eslint --max-warnings=0 --ext=.jsx,.js,.tsx,.ts ./src",
     "test": "yarn test:unit",

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -376,7 +376,9 @@ https://{$GITPOD_DOMAIN} {
 				header_up -Upgrade
 			}
 			# Then handle it with our plugin!
-			gitpod.frontend_dev
+			gitpod.frontend_dev {
+				upstream http://dashboard.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3001
+			}
 		}
 
 		reverse_proxy dashboard.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3001 {

--- a/components/proxy/plugins/frontend_dev/frontend_dev.go
+++ b/components/proxy/plugins/frontend_dev/frontend_dev.go
@@ -2,14 +2,17 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package workspacedownload
+package frontend_dev
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -25,24 +28,26 @@ const (
 )
 
 func init() {
-	caddy.RegisterModule(Config{})
+	caddy.RegisterModule(FrontendDev{})
 	httpcaddyfile.RegisterHandlerDirective(frontendDevModule, parseCaddyfile)
 }
 
-// Config implements an HTTP handler that extracts gitpod headers
-type Config struct {
+// FrontendDev implements an HTTP handler that extracts gitpod headers
+type FrontendDev struct {
+	Upstream    string `json:"upstream,omitempty"`
+	UpstreamUrl *url.URL
 }
 
 // CaddyModule returns the Caddy module information.
-func (Config) CaddyModule() caddy.ModuleInfo {
+func (FrontendDev) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.frontend_dev",
-		New: func() caddy.Module { return new(Config) },
+		New: func() caddy.Module { return new(FrontendDev) },
 	}
 }
 
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
-func (m Config) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+func (m FrontendDev) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	enabled := os.Getenv(frontendDevEnabledEnvVarName)
 	if enabled != "true" {
 		caddy.Log().Sugar().Debugf("Dev URL header present but disabled")
@@ -60,70 +65,127 @@ func (m Config) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 		return caddyhttp.Error(http.StatusInternalServerError, fmt.Errorf("unexpected error forwarding to dev URL"))
 	}
 
-	targetQuery := devURL.RawQuery
 	director := func(req *http.Request) {
-		req.URL.Scheme = devURL.Scheme
-		req.URL.Host = devURL.Host
-		req.Host = devURL.Host // override host header so target proxy can handle this request properly
-
-		req.URL.Path, req.URL.RawPath = joinURLPath(devURL, req.URL)
-		if targetQuery == "" || req.URL.RawQuery == "" {
-			req.URL.RawQuery = targetQuery + req.URL.RawQuery
-		} else {
-			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
-		}
+		req.URL.Scheme = m.UpstreamUrl.Scheme
+		req.URL.Host = m.UpstreamUrl.Host
+		req.Host = m.UpstreamUrl.Host
 		if _, ok := req.Header["User-Agent"]; !ok {
 			// explicitly disable User-Agent so it's not set to default value
 			req.Header.Set("User-Agent", "")
 		}
+		req.Header.Set("Accept-Encoding", "") // we can't handle other than plain text
+		// caddy.Log().Sugar().Infof("director request (mod): %v", req.URL.String())
 	}
-	proxy := httputil.ReverseProxy{Director: director}
+	proxy := httputil.ReverseProxy{Director: director, Transport: &RedirectingTransport{baseUrl: devURL}}
 	proxy.ServeHTTP(w, r)
 
 	return nil
 }
 
-func joinURLPath(a, b *url.URL) (path, rawpath string) {
-	if a.RawPath == "" && b.RawPath == "" {
-		return singleJoiningSlash(a.Path, b.Path), ""
-	}
-	// Same as singleJoiningSlash, but uses EscapedPath to determine
-	// whether a slash should be added
-	apath := a.EscapedPath()
-	bpath := b.EscapedPath()
-
-	aslash := strings.HasSuffix(apath, "/")
-	bslash := strings.HasPrefix(bpath, "/")
-
-	switch {
-	case aslash && bslash:
-		return a.Path + b.Path[1:], apath + bpath[1:]
-	case !aslash && !bslash:
-		return a.Path + "/" + b.Path, apath + "/" + bpath
-	}
-	return a.Path + b.Path, apath + bpath
+type RedirectingTransport struct {
+	baseUrl *url.URL
 }
 
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
+func (rt *RedirectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// caddy.Log().Sugar().Infof("issuing upstream request: %s", req.URL.Path)
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, err
 	}
-	return a + b
+
+	// gpl: Do we have better means to avoid checking the body?
+	if resp.StatusCode < 300 && strings.HasPrefix(resp.Header.Get("Content-type"), "text/html") {
+		// caddy.Log().Sugar().Infof("trying to match request: %s", req.URL.Path)
+		modifiedResp := MatchAndRewriteRootRequest(resp, rt.baseUrl)
+		if modifiedResp != nil {
+			caddy.Log().Sugar().Debugf("using modified upstream response: %s", req.URL.Path)
+			return modifiedResp, nil
+		}
+	}
+	caddy.Log().Sugar().Debugf("forwarding upstream response: %s", req.URL.Path)
+
+	return resp, nil
+}
+
+func MatchAndRewriteRootRequest(or *http.Response, baseUrl *url.URL) *http.Response {
+	// match index.html?
+	prefix := []byte("<!doctype html>")
+	var buf bytes.Buffer
+	bodyReader := io.TeeReader(or.Body, &buf)
+	prefixBuf := make([]byte, len(prefix))
+	_, err := io.ReadAtLeast(bodyReader, prefixBuf, len(prefix))
+	if err != nil {
+		caddy.Log().Sugar().Debugf("prefix match: can't read response body: %w", err)
+		return nil
+	}
+	if !bytes.Equal(prefix, prefixBuf) {
+		caddy.Log().Sugar().Debugf("prefix mismatch: %s", string(prefixBuf))
+		return nil
+	}
+
+	caddy.Log().Sugar().Debugf("match index.html")
+	_, err = io.Copy(&buf, or.Body)
+	if err != nil {
+		caddy.Log().Sugar().Debugf("unable to copy response body: %w, path: %s", err, or.Request.URL.Path)
+		return nil
+	}
+	fullBody := buf.String()
+
+	mainJs := regexp.MustCompile(`"[^"]+?main\.[0-9a-z]+\.js"`)
+	fullBody = mainJs.ReplaceAllStringFunc(fullBody, func(s string) string {
+		return fmt.Sprintf(`"%s/static/js/main.js"`, baseUrl.String())
+	})
+
+	mainCss := regexp.MustCompile(`<link[^>]+?rel="stylesheet">`)
+	fullBody = mainCss.ReplaceAllString(fullBody, "")
+
+	hrefs := regexp.MustCompile(`href="/`)
+	fullBody = hrefs.ReplaceAllString(fullBody, fmt.Sprintf(`href="%s/`, baseUrl.String()))
+
+	or.Body = io.NopCloser(strings.NewReader(fullBody))
+	or.Header.Set("Content-Length", fmt.Sprintf("%d", len(fullBody)))
+	or.Header.Set("Etag", "")
+	return or
 }
 
 // UnmarshalCaddyfile implements Caddyfile.Unmarshaler.
-func (m *Config) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+func (m *FrontendDev) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	if !d.Next() {
+		return d.Err("expected token following filter")
+	}
+
+	for d.NextBlock(0) {
+		key := d.Val()
+		var value string
+		d.Args(&value)
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		switch key {
+		case "upstream":
+			m.Upstream = value
+
+		default:
+			return d.Errf("unrecognized subdirective '%s'", value)
+		}
+	}
+
+	if m.Upstream == "" {
+		return fmt.Errorf("frontend_dev: 'upstream' config field may not be empty")
+	}
+
+	upstreamURL, err := url.Parse(m.Upstream)
+	if err != nil {
+		return fmt.Errorf("frontend_dev: 'upstream' is not a valid URL: %w", err)
+	}
+	m.UpstreamUrl = upstreamURL
 
 	return nil
 }
 
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
-	m := new(Config)
+	m := new(FrontendDev)
 	err := m.UnmarshalCaddyfile(h.Dispenser)
 	if err != nil {
 		return nil, err
@@ -134,6 +196,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 
 // Interface guards
 var (
-	_ caddyhttp.MiddlewareHandler = (*Config)(nil)
-	_ caddyfile.Unmarshaler       = (*Config)(nil)
+	_ caddyhttp.MiddlewareHandler = (*FrontendDev)(nil)
+	_ caddyfile.Unmarshaler       = (*FrontendDev)(nil)
 )

--- a/components/proxy/plugins/frontend_dev/frontend_dev_test.go
+++ b/components/proxy/plugins/frontend_dev/frontend_dev_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package frontend_dev
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const index_html = `<!doctype html>
+<html lang="en">
+
+<head>
+<meta charset="utf-8" />
+<link rel="icon" href="/favicon256.png" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="theme-color" content="#000000" />
+<meta name="robots" content="noindex">
+<meta name="Gitpod" content="Always Ready-to-Code" />
+<link rel="apple-touch-icon" href="/favicon192.png" />
+<link rel="manifest" href="/manifest.json" />
+<title>Dashboard</title>
+<script defer="defer" src="/static/js/main.b009793d.js"></script>
+<link href="/static/css/main.32e61b25.css" rel="stylesheet">
+</head>
+
+<body><noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+</body>
+
+</html>`
+
+func Test_MatchAndRewriteRootRequest(t *testing.T) {
+
+	type Test struct {
+		name         string
+		response     *http.Response
+		newBaseUrl   string
+		expectedBody string
+	}
+	tests := []Test{
+		{
+			name: "should match and rewrite root request",
+			response: &http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				Body: ioutil.NopCloser(strings.NewReader(index_html)),
+			},
+			newBaseUrl: "https://3000-gitpodio-gitpod-hk3453q4csi.ws-eu108.gitpod.io",
+			expectedBody: `<!doctype html>
+<html lang="en">
+
+<head>
+<meta charset="utf-8" />
+<link rel="icon" href="https://3000-gitpodio-gitpod-hk3453q4csi.ws-eu108.gitpod.io/favicon256.png" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="theme-color" content="#000000" />
+<meta name="robots" content="noindex">
+<meta name="Gitpod" content="Always Ready-to-Code" />
+<link rel="apple-touch-icon" href="https://3000-gitpodio-gitpod-hk3453q4csi.ws-eu108.gitpod.io/favicon192.png" />
+<link rel="manifest" href="https://3000-gitpodio-gitpod-hk3453q4csi.ws-eu108.gitpod.io/manifest.json" />
+<title>Dashboard</title>
+<script defer="defer" src="https://3000-gitpodio-gitpod-hk3453q4csi.ws-eu108.gitpod.io/static/js/main.js"></script>
+
+</head>
+
+<body><noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+</body>
+
+</html>`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newBase, err := url.Parse(test.newBaseUrl)
+			if err != nil {
+				t.Errorf("error parsing new base url: %v", err)
+			}
+			actual := MatchAndRewriteRootRequest(test.response, newBase)
+			actualBodyBytes, err := ioutil.ReadAll(actual.Body)
+			if err != nil {
+				t.Errorf("error reading response body: %v", err)
+			}
+			actualBody := string(actualBodyBytes)
+			if strings.Compare(actualBody, test.expectedBody) != 0 {
+				t.Errorf("got %v, want %v", actualBody, test.expectedBody)
+			}
+		})
+	}
+}

--- a/components/proxy/plugins/frontend_dev/go.mod
+++ b/components/proxy/plugins/frontend_dev/go.mod
@@ -1,4 +1,4 @@
-module github.com/gitpod-io/gitpod/proxy/plugins/workspacedownload
+module github.com/gitpod-io/gitpod/proxy/plugins/frontend_dev
 
 go 1.21
 


### PR DESCRIPTION
## Description
This allows you to overlay the Dashboard with any other version, as long as you can reach the source from your browser.

### Steps
Just like before, do:

### Get a workspace with your modified version of dashboard

 1. start a workspace on this branch
 6. start dashboard with `yarn start-local`

### On the Gitpod installation you want to change the dashboard on
In [this preview](https://gpl-frontef258b14851.preview.gitpod-dev.com/workspaces):
  1. login to the preview
 4. become admin by: `leeway run components:make-user-admin` (or as me to do it for you)
    a. go to /admin/users and grant yourself the "developer" role
 7. run `gp url 3000`, and use that value to stick it into the "header editor" of your choice, so it matches this preview
 9. Visit this preview


You should now be able to change the dashboard on the fly, incl. hot-reload. :tada: 

Thank you @selfcontained for the idea and help with webpack!

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9317b88</samp>

Refactored the proxy plugin for frontend development with hot reloading and live reloading. Renamed the package and module from `workspacedownload` to `frontend_dev` and added unit tests for the index.html rewriting logic. Modified the files `frontend_dev.go`, `frontend_dev_test.go`, and `go.mod`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-frontef258b14851</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-frontef258b14851.preview.gitpod-dev.com/workspaces" target="_blank">gpl-frontef258b14851.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-frontend-dev-direct-gha.21161</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-frontef258b14851%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
