### PR TITLE
Update useLatestVersion in autostart options when user pref updaetd

### DIFF
--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -39,9 +39,15 @@ export default function SelectIDE(props: SelectIDEProps) {
 
             // update stored autostart options to match useLatestVersion value set here
             const workspaceAutostartOptions = additionalData?.workspaceAutostartOptions?.map((option) => {
-                // TODO: don't mutate existing user directly
                 if (option.ideSettings) {
-                    option.ideSettings.useLatestVersion = useLatestVersion;
+                    const newOption = {
+                        ...option,
+                        ideSettings: {
+                            ...option.ideSettings,
+                            useLatestVersion,
+                        },
+                    };
+                    return newOption;
                 }
 
                 return option;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When a user changes their ide preference to either use latest version, or stable, we update any records we have under `user.additionalData.workspaceAutostartOptions` and update the ideSettings.useLatestVersion` to whatever they changed their preference to. This helps fix an issue where users can't change from latest/stable after starting a workspace on a repo.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fe41d7c</samp>

Update autostart options for workspaces based on user's IDE choice in `SelectIDE.tsx`. Add TODO comment to refactor user object mutation.

</details>

## Issues
Fixes EXP-865

## How to test
<!-- Provide steps to test this PR -->
* Make sure your user prefs are set to **_NOT_** use the latest version of the ide
* Start a workspace on a repo (should not be the latest version).
* Change your user ide pref to use the latest version
* Go to the create workspace page and select the same repo.
* It should now be using Latest for the IDE
* Turn the use latest pref back off and verify if you try to create a workspace for that same repo it isn't using the latest version.
* You can also do the same steps testing autostart by manually constructing the URL for your repo, and adding `?autostart=true` to the url (before the `#<repo-url>` hash)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-use-lf2431f1eca</li>
	<li><b>🔗 URL</b> - <a href="https://brad-use-lf2431f1eca.preview.gitpod-dev.com/workspaces" target="_blank">brad-use-lf2431f1eca.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-use-latest-autostart-options-gha.21203</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-use-lf2431f1eca%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
