### PR TITLE
[ws-proxy] use ecdsa private key for createKey fake api

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -7,7 +7,8 @@ package proxy
 import (
 	"bytes"
 	"context"
-	"crypto/ed25519"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	crand "crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
@@ -202,12 +203,13 @@ func (ir *ideRoutes) HandleCreateKeyRoute(route *mux.Route, hostKeyList []ssh.Si
 			} `json:"hostKey"`
 		}{}
 
-		_, pvk, err := ed25519.GenerateKey(crand.Reader)
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), crand.Reader)
 		if err != nil {
 			log.WithError(err).Error("failed to generate key")
 			return
 		}
-		block, err := ssh.MarshalPrivateKey(pvk, "")
+
+		block, err := ssh.MarshalPrivateKey(privateKey, "")
 		if err != nil {
 			log.WithError(err).Error("failed to marshal key")
 			return


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR change `/_supervisor/v1/ssh_keys/create` hook endpoint to use ecdsa key. It provides backward compatibility for vscode desktop because `dev-tunnel-ssh` does not support ed25519.

This is just a change in the algorithm of the private key. Note that this endpoint does not have any substantive effect, and these keys will not be used for authentication.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39ca671</samp>

Use ECDSA keys for SSH authentication in ws-proxy. Update `routes.go` to generate and marshal ECDSA keys instead of Ed25519 keys.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in preview env
2. using this version vscode desktop extension https://github.com/gitpod-io/gitpod-vscode-desktop/pull/101
3. it should successfully connect with this preview env
4. you can test with dogfood, it should fail to connect via local SSH, and fallback to the SSH gateway (check the URL if it container vss, vsi)
5. also test with Jetbrains IDE, make sure it still work like before
## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-fake-ap186cc4bcc0</li>
	<li><b>🔗 URL</b> - <a href="https://pd-fake-ap186cc4bcc0.preview.gitpod-dev.com/workspaces" target="_blank">pd-fake-ap186cc4bcc0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-fake-api-use-ecdsa-key-gha.21473</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-fake-ap186cc4bcc0%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
