### PR TITLE
[public-api] improve request exception logging

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -103,7 +103,6 @@ function testPublicAPI(service: any): void {
                     try {
                         return await target[propKey](...args);
                     } finally {
-                        const grpcType = "unary";
                         // emulates frequent unary calls to public API
                         const isTest = await getExperimentsClient().getValueAsync(
                             "public_api_dummy_reliability_test",
@@ -114,13 +113,7 @@ function testPublicAPI(service: any): void {
                             },
                         );
                         if (isTest) {
-                            helloService.sayHello({}).catch((e) => {
-                                console.error(e, {
-                                    userId: user?.id,
-                                    workspaceId: args[0],
-                                    grpcType,
-                                });
-                            });
+                            helloService.sayHello({}).catch((e) => console.error(e));
                         }
                     }
                 }
@@ -129,7 +122,6 @@ function testPublicAPI(service: any): void {
         },
     });
     (async () => {
-        const grpcType = "server-stream";
         const MAX_BACKOFF = 60000;
         const BASE_BACKOFF = 3000;
         let backoff = BASE_BACKOFF;
@@ -162,10 +154,7 @@ function testPublicAPI(service: any): void {
                         backoff = BASE_BACKOFF;
                     } else {
                         backoff = Math.min(2 * backoff, MAX_BACKOFF);
-                        console.error(e, {
-                            userId: user?.id,
-                            grpcType,
-                        });
+                        console.error(e);
                     }
                 }
             } else {

--- a/components/public-api/typescript-common/README.md
+++ b/components/public-api/typescript-common/README.md
@@ -1,5 +1,13 @@
 # Public API TypeScript Common
 
+## Overview
+
+This package serves as a bridge for code conversion between two distinct Gitpod packages: @gitpod/gitpod-protocol and @gitpod/public-api. Its primary responsibility is to ensure seamless translation of application data structures from the gitpod-protocol format to the public-api gRPC format, and vice versa.
+
+## Allowed Usage
+
+Use this package exclusively for tasks that require data structure from @gitpod/gitpod-protocol and @gitpod/public-api. It's important not to introduce dependencies on this package from gitpod-protocol or public-api to ensure changes in one package don't trigger rebuilds of unrelated components such as ws-manager-bridge and supervisor-frontend.
+
 ## Golden tests
 
 Golden tests are used to test the output of a function against a known good output. The output is stored in a file with the same name as the test file but with a `.golden` extension. The test will fail if the output does not match the golden file.

--- a/components/public-api/typescript-common/src/public-api-converter.spec.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.spec.ts
@@ -367,6 +367,16 @@ describe("PublicAPIConverter", () => {
             expect(appError.message).to.equal("too many running workspaces");
         });
 
+        it("BAD_REQUEST", () => {
+            const connectError = converter.toError(new ApplicationError(ErrorCodes.BAD_REQUEST, "bad request"));
+            expect(connectError.code).to.equal(Code.InvalidArgument);
+            expect(connectError.rawMessage).to.equal("bad request");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.BAD_REQUEST);
+            expect(appError.message).to.equal("bad request");
+        });
+
         it("NOT_FOUND", () => {
             const connectError = converter.toError(new ApplicationError(ErrorCodes.NOT_FOUND, "not found"));
             expect(connectError.code).to.equal(Code.NotFound);
@@ -481,14 +491,15 @@ describe("PublicAPIConverter", () => {
         });
 
         it("Any other error is internal", () => {
-            const error = new Error("unknown");
-            const connectError = converter.toError(error);
+            const reason = new Error("unknown");
+            const connectError = converter.toError(reason);
             expect(connectError.code).to.equal(Code.Internal);
-            expect(connectError.rawMessage).to.equal("unknown");
+            expect(connectError.rawMessage).to.equal("Oops! Something went wrong.");
+            expect(connectError.cause).to.equal(reason);
 
             const appError = converter.fromError(connectError);
             expect(appError.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
-            expect(appError.message).to.equal("unknown");
+            expect(appError.message).to.equal("Oops! Something went wrong.");
         });
     });
 });

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -360,6 +360,9 @@ export class PublicAPIConverter {
                     reason,
                 );
             }
+            if (reason.code === ErrorCodes.BAD_REQUEST) {
+                return new ConnectError(reason.message, Code.InvalidArgument, undefined, undefined, reason);
+            }
             if (reason.code === ErrorCodes.NOT_FOUND) {
                 return new ConnectError(reason.message, Code.NotFound, undefined, undefined, reason);
             }
@@ -386,10 +389,13 @@ export class PublicAPIConverter {
             }
             return new ConnectError(reason.message, Code.Unknown, undefined, undefined, reason);
         }
-        return ConnectError.from(reason, Code.Internal);
+        return new ConnectError(`Oops! Something went wrong.`, Code.Internal, undefined, undefined, reason);
     }
 
     fromError(reason: ConnectError): ApplicationError {
+        if (reason.code === Code.InvalidArgument) {
+            return new ApplicationError(ErrorCodes.BAD_REQUEST, reason.rawMessage);
+        }
         if (reason.code === Code.NotFound) {
             return new ApplicationError(ErrorCodes.NOT_FOUND, reason.rawMessage);
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

During rollout we see some functions are failing with Unknown reason, but they are not logged on server side and there is no information to correlate them from a client side.  This PR ensures that all exceptional situations are logged on server side, plus on client side we provide request id and method to look up the entire chain in logs.

It also fixes a missing conversion for invalid argument which is reported as Unknown reason right now.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 895242f</samp>

This pull request improves the error handling, tracing, and documentation of the public API communication between the dashboard and the server components. It uses the `handleError` and `PublicAPIConverter` functions to report errors consistently and with context information. It also adds a README file to the `components/public-api/typescript-common` package and updates the test case for the error message change.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Check that each gRPC request has `x-request-id` response header (for any status code)
<img width="481" alt="Screenshot 2023-12-01 at 11 34 05" src="https://github.com/gitpod-io/gitpod/assets/3082655/9a2e741c-176a-400b-b4af-3b052ae1986d">

- Trigger invalid argument from browser console. Check that it is reported as 400 now, not unknown error. Check that server logs don't log it as `public api exception`.
```
fetch("https://ak-request9e413561ca.preview.gitpod-dev.com/public-api/gitpod.v1.OrganizationService/GetOrganizationSettings", {
  "headers": {
    "connect-protocol-version": "1",
    "content-type": "application/json",
  },
  "referrer": "https://ak-request9e413561ca.preview.gitpod-dev.com/settings",
  "referrerPolicy": "no-referrer-when-downgrade",
  "body": "{\"organizationId\":\"xyz\"}",
  "method": "POST",
  "mode": "cors",
  "credentials": "include"
});
```
- Go to workspaces page, check that you see WatchWorkspaceStatus or LotsOfReplies stream, and then delete server pod to trigger its failure. Check that `reportError` has info about `requestId` as well as `requestMethod`.
<img width="484" alt="Screenshot 2023-12-01 at 12 49 31" src="https://github.com/gitpod-io/gitpod/assets/3082655/1c88f57c-9663-4031-88d0-a183bb207b04">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://ak-request9e413561ca.preview.gitpod-dev.com/workspaces

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
