### PR TITLE
Scope config lookup to org

### DIFF
--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -10,7 +10,7 @@ import { TransactionalDB } from "./typeorm/transactional-db-impl";
 export const ProjectDB = Symbol("ProjectDB");
 export interface ProjectDB extends TransactionalDB<ProjectDB> {
     findProjectById(projectId: string): Promise<Project | undefined>;
-    findProjectsByCloneUrl(cloneUrl: string): Promise<Project[]>;
+    findProjectsByCloneUrl(cloneUrl: string, organizationId?: string): Promise<Project[]>;
     findProjects(orgID: string): Promise<Project[]>;
     findProjectsBySearchTerm(args: FindProjectsBySearchTermArgs): Promise<{ total: number; rows: Project[] }>;
     storeProject(project: Project): Promise<Project>;

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -60,9 +60,9 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
         return repo.findOne({ id: projectId, markedDeleted: false });
     }
 
-    public async findProjectsByCloneUrl(cloneUrl: string): Promise<Project[]> {
+    public async findProjectsByCloneUrl(cloneUrl: string, organizationId?: string): Promise<Project[]> {
         const repo = await this.getRepo();
-        const conditions: FindConditions<DBProject> = { cloneUrl, markedDeleted: false };
+        const conditions: FindConditions<DBProject> = { cloneUrl, markedDeleted: false, teamId: organizationId };
         return repo.find(conditions);
     }
 

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -114,8 +114,8 @@ export class ProjectsService {
         return filteredProjects;
     }
 
-    async findProjectsByCloneUrl(userId: string, cloneUrl: string): Promise<Project[]> {
-        const projects = await this.projectDB.findProjectsByCloneUrl(cloneUrl);
+    async findProjectsByCloneUrl(userId: string, cloneUrl: string, organizationId?: string): Promise<Project[]> {
+        const projects = await this.projectDB.findProjectsByCloneUrl(cloneUrl, organizationId);
         const result: Project[] = [];
         for (const project of projects) {
             if (await this.auth.hasPermissionOnProject(userId, "read_info", project.id)) {

--- a/components/server/src/workspace/context-service.ts
+++ b/components/server/src/workspace/context-service.ts
@@ -120,7 +120,11 @@ export class ContextService {
         if (options?.projectId) {
             project = await this.projectsService.getProject(user.id, options.projectId);
         } else if (CommitContext.is(context)) {
-            const projects = await this.projectsService.findProjectsByCloneUrl(user.id, context.repository.cloneUrl);
+            const projects = await this.projectsService.findProjectsByCloneUrl(
+                user.id,
+                context.repository.cloneUrl,
+                options?.organizationId,
+            );
             if (projects.length > 1) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Multiple projects found for clone URL.");
             }


### PR DESCRIPTION
## Description

When creating a workspace, we check if by any chance there aren't multiple configurations for this repository, because we cannot just guess it by the context URL you provided. This lookup was previously done on a global level, so if anyone in the world configured a repo which you also had configured, you would start getting a `Multiple projects found for clone URL.` error.

This change tweaks the behavior so that even if you had a repo configured across two organizations, only the one for the currently active one will apply.

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 203f6a8</samp>

Added an `organizationId` option to the `findProjectsByCloneUrl` method in various classes to support filtering projects by clone URL and organization. This improves the accuracy and reliability of workspace context creation.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-962

## How to test

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-ws-crea72590a191a</li>
	<li><b>🔗 URL</b> - <a href="https://ft-ws-crea72590a191a.preview.gitpod-dev.com/workspaces" target="_blank">ft-ws-crea72590a191a.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-ws-creation-duplicate-configs-gha.21529</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-ws-crea72590a191a%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
