### PR TITLE
Remove Access Token scope checkbox

### DIFF
--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -169,9 +169,9 @@ function PersonalAccessTokenCreateView() {
                     </Alert>
                 )}
                 {!editToken && (
-                    <Alert type={"warning"} closable={false} showIcon={true} className="my-4">
+                    <Alert type={"warning"} closable={false} showIcon={true} className="my-4 max-w-lg">
                         This token will have complete read / write access to the API. Use it responsibly and revoke it
-                        when necessary.
+                        if necessary.
                     </Alert>
                 )}
                 {modalData && (

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -9,7 +9,6 @@ import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Redirect, useHistory, useParams } from "react-router";
 import Alert from "../components/Alert";
-import { CheckboxInputField, CheckboxListField } from "../components/forms/CheckboxInputField";
 import DateSelector from "../components/DateSelector";
 import { SpinnerOverlayLoader } from "../components/Loader";
 import { personalAccessTokensService } from "../service/public-api";
@@ -47,7 +46,7 @@ function PersonalAccessTokenCreateView() {
         name: "",
         expirationDays: "30",
         expirationDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-        scopes: new Set<string>(),
+        scopes: new Set<string>(AllPermissions[0].scopes), // default to all permissions
     });
     const [modalData, setModalData] = useState<{ token: PersonalAccessToken }>();
 
@@ -169,6 +168,12 @@ function PersonalAccessTokenCreateView() {
                         {errorMsg}
                     </Alert>
                 )}
+                {!editToken && (
+                    <Alert type={"warning"} closable={false} showIcon={true} className="my-4">
+                        This token will have complete read / write access to the API. Use it responsibly and revoke it
+                        when necessary.
+                    </Alert>
+                )}
                 {modalData && (
                     <ShowTokenModal
                         token={modalData.token}
@@ -223,27 +228,6 @@ function PersonalAccessTokenCreateView() {
                                     }}
                                 />
                             )}
-                            <div>
-                                <CheckboxListField label="Permission">
-                                    {AllPermissions.map((item) => (
-                                        <CheckboxInputField
-                                            key={item.name}
-                                            value={item.name}
-                                            label={item.name}
-                                            hint={item.description}
-                                            checked={item.scopes.every((s) => token.scopes.has(s))}
-                                            topMargin={false}
-                                            onChange={(checked) => {
-                                                if (checked) {
-                                                    update({}, item.scopes);
-                                                } else {
-                                                    update({}, undefined, item.scopes);
-                                                }
-                                            }}
-                                        />
-                                    ))}
-                                </CheckboxListField>
-                            </div>
                         </div>
                     </div>
                     <div className="flex gap-2">

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -245,28 +245,21 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.procLimit 1000
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.ioLimits.writeBandwidthPerSecond "250Mi"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.ioLimits.readBandwidthPerSecond "300Mi"
 
-# create three workspace classes (g1-standard, g1-small and g1-large) in server-config configmap
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-small"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].category "GENERAL PURPOSE"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].displayName "Small"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].description "Small workspace class (5GB disk)"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].powerups "2"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].credits.perMinute "0.1666666667"
-
+# create two workspace classes (g1-standard and g1-small) in server-config configmap
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-standard"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].category "GENERAL PURPOSE"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].displayName "Standard"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].description "Standard workspace class (10GB disk)"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].powerups "1"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].isDefault "true"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].credits.perMinute "0.3333333333"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].category "GENERAL PURPOSE"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].displayName "Standard"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].description "Standard workspace class (10GB disk)"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].powerups "1"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].isDefault "true"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[0].credits.perMinute "0.3333333333"
 
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-large"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[2].category "GENERAL PURPOSE"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[2].displayName "Large"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[2].description "Large workspace class (15GB disk)"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[2].powerups "1"
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[2].credits.perMinute "0.6666666666"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[+].id "g1-small"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].category "GENERAL PURPOSE"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].displayName "Small"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].description "Small workspace class (5GB disk)"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].powerups "2"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.workspaceClasses[1].credits.perMinute "0.1666666667"
 
 # create two workspace classes (g1-standard and g1-small) in ws-manager configmap
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.workspace.classes["g1-standard"].name "g1-standard"


### PR DESCRIPTION
## Description

Instead of forcing users to check a box for all scopes on an otherwise unusable token, warn the users about the permissions of the token.

<img width="930" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/7863534d-5440-4480-b9f1-0e6c2a7ee6b7">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-948

## How to test

Make sure that newly created PAT tokens still work. Create a new one in the user preferences and all resources should be accessible by it by default. You can also use it to log in to the CLI

```bash
curl 'https://api.ft-access-e3aa0c98b9.preview.gitpod-dev.com/gitpod.experimental.v1.WorkspacesService/ListWorkspaces' \
  -H 'content-type: application/json' \
  -H 'Authorization: Bearer your_token \
  --data '{}'
```

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-access-e3aa0c98b9</li>
	<li><b>🔗 URL</b> - <a href="https://ft-access-e3aa0c98b9.preview.gitpod-dev.com/workspaces" target="_blank">ft-access-e3aa0c98b9.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-access-tokens-ui-cleanup-gha.21952</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-access-e3aa0c98b9%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>