### PR TITLE
[authorization] Align HTTP handlers before RequestContext rollout

### DIFF
--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -43,7 +43,8 @@ export type UserPermission =
     | "read_tokens"
     | "write_tokens"
     | "read_env_var"
-    | "write_env_var";
+    | "write_env_var"
+    | "code_sync";
 
 export type InstallationResourceType = "installation";
 

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -11,7 +11,7 @@ import * as util from "util";
 import express from "express";
 import { inject, injectable } from "inversify";
 import { BearerAuth } from "../auth/bearer-authenticator";
-import { isWithFunctionAccessGuard } from "../auth/function-access";
+import { WithFunctionAccessGuard } from "../auth/function-access";
 import { CodeSyncResourceDB, ALL_SERVER_RESOURCES, ServerResource, SyncResource } from "@gitpod/gitpod-db/lib";
 import {
     DeleteRequest,
@@ -26,6 +26,8 @@ import { v4 as uuidv4 } from "uuid";
 import { accessCodeSyncStorage, UserRateLimiter } from "../auth/rate-limiter";
 import { Config } from "../config";
 import { CachingBlobServiceClientProvider } from "../util/content-service-sugar";
+import { Authorizer } from "../authorization/authorizer";
+import { FGAFunctionAccessGuard } from "../auth/resource-access";
 
 // By default: 5 kind of resources * 20 revs * 1Mb = 100Mb max in the content service for user data.
 const defaultRevLimit = 20;
@@ -71,17 +73,22 @@ function toObjectName(resource: ServerResource, rev: string, collection: string 
 
 @injectable()
 export class CodeSyncService {
-    @inject(Config)
-    private readonly config: Config;
+    constructor(
+        @inject(Config)
+        private readonly config: Config,
 
-    @inject(BearerAuth)
-    private readonly auth: BearerAuth;
+        @inject(BearerAuth)
+        private readonly auth: BearerAuth,
 
-    @inject(CachingBlobServiceClientProvider)
-    private readonly blobsProvider: CachingBlobServiceClientProvider;
+        @inject(CachingBlobServiceClientProvider)
+        private readonly blobsProvider: CachingBlobServiceClientProvider,
 
-    @inject(CodeSyncResourceDB)
-    private readonly db: CodeSyncResourceDB;
+        @inject(CodeSyncResourceDB)
+        private readonly db: CodeSyncResourceDB,
+
+        @inject(Authorizer)
+        private readonly authorizer: Authorizer,
+    ) {}
 
     get apiRouter(): express.Router {
         const config = this.config.codeSync;
@@ -91,16 +98,16 @@ export class CodeSyncService {
             res.setHeader("x-operation-id", uuidv4());
             return next();
         });
-        router.use(this.auth.restHandler);
+        router.use(this.auth.restHandler); // expects Bearer token and authenticates req.user, throws otherwise
         router.use(async (req, res, next) => {
             if (!User.is(req.user)) {
                 res.sendStatus(400);
                 return;
             }
 
-            const id = req.user.id;
+            const userId = req.user.id;
             try {
-                await UserRateLimiter.instance(this.config.rateLimiter).consume(id, accessCodeSyncStorage);
+                await UserRateLimiter.instance(this.config.rateLimiter).consume(userId, accessCodeSyncStorage);
             } catch (e) {
                 if (e instanceof Error) {
                     throw e;
@@ -110,20 +117,26 @@ export class CodeSyncService {
                 return;
             }
 
-            if (!isWithFunctionAccessGuard(req) || !req.functionGuard?.canAccess(accessCodeSyncStorage)) {
+            const functionGuard = (req.user as WithFunctionAccessGuard).functionGuard;
+            if (!!functionGuard) {
+                // If we authorize with scopes, there is a FunctionGuard
+                const guard = new FGAFunctionAccessGuard(userId, functionGuard);
+                if (!(await guard.canAccess(accessCodeSyncStorage))) {
+                    res.sendStatus(403);
+                    return;
+                }
+            }
+
+            if (!(await this.authorizer.hasPermissionOnUser(userId, "code_sync", userId))) {
                 res.sendStatus(403);
                 return;
             }
+
             return next();
         });
 
         router.get("/v1/manifest", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.sendStatus(400);
-                return;
-            }
-
-            const manifest = await this.db.getManifest(req.user.id);
+            const manifest = await this.db.getManifest(req.user!.id);
             if (!manifest) {
                 res.sendStatus(204);
                 return;
@@ -149,13 +162,8 @@ export class CodeSyncService {
         router.delete("/v1/collection/:collection/resource/:resource/:ref?", this.deleteResource.bind(this));
         router.delete("/v1/resource/:resource/:ref?", this.deleteResource.bind(this));
         router.delete("/v1/resource", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.sendStatus(400);
-                return;
-            }
-
             // This endpoint is used to delete settings-sync data only
-            const userId = req.user.id;
+            const userId = req.user!.id;
             await this.db.deleteSettingsSyncResources(userId, async () => {
                 const request = new DeleteRequest();
                 request.setOwnerId(userId);
@@ -173,36 +181,21 @@ export class CodeSyncService {
         });
 
         router.get("/v1/collection", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.sendStatus(400);
-                return;
-            }
-
-            const collections = await this.db.getCollections(req.user.id);
+            const collections = await this.db.getCollections(req.user!.id);
 
             res.json(collections);
             return;
         });
         router.post("/v1/collection", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.sendStatus(400);
-                return;
-            }
-
-            const collection = await this.db.createCollection(req.user.id);
+            const collection = await this.db.createCollection(req.user!.id);
 
             res.type("text/plain");
             res.send(collection);
             return;
         });
         router.delete("/v1/collection/:collection?", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.sendStatus(400);
-                return;
-            }
-
             const { collection } = req.params;
-            await this.deleteCollection(req.user.id, collection);
+            await this.deleteCollection(req.user!.id, collection);
 
             res.sendStatus(200);
         });
@@ -211,11 +204,6 @@ export class CodeSyncService {
     }
 
     private async getResources(req: express.Request<{ resource: string; collection?: string }>, res: express.Response) {
-        if (!User.is(req.user)) {
-            res.sendStatus(400);
-            return;
-        }
-
         const { resource, collection } = req.params;
         const resourceKey = ALL_SERVER_RESOURCES.find((key) => key === resource);
         if (!resourceKey) {
@@ -224,14 +212,14 @@ export class CodeSyncService {
         }
 
         if (collection) {
-            const valid = await this.db.isCollection(req.user.id, collection);
+            const valid = await this.db.isCollection(req.user!.id, collection);
             if (!valid) {
                 res.sendStatus(405);
                 return;
             }
         }
 
-        const revs = await this.db.getResources(req.user.id, resourceKey, collection);
+        const revs = await this.db.getResources(req.user!.id, resourceKey, collection);
         if (!revs.length) {
             res.sendStatus(204);
             return;
@@ -249,11 +237,6 @@ export class CodeSyncService {
         req: express.Request<{ resource: string; ref: string; collection?: string }>,
         res: express.Response,
     ) {
-        if (!User.is(req.user)) {
-            res.sendStatus(400);
-            return;
-        }
-
         const { resource, ref, collection } = req.params;
         const resourceKey = ALL_SERVER_RESOURCES.find((key) => key === resource);
         if (!resourceKey) {
@@ -262,14 +245,14 @@ export class CodeSyncService {
         }
 
         if (collection) {
-            const valid = await this.db.isCollection(req.user.id, collection);
+            const valid = await this.db.isCollection(req.user!.id, collection);
             if (!valid) {
                 res.sendStatus(405);
                 return;
             }
         }
 
-        const resourceRev = (await this.db.getResource(req.user.id, resourceKey, ref, collection))?.rev;
+        const resourceRev = (await this.db.getResource(req.user!.id, resourceKey, ref, collection))?.rev;
         if (!resourceRev) {
             res.setHeader("etag", "0");
             res.sendStatus(204);
@@ -283,7 +266,7 @@ export class CodeSyncService {
         let content: string;
         const contentType = req.headers["content-type"] || "*/*";
         const request = new DownloadUrlRequest();
-        request.setOwnerId(req.user.id);
+        request.setOwnerId(req.user!.id);
         request.setName(toObjectName(resourceKey, resourceRev, collection));
         request.setContentType(contentType);
         try {
@@ -317,11 +300,6 @@ export class CodeSyncService {
     }
 
     private async postResource(req: express.Request<{ resource: string; collection?: string }>, res: express.Response) {
-        if (!User.is(req.user)) {
-            res.sendStatus(400);
-            return;
-        }
-
         const { resource, collection } = req.params;
         const resourceKey = ALL_SERVER_RESOURCES.find((key) => key === resource);
         if (!resourceKey) {
@@ -330,7 +308,7 @@ export class CodeSyncService {
         }
 
         if (collection) {
-            const valid = await this.db.isCollection(req.user.id, collection);
+            const valid = await this.db.isCollection(req.user!.id, collection);
             if (!valid) {
                 res.sendStatus(405);
                 return;
@@ -346,7 +324,7 @@ export class CodeSyncService {
                   this.config.codeSync?.revLimit ||
                   defaultRevLimit;
         const isEditSessionsResource = resourceKey === "editSessions";
-        const userId = req.user.id;
+        const userId = req.user!.id;
         const contentType = req.headers["content-type"] || "*/*";
         const newRev = await this.db.insert(
             userId,
@@ -403,11 +381,6 @@ export class CodeSyncService {
         req: express.Request<{ resource: string; ref?: string; collection?: string }>,
         res: express.Response,
     ) {
-        if (!User.is(req.user)) {
-            res.sendStatus(400);
-            return;
-        }
-
         // This endpoint is used to delete edit sessions data for now
 
         const { resource, ref, collection } = req.params;
@@ -418,14 +391,14 @@ export class CodeSyncService {
         }
 
         if (collection) {
-            const valid = await this.db.isCollection(req.user.id, collection);
+            const valid = await this.db.isCollection(req.user!.id, collection);
             if (!valid) {
                 res.sendStatus(405);
                 return;
             }
         }
 
-        await this.doDeleteResource(req.user.id, resourceKey, ref, collection);
+        await this.doDeleteResource(req.user!.id, resourceKey, ref, collection);
         res.sendStatus(200);
         return;
     }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -350,7 +350,7 @@ export const guardAccessChecksTotal = new prometheusClient.Counter({
     labelNames: ["type"],
 });
 
-export type GuardAccessCheckType = "fga" | "resource-access";
+export type GuardAccessCheckType = "fga" | "resource-access" | "function-access";
 export function reportGuardAccessCheck(type: GuardAccessCheckType) {
     guardAccessChecksTotal.labels(type).inc();
 }

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -26,31 +26,28 @@ import {
 import { DBWithTracing, TracedWorkspaceDB } from "@gitpod/gitpod-db/lib/traced-db";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
 import { TeamDB } from "@gitpod/gitpod-db/lib/team-db";
-import {
-    HeadlessLogService,
-    HeadlessLogEndpoint,
-    HEADLESS_LOGS_PATH_PREFIX,
-    HEADLESS_LOG_DOWNLOAD_PATH_PREFIX,
-} from "./headless-log-service";
+import { HEADLESS_LOGS_PATH_PREFIX, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./headless-log-service";
 import * as opentracing from "opentracing";
 import { asyncHandler } from "../express-util";
-import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { isWithFunctionAccessGuard } from "../auth/function-access";
 import { accessHeadlessLogs } from "../auth/rate-limiter";
 import { BearerAuth } from "../auth/bearer-authenticator";
 import { ProjectsService } from "../projects/projects-service";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { WorkspaceService } from "./workspace-service";
+import { ctxIsAborted, runWithSubjectId } from "../util/request-context";
+import { SubjectId } from "../auth/subject-id";
 
 @injectable()
 export class HeadlessLogController {
     @inject(TracedWorkspaceDB) protected readonly workspaceDb: DBWithTracing<WorkspaceDB>;
-    @inject(HeadlessLogService) protected readonly headlessLogService: HeadlessLogService;
     @inject(BearerAuth) protected readonly auth: BearerAuth;
     @inject(ProjectsService) protected readonly projectService: ProjectsService;
     @inject(TeamDB) protected readonly teamDb: TeamDB;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     get headlessLogs(): express.Router {
         const router = express.Router();
@@ -60,87 +57,75 @@ export class HeadlessLogController {
             authenticateAndAuthorize,
             asyncHandler(async (req: express.Request, res: express.Response) => {
                 const span = opentracing.globalTracer().startSpan(HEADLESS_LOGS_PATH_PREFIX);
-                try {
-                    const params = { instanceId: req.params.instanceId, terminalId: req.params.terminalId };
-                    const user = req.user as User; // verified by authenticateAndAuthorize
-
-                    const instanceId = params.instanceId;
-                    const ws = await this.authorizeHeadlessLogAccess(span, user, instanceId, res);
-                    if (!ws) {
-                        return;
-                    }
-                    const { workspace, instance } = ws;
-
-                    const logCtx = { userId: user.id, instanceId, workspaceId: workspace!.id };
-                    log.debug(logCtx, HEADLESS_LOGS_PATH_PREFIX);
-
-                    const aborted = new Deferred<boolean>();
+                const user = req.user as User; // verified by authenticateAndAuthorize
+                await runWithSubjectId(SubjectId.fromUserId(user.id), async () => {
                     try {
-                        const head = {
-                            "Content-Type": "text/html; charset=utf-8", // is text/plain, but with that node.js won't stream...
-                            "Transfer-Encoding": "chunked",
-                            "Cache-Control": "no-cache, no-store, must-revalidate", // make sure stream are not re-used on reconnect
-                        };
-                        res.writeHead(200, head);
+                        const instanceId = req.params.instanceId;
+                        const terminalId = req.params.terminalId;
 
-                        const abort = (err: any) => {
-                            aborted.resolve(true);
-                            log.debug(logCtx, "headless-log: aborted");
-                        };
-                        req.on("abort", abort); // abort handling if the reqeuest was aborted
+                        const logCtx = { userId: user.id, instanceId };
+                        try {
+                            const head = {
+                                "Content-Type": "text/html; charset=utf-8", // is text/plain, but with that node.js won't stream...
+                                "Transfer-Encoding": "chunked",
+                                "Cache-Control": "no-cache, no-store, must-revalidate", // make sure stream are not re-used on reconnect
+                            };
+                            res.writeHead(200, head);
 
-                        const queue = new Queue(); // Make sure we forward in the correct order
-                        const writeToResponse = async (chunk: string) =>
-                            queue.enqueue(
-                                () =>
-                                    new Promise<void>(async (resolve, reject) => {
-                                        if (aborted.isResolved && (await aborted.promise)) {
-                                            return;
-                                        }
-
-                                        const done = res.write(chunk, "utf-8", (err?: Error | null) => {
-                                            if (err) {
-                                                reject(err); // propagate write error to upstream
+                            const queue = new Queue(); // Make sure we forward in the correct order
+                            const writeToResponse = async (chunk: string) =>
+                                queue.enqueue(
+                                    () =>
+                                        new Promise<void>(async (resolve, reject) => {
+                                            if (ctxIsAborted()) {
                                                 return;
                                             }
-                                        });
-                                        // handle as per doc: https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback
-                                        if (!done) {
-                                            res.once("drain", resolve);
-                                        } else {
-                                            setImmediate(resolve);
-                                        }
-                                    }),
+
+                                            const done = res.write(chunk, "utf-8", (err?: Error | null) => {
+                                                if (err) {
+                                                    reject(err); // propagate write error to upstream
+                                                    return;
+                                                }
+                                            });
+                                            // handle as per doc: https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback
+                                            if (!done) {
+                                                res.once("drain", resolve);
+                                            } else {
+                                                setImmediate(resolve);
+                                            }
+                                        }),
+                                );
+                            await this.workspaceService.streamWorkspaceLogs(
+                                user.id,
+                                instanceId,
+                                terminalId,
+                                writeToResponse,
+                                async () => {
+                                    const ws = await this.authorizeHeadlessLogAccess(span, user, instanceId, res);
+                                    if (!ws) {
+                                        throw new ApplicationError(ErrorCodes.PERMISSION_DENIED, "permission denied");
+                                    }
+                                },
                             );
-                        const logEndpoint = HeadlessLogEndpoint.fromWithOwnerToken(instance);
-                        await this.headlessLogService.streamWorkspaceLogWhileRunning(
-                            logCtx,
-                            logEndpoint,
-                            instanceId,
-                            params.terminalId,
-                            writeToResponse,
-                            aborted,
-                        );
 
-                        // In an ideal world, we'd use res.addTrailers()/response.trailer here. But despite being introduced with HTTP/1.1 in 1999, trailers are not supported by popular proxies (nginx, for example).
-                        // So we resort to this hand-written solution
-                        res.write(`\n${HEADLESS_LOG_STREAM_STATUS_CODE}: 200`);
+                            // In an ideal world, we'd use res.addTrailers()/response.trailer here. But despite being introduced with HTTP/1.1 in 1999, trailers are not supported by popular proxies (nginx, for example).
+                            // So we resort to this hand-written solution
+                            res.write(`\n${HEADLESS_LOG_STREAM_STATUS_CODE}: 200`);
 
-                        res.end();
-                    } catch (err) {
-                        log.debug(logCtx, "error streaming headless logs", err);
+                            res.end();
+                        } catch (err) {
+                            log.debug(logCtx, "error streaming headless logs", err);
 
-                        res.write(`\n${HEADLESS_LOG_STREAM_STATUS_CODE}: 500`);
-                        res.end();
+                            res.write(`\n${HEADLESS_LOG_STREAM_STATUS_CODE}: 500`);
+                            res.end();
+                        }
+                    } catch (e) {
+                        TraceContext.setError({ span }, e);
+                        throw e;
                     } finally {
-                        aborted.resolve(true); // ensure that the promise gets resolved eventually!
+                        span.finish();
                     }
-                } catch (e) {
-                    TraceContext.setError({ span }, e);
-                    throw e;
-                } finally {
-                    span.finish();
-                }
+                });
             }),
         ]);
         router.get("/", malformedRequestHandler);
@@ -156,39 +141,39 @@ export class HeadlessLogController {
             asyncHandler(async (req: express.Request, res: express.Response) => {
                 const span = opentracing.globalTracer().startSpan(HEADLESS_LOG_DOWNLOAD_PATH_PREFIX);
 
-                try {
-                    const params = { instanceId: req.params.instanceId, taskId: req.params.taskId };
-                    const user = req.user as User; // verified by authenticateAndAuthorize
-
-                    const instanceId = params.instanceId;
-                    const ws = await this.authorizeHeadlessLogAccess(span, user, instanceId, res);
-                    if (!ws) {
-                        return;
-                    }
-                    const { workspace, instance } = ws;
-
-                    const logCtx = { userId: user.id, instanceId, workspaceId: workspace!.id };
-                    log.debug(logCtx, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX);
-
+                const user = req.user as User; // verified by authenticateAndAuthorize
+                await runWithSubjectId(SubjectId.fromUserId(user.id), async () => {
                     try {
-                        const taskId = params.taskId;
-                        const downloadUrl = await this.headlessLogService.getHeadlessLogDownloadUrl(
-                            user.id,
-                            instance,
-                            workspace.ownerId,
-                            taskId,
-                        );
-                        res.send(downloadUrl); // cmp. headless_log_download.go
-                    } catch (err) {
-                        log.error(logCtx, "error retrieving headless log download URL", err);
-                        res.status(500);
+                        const instanceId = req.params.instanceId;
+                        const taskId = req.params.taskId;
+                        try {
+                            const downloadUrl = await this.workspaceService.getHeadlessLogDownloadUrl(
+                                user.id,
+                                instanceId,
+                                taskId,
+                                async () => {
+                                    const ws = await this.authorizeHeadlessLogAccess(span, user, instanceId, res);
+                                    if (!ws) {
+                                        throw new ApplicationError(ErrorCodes.PERMISSION_DENIED, "permission denied");
+                                    }
+                                },
+                            );
+                            res.send(downloadUrl); // cmp. headless_log_download.go
+                        } catch (err) {
+                            log.error(
+                                { userId: user.id, instanceId },
+                                "error retrieving headless log download URL",
+                                err,
+                            );
+                            res.status(500);
+                        }
+                    } catch (e) {
+                        TraceContext.setError({ span }, e);
+                        throw e;
+                    } finally {
+                        span.finish();
                     }
-                } catch (e) {
-                    TraceContext.setError({ span }, e);
-                    throw e;
-                } finally {
-                    span.finish();
-                }
+                });
             }),
         ]);
         router.get("/", malformedRequestHandler);

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -28,6 +28,8 @@ schema: |-
 
     permission read_env_var = self
     permission write_env_var = self
+
+    permission code_sync = self
   }
 
   // There's only one global installation


### PR DESCRIPTION
## Description
In preparation for API tokens, this PR aims to the minimal necessary cleanup around our HTTP handlers. It contains:
 1. proper usage of RequestContext in HTTP handlers (currently blocking the rollout)
 2. guarding HTTP-served resources with FGA guards:
    1. HeadlessLogs: pulled into/behind WorkspaceService
    2. Code-sync: Extended custom handler with FGA check
 3. Tries to clarify the different modes of authorization across our HTTP handlers ([change](https://github.com/gitpod-io/gitpod/compare/gpl/http-auth-cleanup?expand=1#diff-bd6f821f67d3f4ea170ed2d0e38f54fd9094bf17aaaa5cbdba1dd8179adbaa35R298-R319))
 4. Minimal extension/cleanup of RequestContext

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1032

## How to test
 - test log-retrieval for prebuilds still works (online - while build is running - as well as offline)
 - test code-sync
 - verify that we don't see any "SubjectId mismatch" while testing the above

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
