### PR TITLE
Fix admin dashboard convert failed case

### DIFF
--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.golden
@@ -1,0 +1,94 @@
+{
+    "result": {
+        "id": "balabala-wd-id",
+        "metadata": {
+            "ownerId": "ownerId",
+            "organizationId": "organizationId",
+            "configurationId": "",
+            "annotations": {},
+            "name": "description",
+            "pinned": true,
+            "originalContextUrl": "https://github.com/gitpod-io/contextURL"
+        },
+        "spec": {
+            "initializer": {
+                "specs": [
+                    {
+                        "git": {
+                            "remoteUri": "https://github.com/gitpod-io/contextURL.git",
+                            "upstreamRemoteUri": "",
+                            "targetMode": "CLONE_TARGET_MODE_UNSPECIFIED",
+                            "cloneTaget": "",
+                            "checkoutLocation": "contextUrl",
+                            "config": {
+                                "customConfig": {},
+                                "authentication": "AUTH_METHOD_UNSPECIFIED",
+                                "authUser": "",
+                                "authPassword": "",
+                                "authOts": ""
+                            }
+                        }
+                    }
+                ]
+            },
+            "type": "WORKSPACE_TYPE_REGULAR",
+            "ports": [
+                {
+                    "port": "8080",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "https://8080-balabala-ws-id.ws-us106.gitpod.io",
+                    "protocol": "PROTOCOL_HTTP"
+                },
+                {
+                    "port": "3306",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "https://3306-balabala-ws-id.ws-us106.gitpod.io",
+                    "protocol": "PROTOCOL_HTTP"
+                }
+            ],
+            "environmentVariables": [],
+            "git": {
+                "username": "",
+                "email": ""
+            },
+            "timeout": {
+                "disconnected": "1800s"
+            },
+            "admission": "ADMISSION_LEVEL_EVERYONE",
+            "class": "g1-standard",
+            "sshPublicKeys": [],
+            "subassemblyReferences": [],
+            "logUrl": "",
+            "editor": {
+                "name": "code",
+                "version": "stable"
+            }
+        },
+        "status": {
+            "statusVersion": "1701586489",
+            "phase": {
+                "name": "PHASE_STOPPED",
+                "lastTransitionTime": "2023-12-03T06:54:49.619Z"
+            },
+            "workspaceUrl": "https://balabala-ws-id.ws-us106.gitpod.io",
+            "conditions": {
+                "failed": "",
+                "failedReason": "FAILED_REASON_UNSPECIFIED",
+                "timeout": ""
+            },
+            "gitStatus": {
+                "cloneUrl": "https://github.com/gitpod-io/contextURL.git",
+                "branch": "master",
+                "latestCommit": "revision",
+                "uncommitedFiles": [],
+                "totalUncommitedFiles": 0,
+                "untrackedFiles": [],
+                "totalUntrackedFiles": 0,
+                "unpushedCommits": [],
+                "totalUnpushedCommits": 0
+            },
+            "instanceId": "instanceId"
+        }
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.json
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.json
@@ -1,0 +1,149 @@
+{
+  "organizationId": "organizationId",
+  "ownerId": "ownerId",
+  "contextURL": "https://github.com/gitpod-io/contextURL",
+  "description": "description",
+  "context": {
+    "isFile": false,
+    "path": "",
+    "title": "contextTitle",
+    "ref": "master",
+    "refType": "branch",
+    "revision": "revision",
+    "repository": {
+      "cloneUrl": "https://github.com/gitpod-io/contextURL.git",
+      "host": "github.com",
+      "name": "contextURL",
+      "owner": "gitpod-io",
+      "private": true
+    },
+    "normalizedContextURL": "https://github.com/gitpod-io/contextURL",
+    "checkoutLocation": "contextUrl"
+  },
+  "cloneUrl": "https://github.com/gitpod-io/contextURL.git",
+  "config": {
+    "image": "mach4/gitpod-wordpress:delta",
+    "ports": [
+      {
+        "port": 8080,
+        "onOpen": "notify"
+      },
+      {
+        "port": 3306,
+        "onOpen": "ignore"
+      }
+    ],
+    "vscode": {
+      "extensions": [
+        "felixfbecker.php-debug",
+        "felixfbecker.php-intellisense",
+        "aaron-bond.better-comments"
+      ]
+    },
+    "_origin": "repo",
+    "_featureFlags": [],
+    "ideCredentials": "ideCredentials"
+  },
+  "imageSource": {
+    "baseImageResolved": "mach4/gitpod-wordpress:delta"
+  },
+  "imageNameResolved": "eu.gcr.io/gitpod-dev/workspace-images:e4ac1036c2a8779f05f6707d3d716d7759f0d9d199d4810b9fd2abffdae92355",
+  "baseImageNameResolved": "docker.io/mach4/gitpod-wordpress@sha256:995aff430a51e6183874bc76c46bfc662c711a8cd21be1f0797e6296fc05231d",
+  "shareable": true,
+  "type": "regular",
+  "softDeleted": null,
+  "deleted": false,
+  "pinned": true,
+  "workspaceId": "balabala-wd-id",
+  "region": "us106",
+  "startedTime": "2023-12-03T04:20:04.988Z",
+  "stoppingTime": "2023-12-03T06:52:09.819Z",
+  "stoppedTime": "2023-12-03T06:54:49.619Z",
+  "ideUrl": "https://balabala-ws-id.ws-us106.gitpod.io",
+  "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-images:e4ac1036c2a8779f05f6707d3d716d7759f0d9d199d4810b9fd2abffdae92355",
+  "status": {
+    "phase": "stopped",
+    "nodeIp": "10.10.0.158",
+    "message": "",
+    "podName": "ws-d839da0f-8f67-456c-81fc-3b590b547aba",
+    "timeout": "30m0s",
+    "version": 43227381,
+    "nodeName": "workspace-ws-us106-pool-8rc7",
+    "conditions": {
+      "failed": "",
+      "timeout": "",
+      "deployed": true,
+      "pullingImages": false,
+      "stoppedByRequest": true,
+      "firstUserActivity": "2023-12-03T04:20:06.000Z",
+      "headlessTaskFailed": ""
+    },
+    "ownerToken": "ownerToken",
+    "exposedPorts": [
+      {
+        "url": "https://8080-balabala-ws-id.ws-us106.gitpod.io",
+        "port": 8080,
+        "protocol": "http",
+        "visibility": "private"
+      },
+      {
+        "url": "https://3306-balabala-ws-id.ws-us106.gitpod.io",
+        "port": 3306,
+        "protocol": "http",
+        "visibility": "private"
+      }
+    ]
+  },
+  "gitStatus": {
+    "branch": "master",
+    "latestCommit": "1eb84119dedc91c54b28c538332d5deec76f4415",
+    "untrackedFiles": [
+      ".vscode/settings.json"
+    ],
+    "uncommitedFiles": [
+      ".htaccess"
+    ],
+    "totalUntrackedFiles": 79,
+    "totalUncommitedFiles": 2
+  },
+  "phasePersisted": "stopped",
+  "configuration": {
+    "ideImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-3bb09152fc5248f5b99b33b4d8a7f101aa082441",
+    "ideImageLayers": [
+      "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-49bb715b599dce2356dd02a6ede7ae8cf10d8d12",
+      "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:commit-a96456ae29513e367719ff1c720adb2c59a0bd49"
+    ],
+    "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-be35ce16a80342b0e57d85d486544e9608044d9a",
+    "ideConfig": {
+      "useLatest": false,
+      "ide": "code"
+    },
+    "ideSetup": {
+      "envvars": [
+        {
+          "name": "GITPOD_CONFIGCAT_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "GITPOD_IDE_ALIAS",
+          "value": "code"
+        }
+      ],
+      "tasks": []
+    },
+    "regionPreference": "north-america",
+    "fromBackup": true,
+    "featureFlags": [
+      "registry_facade",
+      "workspace_connection_limiting",
+      "workspace_class_limiting"
+    ]
+  },
+  "imageBuildInfo": null,
+  "workspaceClass": "g1-standard",
+  "usageAttributionId": "team:usageAttributionId",
+  "instanceId": "instanceId",
+  "workspaceCreationTime": "2022-08-21T15:26:33.843Z",
+  "instanceCreationTime": "2023-12-03T04:18:51.343Z",
+  "phase": "stopped"
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.golden
@@ -1,0 +1,105 @@
+{
+    "result": {
+        "id": "longlong-650a-413a-b5ed-aaaaa",
+        "metadata": {
+            "ownerId": "ownerId",
+            "organizationId": "organizationId",
+            "configurationId": "",
+            "annotations": {},
+            "name": "empty",
+            "pinned": true,
+            "originalContextUrl": "https://github.com/gitpod-io/empty"
+        },
+        "spec": {
+            "initializer": {
+                "specs": [
+                    {
+                        "git": {
+                            "remoteUri": "https://github.com/gitpod-io/empty.git",
+                            "upstreamRemoteUri": "",
+                            "targetMode": "CLONE_TARGET_MODE_UNSPECIFIED",
+                            "cloneTaget": "",
+                            "checkoutLocation": "",
+                            "config": {
+                                "customConfig": {},
+                                "authentication": "AUTH_METHOD_UNSPECIFIED",
+                                "authUser": "",
+                                "authPassword": "",
+                                "authOts": ""
+                            }
+                        }
+                    }
+                ]
+            },
+            "type": "WORKSPACE_TYPE_REGULAR",
+            "ports": [
+                {
+                    "port": "8080",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "",
+                    "protocol": "PROTOCOL_HTTP"
+                },
+                {
+                    "port": "8081",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "",
+                    "protocol": "PROTOCOL_HTTP"
+                },
+                {
+                    "port": "8082",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "",
+                    "protocol": "PROTOCOL_HTTP"
+                },
+                {
+                    "port": "8083",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "",
+                    "protocol": "PROTOCOL_HTTP"
+                },
+                {
+                    "port": "3306",
+                    "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+                    "url": "",
+                    "protocol": "PROTOCOL_HTTP"
+                }
+            ],
+            "environmentVariables": [],
+            "git": {
+                "username": "",
+                "email": ""
+            },
+            "admission": "ADMISSION_LEVEL_OWNER_ONLY",
+            "class": "",
+            "sshPublicKeys": [],
+            "subassemblyReferences": [],
+            "logUrl": ""
+        },
+        "status": {
+            "statusVersion": "1576178411",
+            "phase": {
+                "name": "PHASE_STOPPED",
+                "lastTransitionTime": "2019-12-12T19:20:11.821Z"
+            },
+            "workspaceUrl": "https://longlong-650a-413a-b5ed-aaaaa.ws-us02.gitpod.io",
+            "conditions": {
+                "failed": "",
+                "failedReason": "FAILED_REASON_UNSPECIFIED",
+                "timeout": "workspace timed out after period of inactivity took longer than 00h30m"
+            },
+            "gitStatus": {
+                "cloneUrl": "https://github.com/gitpod-io/empty.git",
+                "branch": "master",
+                "latestCommit": "revision",
+                "uncommitedFiles": [],
+                "totalUncommitedFiles": 0,
+                "untrackedFiles": [],
+                "totalUntrackedFiles": 0,
+                "unpushedCommits": [],
+                "totalUnpushedCommits": 0
+            },
+            "instanceId": "instanceId"
+        }
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.json
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.json
@@ -1,0 +1,125 @@
+{
+  "organizationId": "organizationId",
+  "ownerId": "ownerId",
+  "contextURL": "https://github.com/gitpod-io/empty",
+  "projectId": null,
+  "description": "empty",
+  "context": {
+    "isFile": false,
+    "path": "",
+    "title": "gitpod-io/empty - master",
+    "ref": "master",
+    "refType": "branch",
+    "revision": "revision",
+    "repository": {
+      "cloneUrl": "https://github.com/gitpod-io/empty.git",
+      "host": "github.com",
+      "name": "empty",
+      "owner": "gitpod.io",
+      "private": false
+    }
+  },
+  "config": {
+    "image": "gitpod/workspace-base",
+    "ports": [
+      {
+        "port": 8080,
+        "onOpen": "notify"
+      },
+      {
+        "port": 8081,
+        "onOpen": "ignore"
+      },
+      {
+        "port": 8082,
+        "onOpen": "ignore"
+      },
+      {
+        "port": 8083,
+        "onOpen": "ignore"
+      },
+      {
+        "port": 3306,
+        "onOpen": "ignore"
+      }
+    ],
+    "tasks": [
+      {
+        "init": "npm install",
+        "command": "/etc/docker/startup.sh"
+      }
+    ],
+    "vscode": {
+      "extensions": [
+      ]
+    }
+  },
+  "imageSource": {
+    "baseImageResolved": "gitpod/workspace-base"
+  },
+  "imageNameResolved": "gitpod/workspace-base",
+  "baseImageNameResolved": "gitpod/workspace-base",
+  "shareable": false,
+  "type": "regular",
+  "softDeleted": null,
+  "deleted": false,
+  "pinned": true,
+  "basedOnPrebuildId": null,
+  "basedOnSnapshotId": null,
+  "workspaceId": "longlong-650a-413a-b5ed-aaaaa",
+  "region": "us02",
+  "startedTime": "2019-12-12T18:38:38.625Z",
+  "deployedTime": "2019-12-12T18:38:21.501Z",
+  "stoppedTime": "2019-12-12T19:20:11.821Z",
+  "ideUrl": "https://longlong-650a-413a-b5ed-aaaaa.ws-us02.gitpod.io",
+  "workspaceImage": "gitpod/workspace-base",
+  "status": {
+    "repo": {
+      "branch": "master",
+      "latestCommit": "latestCommit",
+      "untrackedFiles": [
+        "a.jpg"
+      ],
+      "uncommitedFiles": [
+        "package.json"
+      ]
+    },
+    "phase": "stopped",
+    "conditions": {
+      "timeout": "workspace timed out after period of inactivity took longer than 00h30m",
+      "deployed": false,
+      "pullingImages": false,
+      "serviceExists": false
+    },
+    "exposedPorts": [
+      {
+        "port": 8080,
+        "targetPort": 38080
+      },
+      {
+        "port": 8081,
+        "targetPort": 38081
+      },
+      {
+        "port": 8082,
+        "targetPort": 38082
+      },
+      {
+        "port": 8083,
+        "targetPort": 38083
+      },
+      {
+        "port": 3306,
+        "targetPort": 33306
+      }
+    ]
+  },
+  "gitStatus": null,
+  "phasePersisted": "stopped",
+  "configuration": null,
+  "imageBuildInfo": null,
+  "instanceId": "instanceId",
+  "workspaceCreationTime": "2019-08-08T20:38:43.425Z",
+  "instanceCreationTime": "2019-12-12T18:38:21.095Z",
+  "phase": "stopped"
+}

--- a/components/public-api/typescript-common/scripts/new-fixtures.js
+++ b/components/public-api/typescript-common/scripts/new-fixtures.js
@@ -11,9 +11,13 @@
 const testName = process.argv[2];
 const numOfFiles = process.argv[3];
 
-const { writeFileSync } = require("node:fs");
+const { writeFileSync, existsSync } = require("node:fs");
 const { join } = require("node:path");
 
 for (let i = 0; i < numOfFiles; i++) {
-    writeFileSync(join(__dirname, `../fixtures/${testName}_${i + 1}.json`), JSON.stringify({}));
+    const name = join(__dirname, `../fixtures/${testName}_${i + 1}.json`);
+    if (existsSync(name)) {
+        continue;
+    }
+    writeFileSync(name, JSON.stringify({}));
 }

--- a/components/public-api/typescript-common/src/fixtures.spec.ts
+++ b/components/public-api/typescript-common/src/fixtures.spec.ts
@@ -34,8 +34,13 @@ const isUpdating = process.argv.includes("-update");
 export async function startFixtureTest(path: string, testResult: (input: any) => Promise<any>) {
     const files = glob.sync(join(__dirname, path));
     if (files.length === 0) {
-        assert.fail("no input files found with glob " + path);
+        assert.fail(
+            "no input files found with glob " +
+                path +
+                `. Try \`node scripts/new-fixtures.js ${path.split("/").pop()?.replace("_*.json", "")} 1\``,
+        );
     }
+
     for (const file of files) {
         const input = JSON.parse(readFileSync(file).toString());
         let result: any | undefined;

--- a/components/public-api/typescript-common/src/public-api-converter.spec.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.spec.ts
@@ -29,6 +29,7 @@ import { OrganizationRole } from "@gitpod/public-api/lib/gitpod/v1/organization_
 import { BranchMatchingStrategy } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { AuthProviderType } from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
 import { Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { WorkspaceAndInstance } from "@gitpod/gitpod-protocol";
 
 describe("PublicAPIConverter", () => {
     const converter = new PublicAPIConverter();
@@ -80,6 +81,15 @@ describe("PublicAPIConverter", () => {
 
         it("toWorkspace2", async () => {
             await startFixtureTest("../fixtures/toWorkspace2_*.json", async (input) => converter.toWorkspace(input));
+        });
+
+        it("toWorkspace3_adminPage", async () => {
+            await startFixtureTest("../fixtures/toWorkspace3_adminPage_*.json", async (input) => {
+                return converter.toWorkspace({
+                    workspace: WorkspaceAndInstance.toWorkspace(input),
+                    latestInstance: WorkspaceAndInstance.toInstance(input),
+                });
+            });
         });
 
         it("toConfiguration", async () => {

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -208,7 +208,7 @@ export class PublicAPIConverter {
             }
             return spec;
         }
-        spec.editor = this.toEditor(arg.configuration.ideConfig);
+        spec.editor = this.toEditor(arg.configuration?.ideConfig);
         spec.ports = this.toPorts(arg.status.exposedPorts);
         if (arg.status.timeout) {
             spec.timeout = new UpdateWorkspaceRequest_UpdateTimeout({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e558dc</samp>

This pull request adds and modifies some files for testing the public API converter module, which converts workspace and instance objects to different formats. It also fixes a possible bug in the converter module by adding a null check for a property.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1020

## How to test
<!-- Provide steps to test this PR -->
No need to test it.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
