### PR TITLE
[code] Update code dockerfile

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -12,6 +12,7 @@ ARG CODE_COMMIT
 ARG CODE_QUALITY
 ARG CODE_VERSION
 
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM ubuntu:22.04 as code_builder
+FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
 
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
@@ -11,6 +11,9 @@ ENV VSCODE_ARCH=x64
 ARG CODE_COMMIT
 ARG CODE_QUALITY
 ARG CODE_VERSION
+
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
 
 RUN mkdir /gp-code \
     && cd /gp-code \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -12,6 +12,7 @@ ARG CODE_COMMIT
 ARG CODE_QUALITY
 ARG CODE_VERSION
 
+RUN sudo mkdir -m 0755 -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -2,25 +2,11 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM gitpod/openvscode-server-linux-build-agent:centos7-devtoolset8-x64 as dependencies_builder
-
-ARG CODE_COMMIT
-
-RUN mkdir /gp-code \
-    && cd /gp-code \
-    && git init \
-    && git remote add origin https://github.com/gitpod-io/openvscode-server \
-    && git fetch origin $CODE_COMMIT --depth=1 \
-    && git reset --hard FETCH_HEAD
-WORKDIR /gp-code
-RUN yarn --cwd remote --frozen-lockfile --network-timeout 180000
-
-
-FROM gitpod/openvscode-server-linux-build-agent:bionic-x64 as code_builder
+FROM ubuntu:22.04 as code_builder
 
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
-ENV VSCODE_SKIP_NODE_VERSION_CHECK=1
+ENV VSCODE_ARCH=x64
 
 ARG CODE_COMMIT
 ARG CODE_QUALITY
@@ -34,11 +20,9 @@ RUN mkdir /gp-code \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code
 ENV npm_config_arch=x64
-RUN yarn --frozen-lockfile --network-timeout 180000
-
-# copy remote dependencies build in dependencies_builder image
-RUN rm -rf remote/node_modules/
-COPY --from=dependencies_builder /gp-code/remote/node_modules/ /gp-code/remote/node_modules/
+RUN mkdir -p .build \
+    && yarn --cwd build --frozen-lockfile --network-timeout 180000 \
+    && ./build/azure-pipelines/linux/install.sh
 
 # check that the provided codeVersion is the correct one for the given codeCommit
 RUN commitVersion=$(cat package.json | jq -r .version) \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<details>
<summary>Summary generated by Copilot</summary>

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f71db7</samp>

Update code_builder stage in `leeway.Dockerfile` to use Ubuntu 22.04 and upstream script. This improves the simplicity and compatibility of the code IDE component.

</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
