### PR TITLE
[ws-proxy] only get username if workspace not managed by mk2

### DIFF
--- a/components/ws-proxy/pkg/common/infoprovider.go
+++ b/components/ws-proxy/pkg/common/infoprovider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	wsapi "github.com/gitpod-io/gitpod/ws-manager/api"
-	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 )
 
 const (
@@ -64,8 +63,6 @@ type WorkspaceInfo struct {
 	OwnerUserId   string
 	SSHPublicKeys []string
 	IsRunning     bool
-
-	SSHKey *workspacev1.SSHKey
 
 	IsEnabledSSHCA bool
 	IsManagedByMk2 bool

--- a/components/ws-proxy/pkg/common/infoprovider.go
+++ b/components/ws-proxy/pkg/common/infoprovider.go
@@ -68,4 +68,5 @@ type WorkspaceInfo struct {
 	SSHKey *workspacev1.SSHKey
 
 	IsEnabledSSHCA bool
+	IsManagedByMk2 bool
 }

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -156,7 +156,6 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 		StartedAt:       ws.CreationTimestamp.Time,
 		OwnerUserId:     ws.Spec.Ownership.Owner,
 		SSHPublicKeys:   ws.Spec.SshPublicKeys,
-		SSHKey:          ws.Spec.SSHKey,
 		IsRunning:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 		IsEnabledSSHCA:  ws.Spec.SSHGatewayCAPublicKey != "",
 		IsManagedByMk2:  managedByMk2,

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	wsapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
@@ -137,6 +138,11 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 	if ws.Spec.Admission.Level == workspacev1.AdmissionLevelEveryone {
 		admission = wsapi.AdmissionLevel_ADMIT_EVERYONE
 	}
+	managedByMk2 := true
+	if managedBy, ok := ws.Labels[wsk8s.WorkspaceManagedByLabel]; ok && managedBy != "ws-manager-mk2" {
+		managedByMk2 = false
+	}
+
 	wsinfo := &common.WorkspaceInfo{
 		WorkspaceID:     ws.Spec.Ownership.WorkspaceID,
 		InstanceID:      ws.Name,
@@ -153,6 +159,7 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 		SSHKey:          ws.Spec.SSHKey,
 		IsRunning:       ws.Status.Phase == workspacev1.WorkspacePhaseRunning,
 		IsEnabledSSHCA:  ws.Spec.SSHGatewayCAPublicKey != "",
+		IsManagedByMk2:  managedByMk2,
 	}
 
 	r.store.Update(req.Name, wsinfo)

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -370,7 +370,7 @@ func (s *Server) HandleConn(c net.Conn) {
 	if err != nil {
 		s.TrackSSHConnection(wsInfo, "connect", ErrConnFailed)
 		ReportSSHAttemptMetrics(ErrConnFailed)
-		log.WithField("workspaceIP", wsInfo.IPAddress).WithError(err).Error("dail failed")
+		log.WithField("workspaceIP", wsInfo.IPAddress).WithError(err).Error("dial failed")
 		return
 	}
 	defer conn.Close()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[ws-proxy] only get username if workspace not managed by mk2

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3d5c859</samp>

This pull request enhances the ws-proxy component to support workspaces managed by the new workspace controller mk2. It adds a new field `IsManagedByMk2` to the `WorkspaceInfo` type and uses it to handle SSH connections and pod detection.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1297

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-ws-proxea4f3f5894</li>
	<li><b>🔗 URL</b> - <a href="https://pd-ws-proxea4f3f5894.preview.gitpod-dev.com/workspaces" target="_blank">pd-ws-proxea4f3f5894.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-ws-proxy-ssh-username-gha.21206</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-ws-proxea4f3f5894%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
