### PR TITLE
New Prebuild Settings UI for repo configs

### DIFF
--- a/components/dashboard/src/components/forms/SelectInputField.tsx
+++ b/components/dashboard/src/components/forms/SelectInputField.tsx
@@ -11,7 +11,7 @@ import { InputField } from "./InputField";
 
 type Props = {
     label?: ReactNode;
-    value: string;
+    value: React.SelectHTMLAttributes<HTMLSelectElement>["value"];
     id?: string;
     hint?: ReactNode;
     error?: ReactNode;
@@ -67,7 +67,7 @@ export const SelectInputField: FunctionComponent<Props> = memo(
 );
 
 type SelectInputProps = {
-    value: string;
+    value: React.SelectHTMLAttributes<HTMLSelectElement>["value"];
     className?: string;
     id?: string;
     disabled?: boolean;

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -8,6 +8,8 @@ import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-c
 import { useQuery } from "@tanstack/react-query";
 import { getGitpodService } from "../../service/service";
 
+export const DEFAULT_WS_CLASS = "g1-standard";
+
 export const useWorkspaceClasses = () => {
     return useQuery<SupportedWorkspaceClass[]>({
         queryKey: ["workspace-classes"],

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -17,12 +17,16 @@ import { ConfigurationDetailGeneral } from "./ConfigurationDetailGeneral";
 import { ConfigurationDetailWorkspaces } from "./ConfigurationDetailWorkspaces";
 import { ConfigurationDetailPrebuilds } from "./ConfigurationDetailPrebuilds";
 import { ConfigurationVariableList } from "./variables/ConfigurationVariableList";
+import { useWorkspaceClasses } from "../../data/workspaces/workspace-classes-query";
 
 type PageRouteParams = {
     id: string;
 };
 
 const ConfigurationDetailPage: FC = () => {
+    // preload some data we may show
+    useWorkspaceClasses();
+
     const { id } = useParams<PageRouteParams>();
     let { path, url } = useRouteMatch();
 

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
@@ -4,19 +4,55 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useState } from "react";
+import { FC, useCallback, useState } from "react";
 import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { ConfigurationSettingsField } from "./ConfigurationSettingsField";
 import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { Switch } from "@podkit/switch/Switch";
 import { TextMuted } from "@podkit/typography/TextMuted";
+import { PrebuildSettingsForm } from "./prebuilds/PrebuildSettingsForm";
+import { useConfigurationMutation } from "../../data/configurations/configuration-queries";
+import { useToast } from "../../components/toasts/Toasts";
 
 type Props = {
     configuration: Configuration;
 };
 export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
-    // TODO: hook this up to just use configuration as state and wire up optimistic update for mutation
+    const { toast } = useToast();
+    const updateConfiguration = useConfigurationMutation();
+
     const [enabled, setEnabled] = useState(!!configuration.prebuildSettings?.enabled);
+
+    const updateEnabled = useCallback(
+        (newEnabled: boolean) => {
+            setEnabled(newEnabled);
+            updateConfiguration.mutate(
+                {
+                    configurationId: configuration.id,
+                    prebuildSettings: {
+                        ...configuration.prebuildSettings,
+                        enabled: newEnabled,
+                    },
+                },
+                {
+                    onError: (err) => {
+                        toast(
+                            <>
+                                <span>
+                                    {newEnabled
+                                        ? "There was a problem enabling prebuilds"
+                                        : "There was a problem disabling prebuilds"}
+                                </span>
+                                {err?.message && <p>{err.message}</p>}
+                            </>,
+                        );
+                        setEnabled(!newEnabled);
+                    },
+                },
+            );
+        },
+        [configuration.id, configuration.prebuildSettings, toast, updateConfiguration],
+    );
 
     return (
         <>
@@ -26,10 +62,10 @@ export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
 
                 <div className="flex gap-4 mt-6">
                     {/* TODO: wrap this in a SwitchInputField that handles the switch, label and description and htmlFor/id automatically */}
-                    <Switch checked={enabled} onCheckedChange={setEnabled} id="prebuilds-enabled" />
+                    <Switch checked={enabled} onCheckedChange={updateEnabled} id="prebuilds-enabled" />
                     <div className="flex flex-col">
                         <label className="font-semibold" htmlFor="prebuilds-enabled">
-                            Prebuilds are enabled
+                            {enabled ? "Prebuilds are enabled" : "Prebuilds are disabled"}
                         </label>
                         <TextMuted>
                             Enabling requires permissions to configure repository webhooks.{" "}
@@ -46,6 +82,8 @@ export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
                     </div>
                 </div>
             </ConfigurationSettingsField>
+
+            {enabled && <PrebuildSettingsForm configuration={configuration} />}
         </>
     );
 };

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
@@ -16,6 +16,9 @@ import { TextInputField } from "../../../components/forms/TextInputField";
 import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { InputFieldHint } from "../../../components/forms/InputFieldHint";
+import { DEFAULT_WS_CLASS } from "../../../data/workspaces/workspace-classes-query";
+
+const DEFAULT_PREBUILD_COMMIT_INTERVAL = 20;
 
 type Props = {
     configuration: Configuration;
@@ -25,7 +28,9 @@ export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
     const { toast } = useToast();
     const updateConfiguration = useConfigurationMutation();
 
-    const [interval, setInterval] = useState<string>(`${configuration.prebuildSettings?.prebuildInterval ?? 20}`);
+    const [interval, setInterval] = useState<string>(
+        `${configuration.prebuildSettings?.prebuildInterval ?? DEFAULT_PREBUILD_COMMIT_INTERVAL}`,
+    );
     const [branchStrategy, setBranchStrategy] = useState<BranchMatchingStrategy>(
         configuration.prebuildSettings?.branchStrategy ?? BranchMatchingStrategy.DEFAULT_BRANCH,
     );
@@ -33,7 +38,7 @@ export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
         configuration.prebuildSettings?.branchMatchingPattern || "**",
     );
     const [workspaceClass, setWorkspaceClass] = useState<string>(
-        configuration.prebuildSettings?.workspaceClass || "g1-standard",
+        configuration.prebuildSettings?.workspaceClass || DEFAULT_WS_CLASS,
     );
 
     const handleSubmit = useCallback(

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BranchMatchingStrategy, Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { FC, FormEvent, useCallback, useState } from "react";
+import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
+import { InputField } from "../../../components/forms/InputField";
+import { PartialConfiguration, useConfigurationMutation } from "../../../data/configurations/configuration-queries";
+import { useToast } from "../../../components/toasts/Toasts";
+import { SelectInputField } from "../../../components/forms/SelectInputField";
+import { TextInputField } from "../../../components/forms/TextInputField";
+import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
+import { LoadingButton } from "@podkit/buttons/LoadingButton";
+
+type Props = {
+    configuration: Configuration;
+};
+
+export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
+    const { toast } = useToast();
+    const updateConfiguration = useConfigurationMutation();
+
+    const [interval, setInterval] = useState<string>(`${configuration.prebuildSettings?.prebuildInterval ?? 20}`);
+    const [branchStrategy, setBranchStrategy] = useState<BranchMatchingStrategy>(
+        configuration.prebuildSettings?.branchStrategy ?? BranchMatchingStrategy.DEFAULT_BRANCH,
+    );
+    const [branchMatchingPattern, setBranchMatchingPattern] = useState<string>(
+        configuration.prebuildSettings?.branchMatchingPattern || "**",
+    );
+    const [workspaceClass, setWorkspaceClass] = useState<string>(
+        configuration.prebuildSettings?.workspaceClass || "g1-standard",
+    );
+
+    const handleSubmit = useCallback(
+        (e: FormEvent) => {
+            e.preventDefault();
+
+            const newInterval = Math.abs(Math.min(Number.parseInt(interval), 100)) || 0;
+
+            const updatedConfig: PartialConfiguration = {
+                configurationId: configuration.id,
+                prebuildSettings: {
+                    ...configuration.prebuildSettings,
+                    prebuildInterval: newInterval,
+                    branchStrategy,
+                    branchMatchingPattern,
+                    workspaceClass,
+                },
+            };
+
+            updateConfiguration.mutate(updatedConfig, {
+                onSuccess: () => {
+                    toast("Your prebuild settings were updated.");
+                },
+            });
+        },
+        [
+            branchMatchingPattern,
+            branchStrategy,
+            configuration.id,
+            configuration.prebuildSettings,
+            interval,
+            toast,
+            updateConfiguration,
+            workspaceClass,
+        ],
+    );
+
+    // TODO: Figure out if there's a better way to deal with grpc enums in the UI
+    const handleBranchStrategyChange = useCallback((val) => {
+        // This is pretty hacky, trying to coerce value into a number and then cast it to the enum type
+        // Would be better if we treated these as strings instead of special enums
+        setBranchStrategy(parseInt(val, 10) as BranchMatchingStrategy);
+    }, []);
+
+    return (
+        <ConfigurationSettingsField>
+            <form onSubmit={handleSubmit}>
+                <Heading3>Prebuild Settings</Heading3>
+                <Subheading className="max-w-lg">These settings will be applied on every Prebuild.</Subheading>
+
+                <InputField
+                    label="Commit interval"
+                    hint="The number of commits to be skipped between prebuild runs."
+                    id="prebuild-interval"
+                >
+                    <input
+                        type="number"
+                        id="prebuild-interval"
+                        min="0"
+                        max="100"
+                        step="5"
+                        value={interval}
+                        onChange={({ target }) => setInterval(target.value)}
+                    />
+                </InputField>
+
+                <SelectInputField
+                    label="Branch Filter"
+                    hint="Run prebuilds on the selected branches only."
+                    value={branchStrategy}
+                    onChange={handleBranchStrategyChange}
+                >
+                    <option value={BranchMatchingStrategy.ALL_BRANCHES}>All branches</option>
+                    <option value={BranchMatchingStrategy.DEFAULT_BRANCH}>Default branch</option>
+                    <option value={BranchMatchingStrategy.MATCHED_BRANCHES}>Match branches by pattern</option>
+                </SelectInputField>
+
+                {branchStrategy === BranchMatchingStrategy.MATCHED_BRANCHES && (
+                    <TextInputField
+                        label="Branch name pattern"
+                        hint="Glob patterns separated by commas are supported."
+                        value={branchMatchingPattern}
+                        onChange={setBranchMatchingPattern}
+                    />
+                )}
+
+                <WorkspaceClassOptions value={workspaceClass} onChange={setWorkspaceClass} />
+
+                <LoadingButton className="mt-8" type="submit" loading={updateConfiguration.isLoading}>
+                    Save
+                </LoadingButton>
+            </form>
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
@@ -15,6 +15,7 @@ import { SelectInputField } from "../../../components/forms/SelectInputField";
 import { TextInputField } from "../../../components/forms/TextInputField";
 import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
+import { InputFieldHint } from "../../../components/forms/InputFieldHint";
 
 type Props = {
     configuration: Configuration;
@@ -119,7 +120,11 @@ export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
                     />
                 )}
 
+                <Heading3 className="mt-8">Machine type</Heading3>
+                <Subheading>Choose the workspace machine type for your prebuilds.</Subheading>
+
                 <WorkspaceClassOptions value={workspaceClass} onChange={setWorkspaceClass} />
+                <InputFieldHint>Use a smaller machine type for cost optimization.</InputFieldHint>
 
                 <LoadingButton className="mt-8" type="submit" loading={updateConfiguration.isLoading}>
                     Save

--- a/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
+++ b/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { useWorkspaceClasses } from "../../../data/workspaces/workspace-classes-query";
+import { LoadingState } from "@podkit/loading/LoadingState";
+import { cn } from "@podkit/lib/cn";
+import Alert from "../../../components/Alert";
+import { Label } from "@podkit/forms/Label";
+import { RadioGroup, RadioGroupItem } from "@podkit/forms/RadioListField";
+
+type Props = {
+    value: string;
+    className?: string;
+    onChange: (newValue: string) => void;
+};
+export const WorkspaceClassOptions: FC<Props> = ({ value, className, onChange }) => {
+    const { data: classes, isLoading } = useWorkspaceClasses();
+
+    if (isLoading) {
+        return <LoadingState />;
+    }
+
+    if (!classes) {
+        return <Alert type="error">There was a problem loading workspace classes.</Alert>;
+    }
+
+    return (
+        <RadioGroup value={value} onValueChange={onChange} className={cn("mt-4", className)}>
+            {classes.map((wsClass) => (
+                <Label className="flex items-start space-x-2 my-2" key={wsClass.id}>
+                    <RadioGroupItem value={wsClass.id} />
+                    <div className="flex flex-col space-y-2">
+                        <span className="font-bold">{wsClass.displayName}</span>
+                        <span>{wsClass.description}</span>
+                    </div>
+                </Label>
+            ))}
+        </RadioGroup>
+    );
+};

--- a/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
+++ b/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
@@ -29,12 +29,12 @@ export const WorkspaceClassOptions: FC<Props> = ({ value, className, onChange })
     }
 
     return (
-        <RadioGroup value={value} onValueChange={onChange} className={cn("mt-4", className)}>
+        <RadioGroup value={value} onValueChange={onChange} className={cn("my-4 gap-4", className)}>
             {classes.map((wsClass) => (
-                <Label className="flex items-start space-x-2 my-2" key={wsClass.id}>
+                <Label className="flex items-start space-x-2" key={wsClass.id}>
                     <RadioGroupItem value={wsClass.id} />
                     <div className="flex flex-col space-y-2">
-                        <span className="font-bold">{wsClass.displayName}</span>
+                        <span className="font-semibold">{wsClass.displayName}</span>
                         <span>{wsClass.description}</span>
                     </div>
                 </Label>

--- a/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
+++ b/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
@@ -6,15 +6,12 @@
 
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import React, { useCallback, useState } from "react";
-import { useWorkspaceClasses } from "../../../data/workspaces/workspace-classes-query";
-import { Label } from "@podkit/forms/Label";
-import { RadioGroup, RadioGroupItem } from "@podkit/forms/RadioListField";
 import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
 import { useToast } from "../../../components/toasts/Toasts";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
-import { LoadingState } from "@podkit/loading/LoadingState";
 import { useConfigurationMutation } from "../../../data/configurations/configuration-queries";
+import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
 
 interface Props {
     configuration: Configuration;
@@ -27,8 +24,6 @@ export const ConfigurationWorkspaceSizeOptions = ({ configuration }: Props) => {
     const classChanged = selectedValue !== configuration.workspaceSettings?.workspaceClass;
 
     const updateConfiguration = useConfigurationMutation();
-    const { data: classes, isError, isLoading } = useWorkspaceClasses();
-
     const { toast } = useToast();
 
     const setWorkspaceClass = useCallback(
@@ -56,31 +51,14 @@ export const ConfigurationWorkspaceSizeOptions = ({ configuration }: Props) => {
         [configuration.id, selectedValue, toast, updateConfiguration],
     );
 
-    if (isError || !classes) {
-        return <div>Something went wrong</div>;
-    }
-
-    if (isLoading) {
-        return <LoadingState />;
-    }
-
     return (
         <ConfigurationSettingsField>
             <form onSubmit={setWorkspaceClass}>
                 <Heading3>Workspace Size Options</Heading3>
                 <Subheading>Choose the size of your workspace based on the resources you need.</Subheading>
 
-                <RadioGroup value={selectedValue} onValueChange={setSelectedValue} className="mt-4">
-                    {classes.map((wsClass) => (
-                        <Label className="flex items-start space-x-2 my-2">
-                            <RadioGroupItem value={wsClass.id} />
-                            <div className="flex flex-col space-y-2">
-                                <span className="font-bold">{wsClass.displayName}</span>
-                                <span>{wsClass.description}</span>
-                            </div>
-                        </Label>
-                    ))}
-                </RadioGroup>
+                <WorkspaceClassOptions value={selectedValue} onChange={setSelectedValue} />
+
                 <LoadingButton
                     className="mt-8"
                     type="submit"

--- a/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
+++ b/components/dashboard/src/repositories/detail/workspaces/WorkpaceSizeOptions.tsx
@@ -12,6 +12,7 @@ import { useToast } from "../../../components/toasts/Toasts";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { useConfigurationMutation } from "../../../data/configurations/configuration-queries";
 import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
+import { DEFAULT_WS_CLASS } from "../../../data/workspaces/workspace-classes-query";
 
 interface Props {
     configuration: Configuration;
@@ -19,7 +20,7 @@ interface Props {
 
 export const ConfigurationWorkspaceSizeOptions = ({ configuration }: Props) => {
     const [selectedValue, setSelectedValue] = useState(
-        configuration.workspaceSettings?.workspaceClass || "g1-standard",
+        configuration.workspaceSettings?.workspaceClass || DEFAULT_WS_CLASS,
     );
     const classChanged = selectedValue !== configuration.workspaceSettings?.workspaceClass;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds the prebuild settings UI in the repo config area and sets up the api to it.

| Disabled | Enabled |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/367275/5834ee0f-6a22-4646-90bf-0f1ea3c04bd8) | ![image](https://github.com/gitpod-io/gitpod/assets/367275/bd89136d-5aa0-4502-97c0-7f28487a9c03) | 

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dccbe44</samp>

This pull request adds and improves features for editing the prebuild settings of a repository configuration in the dashboard. It introduces new components for the prebuild settings form, the workspace class options, and the select input field, and refactors some existing components for better code reuse and UI feedback. It also updates the `updateConfiguration` mutation to handle the prebuild settings.

</details>

## Issue
Fixes EXP-874

## How to test
<!-- Provide steps to test this PR -->
* Import a Repository via the Repositories link in the org menu
* Click the Prebuilds sidebar link
* Toggle prebuilds on and try adjusting some settings

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-new-pb880b15de3</li>
	<li><b>🔗 URL</b> - <a href="https://brad-new-pb880b15de3.preview.gitpod-dev.com/workspaces" target="_blank">brad-new-pb880b15de3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-new-prebuild-settings-gha.21243</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-new-pb880b15de3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
