### PR TITLE
[ssh gateway] improve logs for errors

### DIFF
--- a/components/ws-proxy/pkg/sshproxy/forward.go
+++ b/components/ws-proxy/pkg/sshproxy/forward.go
@@ -19,7 +19,7 @@ import (
 func (s *Server) ChannelForward(ctx context.Context, session *Session, targetConn ssh.Conn, originChannel ssh.NewChannel) {
 	targetChan, targetReqs, err := targetConn.OpenChannel(originChannel.ChannelType(), originChannel.ExtraData())
 	if err != nil {
-		log.WithFields(log.OWI("", session.WorkspaceID, session.InstanceID)).Error("open target channel error")
+		log.WithFields(log.OWI("", session.WorkspaceID, session.InstanceID)).WithError(err).Error("open target channel error")
 		_ = originChannel.Reject(ssh.ConnectionFailed, "open target channel error")
 		return
 	}
@@ -27,7 +27,7 @@ func (s *Server) ChannelForward(ctx context.Context, session *Session, targetCon
 
 	originChan, originReqs, err := originChannel.Accept()
 	if err != nil {
-		log.WithFields(log.OWI("", session.WorkspaceID, session.InstanceID)).Error("accept origin channel failed")
+		log.WithFields(log.OWI("", session.WorkspaceID, session.InstanceID)).WithError(err).Error("accept origin channel failed")
 		return
 	}
 	if originChannel.ChannelType() == "session" {

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -284,6 +285,9 @@ func (s *Server) HandleConn(c net.Conn) {
 	clientConn, clientChans, clientReqs, err := ssh.NewServerConn(c, s.sshConfig)
 	if err != nil {
 		c.Close()
+		if errors.Is(err, io.EOF) {
+			return
+		}
 		ReportSSHAttemptMetrics(err)
 		log.WithError(err).Error("failed to create new server connection")
 		return


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ssh gateway] improve logs for errors by removing io.EOF error, the most case of this error is healthy check.

and also add error field if open channel failed

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7807036</samp>

Improve error logging and handling for SSH proxying in `ws-proxy`. Make the log messages more informative and avoid logging expected errors.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1340

## How to test
<!-- Provide steps to test this PR -->
1. use `nc test.ssh.ws-dev.pd-reduce-error-logs.preview.gitpod-dev.com 22` to connect to ws-proxy, then use `Ctrl+C` to stop nc program
2. use `kubectl logs -f ws-proxy-xxxxxx` to check the log, make sure there is no EOF error.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
