### PR TITLE
[iam] Use proper subjectId in updateOIDCUserOnSignin

### DIFF
--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -162,7 +162,7 @@ export class IamSessionApp {
                 primaryEmail: recent.primaryEmail,
                 lastSigninTime: new Date().toISOString(),
             });
-            await this.userService.updateUser(user.id, {
+            await this.userService.updateUser(SYSTEM_USER_ID, {
                 id: user.id,
                 fullName: payload.claims.name,
             });


### PR DESCRIPTION
## Description
Showed up in dedicated logs

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 74ff7a3</samp>

Fixed a bug in `IamSessionApp` that prevented updating the user's last sign-in time. Changed the `updateUser` method to use the `SYSTEM_USER_ID` constant instead of the `user.id` variable.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related: EXP-918

## How to test
 - go to https://gpl-subjec53aa308c9b.preview.gitpod-dev.com/workspaces, and login using SSO, "supercorp"
 - open a workspace, and check that there is no line containing "SubjectId mismatch" in the logs :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
