### PR TITLE
[server] hook verification API service

### DIFF
--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -57,6 +57,8 @@ import { SCMService } from "@gitpod/public-api/lib/gitpod/v1/scm_connect";
 import { SSHService } from "@gitpod/public-api/lib/gitpod/v1/ssh_connect";
 import { PrebuildServiceAPI } from "./prebuild-service-api";
 import { PrebuildService } from "@gitpod/public-api/lib/gitpod/v1/prebuild_connect";
+import { VerificationServiceAPI } from "./verification-service-api";
+import { VerificationService } from "@gitpod/public-api/lib/gitpod/v1/verification_connect";
 
 decorate(injectable(), PublicAPIConverter);
 
@@ -84,6 +86,7 @@ export class API {
     @inject(UserService) private readonly userService: UserService;
     @inject(BearerAuth) private readonly bearerAuthenticator: BearerAuth;
     @inject(PrebuildServiceAPI) private readonly prebuildServiceApi: PrebuildServiceAPI;
+    @inject(VerificationServiceAPI) private readonly verificationServiceApi: VerificationServiceAPI;
 
     listenPrivate(): http.Server {
         const app = express();
@@ -133,6 +136,7 @@ export class API {
                         service(SCMService, this.scmServiceAPI),
                         service(SSHService, this.sshServiceApi),
                         service(PrebuildService, this.prebuildServiceApi),
+                        service(VerificationService, this.verificationServiceApi),
                     ]) {
                         router.service(type, new Proxy(impl, this.interceptService(type)));
                     }
@@ -387,6 +391,7 @@ export class API {
         bind(SSHServiceAPI).toSelf().inSingletonScope();
         bind(StatsServiceAPI).toSelf().inSingletonScope();
         bind(PrebuildServiceAPI).toSelf().inSingletonScope();
+        bind(VerificationServiceAPI).toSelf().inSingletonScope();
         bind(API).toSelf().inSingletonScope();
     }
 }

--- a/components/server/src/api/teams.spec.db.ts
+++ b/components/server/src/api/teams.spec.db.ts
@@ -34,6 +34,7 @@ import { ContextService } from "../workspace/context-service";
 import { ContextParser } from "../workspace/context-parser-service";
 import { SSHKeyService } from "../user/sshkey-service";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
+import { VerificationService } from "../auth/verification-service";
 
 const expect = chai.expect;
 
@@ -65,6 +66,7 @@ export class APITeamsServiceSpec {
         this.container.bind(ContextParser).toConstantValue({} as ContextParser);
         this.container.bind(SSHKeyService).toConstantValue({} as SSHKeyService);
         this.container.bind(PrebuildManager).toConstantValue({} as PrebuildManager);
+        this.container.bind(VerificationService).toConstantValue({} as VerificationService);
 
         // Clean-up database
         const typeorm = testContainer.get<TypeORM>(TypeORM);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a597fa6</samp>

This file adds the verification service to the server API, enabling clients to confirm their contact details. It uses the `VerificationServiceAPI` and `VerificationService` classes from the verification service module.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://ak-hook-ve78d2fc50b2.preview.gitpod-dev.com/workspaces

Run `time leeway run dev:preview --dont-test` from a Gitpod workspace if a preview env is down.

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
