### PR TITLE
Update alpine to v3.19

### DIFF
--- a/components/ide/code/codehelper/leeway.Dockerfile
+++ b/components/ide/code/codehelper/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM alpine:3.16 as base_builder
+FROM alpine:3.19 as base_builder
 RUN mkdir /ide
 
 FROM scratch

--- a/components/supervisor/leeway.Dockerfile
+++ b/components/supervisor/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM alpine:3.16 as docker_cli_builder
+FROM alpine:3.19 as docker_cli_builder
 
 RUN apk add wget tar
 

--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -22,7 +22,7 @@
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
 FROM alpine:3.19 AS builder
 
-ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_3_P2.tar.gz
+ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_5_P1.tar.gz
 
 WORKDIR /build
 
@@ -52,7 +52,8 @@ RUN ./configure \
     --sysconfdir=/etc/ssh \
     --with-ldflags=-static \
     --with-privsep-user=nobody \
-    --with-ssl-engine
+    --with-ssl-engine \
+    --with-pie
 
 ENV aports=https://raw.githubusercontent.com/alpinelinux/aports/master/main/openssh
 RUN curl -fsSL \

--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -20,7 +20,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
-FROM alpine:3.18 AS builder
+FROM alpine:3.19 AS builder
 
 ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_3_P2.tar.gz
 


### PR DESCRIPTION
### Description

Update alpine to v3.19 and openssh to v9.5-P1 (9.3 detects zlib 1.3 as old)

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 687efeb</samp>

Update the base image for several leeway.Dockerfile stages from alpine:3.16 or alpine:3.18 to alpine:3.19. This improves consistency and security across the components.

</details>

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-alpine</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-alpine.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-alpine.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-alpine-gha.21697</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-alpine%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

