### PR TITLE
Fix relative URLs on the Integrations page

### DIFF
--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -94,14 +94,18 @@ function GitProviders() {
     };
 
     const getSettingsUrl = (ap: AuthProviderDescription) => {
+        const url = new URL(`https://${ap.host}`);
         switch (ap.type) {
             case AuthProviderType.GITHUB:
-                return `${ap.host}/settings/developers`;
+                url.pathname = "settings/developers";
+                break;
             case AuthProviderType.GITLAB:
-                return `${ap.host}/-/profile/applications`;
+                url.pathname = "-/profile/applications";
+                break;
             default:
                 return undefined;
         }
+        return url;
     };
 
     const gitProviderMenu = (provider: AuthProviderDescription) => {


### PR DESCRIPTION
## Description

Fixes an issue where if you hit <kbd>Manage on ...</kbd>, you will be led to a 404, because we treat, what should be treated as an absolute URL, as a relative one. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1048

## How to test

1. Open the preview env
2. Go to user settings -> integrations
3. Click on the overflow menu on any GitHub / GitLab provider and choose <kbd>Manage on ...</kbd>. A tab should open with the SCM to update your scopes.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-rel3f04fb431f</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-rel3f04fb431f.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-rel3f04fb431f.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-relative-urls-integrations-page-gha.21732</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-rel3f04fb431f%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>