### PR TITLE
Delete owned user on member removal

### DIFF
--- a/components/dashboard/src/data/organizations/members-query.ts
+++ b/components/dashboard/src/data/organizations/members-query.ts
@@ -33,7 +33,6 @@ export function useListOrganizationMembers() {
             return response.members;
         },
         {
-            staleTime: 1000 * 60 * 5, // 5 minutes
             enabled: !!organizationId,
         },
     );

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -33,7 +33,7 @@ export const useUserLoader = () => {
             if (!doRetryUserLoader) {
                 return false;
             }
-            return error.code !== ErrorCodes.NOT_AUTHENTICATED;
+            return error.code !== ErrorCodes.NOT_AUTHENTICATED && error.code !== ErrorCodes.USER_DELETED;
         },
         // docs: https://tanstack.com/query/v4/docs/react/guides/query-retries
         // backoff by doubling, max. 10s

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -23,6 +23,7 @@ const expect = chai.expect;
 describe("OrganizationService", async () => {
     let container: Container;
     let os: OrganizationService;
+    let userService: UserService;
 
     let owner: User;
     let member: User;
@@ -45,7 +46,7 @@ describe("OrganizationService", async () => {
                 }
             });
         os = container.get(OrganizationService);
-        const userService = container.get<UserService>(UserService);
+        userService = container.get<UserService>(UserService);
         owner = await userService.createUser({
             identity: {
                 authId: "github|1234",
@@ -156,6 +157,30 @@ describe("OrganizationService", async () => {
 
         // try remove the member again
         await expectError(ErrorCodes.NOT_FOUND, os.removeOrganizationMember(member.id, org.id, member.id));
+    });
+
+    it("should delete owned user when removing it", async () => {
+        const ownedMember = await userService.createUser({
+            organizationId: org.id,
+            identity: {
+                authId: "github|1234",
+                authName: "github",
+                authProviderId: "github",
+            },
+        });
+        await os.addOrUpdateMember(owner.id, org.id, ownedMember.id, "member");
+
+        const members = await os.listMembers(owner.id, org.id);
+        expect(members.some((m) => m.userId === ownedMember.id)).to.be.true;
+
+        // remove it and assert it's gone
+        await os.removeOrganizationMember(owner.id, org.id, ownedMember.id);
+        const members2 = await os.listMembers(owner.id, org.id);
+        expect(members2.some((m) => m.userId === ownedMember.id)).to.be.false;
+        // also assert that the user is gone
+        const deleted = await userService.findUserById(ownedMember.id, ownedMember.id);
+        // await expectError(ErrorCodes.NOT_FOUND, () => deleted);
+        expect(deleted.markedDeleted).to.be.true;
     });
 
     it("should listOrganizationsByMember", async () => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In case a user gets removed from the org that is owned by it, with this PR we'll also delete the user.
The PR introduces an additional dialog warning about this consequence:

<img width="504" alt="Screenshot 2023-12-07 at 16 06 55" src="https://github.com/gitpod-io/gitpod/assets/372735/4ffc0a06-5ebb-40de-9ad6-3f4f5c43a103">

The change will also redirect deleted users to logout and then login, so they have their session destroyed and can potentially create a fresh user.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 73a3346</samp>

No summary available (Limit exceeded: required to process 69717 tokens, but only 50000 are allowed per call)

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [EXP-480](https://linear.app/gitpod/issue/EXP-480/remove-users-on-user-management-page-does-not-work)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-delete-users</li>
        <li><b>🔗 URL</b> - <a href="https://se-delete-users.preview.gitpod-dev.com/workspaces" target="_blank">se-delete-users.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-delete-users%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
