### PR TITLE
Updating a few styles after design review

### DIFF
--- a/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
+++ b/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
@@ -33,17 +33,17 @@ export const BreadcrumbNav: FC<BreadcrumbPageNavProps> = ({ pageTitle, pageDescr
             {backLink && (
                 <LinkButton
                     variant={"ghost"}
-                    className="py-1 px-0 hover:bg-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                    className="py-1 pl-0 pr-2 hover:bg-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-200 flex flex-row gap-1 items-center"
                     href={backLink}
                 >
                     <ChevronLeft size={24} />
+                    <Heading3 asChild>
+                        <h1>{pageTitle}</h1>
+                    </Heading3>
                 </LinkButton>
             )}
-            <Heading3 asChild>
-                <h1>{pageTitle}</h1>
-            </Heading3>
             <MiddleDot />
-            <p className="text-gray-900 dark:text-gray-300 text-lg">{pageDescription}</p>
+            <p className="text-pk-content-primary text-lg">{pageDescription}</p>
         </section>
     );
 };

--- a/components/dashboard/src/components/podkit/forms/RadioListField.tsx
+++ b/components/dashboard/src/components/podkit/forms/RadioListField.tsx
@@ -14,18 +14,22 @@ export const RadioGroupItem = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
 >(({ className, ...props }, ref) => {
     return (
-        <RadioGroupPrimitive.Item
-            ref={ref}
-            className={cn(
-                "aspect-square h-4 w-4 my-0 rounded-full border-2 ring-offset-white dark:ring-offset-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 p-0 text-black dark:text-gray-200 border-black dark:border-gray-200 bg-inherit",
-                className,
-            )}
-            {...props}
-        >
-            <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-                <Circle className="h-1.5 w-1.5 fill-current text-current" />
-            </RadioGroupPrimitive.Indicator>
-        </RadioGroupPrimitive.Item>
+        // TODO: Decide if we want to keep this here, or move it to another layer of abstraction
+        // This allows the radio height to match text-sm (which should be used for labels here) line-height
+        <span className="h-5 flex items-center">
+            <RadioGroupPrimitive.Item
+                ref={ref}
+                className={cn(
+                    "aspect-square h-4 w-4 my-0 rounded-full border-2 ring-offset-white dark:ring-offset-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 p-0 text-black dark:text-gray-200 border-black dark:border-gray-200 bg-inherit",
+                    className,
+                )}
+                {...props}
+            >
+                <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+                    <Circle className="h-1.5 w-1.5 fill-current text-current" />
+                </RadioGroupPrimitive.Indicator>
+            </RadioGroupPrimitive.Item>
+        </span>
     );
 });
 RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;

--- a/components/dashboard/src/components/podkit/tables/Table.tsx
+++ b/components/dashboard/src/components/podkit/tables/Table.tsx
@@ -27,7 +27,13 @@ export const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLA
         return (
             <thead
                 ref={ref}
-                className="[&_th]:py-2 [&_th]:px-4 [&_th]:bg-gray-100 [&_th]:font-semibold dark:[&_th]:bg-gray-800 [&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md"
+                className={cn(
+                    // extra padding on top to account for bottom border
+                    "[&_th]:pb-2 [&_th]:pt-3 [&_th]:px-4",
+                    "[&_th]:font-semibold",
+                    "[&_th]:bg-pk-surface-tertiary",
+                    "[&_th:first-child]:rounded-tl-md [&_th:last-child]:rounded-tr-md",
+                )}
                 {...props}
             />
         );
@@ -37,7 +43,7 @@ TableHeader.displayName = "TableHeader";
 
 export const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
     ({ className, ...props }, ref) => {
-        return <tr ref={ref} className="border-b dark:border-gray-700" {...props} />;
+        return <tr ref={ref} className="border-b border-pk-border-base" {...props} />;
     },
 );
 TableRow.displayName = "TableRow";

--- a/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
@@ -12,7 +12,5 @@ interface Props {
 }
 
 export const ConfigurationSettingsField = ({ children, className }: Props) => {
-    return (
-        <div className={cn("border border-gray-300 dark:border-gray-700 rounded-xl p-6", className)}>{children}</div>
-    );
+    return <div className={cn("border border-pk-border-base rounded-xl p-6", className)}>{children}</div>;
 };

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildSettingsForm.tsx
@@ -11,12 +11,12 @@ import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { InputField } from "../../../components/forms/InputField";
 import { PartialConfiguration, useConfigurationMutation } from "../../../data/configurations/configuration-queries";
 import { useToast } from "../../../components/toasts/Toasts";
-import { SelectInputField } from "../../../components/forms/SelectInputField";
 import { TextInputField } from "../../../components/forms/TextInputField";
 import { WorkspaceClassOptions } from "../shared/WorkspaceClassOptions";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { InputFieldHint } from "../../../components/forms/InputFieldHint";
 import { DEFAULT_WS_CLASS } from "../../../data/workspaces/workspace-classes-query";
+import { Select, SelectItem, SelectTrigger, SelectValue, SelectContent } from "@podkit/select/Select";
 
 const DEFAULT_PREBUILD_COMMIT_INTERVAL = 20;
 
@@ -95,6 +95,7 @@ export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
                     id="prebuild-interval"
                 >
                     <input
+                        className="w-20"
                         type="number"
                         id="prebuild-interval"
                         min="0"
@@ -105,16 +106,20 @@ export const PrebuildSettingsForm: FC<Props> = ({ configuration }) => {
                     />
                 </InputField>
 
-                <SelectInputField
-                    label="Branch Filter"
-                    hint="Run prebuilds on the selected branches only."
-                    value={branchStrategy}
-                    onChange={handleBranchStrategyChange}
-                >
-                    <option value={BranchMatchingStrategy.ALL_BRANCHES}>All branches</option>
-                    <option value={BranchMatchingStrategy.DEFAULT_BRANCH}>Default branch</option>
-                    <option value={BranchMatchingStrategy.MATCHED_BRANCHES}>Match branches by pattern</option>
-                </SelectInputField>
+                <InputField label="Branch Filter" hint="Run prebuilds on the selected branches only.">
+                    <Select value={`${branchStrategy}`} onValueChange={handleBranchStrategyChange}>
+                        <SelectTrigger className="w-60">
+                            <SelectValue placeholder="Select a branch filter" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value={`${BranchMatchingStrategy.ALL_BRANCHES}`}>All branches</SelectItem>
+                            <SelectItem value={`${BranchMatchingStrategy.DEFAULT_BRANCH}`}>Default branch</SelectItem>
+                            <SelectItem value={`${BranchMatchingStrategy.MATCHED_BRANCHES}`}>
+                                Match branches by pattern
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                </InputField>
 
                 {branchStrategy === BranchMatchingStrategy.MATCHED_BRANCHES && (
                     <TextInputField

--- a/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
+++ b/components/dashboard/src/repositories/detail/shared/WorkspaceClassOptions.tsx
@@ -33,9 +33,9 @@ export const WorkspaceClassOptions: FC<Props> = ({ value, className, onChange })
             {classes.map((wsClass) => (
                 <Label className="flex items-start space-x-2" key={wsClass.id}>
                     <RadioGroupItem value={wsClass.id} />
-                    <div className="flex flex-col space-y-2">
+                    <div className="flex flex-col text-sm">
                         <span className="font-semibold">{wsClass.displayName}</span>
-                        <span>{wsClass.description}</span>
+                        <span className="text-pk-content-tertiary">{wsClass.description}</span>
                     </div>
                 </Label>
             ))}

--- a/components/dashboard/src/repositories/detail/variables/ConfigurationVariableList.tsx
+++ b/components/dashboard/src/repositories/detail/variables/ConfigurationVariableList.tsx
@@ -43,10 +43,9 @@ export const ConfigurationVariableList = ({ configuration }: Props) => {
                 </div>
             </div>
             {data.length === 0 ? (
-                <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full p-6 flex flex-col justify-center space-y-3">
-                    <span className="font-bold text-base">No environment variables are set</span>
-                    {/* todo: change to podkit color abstractions */}
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                <div className="bg-pk-surface-secondary rounded-xl w-full p-6 flex flex-col justify-center space-y-3">
+                    <span className="font-semi-bold text-base">No environment variables are set</span>
+                    <span className="text-sm text-pk-content-secondary">
                         All configuration-specific environment variables will be visible in prebuilds and optionally in
                         workspaces for this repository.
                     </span>
@@ -71,7 +70,7 @@ export const ConfigurationVariableList = ({ configuration }: Props) => {
                     </TableBody>
                 </Table>
             )}
-            <Button className="my-4" onClick={() => setShowAddVariableModal(true)}>
+            <Button className="mt-4" onClick={() => setShowAddVariableModal(true)}>
                 Add Variable
             </Button>
         </ConfigurationSettingsField>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Includes a number of style adjustments that came out of a design review of these UIs.

* Adjusting table header top padding
* Breadcrumb nav - include heading in back button
* Adjust font weight on radio labels and empty state for env vars
* Adjust input widths on prebuild settings form (swapped to pk select input too)
* Updated a few colors to use new pk classes

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 826c8f3</samp>

This pull request updates various components in the dashboard to use the podkit design system and improve the UI and accessibility. It changes the colors, spacing, and text classes of some elements in the podkit table, prebuild settings form, configuration variable list, breadcrumb navigation, radio list field, configuration settings field, and workspace class options components.

</details>


## How to test
<!-- Provide steps to test this PR -->
* Visit preview env: https://brad-repo-6dc8233d98.preview.gitpod-dev.com/workspaces
* Take a peek at the repo config list page and the detail pages mentioned to see if you notice anything odd. Some of the changes are very subtle so probably not that noticeable.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - brad-repo-6dc8233d98</li>
	<li><b>🔗 URL</b> - <a href="https://brad-repo-6dc8233d98.preview.gitpod-dev.com/workspaces" target="_blank">brad-repo-6dc8233d98.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - brad-repo-config-style-updates-gha.21636</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-brad-repo-6dc8233d98%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
