### PR TITLE
[authorizer] prepare Authorizer for SubjectId rollout

### DIFF
--- a/components/server/src/auth/subject-id.ts
+++ b/components/server/src/auth/subject-id.ts
@@ -73,7 +73,7 @@ export class SubjectId {
 /**
  * Interface type meant for backwards compatibility
  */
-export type Subject = string | SubjectId;
+export type Subject = string | SubjectId | undefined;
 export namespace Subject {
     export function toId(subject: Subject): SubjectId {
         if (SubjectId.is(subject)) {

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -520,18 +520,26 @@ export class Authorizer {
     }
 }
 
-async function getSubjectFromCtx(passed: Subject): Promise<SubjectId> {
+export async function getSubjectFromCtx(passed: Subject): Promise<SubjectId> {
     const ctxSubjectId = ctxTrySubjectId();
     const ctxUserId = ctxSubjectId?.userId();
 
-    const passedSubjectId = Subject.toId(passed);
-    const passedUserId = passedSubjectId.userId();
+    const passedSubjectId = !!passed ? Subject.toId(passed) : undefined;
+    const passedUserId = passedSubjectId?.userId();
 
     // Check: Do the subjectIds match?
-    const matchingSubjectId = ctxUserId === passedUserId;
-    const match = !ctxUserId ? "ctx-user-id-missing" : matchingSubjectId ? "match" : "mismatch";
+    function matchSubjectIds(ctxUserId: string | undefined, passedSubjectId: string | undefined) {
+        if (!ctxUserId) {
+            return "ctx-user-id-missing";
+        }
+        if (!passedSubjectId) {
+            return "passed-subject-id-missing";
+        }
+        return ctxUserId === passedUserId ? "match" : "mismatch";
+    }
+    const match = matchSubjectIds(ctxUserId, passedUserId);
     reportAuthorizerSubjectId(match);
-    if (match !== "match") {
+    if (match === "mismatch") {
         try {
             // Get hold of the stack trace
             throw new Error("Authorizer: SubjectId mismatch");
@@ -553,6 +561,16 @@ async function getSubjectFromCtx(passed: Subject): Promise<SubjectId> {
             : undefined,
     });
     if (!authViaContext) {
+        if (!passedSubjectId) {
+            const err = new ApplicationError(ErrorCodes.PERMISSION_DENIED, `Cannot authorize request`);
+            log.error("Authorizer: Cannot authorize request: missing SubjectId", err, {
+                match,
+                ctxSubjectId,
+                ctxUserId,
+                passedUserId,
+            });
+            throw err;
+        }
         return passedSubjectId;
     }
 

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -376,7 +376,7 @@ export const authorizerSubjectId = new prometheusClient.Counter({
     help: "Counter for the number of authorizer permission checks",
     labelNames: ["match"],
 });
-type AuthorizerSubjectIdMatch = "ctx-user-id-missing" | "match" | "mismatch";
+type AuthorizerSubjectIdMatch = "ctx-user-id-missing" | "passed-subject-id-missing" | "match" | "mismatch";
 export function reportAuthorizerSubjectId(match: AuthorizerSubjectIdMatch) {
     authorizerSubjectId.labels(match).inc();
 }

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -334,12 +334,18 @@ export function createTestContainer() {
 }
 
 export function withTestCtx<T>(subject: Subject | User, p: () => Promise<T>): Promise<T> {
+    let subjectId: SubjectId | undefined = undefined;
+    if (SubjectId.is(subject)) {
+        subjectId = subject;
+    } else if (subject !== undefined) {
+        subjectId = SubjectId.fromUserId(User.is(subject) ? subject.id : subject);
+    }
     return runWithRequestContext(
         {
             requestKind: "testContext",
             requestMethod: "testMethod",
             signal: new AbortController().signal,
-            subjectId: SubjectId.is(subject) ? subject : SubjectId.fromUserId(User.is(subject) ? subject.id : subject),
+            subjectId,
         },
         p,
     );


### PR DESCRIPTION
## Description
Prepares the central function in `Authorizer` to switch the way we determine `SubjectId`, and adds exhaustive tests for it.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1f93161</samp>

Refactored and tested the authorization logic for handling different subjects in the request context. Moved some types and functions to separate files for better organization and readability. Added error handling and metrics for missing subject id when a feature flag is on. Improved the documentation and comments for the request context interface and related utilities.

</details>

## Related Issue(s)
Related: EXP-1022

## How to test
 - check that the tests in CI are :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
