### PR TITLE
[content-service] do git config after we have an init'd folder

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -331,7 +331,7 @@ func (c *Client) Status(ctx context.Context) (res *Status, err error) {
 	}, nil
 }
 
-func (c *Client) Configure(ctx context.Context) (err error) {
+func (c *Client) configure(ctx context.Context) (err error) {
 
 	// we should only do this after having a directory to work with
 	// https://github.blog/2019-11-03-highlights-from-git-2-24/
@@ -352,6 +352,11 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 	if err != nil {
 		log.WithError(err).Error("cannot create clone location")
 	}
+
+	// explicitly avoid returning configure errors
+	// this way if it fails, it doesn't fail workspace start
+	cErr := c.configure(ctx)
+	log.WithError(cErr).Error("cannot configure git")
 
 	args := []string{"--depth=1", "--shallow-submodules", c.RemoteURI}
 

--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -331,32 +331,12 @@ func (c *Client) Status(ctx context.Context) (res *Status, err error) {
 	}, nil
 }
 
-func (c *Client) configure(ctx context.Context) (err error) {
-
-	// we should only do this after having a directory to work with
-	// https://github.blog/2019-11-03-highlights-from-git-2-24/
-	mErr := c.Git(ctx, "-C", c.Location, "config", "feature.manyFiles", "true")
-	// commit-graph after every git fetch command that downloads a pack-file from a remote
-	gErr := c.Git(ctx, "-C", c.Location, "config", "fetch.writeCommitGraph", "true")
-
-	if mErr != nil || gErr != nil {
-		return fmt.Errorf("manyFiles error: %v, writeCommitGraph error: %v", mErr, gErr)
-	}
-
-	return nil
-}
-
 // Clone runs git clone
 func (c *Client) Clone(ctx context.Context) (err error) {
 	err = os.MkdirAll(c.Location, 0775)
 	if err != nil {
 		log.WithError(err).Error("cannot create clone location")
 	}
-
-	// explicitly avoid returning configure errors
-	// this way if it fails, it doesn't fail workspace start
-	cErr := c.configure(ctx)
-	log.WithError(cErr).Error("cannot configure git")
 
 	args := []string{"--depth=1", "--shallow-submodules", c.RemoteURI}
 

--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -331,6 +331,21 @@ func (c *Client) Status(ctx context.Context) (res *Status, err error) {
 	}, nil
 }
 
+func (c *Client) Configure(ctx context.Context) (err error) {
+
+	// we should only do this after having a directory to work with
+	// https://github.blog/2019-11-03-highlights-from-git-2-24/
+	mErr := c.Git(ctx, "-C", c.Location, "config", "feature.manyFiles", "true")
+	// commit-graph after every git fetch command that downloads a pack-file from a remote
+	gErr := c.Git(ctx, "-C", c.Location, "config", "fetch.writeCommitGraph", "true")
+
+	if mErr != nil || gErr != nil {
+		return fmt.Errorf("manyFiles error: %v, writeCommitGraph error: %v", mErr, gErr)
+	}
+
+	return nil
+}
+
 // Clone runs git clone
 func (c *Client) Clone(ctx context.Context) (err error) {
 	err = os.MkdirAll(c.Location, 0775)

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -100,13 +100,13 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 
 		// we should only do this after having a directory to work with
 		// https://github.blog/2019-11-03-highlights-from-git-2-24/
-		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
+		err = ws.Git(ctx, "-C", ws.Location, "config", "feature.manyFiles", "true")
 		if err != nil {
 			log.WithError(err).Error("cannot configure feature.manyFiles")
 		}
 
 		// commit-graph after every git fetch command that downloads a pack-file from a remote
-		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
+		err = ws.Git(ctx, "-C", ws.Location, "config", "fetch.writeCommitGraph", "true")
 		if err != nil {
 			log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
 		}

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -98,19 +98,8 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			}
 		}
 
-		// we should only do this after having a directory to work with
-		// https://github.blog/2019-11-03-highlights-from-git-2-24/
-		err = ws.Git(ctx, "-C", ws.Location, "config", "feature.manyFiles", "true")
-		if err != nil {
-			log.WithError(err).Error("cannot configure feature.manyFiles")
-		}
-
-		// commit-graph after every git fetch command that downloads a pack-file from a remote
-		err = ws.Git(ctx, "-C", ws.Location, "config", "fetch.writeCommitGraph", "true")
-		if err != nil {
-			log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
-		}
-
+		err = ws.Configure(ctx)
+		log.WithError(err).Error("cannot configure git")
 		log.WithField("stage", "init").WithField("location", ws.Location).Debug("Running git clone on workspace")
 		err = ws.Clone(ctx)
 		if err != nil {

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -112,12 +112,12 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 
 		// we can only do `git config` stuffs after having a directory that is also git init'd
 		// https://github.blog/2019-11-03-highlights-from-git-2-24/
-		err = ws.Git(ctx, "-C", ws.Location, "config", "feature.manyFiles", "true")
+		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
 		if err != nil {
 			log.WithError(err).WithField("location", ws.Location).Error("cannot configure feature.manyFiles")
 		}
 		// commit-graph after every git fetch command that downloads a pack-file from a remote
-		err = ws.Git(ctx, "-C", ws.Location, "config", "fetch.writeCommitGraph", "true")
+		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
 		if err != nil {
 			log.WithError(err).WithField("location", ws.Location).Error("cannot configure fetch.writeCommitGraph")
 		}

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -110,9 +110,21 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			return err
 		}
 
+		// we can only do `git config` stuffs after having a directory that is also git init'd
+		// https://github.blog/2019-11-03-highlights-from-git-2-24/
+		err = ws.Git(ctx, "-C", ws.Location, "config", "feature.manyFiles", "true")
+		if err != nil {
+			log.WithError(err).WithField("location", ws.Location).Error("cannot configure feature.manyFiles")
+		}
+		// commit-graph after every git fetch command that downloads a pack-file from a remote
+		err = ws.Git(ctx, "-C", ws.Location, "config", "fetch.writeCommitGraph", "true")
+		if err != nil {
+			log.WithError(err).WithField("location", ws.Location).Error("cannot configure fetch.writeCommitGraph")
+		}
+
 		err = ws.Git(ctx, "config", "--replace-all", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
 		if err != nil {
-			log.WithError(err).WithField("location", ws.Location).Error("cannot configure fecth behavior")
+			log.WithError(err).WithField("location", ws.Location).Error("cannot configure fetch behavior")
 		}
 
 		err = ws.Git(ctx, "config", "--replace-all", "checkout.defaultRemote", "origin")

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -75,18 +75,6 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		return
 	}
 
-	// https://github.blog/2019-11-03-highlights-from-git-2-24/
-	err = ws.Git(ctx, "config", "feature.manyFiles", "true")
-	if err != nil {
-		log.WithError(err).Error("cannot configure feature.manyFiles")
-	}
-
-	// commit-graph after every git fetch command that downloads a pack-file from a remote
-	err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
-	if err != nil {
-		log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
-	}
-
 	gitClone := func() error {
 		if err := os.MkdirAll(ws.Location, 0775); err != nil {
 			log.WithError(err).WithField("location", ws.Location).Error("cannot create directory")
@@ -108,6 +96,19 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 				}
 				return err
 			}
+		}
+
+		// we should only do this after having a directory to work with
+		// https://github.blog/2019-11-03-highlights-from-git-2-24/
+		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
+		if err != nil {
+			log.WithError(err).Error("cannot configure feature.manyFiles")
+		}
+
+		// commit-graph after every git fetch command that downloads a pack-file from a remote
+		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
+		if err != nil {
+			log.WithError(err).Error("cannot configure fetch.writeCommitGraph")
 		}
 
 		log.WithField("stage", "init").WithField("location", ws.Location).Debug("Running git clone on workspace")

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -98,8 +98,6 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			}
 		}
 
-		err = ws.Configure(ctx)
-		log.WithError(err).Error("cannot configure git")
 		log.WithField("stage", "init").WithField("location", ws.Location).Debug("Running git clone on workspace")
 		err = ws.Clone(ctx)
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Related to https://github.com/gitpod-io/gitpod/pull/18612

w/o, we get errors like:
`git config feature.manyFiles true failed (chdir /dst/<repo to clone>: no such file or directory)`

We don't return failed config as an error, so it shouldn't block workspace start, but it also means we aren't getting the benefit of these recent suggestions.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c28d32b</samp>

Fix git configuration for content-service initializer. Ensure that `components/content-service/pkg/initializer/git.go` runs git commands in the correct order and with the necessary features enabled.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
From a preview in https://kylos101-git-config.preview.gitpod-dev.com/workspaces (created via `leeway run dev:preview`)

1. Verify the config ([ref](https://github.blog/2019-11-03-highlights-from-git-2-24/)) is set:
```
gitpod@kylos101-dotfiles-pxk9pkhcs63:/workspace/dotfiles$ git config --list | grep manyfiles
feature.manyfiles=true
gitpod@kylos101-dotfiles-pxk9pkhcs63:/workspace/dotfiles$ git config --list | grep writecommitgraph
fetch.writecommitgraph=true
```
2. Open a repo and commit/push something to it
3. These should no longer register as errors in the logs - we were never setting these values

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
