### PR TITLE
wrap menu item w/ separate flag check

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -28,6 +28,7 @@ const featureFlags = {
     repositoryFinderSearch: false,
     createProjectModal: false,
     repoConfigListAndDetail: false,
+    showRepoConfigMenuItem: false,
 };
 
 type FeatureFlags = typeof featureFlags;

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -24,6 +24,7 @@ export default function OrganizationSelector() {
     const { data: billingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
     const repoConfigListAndDetail = useFeatureFlag("repoConfigListAndDetail");
+    const showRepoConfigMenuItem = useFeatureFlag("showRepoConfigMenuItem");
 
     // we should have an API to ask for permissions, until then we duplicate the logic here
     const canCreateOrgs = user && !isOrganizationOwned(user);
@@ -55,7 +56,8 @@ export default function OrganizationSelector() {
 
     // Show members if we have an org selected
     if (currentOrg.data) {
-        if (repoConfigListAndDetail) {
+        // Check both flags as one just controls if the menu item is present, the other if the page is accessible
+        if (repoConfigListAndDetail && showRepoConfigMenuItem) {
             linkEntries.push({
                 title: "Repositories",
                 customContent: <LinkEntry>Repositories</LinkEntry>,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds a new feature flag, `showRepoConfigMenuItem`, which just gates if the `Repositories` link is present in the org menu. The aim here is to quietly release the new repo config UI for dedicated customers, but keep it hidden in the org menu for them. This lets us reach out individually for feedback from some specific customers.

<details>
<summary>Summary generated by Copilot</summary>

copilot:summary

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
