### PR TITLE
[jb] Add joinLink2 endpoint

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -64,15 +64,15 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     private val settings = service<GitpodSettingsState>()
 
     private val httpClient = HttpClient.newBuilder()
-        .followRedirects(HttpClient.Redirect.ALWAYS)
-        .build()
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .build()
 
     private val jacksonMapper = jacksonObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
     override suspend fun connect(
-        parameters: Map<String, String>,
-        requestor: ConnectionRequestor
+            parameters: Map<String, String>,
+            requestor: ConnectionRequestor
     ): GatewayConnectionHandle {
         if (parameters["gitpodHost"] == null) {
             throw IllegalArgumentException("bad gitpodHost parameter")
@@ -81,14 +81,14 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             throw IllegalArgumentException("bad workspaceId parameter")
         }
         val connectParams = ConnectParams(
-            parameters["gitpodHost"]!!,
-            parameters["workspaceId"]!!,
-            parameters["backendPort"],
-            parameters["debugWorkspace"] == "true"
+                parameters["gitpodHost"]!!,
+                parameters["workspaceId"]!!,
+                parameters["backendPort"],
+                parameters["debugWorkspace"] == "true"
         )
 
         var connectionKeyId =
-            "${connectParams.gitpodHost}-${connectParams.resolvedWorkspaceId}-${connectParams.backendPort}"
+                "${connectParams.gitpodHost}-${connectParams.resolvedWorkspaceId}-${connectParams.backendPort}"
 
         var found = true
         val connectionLifetime = activeConnections.computeIfAbsent(connectionKeyId) {
@@ -98,7 +98,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
 
         if (found) {
             val message =
-                "You are trying to connect to a workspace that has a client already open. Check for opened JetBrains clients on your machine"
+                    "You are trying to connect to a workspace that has a client already open. Check for opened JetBrains clients on your machine"
             val title = connectParams.title
             val okButton = Messages.getOkButton()
             val options = arrayOf(okButton)
@@ -139,19 +139,19 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                     panel {
                         row {
                             icon(GitpodIcons.Logo2x)
-                                .horizontalAlign(HorizontalAlign.CENTER)
+                                    .horizontalAlign(HorizontalAlign.CENTER)
                         }
                         row {
                             cell(phaseMessage)
-                                .bold()
-                                .horizontalAlign(HorizontalAlign.CENTER)
+                                    .bold()
+                                    .horizontalAlign(HorizontalAlign.CENTER)
                         }
                         row {
                             cell(statusMessage)
-                                .horizontalAlign(HorizontalAlign.CENTER)
-                                .applyToComponent {
-                                    foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND
-                                }
+                                    .horizontalAlign(HorizontalAlign.CENTER)
+                                    .applyToComponent {
+                                        foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND
+                                    }
                         }
                         panel {
                             row {
@@ -195,7 +195,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                             continue
                         }
                         resolvedIdeUrl =
-                            update.ideUrl.replace(connectParams.actualWorkspaceId, connectParams.resolvedWorkspaceId)
+                                update.ideUrl.replace(connectParams.actualWorkspaceId, connectParams.resolvedWorkspaceId)
                         lastUpdate = update
                         if (!update.status.conditions.failed.isNullOrBlank()) {
                             setErrorMessage(update.status.conditions.failed)
@@ -268,16 +268,16 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     val ownerToken = client.server.getOwnerToken(update.workspaceId).await()
 
                                     var credentials = resolveCredentialsWithDirectSSH(
-                                        ideUrl,
-                                        ownerToken,
-                                        connectParams,
-                                    )
-                                    if (credentials == null) {
-                                        credentials = resolveCredentialsWithWebSocketTunnel(
                                             ideUrl,
                                             ownerToken,
                                             connectParams,
-                                            connectionLifetime
+                                    )
+                                    if (credentials == null) {
+                                        credentials = resolveCredentialsWithWebSocketTunnel(
+                                                ideUrl,
+                                                ownerToken,
+                                                connectParams,
+                                                connectionLifetime
                                         )
                                     }
                                     if (credentials == null) {
@@ -291,9 +291,9 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                         return@thinClientJob
                                     }
                                     val clientHandle = connectionHandleFactory.connect(
-                                        connectionLifetime,
-                                        SshHostTunnelConnector(credentials),
-                                        URI(joinLinkResp.joinLink)
+                                            connectionLifetime,
+                                            SshHostTunnelConnector(credentials),
+                                            URI(joinLinkResp.joinLink)
                                     )
                                     clientHandle.clientClosed.advise(connectionLifetime) {
                                         application.invokeLater {
@@ -307,25 +307,28 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                             }
                                         }
                                     }
-                                    val backendStatusJob = launch backendStatusJob@{
-                                        while (isActive) {
-                                            try {
-                                                delay(5000)
-                                                val updatedJoinLinkResp = resolveJoinLink(ideUrl, ownerToken, connectParams)
-                                                if (updatedJoinLinkResp != null && joinLinkResp != null && joinLinkResp!!.appPid > 0 && updatedJoinLinkResp.appPid > 0 &&  updatedJoinLinkResp.appPid != joinLinkResp!!.appPid) {
-                                                    clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
-                                                    clientHandle.notifyReconnect()
-                                                    joinLinkResp = updatedJoinLinkResp
-                                                }
-                                            } catch(t: Throwable) {
-                                                if (t is CancellationException) {
-                                                    return@backendStatusJob
+                                    var backendStatusJob: Job? = null
+                                    if (joinLinkResp.appPid > 0) {
+                                        backendStatusJob = launch backendStatusJob@{
+                                            while (isActive) {
+                                                try {
+                                                    delay(5000)
+                                                    val updatedJoinLinkResp = resolveJoinLink(ideUrl, ownerToken, connectParams)
+                                                    if (updatedJoinLinkResp != null && joinLinkResp != null && joinLinkResp!!.appPid > 0 && updatedJoinLinkResp.appPid > 0 && updatedJoinLinkResp.appPid != joinLinkResp!!.appPid) {
+                                                        clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
+                                                        clientHandle.notifyReconnect()
+                                                        joinLinkResp = updatedJoinLinkResp
+                                                    }
+                                                } catch (t: Throwable) {
+                                                    if (t is CancellationException) {
+                                                        return@backendStatusJob
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                     connectionLifetime.onTerminationOrNow {
-                                        backendStatusJob.cancel()
+                                        backendStatusJob?.cancel()
                                     }
                                     thinClient = clientHandle
                                 } catch (t: Throwable) {
@@ -333,8 +336,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                         throw t
                                     }
                                     thisLogger().error(
-                                        "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to connect:",
-                                        t
+                                            "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to connect:",
+                                            t
                                     )
                                     setErrorMessage("" + t.message)
                                 }
@@ -342,16 +345,16 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                         }
                     } catch (e: Throwable) {
                         thisLogger().error(
-                            "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to process workspace update:",
-                            e
+                                "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to process workspace update:",
+                                e
                         )
                     }
                 }
                 connectionLifetime.terminate()
             } catch (t: Throwable) {
                 thisLogger().error(
-                    "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to process workspace updates:",
-                    t
+                        "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to process workspace updates:",
+                        t
                 )
                 setErrorMessage("failed to process workspace updates ${t.message}")
             }
@@ -361,10 +364,10 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun resolveCredentialsWithWebSocketTunnel(
-        ideUrl: URL,
-        ownerToken: String,
-        connectParams: ConnectParams,
-        connectionLifetime: Lifetime,
+            ideUrl: URL,
+            ownerToken: String,
+            connectParams: ConnectParams,
+            connectionLifetime: Lifetime,
     ): RemoteCredentialsHolder? {
         val keyPair = createSSHKeyPair(ideUrl, connectParams, ownerToken)
         if (keyPair == null || keyPair.privateKey.isNullOrEmpty()) {
@@ -381,10 +384,10 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             val proxies = CommonProxy.getInstance().select(ideUrl)
             val sslContext = CertificateManager.getInstance().sslContext
             val sshWebSocketServer = GitpodWebSocketTunnelServer(
-                "wss://${ideUrl.host}/_supervisor/tunnel/ssh",
-                ownerToken,
-                proxies,
-                sslContext
+                    "wss://${ideUrl.host}/_supervisor/tunnel/ssh",
+                    ownerToken,
+                    proxies,
+                    sslContext
             )
             sshWebSocketServer.start(connectionLifetime)
 
@@ -401,26 +404,26 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             }
 
             return resolveCredentials(
-                "localhost",
-                sshWebSocketServer.port,
-                userName,
-                null,
-                privateKeyFile.absolutePathString(),
-                hostKeys
+                    "localhost",
+                    sshWebSocketServer.port,
+                    userName,
+                    null,
+                    privateKeyFile.absolutePathString(),
+                    hostKeys
             )
         } catch (t: Throwable) {
             thisLogger().error(
-                "${connectParams.gitpodHost}: web socket tunnel: failed to connect:",
-                t
+                    "${connectParams.gitpodHost}: web socket tunnel: failed to connect:",
+                    t
             )
             return null
         }
     }
 
     private suspend fun resolveCredentialsWithDirectSSH(
-        ideUrl: URL,
-        ownerToken: String,
-        connectParams: ConnectParams
+            ideUrl: URL,
+            ownerToken: String,
+            connectParams: ConnectParams
     ): RemoteCredentialsHolder? {
         if (settings.forceHttpTunnel) {
             return null
@@ -433,33 +436,33 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
 
         try {
             val sshHostUrl =
-                URL(
-                    ideUrl.toString().replace(
-                        connectParams.resolvedWorkspaceId,
-                        "${connectParams.resolvedWorkspaceId}.ssh"
+                    URL(
+                            ideUrl.toString().replace(
+                                    connectParams.resolvedWorkspaceId,
+                                    "${connectParams.resolvedWorkspaceId}.ssh"
+                            )
                     )
-                )
             return resolveCredentials(
-                sshHostUrl.host,
-                22,
-                connectParams.resolvedWorkspaceId,
-                ownerToken,
-                null,
-                hostKeys
+                    sshHostUrl.host,
+                    22,
+                    connectParams.resolvedWorkspaceId,
+                    ownerToken,
+                    null,
+                    hostKeys
             )
         } catch (t: Throwable) {
             thisLogger().error(
-                "${connectParams.gitpodHost}: direct SSH: failed to resolve credentials",
-                t
+                    "${connectParams.gitpodHost}: direct SSH: failed to resolve credentials",
+                    t
             )
             return null
         }
     }
 
     private suspend fun resolveJoinLink(
-        ideUrl: URL,
-        ownerToken: String,
-        connectParams: ConnectParams
+            ideUrl: URL,
+            ownerToken: String,
+            connectParams: ConnectParams
     ): JoinLinkResp? {
         var resolveJoinLinkUrl = "https://24000-${ideUrl.host}/joinLink2"
         if (!connectParams.backendPort.isNullOrBlank()) {
@@ -479,19 +482,19 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             resolveJoinLinkUrl += "?backendPort=${connectParams.backendPort}"
         }
         rawResp = fetchWS(resolveJoinLinkUrl, connectParams, ownerToken)
-        if (rawResp != null){
+        if (rawResp != null) {
             return JoinLinkResp(-1, rawResp)
         }
-        return  null
+        return null
     }
 
     private fun resolveCredentials(
-        host: String,
-        port: Int,
-        userName: String?,
-        password: String?,
-        privateKeyFile: String?,
-        hostKeys: List<SSHHostKey>
+            host: String,
+            port: Int,
+            userName: String?,
+            password: String?,
+            privateKeyFile: String?,
+            hostKeys: List<SSHHostKey>
     ): RemoteCredentialsHolder {
         val credentials = RemoteCredentialsHolder()
         credentials.setHost(host)
@@ -506,9 +509,9 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             credentials.authType = AuthType.KEY_PAIR
         }
         var builder = credentials.connectionBuilder(
-            null,
-            ProgressManager.getGlobalProgressIndicator(),
-            false
+                null,
+                ProgressManager.getGlobalProgressIndicator(),
+                false
         ).withParsingOpenSSHConfig(true)
         if (hostKeys.isNotEmpty()) {
             builder = builder.withSshConnectionConfig {
@@ -516,10 +519,10 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                 if (hostKeyVerifier is OpenSshLikeHostKeyVerifier) {
                     val acceptHostKey = acceptHostKey(host, hostKeys)
                     it.copy(
-                        hostKeyVerifier = hostKeyVerifier.copy(
-                            acceptChangedHostKey = acceptHostKey,
-                            acceptUnknownHostKey = acceptHostKey
-                        )
+                            hostKeyVerifier = hostKeyVerifier.copy(
+                                    acceptChangedHostKey = acceptHostKey,
+                                    acceptUnknownHostKey = acceptHostKey
+                            )
                     )
                 } else {
                     it
@@ -531,12 +534,12 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun createSSHKeyPair(
-        ideUrl: URL,
-        connectParams: ConnectParams,
-        ownerToken: String
+            ideUrl: URL,
+            connectParams: ConnectParams,
+            ownerToken: String
     ): CreateSSHKeyPairResponse? {
         val value =
-            fetchWS("https://${ideUrl.host}/_supervisor/v1/ssh_keys/create", connectParams, ownerToken)
+                fetchWS("https://${ideUrl.host}/_supervisor/v1/ssh_keys/create", connectParams, ownerToken)
         if (value.isNullOrBlank()) {
             return null
         }
@@ -547,11 +550,11 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun resolveHostKeys(
-        ideUrl: URL,
-        connectParams: ConnectParams
+            ideUrl: URL,
+            connectParams: ConnectParams
     ): List<SSHHostKey>? {
         val hostKeysValue =
-            fetchWS("https://${ideUrl.host}/_ssh/host_keys", connectParams, null)
+                fetchWS("https://${ideUrl.host}/_ssh/host_keys", connectParams, null)
         if (hostKeysValue.isNullOrBlank()) {
             return null
         }
@@ -585,8 +588,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private fun acceptHostKey(
-        host: String,
-        hostKeys: List<SSHHostKey>
+            host: String,
+            hostKeys: List<SSHHostKey>
     ): AskAboutHostKey {
         val hostKeysByType = hostKeys.groupBy({ it.type.lowercase() }) { it.hostKey }
         val acceptHostKey: AskAboutHostKey = { hostName, keyType, fingerprint, _ ->
@@ -600,12 +603,12 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             var matchedFingerprint = false
             for (hostKey in matchedHostKeys!!) {
                 for (digest in listOf(
-                    DigestUtil.md5(),
-                    DigestUtil.sha256(),
-                    DigestUtil.sha1()
+                        DigestUtil.md5(),
+                        DigestUtil.sha256(),
+                        DigestUtil.sha1()
                 )) {
                     val bytes =
-                        digest.digest(Base64.getDecoder().decode(hostKey))
+                            digest.digest(Base64.getDecoder().decode(hostKey))
                     val hostKeyFingerprint = toHexString(bytes, "", ":")
                     if (hostKeyFingerprint == fingerprint) {
                         matchedFingerprint = true
@@ -619,9 +622,9 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     private suspend fun fetchWS(
-        endpointUrl: String,
-        connectParams: ConnectParams,
-        ownerToken: String?,
+            endpointUrl: String,
+            connectParams: ConnectParams,
+            ownerToken: String?,
     ): String? {
         val maxRequestTimeout = 30 * 1000L
         val timeoutDelayGrowFactor = 1.5
@@ -630,15 +633,15 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
             coroutineContext.job.ensureActive()
             try {
                 var httpRequestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(endpointUrl))
-                    .GET()
-                    .timeout(Duration.ofMillis(requestTimeout))
+                        .uri(URI.create(endpointUrl))
+                        .GET()
+                        .timeout(Duration.ofMillis(requestTimeout))
                 if (!ownerToken.isNullOrBlank()) {
                     httpRequestBuilder = httpRequestBuilder.header("x-gitpod-owner-token", ownerToken)
                 }
                 val httpRequest = httpRequestBuilder.build()
                 val response =
-                    httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString()).await()
+                        httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString()).await()
                 if (response.statusCode() == 200) {
                     return response.body()
                 }
@@ -652,8 +655,8 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                     throw t
                 }
                 thisLogger().warn(
-                    "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to fetch '$endpointUrl', trying again...:",
-                    t
+                        "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to fetch '$endpointUrl', trying again...:",
+                        t
                 )
             }
             requestTimeout = (requestTimeout * timeoutDelayGrowFactor).toLong()
@@ -664,13 +667,13 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
     }
 
     override fun isApplicable(parameters: Map<String, String>): Boolean =
-        parameters.containsKey("gitpodHost")
+            parameters.containsKey("gitpodHost")
 
     data class ConnectParams(
-        val gitpodHost: String,
-        val actualWorkspaceId: String,
-        val backendPort: String?,
-        val debugWorkspace: Boolean,
+            val gitpodHost: String,
+            val actualWorkspaceId: String,
+            val backendPort: String?,
+            val debugWorkspace: Boolean,
     ) {
         val resolvedWorkspaceId = "${if (debugWorkspace) "debug-" else ""}$actualWorkspaceId"
         val title = "$resolvedWorkspaceId ($gitpodHost)"

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -313,7 +313,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                                 delay(5000)
                                                 val updatedJoinLinkResp = resolveJoinLink(ideUrl, ownerToken, connectParams)
                                                 if (updatedJoinLinkResp != null && joinLinkResp != null && updatedJoinLinkResp.appPid != joinLinkResp!!.appPid) {
-                                                    clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), false)
+                                                    clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
                                                     joinLinkResp = updatedJoinLinkResp
                                                 }
                                             } catch(t: Throwable) {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -315,14 +315,18 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                                     delay(5000)
                                                     val updatedJoinLinkResp = resolveJoinLink(ideUrl, ownerToken, connectParams)
                                                     if (updatedJoinLinkResp != null && joinLinkResp != null && joinLinkResp!!.appPid > 0 && updatedJoinLinkResp.appPid > 0 && updatedJoinLinkResp.appPid != joinLinkResp!!.appPid) {
-                                                        clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
                                                         clientHandle.notifyReconnect()
+                                                        clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
                                                         joinLinkResp = updatedJoinLinkResp
                                                     }
                                                 } catch (t: Throwable) {
                                                     if (t is CancellationException) {
                                                         return@backendStatusJob
                                                     }
+                                                    thisLogger().error(
+                                                            "${connectParams.gitpodHost}: ${connectParams.resolvedWorkspaceId}: failed to reconnect:",
+                                                            t
+                                                    )
                                                 }
                                             }
                                         }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -314,6 +314,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                                 val updatedJoinLinkResp = resolveJoinLink(ideUrl, ownerToken, connectParams)
                                                 if (updatedJoinLinkResp != null && joinLinkResp != null && updatedJoinLinkResp.appPid != joinLinkResp!!.appPid) {
                                                     clientHandle.updateJoinLink(URI(updatedJoinLinkResp.joinLink), true)
+                                                    clientHandle.notifyReconnect()
                                                     joinLinkResp = updatedJoinLinkResp
                                                 }
                                             } catch(t: Throwable) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2827df</samp>

Add a new endpoint to the JetBrains IDE launcher for getting the app PID and the join link for Code With Me. Update the response structs and the join link resolver function in `main.go`.

</details>

## How to test
<!-- Provide steps to test this PR -->
1. Connect to workspace in preview env
2. Update backend settings and click `update and restart`
3. IDE should restart and reconnect successfully

**Also  Test connection works when new endpoint is missing on dogfood**

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-painful-boa</li>
	<li><b>🔗 URL</b> - <a href="https://jp-painful-boa.preview.gitpod-dev.com/workspaces" target="_blank">jp-painful-boa.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-painful-boa-gha.21289</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-painful-boa%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
