### PR TITLE
Prevent a single error from breaking query client cache indefinitely

### DIFF
--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -205,7 +205,13 @@ export function hydrate(value: any): any {
             console.error("unsupported message type", messageName);
             return value;
         }
-        return (constructor as any).fromJsonString(json);
+        // Ensure an error w/ a single message doesn't prevent the entire cache from loading, as it will never get pruned
+        try {
+            return (constructor as any).fromJsonString(json);
+        } catch (e) {
+            console.error("unable to hydrate message", messageName, e, json);
+            return undefined;
+        }
     }
     if (value instanceof Object) {
         for (const key in value) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes the hydration logic in the query client cache so a single bad message (or outdated one) doesn't prevent the entire cache from loading. This can happen when new properties are added to objects, but instead of us ignoring outdated messages, we were just disabling the client cache by never hydrating it. We also were not able to "bust" it w/ our cache buster version since we never finished loading it.

We were seeing errors like the following in the js console:

```
unable to load query client from cache Error: cannot decode message gitpod.v1.Workspace from JSON: key "organizationId" is unknown
```

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 016e5e2</samp>

Improve error handling for cache loading in `setup.tsx`. Add a try-catch block to skip malformed messages and avoid blocking the cache pruning.

</details>

## How to test
<!-- Provide steps to test this PR -->
This is quite tricky to test, as it relies on having older data in your query client cache stored in indexed db. The best verification would be to test out the preview environment by navigating around the app, starting a workspace, and visiting the workspaces page. Then reload the app and ensure we don't see any errors in the js console saying we couldn't load the cache.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
