### PR TITLE
[dashboard] proactively reconnect grpc streams

### DIFF
--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -113,6 +113,9 @@ export const ErrorCodes = {
     // 498 The operation was cancelled, typically by the caller.
     CANCELLED: 498 as const,
 
+    // 4981 The deadline expired before the operation could complete.
+    DEADLINE_EXCEEDED: 4981 as const,
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR: 500 as const,
 

--- a/components/public-api/typescript-common/src/public-api-converter.spec.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.spec.ts
@@ -455,6 +455,18 @@ describe("PublicAPIConverter", () => {
             expect(appError.message).to.equal("cancelled");
         });
 
+        it("DEADLINE_EXCEEDED", () => {
+            const connectError = converter.toError(
+                new ApplicationError(ErrorCodes.DEADLINE_EXCEEDED, "deadline exceeded"),
+            );
+            expect(connectError.code).to.equal(Code.DeadlineExceeded);
+            expect(connectError.rawMessage).to.equal("deadline exceeded");
+
+            const appError = converter.fromError(connectError);
+            expect(appError.code).to.equal(ErrorCodes.DEADLINE_EXCEEDED);
+            expect(appError.message).to.equal("deadline exceeded");
+        });
+
         it("INTERNAL_SERVER_ERROR", () => {
             const connectError = converter.toError(
                 new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "internal server error"),

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -384,6 +384,9 @@ export class PublicAPIConverter {
             if (reason.code === ErrorCodes.CANCELLED) {
                 return new ConnectError(reason.message, Code.Canceled, undefined, undefined, reason);
             }
+            if (reason.code === ErrorCodes.DEADLINE_EXCEEDED) {
+                return new ConnectError(reason.message, Code.DeadlineExceeded, undefined, undefined, reason);
+            }
             if (reason.code === ErrorCodes.INTERNAL_SERVER_ERROR) {
                 return new ConnectError(reason.message, Code.Internal, undefined, undefined, reason);
             }
@@ -449,6 +452,9 @@ export class PublicAPIConverter {
         }
         if (reason.code === Code.Canceled) {
             return new ApplicationError(ErrorCodes.CANCELLED, reason.rawMessage);
+        }
+        if (reason.code === Code.DeadlineExceeded) {
+            return new ApplicationError(ErrorCodes.DEADLINE_EXCEEDED, reason.rawMessage);
         }
         if (reason.code === Code.Internal) {
             return new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, reason.rawMessage);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR addresses the issue where GCP LB is set to terminate connections every 10 minutes. This results in unpredicted behavior across different browsers when using Connect WEB, leading to the reporting of an 'unknown error' instead of a specific failure. Particularly impacted are gRPC server-side streams due to their long-running nature. To mitigate this, the PR introduces a proactive approach by reconnecting gRPC streams 3 minutes before the timeout. This ensures errors are correctly reported as 'deadline exceeded' (actually 'cancelled' because of https://github.com/connectrpc/connect-es/issues/954) rather than as an unknown error.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 37667e4</samp>

This pull request enhances the public API service and its client by adding a timeout option for streaming calls, improving the error handling and testing logic, and supporting a new error code for deadline exceeded errors. It affects the files `public-api.ts`, `service.tsx`, `public-api-converter.ts`, `error.ts`, and `public-api-converter.spec.ts`.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Use `yarn telepresence` in dashboard to update timeout to the lower value like 1 min.
- Open dashboard, check LotsOfReplies request, and check out that it gets reconnected within one minute on deadline exceeded error.
- Kill the server, checks out that LotsOfReplies is reconnected again.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://ak-dashboa61b82253e9.preview.gitpod-dev.com/workspaces

Run `time leeway run dev:preview --dont-test` from Gitpod workspace if it is down.

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
