### PR TITLE
[wip] ApiTokenV0

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -11,6 +11,7 @@ const (
 	OIDCServiceEnabledFlag                         = "oidcServiceEnabled"
 	SupervisorPersistServerAPIChannelWhenStartFlag = "supervisor_persist_serverapi_channel_when_start"
 	SupervisorUsePublicAPIFlag                     = "supervisor_experimental_publicapi"
+	ApiTokenV0Flag                                 = "apitokenv0_oauth"
 	ServiceWaiterSkipComponentsFlag                = "service_waiter_skip_components"
 )
 
@@ -28,4 +29,8 @@ func SupervisorPersistServerAPIChannelWhenStart(ctx context.Context, client Clie
 
 func SupervisorUsePublicAPI(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, SupervisorUsePublicAPIFlag, false, attributes)
+}
+
+func SupervisorUseApiTokenV0(ctx context.Context, client Client, attributes Attributes) bool {
+	return client.GetBoolValue(ctx, ApiTokenV0Flag, false, attributes)
 }

--- a/components/server/src/auth/api-token-v0.spec.ts
+++ b/components/server/src/auth/api-token-v0.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+import { Container } from "inversify";
+import "mocha";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { ApiAccessTokenV0 } from "./api-token-v0";
+import { AuthJWT } from "./jwt";
+
+const expect = chai.expect;
+
+describe("AuthProviderService", async () => {
+    let container: Container;
+    let authJwt: AuthJWT;
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        authJwt = container.get(AuthJWT);
+    });
+
+    it("should encode+decode w/ userId", async () => {
+        const userId = "u1";
+        const token = new ApiAccessTokenV0(userId, [{ permission: "user_read", targetId: userId }], userId);
+        const encoded = await token.encode(authJwt);
+
+        const decodedToken = await ApiAccessTokenV0.parse(encoded, authJwt);
+        expect(decodedToken).to.deep.equal(token);
+    });
+
+    it("should encode+decode w/o userId", async () => {
+        const userId = "u1";
+        const token = new ApiAccessTokenV0(userId, [{ permission: "user_read", targetId: userId }]);
+        const encoded = await token.encode(authJwt);
+
+        const decodedToken = await ApiAccessTokenV0.parse(encoded, authJwt);
+        expect(decodedToken).to.deep.equal(token);
+    });
+});

--- a/components/server/src/auth/api-token-v0.ts
+++ b/components/server/src/auth/api-token-v0.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as crypto from "crypto";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { AuthJWT } from "./jwt";
+import { SubjectId } from "./subject-id";
+
+export type ApiTokenScope = {
+    permission: ApiTokenScopePermission;
+    targetId: string;
+};
+export type ApiTokenScopePermission = keyof typeof ApiTokenScopePermissions;
+const ApiTokenScopePermissions = {
+    user_read: true,
+    user_write: true,
+    workspace: true,
+};
+export namespace ApiTokenScope {
+    const PERMISSION_SEPARATOR = ":";
+    const SCOPE_SEPARATOR = ",";
+    export function userRead(userId: string): ApiTokenScope {
+        return {
+            permission: "user_read",
+            targetId: userId,
+        };
+    }
+    export function userWrite(userId: string): ApiTokenScope {
+        return {
+            permission: "user_write",
+            targetId: userId,
+        };
+    }
+    export function workspaceOwner(workspaceId: string): ApiTokenScope {
+        return {
+            permission: "workspace",
+            targetId: workspaceId,
+        };
+    }
+    export function decode(encoded: string): ApiTokenScope {
+        const parts = encoded.split(PERMISSION_SEPARATOR);
+        if (parts.length !== 2) {
+            throw new Error("Unexpected number of parts in API scope");
+        }
+        const [permission, targetId] = parts;
+        if (!ApiTokenScopePermissions[permission as ApiTokenScopePermission]) {
+            throw new Error(`Invalid API scope permission ${permission}`);
+        }
+        return {
+            permission: permission as ApiTokenScopePermission,
+            targetId,
+        };
+    }
+    export function encode(...scope: ApiTokenScope[]): string {
+        return scope.map((s) => `${s.permission}${PERMISSION_SEPARATOR}${s.targetId}`).join(SCOPE_SEPARATOR);
+    }
+}
+
+export class ApiAccessToken {
+    private static PREFIX = "gitpod_apitokenv0_";
+
+    public constructor(readonly id: string, readonly scopes: ApiTokenScope[]) {}
+
+    public static create(scopes: ApiTokenScope[]): ApiAccessToken {
+        return new ApiAccessToken(crypto.randomBytes(30).toString("hex"), scopes);
+    }
+
+    public static validatePrefix(token: string): boolean {
+        return token.startsWith(ApiAccessToken.PREFIX);
+    }
+
+    // TODO(gpl) we'd want to extract the dependency to authJWT out
+    public static async parse(token: string, authJWT: AuthJWT): Promise<ApiAccessToken> {
+        if (!ApiAccessToken.validatePrefix(token)) {
+            throw new Error("Invalid API token prefix");
+        }
+        const jwtToken = token.substring(ApiAccessToken.PREFIX.length);
+
+        const payload = await authJWT.verify(jwtToken);
+        log.debug("API token verified", { payload });
+
+        if (!payload.sub) {
+            throw new Error("Subject claim is missing in API token JWT");
+        }
+        const subjectId = SubjectId.tryParse(payload.sub);
+
+        const scopes = payload.scopes;
+        if (!scopes || !Array.isArray(scopes)) {
+            throw new Error("Scopes claim is missing or malformed in API token JWT");
+        }
+        return new ApiAccessToken(subjectId.value, scopes as ApiTokenScope[]);
+    }
+
+    public async encode(authJWT: AuthJWT): Promise<string> {
+        const subjectIdStr = this.subjectId.toString();
+        const payload = {
+            sub: subjectIdStr,
+            scopes: this.scopes,
+        };
+        const jwt = await authJWT.sign(subjectIdStr, payload);
+        return `${ApiAccessToken.PREFIX}${jwt}`;
+    }
+
+    public subjectId(): SubjectId {
+        return new SubjectId("apitokenv0", this.id);
+    }
+}

--- a/components/server/src/auth/api-token-v0.ts
+++ b/components/server/src/auth/api-token-v0.ts
@@ -81,11 +81,7 @@ export class ApiAccessTokenV0 {
         readonly scopes: ApiTokenScope[],
         /** This parameter is temporary, too ease the rollout of ApiTokens. Once we got rid of the websocket API (and all other impls that require a userId), we can get rid of it */
         readonly _userId?: string,
-    ) {
-        if (!!_userId && _userId !== id) {
-            throw new Error("ApiTokenV0: Invalid userId");
-        }
-    }
+    ) {}
 
     public static create(scopes: ApiTokenScope[], _userId?: string): ApiAccessTokenV0 {
         return new ApiAccessTokenV0(crypto.randomBytes(30).toString("hex"), scopes, _userId);

--- a/components/server/src/auth/api-token-v0.ts
+++ b/components/server/src/auth/api-token-v0.ts
@@ -16,8 +16,10 @@ export type ApiTokenScope = {
 export type ApiTokenScopePermission = keyof typeof ApiTokenScopePermissions;
 const ApiTokenScopePermissions = {
     user_read: true,
-    user_write: true,
-    workspace: true,
+    user_code_sync: true,
+    user_write_env_var: true,
+    workspace_owner: true,
+    organization_member: true,
 };
 export namespace ApiTokenScope {
     const PERMISSION_SEPARATOR = ":";
@@ -28,16 +30,28 @@ export namespace ApiTokenScope {
             targetId: userId,
         };
     }
-    export function userWrite(userId: string): ApiTokenScope {
+    export function userCodeSync(userId: string): ApiTokenScope {
         return {
-            permission: "user_write",
+            permission: "user_code_sync",
+            targetId: userId,
+        };
+    }
+    export function userWriteEnvVar(userId: string): ApiTokenScope {
+        return {
+            permission: "user_write_env_var",
             targetId: userId,
         };
     }
     export function workspaceOwner(workspaceId: string): ApiTokenScope {
         return {
-            permission: "workspace",
+            permission: "workspace_owner",
             targetId: workspaceId,
+        };
+    }
+    export function organizationMember(organizationId: string): ApiTokenScope {
+        return {
+            permission: "organization_member",
+            targetId: organizationId,
         };
     }
     export function decode(encoded: string): ApiTokenScope {
@@ -73,8 +87,8 @@ export class ApiAccessTokenV0 {
         }
     }
 
-    public static create(scopes: ApiTokenScope[]): ApiAccessTokenV0 {
-        return new ApiAccessTokenV0(crypto.randomBytes(30).toString("hex"), scopes);
+    public static create(scopes: ApiTokenScope[], _userId?: string): ApiAccessTokenV0 {
+        return new ApiAccessTokenV0(crypto.randomBytes(30).toString("hex"), scopes, _userId);
     }
 
     public static validatePrefix(token: string): boolean {

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -21,7 +21,7 @@ import { TokenResourceGuard, WithResourceAccessGuard } from "./resource-access";
 import { UserService } from "../user/user-service";
 import { SubjectId } from "./subject-id";
 import { AuthJWT } from "./jwt";
-import { ApiAccessToken } from "./api-token-v0";
+import { ApiAccessTokenV0 } from "./api-token-v0";
 
 export function getBearerToken(authorizationHeader: string | undefined | null): string | undefined {
     if (!authorizationHeader || !(typeof authorizationHeader === "string")) {
@@ -177,9 +177,9 @@ export class BearerAuth {
             }
         }
 
-        if (ApiAccessToken.validatePrefix(token)) {
+        if (ApiAccessTokenV0.validatePrefix(token)) {
             try {
-                const parsed = await ApiAccessToken.parse(token, this.authJWT);
+                const parsed = await ApiAccessTokenV0.parse(token, this.authJWT);
                 return parsed.subjectId();
             } catch (e) {
                 log.error("Failed to authenticate using PAT", e);

--- a/components/server/src/auth/express.ts
+++ b/components/server/src/auth/express.ts
@@ -21,11 +21,19 @@ export function getAuthorizingSubjectId(req: express.Request): SubjectId | undef
     return req.user?.id ? SubjectId.fromUserId(req.user.id) : undefined;
 }
 
-export async function runWithReqSubjectId(req: express.Request, res: express.Response, next: express.NextFunction) {
-    const subjectId = getAuthorizingSubjectId(req);
-    if (!subjectId) {
+export function runWithReqSubjectId() {
+    return runWithReqSubjectIdOr((req, res, next) => {
         res.sendStatus(401);
-        return;
-    }
-    return await runWithSubjectId(subjectId, async () => next());
+    });
+}
+
+export function runWithReqSubjectIdOr(handler: express.RequestHandler) {
+    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        const subjectId = getAuthorizingSubjectId(req);
+        if (!subjectId) {
+            handler(req, res, next);
+            return;
+        }
+        return runWithSubjectId(subjectId, next);
+    };
 }

--- a/components/server/src/auth/express.ts
+++ b/components/server/src/auth/express.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import express from "express";
+import { runWithSubjectId } from "../util/request-context";
+import { SubjectId } from "./subject-id";
+
+/**
+ *
+ * @param req
+ * @returns req.subjectId if set, SubjectId.fromUserId(req.user.id) otherwise
+ */
+export function getAuthorizingSubjectId(req: express.Request): SubjectId | undefined {
+    // If set, we strictly prefer the subjectId (which might be a token) to not inadvertently elevate privileges.
+    if (!!req.subjectId) {
+        return req.subjectId;
+    }
+    return req.user?.id ? SubjectId.fromUserId(req.user.id) : undefined;
+}
+
+export async function runWithReqSubjectId(req: express.Request, res: express.Response, next: express.NextFunction) {
+    const subjectId = getAuthorizingSubjectId(req);
+    if (!subjectId) {
+        res.sendStatus(401);
+        return;
+    }
+    return await runWithSubjectId(subjectId, async () => next());
+}

--- a/components/server/src/auth/subject-id.ts
+++ b/components/server/src/auth/subject-id.ts
@@ -20,7 +20,7 @@ const SubjectKindByShortName: ReadonlyMap<string, SubjectKind> = new Map(
 export class SubjectId {
     private static readonly SEPARATOR = "_";
 
-    constructor(public readonly kind: SubjectKind, public readonly value: string) {}
+    constructor(public readonly kind: SubjectKind, public readonly value: string, private readonly _userId?: string) {}
 
     public static fromUserId(userId: string): SubjectId {
         return new SubjectId("user", userId);
@@ -64,7 +64,7 @@ export class SubjectId {
         if (this.kind === "user") {
             return this.value;
         }
-        return undefined;
+        return this._userId; //undefined; Temporary for the rollout of API tokens
     }
 
     public equals(other: SubjectId): boolean {

--- a/components/server/src/auth/subject-id.ts
+++ b/components/server/src/auth/subject-id.ts
@@ -4,9 +4,12 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { User } from "@gitpod/gitpod-protocol";
+
 export type SubjectKind = keyof typeof SubjectKindNames;
 const SubjectKindNames = {
     user: "user",
+    apitokenv0: "apitokenv0",
 };
 const SubjectKindByShortName: ReadonlyMap<string, SubjectKind> = new Map(
     Object.keys(SubjectKindNames).map((k) => {
@@ -75,7 +78,10 @@ export class SubjectId {
  */
 export type Subject = string | SubjectId | undefined;
 export namespace Subject {
-    export function toId(subject: Subject): SubjectId {
+    export function toId(subject: User | Subject): SubjectId {
+        if (User.is(subject)) {
+            return SubjectId.fromUserId(subject.id);
+        }
         if (SubjectId.is(subject)) {
             return subject;
         }

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -482,13 +482,20 @@ export class Authorizer {
                             set(rel.apitokenv0(tokenId).user_read.anyUser),
                             set(rel.user(s.targetId).apitoken.apitokenv0(tokenId)),
                         ];
-                    case "user_write":
+                    case "user_code_sync":
                         return [
-                            set(rel.apitokenv0(tokenId).user_write.anyUser),
+                            set(rel.apitokenv0(tokenId).user_code_sync.anyUser),
                             set(rel.user(s.targetId).apitoken.apitokenv0(tokenId)),
                         ];
-                    case "workspace":
+                    case "user_write_env_var":
+                        return [
+                            set(rel.apitokenv0(tokenId).user_write_env_var.anyUser),
+                            set(rel.user(s.targetId).apitoken.apitokenv0(tokenId)),
+                        ];
+                    case "workspace_owner":
                         return [set(rel.workspace(s.targetId).owner.apitokenv0(tokenId))];
+                    case "organization_member":
+                        return [set(rel.organization(s.targetId).member.apitokenv0(tokenId))];
                 }
             })
             .flat();

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -12,14 +12,28 @@ export const InstallationID = "1";
 
 export type ResourceType =
     | UserResourceType
+    | Apitokenv0ResourceType
     | InstallationResourceType
     | OrganizationResourceType
     | ProjectResourceType
     | WorkspaceResourceType;
 
-export const AllResourceTypes: ResourceType[] = ["user", "installation", "organization", "project", "workspace"];
+export const AllResourceTypes: ResourceType[] = [
+    "user",
+    "apitokenv0",
+    "installation",
+    "organization",
+    "project",
+    "workspace",
+];
 
-export type Relation = UserRelation | InstallationRelation | OrganizationRelation | ProjectRelation | WorkspaceRelation;
+export type Relation =
+    | UserRelation
+    | Apitokenv0Relation
+    | InstallationRelation
+    | OrganizationRelation
+    | ProjectRelation
+    | WorkspaceRelation;
 
 export type Permission =
     | UserPermission
@@ -30,7 +44,7 @@ export type Permission =
 
 export type UserResourceType = "user";
 
-export type UserRelation = "self" | "organization" | "installation";
+export type UserRelation = "self" | "apitoken" | "organization" | "installation";
 
 export type UserPermission =
     | "read_info"
@@ -45,6 +59,10 @@ export type UserPermission =
     | "read_env_var"
     | "write_env_var"
     | "code_sync";
+
+export type Apitokenv0ResourceType = "apitokenv0";
+
+export type Apitokenv0Relation = "user_write" | "user_read";
 
 export type InstallationResourceType = "installation";
 
@@ -132,6 +150,26 @@ export const rel = {
                 };
             },
 
+            get apitoken() {
+                const result2 = {
+                    ...result,
+                    relation: "apitoken",
+                };
+                return {
+                    apitokenv0(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "apitokenv0",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
             get organization() {
                 const result2 = {
                     ...result,
@@ -165,6 +203,56 @@ export const rel = {
                                 object: {
                                     objectType: "installation",
                                     objectId: InstallationID,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+        };
+    },
+
+    apitokenv0(id: string) {
+        const result: Partial<v1.Relationship> = {
+            resource: {
+                objectType: "apitokenv0",
+                objectId: id,
+            },
+        };
+        return {
+            get user_write() {
+                const result2 = {
+                    ...result,
+                    relation: "user_write",
+                };
+                return {
+                    get anyUser() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: "*",
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get user_read() {
+                const result2 = {
+                    ...result,
+                    relation: "user_read",
+                };
+                return {
+                    get anyUser() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: "*",
                                 },
                             },
                         } as v1.Relationship;
@@ -428,6 +516,17 @@ export const rel = {
                             subject: {
                                 object: {
                                     objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                    apitokenv0(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "apitokenv0",
                                     objectId: objectId,
                                 },
                             },

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -62,7 +62,7 @@ export type UserPermission =
 
 export type Apitokenv0ResourceType = "apitokenv0";
 
-export type Apitokenv0Relation = "user_write" | "user_read";
+export type Apitokenv0Relation = "user_code_sync" | "user_write_env_var" | "user_read";
 
 export type InstallationResourceType = "installation";
 
@@ -220,10 +220,30 @@ export const rel = {
             },
         };
         return {
-            get user_write() {
+            get user_code_sync() {
                 const result2 = {
                     ...result,
-                    relation: "user_write",
+                    relation: "user_code_sync",
+                };
+                return {
+                    get anyUser() {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "user",
+                                    objectId: "*",
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                };
+            },
+
+            get user_write_env_var() {
+                const result2 = {
+                    ...result,
+                    relation: "user_write_env_var",
                 };
                 return {
                     get anyUser() {
@@ -352,6 +372,17 @@ export const rel = {
                             subject: {
                                 object: {
                                     objectType: "user",
+                                    objectId: objectId,
+                                },
+                            },
+                        } as v1.Relationship;
+                    },
+                    apitokenv0(objectId: string) {
+                        return {
+                            ...result2,
+                            subject: {
+                                object: {
+                                    objectType: "apitokenv0",
                                     objectId: objectId,
                                 },
                             },

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -100,7 +100,7 @@ export class CodeSyncService {
             return next();
         });
         router.use(this.auth.restHandler); // expects Bearer token and authenticates req.user, throws otherwise
-        router.use(runWithReqSubjectId);
+        router.use(runWithReqSubjectId());
         router.use(async (req, res, next) => {
             const userId = getUserId(req);
             if (!userId) {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -132,6 +132,7 @@ import { ScmService } from "./scm/scm-service";
 import { ContextService } from "./workspace/context-service";
 import { RateLimitter } from "./rate-limitter";
 import { AnalyticsController } from "./analytics-controller";
+import { ApiTokenRepository } from "./oauth-server/api-token-repository";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -261,6 +262,7 @@ export const productionContainerModule = new ContainerModule(
             .inSingletonScope();
 
         bind(OAuthController).toSelf().inSingletonScope();
+        bind(ApiTokenRepository).toSelf().inSingletonScope();
 
         bind(HeadlessLogService).toSelf().inSingletonScope();
         bind(HeadlessLogController).toSelf().inSingletonScope();

--- a/components/server/src/oauth-server/api-token-repository.ts
+++ b/components/server/src/oauth-server/api-token-repository.ts
@@ -16,7 +16,7 @@ import { inject, injectable } from "inversify";
 // import { Authorizer } from "../authorization/authorizer";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
-import { ApiAccessToken, ApiTokenScope } from "../auth/api-token-v0";
+import { ApiAccessTokenV0, ApiTokenScope } from "../auth/api-token-v0";
 import { AuthJWT } from "../auth/jwt";
 import { Authorizer } from "../authorization/authorizer";
 
@@ -38,7 +38,7 @@ export class ApiTokenRepository implements OAuthTokenRepository {
         log.info("issuing token", { userId: user?.id, scopes });
 
         const expiry = tokenExpiryInFuture.getEndDate();
-        const apiToken = ApiAccessToken.create(scopes.map((s) => ApiTokenScope.decode(s.name)));
+        const apiToken = ApiAccessTokenV0.create(scopes.map((s) => ApiTokenScope.decode(s.name)));
         const accessToken = await apiToken.encode(this.authJWT);
         return <OAuthToken>{
             accessToken,
@@ -53,7 +53,7 @@ export class ApiTokenRepository implements OAuthTokenRepository {
         const scopes = accessToken.scopes.map((s) => s.name);
 
         log.info("persisting token", { accessToken: new TrustedValue(accessToken), scopes });
-        const apiAccessToken = await ApiAccessToken.parse(accessToken.accessToken, this.authJWT);
+        const apiAccessToken = await ApiAccessTokenV0.parse(accessToken.accessToken, this.authJWT);
         await this.authorizer.addApiToken(apiAccessToken.id, apiAccessToken.scopes);
 
         // // Does the token already exist?

--- a/components/server/src/oauth-server/api-token-repository.ts
+++ b/components/server/src/oauth-server/api-token-repository.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import {
+    DateInterval,
+    OAuthClient,
+    OAuthScope,
+    OAuthToken,
+    OAuthTokenRepository,
+    OAuthUser,
+} from "@jmondi/oauth2-server";
+import { inject, injectable } from "inversify";
+// import { Authorizer } from "../authorization/authorizer";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
+import { ApiAccessToken, ApiTokenScope } from "../auth/api-token-v0";
+import { AuthJWT } from "../auth/jwt";
+import { Authorizer } from "../authorization/authorizer";
+
+// OAuth token expiry
+const tokenExpiryInFuture = new DateInterval("7d");
+
+@injectable()
+export class ApiTokenRepository implements OAuthTokenRepository {
+    constructor(
+        @inject(AuthJWT) private readonly authJWT: AuthJWT,
+        @inject(Authorizer) private readonly authorizer: Authorizer,
+    ) {}
+
+    async issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser): Promise<OAuthToken> {
+        if (!user) {
+            // this would otherwise break persisting of an DBOAuthAuthCodeEntry in AuthCodeRepositoryDB
+            throw new Error("Cannot issue auth code for unknown user.");
+        }
+        log.info("issuing token", { userId: user?.id, scopes });
+
+        const expiry = tokenExpiryInFuture.getEndDate();
+        const apiToken = ApiAccessToken.create(scopes.map((s) => ApiTokenScope.decode(s.name)));
+        const accessToken = await apiToken.encode(this.authJWT);
+        return <OAuthToken>{
+            accessToken,
+            accessTokenExpiresAt: expiry,
+            client,
+            user,
+            scopes: scopes,
+        };
+    }
+
+    async persist(accessToken: OAuthToken): Promise<void> {
+        const scopes = accessToken.scopes.map((s) => s.name);
+
+        log.info("persisting token", { accessToken: new TrustedValue(accessToken), scopes });
+        const apiAccessToken = await ApiAccessToken.parse(accessToken.accessToken, this.authJWT);
+        await this.authorizer.addApiToken(apiAccessToken.id, apiAccessToken.scopes);
+
+        // // Does the token already exist?
+        // let dbToken: GitpodToken;
+        // const tokenHash = crypto.createHash("sha256").update(accessToken.accessToken, "utf8").digest("hex");
+        // const userAndToken = await this.findUserByGitpodToken(tokenHash);
+        // if (userAndToken) {
+        //     // Yes, update it (~)
+        //     // NOTE(rl): as we don't support refresh tokens yet this is not really required
+        //     // since the OAuth server lib calls issueRefreshToken immediately after issueToken
+        //     // We do not allow changes of name, type, user or scope.
+        //     dbToken = userAndToken.token as GitpodToken & { user: DBUser };
+        //     const repo = await this.getGitpodTokenRepo();
+        //     await repo.update(tokenHash, dbToken);
+        //     return;
+        // } else {
+        //     if (!accessToken.user) {
+        //         log.error({}, "No user in accessToken", { accessToken });
+        //         return;
+        //     }
+        //     dbToken = {
+        //         tokenHash,
+        //         name: accessToken.client.id,
+        //         type: GitpodTokenType.MACHINE_AUTH_TOKEN,
+        //         userId: accessToken.user.id.toString(),
+        //         scopes: scopes,
+        //         created: new Date().toISOString(),
+        //     };
+        //     return this.storeGitpodToken(dbToken);
+        // }
+    }
+
+    async revoke(accessTokenToken: OAuthToken): Promise<void> {
+        log.info("deleting token", { accessTokenToken: new TrustedValue(accessTokenToken) });
+    }
+
+    // NOTE(gpl): refresh is not implemented
+    async issueRefreshToken(accessToken: OAuthToken): Promise<OAuthToken> {
+        // // NOTE(rl): this exists for the OAuth server code - Gitpod tokens are non-refreshable (atm)
+        // accessToken.refreshToken = "refreshtokentoken";
+        // accessToken.refreshTokenExpiresAt = new DateInterval("30d").getEndDate();
+        // await this.persist(accessToken);
+        return accessToken;
+    }
+
+    async isRefreshTokenRevoked(refreshToken: OAuthToken): Promise<boolean> {
+        return Date.now() > (refreshToken.refreshTokenExpiresAt?.getTime() ?? 0);
+    }
+
+    async getByRefreshToken(refreshTokenToken: string): Promise<OAuthToken> {
+        throw new Error("Not implemented");
+    }
+}

--- a/components/server/src/oauth-server/oauth-authorization-server.ts
+++ b/components/server/src/oauth-server/oauth-authorization-server.ts
@@ -9,17 +9,17 @@ import {
     DateInterval,
     JwtService,
     OAuthAuthCodeRepository,
+    OAuthClientRepository,
+    OAuthScopeRepository,
     OAuthTokenRepository,
     OAuthUserRepository,
 } from "@jmondi/oauth2-server";
-import { inMemoryClientRepository, inMemoryScopeRepository } from "./repository";
-
-export const clientRepository = inMemoryClientRepository;
-const scopeRepository = inMemoryScopeRepository;
 
 export function createAuthorizationServer(
     authCodeRepository: OAuthAuthCodeRepository,
+    clientRepository: OAuthClientRepository,
     userRepository: OAuthUserRepository,
+    scopeRepository: OAuthScopeRepository,
     tokenRepository: OAuthTokenRepository,
     jwtSecret: string,
 ): AuthorizationServer {

--- a/components/server/src/oauth-server/oauth-controller.ts
+++ b/components/server/src/oauth-server/oauth-controller.ts
@@ -190,7 +190,7 @@ export class OAuthController {
             }
         }
 
-        router.get("/oauth/authorize", async (req: express.Request, res: express.Response) => {
+        router.get("/authorize", async (req: express.Request, res: express.Response) => {
             const clientID = req.query.client_id;
             if (!clientID) {
                 res.sendStatus(400);
@@ -236,7 +236,7 @@ export class OAuthController {
             }
         });
 
-        router.post("/oauth/token", async (req: express.Request, res: express.Response) => {
+        router.post("/token", async (req: express.Request, res: express.Response) => {
             const response = new OAuthResponse(res);
             try {
                 const { authorizationServer } = await getAuthorizationServer(ctxUserId());
@@ -252,7 +252,7 @@ export class OAuthController {
             }
         });
 
-        router.get("/oauth/inspect", async (req: express.Request, res: express.Response) => {
+        router.get("/inspect", async (req: express.Request, res: express.Response) => {
             const clientId = req.query.client as string;
             if (typeof clientId !== "string" || !Object.keys(inMemoryDatabase.clients).includes(clientId)) {
                 return res.sendStatus(400);

--- a/components/server/src/one-time-secret-server.ts
+++ b/components/server/src/one-time-secret-server.ts
@@ -25,7 +25,7 @@ export class OneTimeSecretServer {
     }
 
     protected addHandler(router: express.Router) {
-        router.get("/ots/get/:id", async (req, res, next) => {
+        router.get("/get/:id", async (req, res, next) => {
             const spanCtx =
                 opentracing.globalTracer().extract(opentracing.FORMAT_HTTP_HEADERS, req.headers) || undefined;
             const span = opentracing.globalTracer().startSpan("getOneTimeSecret", { childOf: spanCtx });

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -301,7 +301,7 @@ export class Server {
         // Authorization: Session only
         app.use(this.userController.apiRouter);
         app.use("/workspace-download", this.workspaceDownloadService.apiRouter);
-        app.use(this.oauthController.oauthRouter);
+        app.use("/oauth", this.oauthController.oauthRouter);
         app.use("/_analytics", this.analyticsController.router);
 
         // Authorization: Session or Bearer token
@@ -312,7 +312,7 @@ export class Server {
         app.use("/code-sync", this.codeSyncService.apiRouter);
 
         // Authorization: none
-        app.use(this.oneTimeSecretServer.apiRouter);
+        app.use("/ots", this.oneTimeSecretServer.apiRouter);
         app.use(this.newsletterSubscriptionController.apiRouter);
         app.use("/live", this.livenessController.apiRouter);
         app.use("/version", (req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/components/server/src/typings/express/index.d.ts
+++ b/components/server/src/typings/express/index.d.ts
@@ -6,6 +6,7 @@
 
 import { User as GitpodUser } from "@gitpod/gitpod-protocol";
 import { AuthFlow } from "../../auth/auth-provider";
+import { SubjectId } from "../../auth/subject-id";
 
 // use declaration merging (https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to augment the standard passport/express definitions
 declare global {
@@ -14,6 +15,12 @@ declare global {
 
         interface Request {
             authFlow?: AuthFlow;
+
+            /**
+             * The subject id that authorizes this request.
+             * It also implies that this request requires FGA-based authorization!
+             */
+            subjectId?: SubjectId;
         }
     }
 }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -624,7 +624,14 @@ export class UserController {
 
     private createGitpodServer(user: User, resourceGuard: ResourceAccessGuard) {
         const server = this.serverFactory();
-        server.initialize(undefined, user.id, resourceGuard, ClientMetadata.from(user.id), undefined, {});
+        server.initialize(
+            undefined,
+            user.id,
+            resourceGuard,
+            ClientMetadata.from(SubjectId.fromUserId(user.id)),
+            undefined,
+            {},
+        );
         return server;
     }
 

--- a/components/server/src/util/request-context.ts
+++ b/components/server/src/util/request-context.ts
@@ -94,11 +94,23 @@ export function ctxTrySubjectId(): SubjectId | undefined {
 }
 
 /**
+ * @returns the SubjectId this request is authenticated with
+ * @throws 500/INTERNAL_SERVER_ERROR if there is no subjectId
+ */
+export function ctxSubjectId(): SubjectId {
+    const subjectId = ctxGet().subjectId;
+    if (!subjectId) {
+        throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "No subjectId available");
+    }
+    return subjectId;
+}
+
+/**
  * @throws 500/INTERNAL_SERVER_ERROR if there is no userId
  * @returns The userId associated with the current request.
  */
 export function ctxUserId(): string {
-    const userId = ctxGet()?.subjectId?.userId();
+    const userId = ctxGet().subjectId?.userId();
     if (!userId) {
         throw new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "No userId available");
     }

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -57,7 +57,7 @@ export class HeadlessLogController {
         const router = express.Router();
 
         router.use(this.auth.restHandlerOptionally);
-        router.use(runWithReqSubjectId);
+        router.use(runWithReqSubjectId());
         router.get("/:instanceId/:terminalId", [
             authenticateAndAuthorize,
             asyncHandler(async (req: express.Request, res: express.Response) => {
@@ -143,7 +143,7 @@ export class HeadlessLogController {
         const router = express.Router();
 
         router.use(this.auth.restHandlerOptionally);
-        router.use(runWithReqSubjectId);
+        router.use(runWithReqSubjectId());
         router.get("/:instanceId/:taskId", [
             authenticateAndAuthorize,
             asyncHandler(async (req: express.Request, res: express.Response) => {

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -14,7 +14,7 @@ schema: |-
 
     // permissions
     permission read_info = self + organization->member + organization->owner + installation->admin + apitoken->user_read
-    permission write_info = self + apitoken->user_write
+    permission write_info = self
     permission delete = self + organization->owner + installation->admin
 
     permission make_admin = installation->admin + organization->installation_admin
@@ -23,20 +23,20 @@ schema: |-
     permission admin_control = installation->admin + organization->installation_admin
 
     permission read_ssh = self + apitoken->user_read
-    permission write_ssh = self + apitoken->user_write
+    permission write_ssh = self
 
     permission read_tokens = self + apitoken->user_read
-    permission write_tokens = self + apitoken->user_write
+    permission write_tokens = self
 
     permission read_env_var = self + apitoken->user_read
-    permission write_env_var = self + apitoken->user_write
+    permission write_env_var = self + apitoken->user_write_env_var
 
-    permission code_sync = self
+    permission code_sync = self + apitoken->user_code_sync
   }
 
   definition apitokenv0 {
-    // TODO(gpl) This style limits the apitokens to be restricted to a single user only, but the alternatives look too complicated
-    relation user_write: user:*
+    relation user_code_sync: user:*
+    relation user_write_env_var: user:*
     relation user_read: user:*
   }
 
@@ -58,7 +58,7 @@ schema: |-
     relation installation: installation
 
     // Every user in an organization is automatically a member
-    relation member: user
+    relation member: user | apitokenv0
     // Some users in an organization may additionally have the `owner` role
     relation owner: user
     // users who can snapshot workspaces

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -6,13 +6,15 @@ schema: |-
   definition user {
     relation self: user
 
+    relation apitoken: apitokenv0
+
     // Only ONE of the following relations is ever present for a given user (XOR)
     relation organization: organization
     relation installation: installation
 
     // permissions
-    permission read_info = self + organization->member + organization->owner + installation->admin
-    permission write_info = self
+    permission read_info = self + organization->member + organization->owner + installation->admin + apitoken->user_read
+    permission write_info = self + apitoken->user_write
     permission delete = self + organization->owner + installation->admin
 
     permission make_admin = installation->admin + organization->installation_admin
@@ -20,16 +22,22 @@ schema: |-
     // administrate is for changes such as blocking or verifiying, i.e. things that only admins can do on user
     permission admin_control = installation->admin + organization->installation_admin
 
-    permission read_ssh = self
-    permission write_ssh = self
+    permission read_ssh = self + apitoken->user_read
+    permission write_ssh = self + apitoken->user_write
 
-    permission read_tokens = self
-    permission write_tokens = self
+    permission read_tokens = self + apitoken->user_read
+    permission write_tokens = self + apitoken->user_write
 
-    permission read_env_var = self
-    permission write_env_var = self
+    permission read_env_var = self + apitoken->user_read
+    permission write_env_var = self + apitoken->user_write
 
     permission code_sync = self
+  }
+
+  definition apitokenv0 {
+    // TODO(gpl) This style limits the apitokens to be restricted to a single user only, but the alternatives look too complicated
+    relation user_write: user:*
+    relation user_read: user:*
   }
 
   // There's only one global installation
@@ -116,7 +124,7 @@ schema: |-
   definition workspace {
     relation org: organization
     // The user that created the workspace
-    relation owner: user
+    relation owner: user | apitokenv0
     // Whether this workspace is shared (globally)
     relation shared: user:*
 

--- a/components/supervisor/pkg/serverapi/publicapi.go
+++ b/components/supervisor/pkg/serverapi/publicapi.go
@@ -42,6 +42,8 @@ type APIInterface interface {
 const (
 	// KindGitpod marks tokens that provide access to the Gitpod server API.
 	KindGitpod = "gitpod"
+
+	KindApiTokenV0 = "apitokenv0"
 )
 
 var errNotConnected = errors.New("not connected to server/public api")

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"github.com/gitpod-io/gitpod/common-go/experiments"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/supervisor/api"
@@ -310,8 +309,8 @@ func (s RegistrableTokenService) RegisterREST(mux *runtime.ServeMux, grpcEndpoin
 }
 
 // NewInMemoryTokenService produces a new InMemoryTokenService.
-func NewInMemoryTokenService(exps experiments.Client, ownerID string) *InMemoryTokenService {
-	useApiTokenV0 := true
+func NewInMemoryTokenService(useApiTokenV0 bool) *InMemoryTokenService {
+	// useApiTokenV0 := true
 	// if exps != nil && ownerID != "" {
 	// 	useApiTokenV0 = experiments.SupervisorUseApiTokenV0(context.Background(), exps, experiments.Attributes{
 	// 		UserID: ownerID,

--- a/components/supervisor/pkg/supervisor/services_test.go
+++ b/components/supervisor/pkg/supervisor/services_test.go
@@ -240,7 +240,7 @@ func TestInMemoryTokenServiceGetToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			service := NewInMemoryTokenService()
+			service := NewInMemoryTokenService(nil, "")
 			if test.Cache != nil {
 				service.token = test.Cache
 			}
@@ -363,7 +363,7 @@ func TestInMemoryTokenServiceSetToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			service := NewInMemoryTokenService()
+			service := NewInMemoryTokenService(nil, "")
 			_, err := service.SetToken(context.Background(), test.Req)
 			res := Expectation{
 				TokenCount: len(service.token),

--- a/components/supervisor/pkg/supervisor/services_test.go
+++ b/components/supervisor/pkg/supervisor/services_test.go
@@ -240,7 +240,7 @@ func TestInMemoryTokenServiceGetToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			service := NewInMemoryTokenService(nil, "")
+			service := NewInMemoryTokenService(false)
 			if test.Cache != nil {
 				service.token = test.Cache
 			}
@@ -363,7 +363,7 @@ func TestInMemoryTokenServiceSetToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			service := NewInMemoryTokenService(nil, "")
+			service := NewInMemoryTokenService(false)
 			_, err := service.SetToken(context.Background(), test.Req)
 			res := Expectation{
 				TokenCount: len(service.token),

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -212,7 +212,10 @@ func Run(options ...RunOption) {
 	}
 	exps := experiments.NewClient(experimentsClientOpts...)
 
-	tokenService := NewInMemoryTokenService(exps, cfg.OwnerId)
+	useApiTokenV0 := experiments.SupervisorUseApiTokenV0(context.Background(), exps, experiments.Attributes{
+		UserID: cfg.OwnerId,
+	})
+	tokenService := NewInMemoryTokenService(useApiTokenV0)
 
 	if !opts.RunGP {
 		tkns, err := cfg.GetTokens(true)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a4521b4</samp>

This pull request adds support for fine-grained authorization (FGA) for Gitpod tokens, which are a new type of personal access token that can have specific scopes and relations to resources. It also refactors some existing code to use the new FGA-backed tokens and the SubjectId class, which represents the subject identifier of a token or a user. It updates the Spicedb schema, the OAuth2 server library, the BearerAuth class, the Authorizer class, and various services and controllers to handle the FGA logic and the subjectId property in requests.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-1025-apitokenv0</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-1025-apitokenv0.preview.gitpod-dev.com/workspaces" target="_blank">gpl-1025-apitokenv0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-1025-apitokenv0-gha.21734</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-1025-apitokenv0%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
