### PR TITLE
add GitpodV1APIServerErrors alert

### DIFF
--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -57,6 +57,19 @@ spec:
         summary: The error rate of the JSON RPC API is high on {{ $labels.cluster }}. Investigation required.
         description: JSON RPC API error rate high
 
+    - alert: GitpodV1APIServerErrors
+      expr: sum(rate(grpc_server_handled_total{grpc_code=~"Internal|Unknown|DataLoss", grpc_service=~"gitpod.v1.*"}[5m])) by (cluster) / sum(rate(grpc_server_handled_total{grpc_service=~"gitpod.v1.*"}[5m])) by (cluster) > 0.01
+      for: 5m
+      labels:
+        severity: critical
+        team: webapp
+        dedicated: included
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodV1APIServerErrors.md
+        summary: gitpod.v1 API is returning higher number of errors on {{ $labels.cluster }}. Investigation required.
+        description: gitpod.v1 API is returning higher number of errors
+
+
     - alert: WebsocketConnectionRateHigh
       # Reasoning: the values are taken from past data
       expr: sum(rate(gitpod_server_api_connections_total[2m])) by (pod) > 5


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See in grafana for last 30 days [[1](https://grafana.gitpod.io/explore?panes=%7B%222rm%22:%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%28rate%28grpc_server_handled_total%7Bgrpc_code%3D~%5C%22Internal%7CUnknown%7CDataLoss%5C%22,%20grpc_service%3D~%5C%22gitpod.v1.%2A%5C%22%7D%5B5m%5D%29%29%20%2F%20sum%28rate%28grpc_server_handled_total%7Bgrpc_service%3D~%5C%22gitpod.v1.%2A%5C%22%7D%5B5m%5D%29%29%20%3E%200.01%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1)]

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 43f6c0c</samp>

Add a new Prometheus alert rule for gitpod.v1 API errors in `operations/observability/mixins/meta/rules/server.yaml`. The rule helps monitor and troubleshoot the new version of the API that is being deployed.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
