### PR TITLE
[db] fix the query for non-fga migrated users

### DIFF
--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -297,6 +297,39 @@ class UserDBSpec {
         expect(result.some((t) => t.tokenHash === token.tokenHash)).to.be.true;
         expect(result.some((t) => t.tokenHash === token2.tokenHash)).to.be.true;
     }
+
+    @test(timeout(10000))
+    public async findUserIdsNotYetMigratedToFgaVersion() {
+        let user1 = await this.db.newUser();
+        user1.name = "ABC";
+        user1.fgaRelationshipsVersion = 0;
+        user1 = await this.db.storeUser(user1);
+
+        let user2 = await this.db.newUser();
+        user2.name = "ABC2";
+        user2.fgaRelationshipsVersion = 1;
+        user2 = await this.db.storeUser(user2);
+
+        let user3 = await this.db.newUser();
+        user3.name = "ABC3";
+        user3.fgaRelationshipsVersion = 0;
+        user3 = await this.db.storeUser(user3);
+
+        const result = await this.db.findUserIdsNotYetMigratedToFgaVersion(1, 10);
+        expect(result).to.not.be.undefined;
+        expect(result.length).to.eq(2);
+        expect(result.some((id) => id === user1.id)).to.be.true;
+        expect(result.some((id) => id === user2.id)).to.be.false;
+        expect(result.some((id) => id === user3.id)).to.be.true;
+
+        const result2 = await this.db.findUserIdsNotYetMigratedToFgaVersion(1, 1);
+        expect(result2).to.not.be.undefined;
+        expect(result2.length).to.eq(1);
+
+        const result3 = await this.db.findUserIdsNotYetMigratedToFgaVersion(2, 10);
+        expect(result3).to.not.be.undefined;
+        expect(result3.length).to.eq(3);
+    }
 }
 
 namespace TestData {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes the query for listing users that should be migrated by the FGA job.
At the moment the query is wrong and returns empty lists. As a consequence many users that haven't been active recently are not considered by FGA and can therefore not be found using our admin dashboard.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d43464b</samp>

Improve FGA migration query and add test case. The changes exclude built-in users from the query that selects users who need to migrate to a newer fine-grained access (FGA) version. The changes also add a unit test to verify the query logic and results.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #EXP-1021

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
