### PR TITLE
Revert and fixing "Revert "Add org-level workspace class restrictions"" - Dashboard

### DIFF
--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -64,12 +64,8 @@ export default function SelectWorkspaceClassComponent({
             return undefined;
         }
         const defaultClassId = workspaceClasses.find((ws) => ws.isDefault)?.id;
-        const selectedOne = workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
-        if (selectedOne) {
-            internalOnSelectionChange(selectedOne.id);
-        }
-        return selectedOne;
-    }, [selectedWorkspaceClass, workspaceClasses, internalOnSelectionChange]);
+        return workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
+    }, [selectedWorkspaceClass, workspaceClasses]);
     return (
         <Combobox
             getElements={getElements}

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -7,8 +7,8 @@
 import { FC, useCallback, useEffect, useMemo } from "react";
 import WorkspaceClassIcon from "../icons/WorkspaceClass.svg";
 import { Combobox, ComboboxElement, ComboboxSelectedItem } from "./podkit/combobox/Combobox";
-import { useWorkspaceClasses } from "../data/workspaces/workspace-classes-query";
 import { WorkspaceClass } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { useOrgWorkspaceClassesQuery } from "../data/organizations/org-workspace-classes-query";
 
 interface SelectWorkspaceClassProps {
     selectedWorkspaceClass?: string;
@@ -25,7 +25,7 @@ export default function SelectWorkspaceClassComponent({
     setError,
     onSelectionChange,
 }: SelectWorkspaceClassProps) {
-    const { data: workspaceClasses, isLoading: workspaceClassesLoading } = useWorkspaceClasses();
+    const { data: workspaceClasses, isLoading: workspaceClassesLoading } = useOrgWorkspaceClassesQuery();
 
     const getElements = useCallback((): ComboboxElement[] => {
         return (workspaceClasses || [])?.map((c) => ({
@@ -37,6 +37,12 @@ export default function SelectWorkspaceClassComponent({
 
     useEffect(() => {
         if (!workspaceClasses) {
+            return;
+        }
+        if (workspaceClasses.length === 0) {
+            setError?.(
+                "No allowed workspace classes available. Please contact an admin to update organization settings.",
+            );
             return;
         }
         // if the selected workspace class is not supported, we set an error and ask the user to pick one
@@ -58,8 +64,12 @@ export default function SelectWorkspaceClassComponent({
             return undefined;
         }
         const defaultClassId = workspaceClasses.find((ws) => ws.isDefault)?.id;
-        return workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
-    }, [selectedWorkspaceClass, workspaceClasses]);
+        const selectedOne = workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
+        if (selectedOne) {
+            internalOnSelectionChange(selectedOne.id);
+        }
+        return selectedOne;
+    }, [selectedWorkspaceClass, workspaceClasses, internalOnSelectionChange]);
     return (
         <Combobox
             getElements={getElements}

--- a/components/dashboard/src/components/forms/CheckboxInputField.tsx
+++ b/components/dashboard/src/components/forms/CheckboxInputField.tsx
@@ -11,7 +11,7 @@ import { InputField } from "./InputField";
 import { InputFieldHint } from "./InputFieldHint";
 
 type CheckboxListFieldProps = {
-    label: string;
+    label?: string;
     error?: ReactNode;
     className?: string;
     topMargin?: boolean;
@@ -63,11 +63,11 @@ export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({
     return (
         // Intentionally not passing label and hint to InputField because we want to render them differently for checkboxes.
         <InputField error={error} topMargin={topMargin} className={containerClassName}>
-            <label className="flex space-x-2 justify-start items-start max-w-lg" htmlFor={elementId}>
+            <label className="flex space-x-2 cursor-pointer justify-start items-start max-w-lg" htmlFor={elementId}>
                 <input
                     type="checkbox"
                     className={classNames(
-                        "h-4 w-4 mt-0.5 rounded cursor-pointer border-2 dark:filter-invert",
+                        "h-4 w-4 mt-0.5 rounded border-2 dark:filter-invert",
                         "focus:ring-2 ring-blue-400",
                         "border-gray-600 dark:border-gray-900 bg-transparent",
                         "checked:bg-gray-600 dark:checked:bg-gray-900",
@@ -79,14 +79,14 @@ export const CheckboxInputField: FC<CheckboxInputFieldProps> = ({
                     onChange={handleChange}
                 />
                 <div className="flex flex-col">
-                    <span
+                    <div
                         className={classNames(
                             "text-sm font-semibold cursor-pointer",
                             disabled ? "text-gray-400 dark:text-gray-400" : "text-gray-600 dark:text-gray-100",
                         )}
                     >
                         {label}
-                    </span>
+                    </div>
 
                     {hint && <InputFieldHint disabled={disabled}>{hint}</InputFieldHint>}
                 </div>

--- a/components/dashboard/src/components/podkit/switch/Switch.tsx
+++ b/components/dashboard/src/components/podkit/switch/Switch.tsx
@@ -4,9 +4,10 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React from "react";
+import React, { ReactNode } from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 import { cn } from "@podkit/lib/cn";
+import { TextMuted } from "@podkit/typography/TextMuted";
 
 export const Switch = React.forwardRef<
     React.ElementRef<typeof SwitchPrimitives.Root>,
@@ -45,3 +46,29 @@ export const Switch = React.forwardRef<
     );
 });
 Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export interface SwitchInputFieldProps extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
+    id?: string;
+    label: ReactNode;
+    description?: ReactNode;
+}
+
+export const SwitchInputField = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, SwitchInputFieldProps>(
+    ({ className, checked, onCheckedChange, label, id, description, ...props }, ref) => {
+        const switchProps = {
+            ...props,
+            className: "",
+        };
+        return (
+            <div className={cn("flex gap-4", className)}>
+                <Switch checked={checked} onCheckedChange={onCheckedChange} id={id} {...switchProps} ref={ref} />
+                <div className="flex flex-col">
+                    <label className="font-semibold cursor-pointer" htmlFor={id}>
+                        {label}
+                    </label>
+                    <TextMuted>{description}</TextMuted>
+                </div>
+            </div>
+        );
+    },
+);

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -29,6 +29,10 @@ const featureFlags = {
     createProjectModal: false,
     repoConfigListAndDetail: false,
     showRepoConfigMenuItem: false,
+    /**
+     * Whether to enable org-level workspace class restrictions
+     */
+    org_workspace_class_restrictions: false,
 };
 
 type FeatureFlags = typeof featureFlags;

--- a/components/dashboard/src/data/organizations/org-workspace-classes-query.ts
+++ b/components/dashboard/src/data/organizations/org-workspace-classes-query.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { organizationClient } from "../../service/public-api";
+import { useCallback } from "react";
+import { useCurrentOrg } from "./orgs-query";
+import { WorkspaceClass } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { noPersistence } from "../setup";
+
+export function useOrgWorkspaceClassesQueryInvalidator() {
+    const organizationId = useCurrentOrg().data?.id;
+    const queryClient = useQueryClient();
+    return useCallback(() => {
+        queryClient.invalidateQueries(getQueryKey(organizationId));
+    }, [organizationId, queryClient]);
+}
+
+export function useOrgWorkspaceClassesQuery() {
+    const organizationId = useCurrentOrg().data?.id;
+    return useQuery<WorkspaceClass[], Error>(
+        getQueryKey(organizationId),
+        async () => {
+            if (!organizationId) {
+                throw new Error("No org selected.");
+            }
+
+            const settings = await organizationClient.listOrganizationWorkspaceClasses({ organizationId });
+            return settings.workspaceClasses || [];
+        },
+        {
+            enabled: !!organizationId,
+        },
+    );
+}
+
+function getQueryKey(organizationId?: string) {
+    // We don't persistence listOrganizationWorkspaceClasses because org settings updated by owner will not notify members to invalidate listOrganizationWorkspaceClasses
+    // TODO: Or we need to handle special ErrorCodes from server somewhere
+    // i.e. CreateAndStartWorkspace respond selected workspace class is not allowed
+    return noPersistence(["listOrganizationWorkspaceClasses", organizationId || "undefined"]);
+}

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -33,7 +33,7 @@ import * as UserClasses from "@gitpod/public-api/lib/gitpod/v1/user_pb";
 // This is used to version the cache
 // If data we cache changes in a non-backwards compatible way, increment this version
 // That will bust any previous cache versions a client may have stored
-const CACHE_VERSION = "20";
+const CACHE_VERSION = "21";
 
 export function noPersistence(queryKey: QueryKey): QueryKey {
     return [...queryKey, "no-persistence"];

--- a/components/dashboard/src/data/setup.tsx
+++ b/components/dashboard/src/data/setup.tsx
@@ -33,7 +33,7 @@ import * as UserClasses from "@gitpod/public-api/lib/gitpod/v1/user_pb";
 // This is used to version the cache
 // If data we cache changes in a non-backwards compatible way, increment this version
 // That will bust any previous cache versions a client may have stored
-const CACHE_VERSION = "21";
+const CACHE_VERSION = "22";
 
 export function noPersistence(queryKey: QueryKey): QueryKey {
     return [...queryKey, "no-persistence"];

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPrebuilds.tsx
@@ -8,7 +8,7 @@ import { FC, useCallback, useState } from "react";
 import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { ConfigurationSettingsField } from "./ConfigurationSettingsField";
 import { Heading3, Subheading } from "@podkit/typography/Headings";
-import { Switch } from "@podkit/switch/Switch";
+import { SwitchInputField } from "@podkit/switch/Switch";
 import { TextMuted } from "@podkit/typography/TextMuted";
 import { PrebuildSettingsForm } from "./prebuilds/PrebuildSettingsForm";
 import { useConfigurationMutation } from "../../data/configurations/configuration-queries";
@@ -60,13 +60,13 @@ export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
                 <Heading3>Prebuilds</Heading3>
                 <Subheading className="max-w-lg">Prebuilds reduce wait time for new workspaces.</Subheading>
 
-                <div className="flex gap-4 mt-6">
-                    {/* TODO: wrap this in a SwitchInputField that handles the switch, label and description and htmlFor/id automatically */}
-                    <Switch checked={enabled} onCheckedChange={updateEnabled} id="prebuilds-enabled" />
-                    <div className="flex flex-col">
-                        <label className="font-semibold" htmlFor="prebuilds-enabled">
-                            {enabled ? "Prebuilds are enabled" : "Prebuilds are disabled"}
-                        </label>
+                <SwitchInputField
+                    className="mt-6"
+                    id="prebuilds-enabled"
+                    checked={enabled}
+                    onCheckedChange={updateEnabled}
+                    label={enabled ? "Prebuilds are enabled" : "Prebuilds are disabled"}
+                    description={
                         <TextMuted>
                             Enabling requires permissions to configure repository webhooks.{" "}
                             <a
@@ -79,8 +79,8 @@ export const ConfigurationDetailPrebuilds: FC<Props> = ({ configuration }) => {
                             </a>
                             .
                         </TextMuted>
-                    </div>
-                </div>
+                    }
+                />
             </ConfigurationSettingsField>
 
             {enabled && <PrebuildSettingsForm configuration={configuration} />}

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Organization, OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
+import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
 import React, { Children, ReactNode, useCallback, useMemo, useState } from "react";
 import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -13,7 +13,7 @@ import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal"
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import { InputField } from "../components/forms/InputField";
 import { TextInputField } from "../components/forms/TextInputField";
-import { Heading2, Subheading } from "../components/typography/headings";
+import { Heading2, Heading3, Subheading } from "../components/typography/headings";
 import { useIsOwner } from "../data/organizations/members-query";
 import { useOrgSettingsQuery } from "../data/organizations/org-settings-query";
 import { useCurrentOrg, useOrganizationsInvalidator } from "../data/organizations/orgs-query";
@@ -28,6 +28,13 @@ import { OrgSettingsPage } from "./OrgSettingsPage";
 import { ErrorCode } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Button } from "@podkit/buttons/Button";
 import { useInstallationDefaultWorkspaceImageQuery } from "../data/installation/default-workspace-image-query";
+import { useToast } from "../components/toasts/Toasts";
+import { useWorkspaceClasses } from "../data/workspaces/workspace-classes-query";
+import { LoadingState } from "@podkit/loading/LoadingState";
+import { LoadingButton } from "@podkit/buttons/LoadingButton";
+import { ConfigurationSettingsField } from "../repositories/detail/ConfigurationSettingsField";
+import { SwitchInputField } from "@podkit/switch/Switch";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 export default function TeamSettingsPage() {
     const user = useCurrentUser();
@@ -39,6 +46,8 @@ export default function TeamSettingsPage() {
     const [teamName, setTeamName] = useState(org?.name || "");
     const [updated, setUpdated] = useState(false);
     const updateOrg = useUpdateOrgMutation();
+
+    const enableOrgWorkspaceClassRestrictions = useFeatureFlag("org_workspace_class_restrictions");
 
     const close = () => setModal(false);
 
@@ -83,56 +92,143 @@ export default function TeamSettingsPage() {
         document.location.href = gitpodHostUrl.asDashboard().toString();
     }, [invalidateOrgs, org, user]);
 
+    const { data: settings, isLoading } = useOrgSettingsQuery();
+    const { data: installationDefaultImage } = useInstallationDefaultWorkspaceImageQuery();
+    const updateTeamSettings = useUpdateOrgSettingsMutation();
+
+    const [showImageEditModal, setShowImageEditModal] = useState(false);
+
+    const handleUpdateTeamSettings = useCallback(
+        async (newSettings: Partial<OrganizationSettings>) => {
+            if (!org?.id) {
+                throw new Error("no organization selected");
+            }
+            if (!isOwner) {
+                throw new Error("no organization settings change permission");
+            }
+            try {
+                await updateTeamSettings.mutateAsync({
+                    ...settings,
+                    ...newSettings,
+                });
+            } catch (error) {
+                console.error(error);
+            }
+        },
+        [updateTeamSettings, org?.id, isOwner, settings],
+    );
+
     return (
         <>
             <OrgSettingsPage>
-                <Heading2>Organization Details</Heading2>
-                <Subheading className="max-w-2xl">Details of your organization within Gitpod.</Subheading>
+                <div className="space-y-4">
+                    <div>
+                        <Heading2>Organization Details</Heading2>
+                        <Subheading>Details of your organization within Gitpod.</Subheading>
+                    </div>
+                    <ConfigurationSettingsField>
+                        {updateOrg.isError && (
+                            <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
+                                <span>Failed to update organization information: </span>
+                                <span>{updateOrg.error.message || "unknown error"}</span>
+                            </Alert>
+                        )}
+                        {updated && (
+                            <Alert type="message" closable={true} className="mb-2 max-w-xl rounded-md">
+                                Organization name has been updated.
+                            </Alert>
+                        )}
+                        <TextInputField
+                            label="Display Name"
+                            hint="The name of your company or organization"
+                            value={teamName}
+                            error={teamNameError.message}
+                            onChange={setTeamName}
+                            disabled={!isOwner}
+                            topMargin={false}
+                            onBlur={teamNameError.onBlur}
+                        />
 
-                {updateOrg.isError && (
-                    <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
-                        <span>Failed to update organization information: </span>
-                        <span>{updateOrg.error.message || "unknown error"}</span>
-                    </Alert>
-                )}
-                {updated && (
-                    <Alert type="message" closable={true} className="mb-2 max-w-xl rounded-md">
-                        Organization name has been updated.
-                    </Alert>
-                )}
-                <form onSubmit={updateTeamInformation}>
-                    <TextInputField
-                        label="Name"
-                        hint="The name of your company or organization"
-                        value={teamName}
-                        error={teamNameError.message}
-                        onChange={setTeamName}
-                        disabled={!isOwner}
-                        onBlur={teamNameError.onBlur}
-                    />
+                        {org && (
+                            <InputField label="Organization ID">
+                                <InputWithCopy value={org.id} tip="Copy Organization ID" />
+                            </InputField>
+                        )}
 
-                    {isOwner && (
-                        <Button className="mt-4" type="submit" disabled={org?.name === teamName || !orgFormIsValid}>
-                            Update Organization
-                        </Button>
+                        {isOwner && (
+                            <Button
+                                onClick={updateTeamInformation}
+                                className="mt-4"
+                                type="submit"
+                                disabled={org?.name === teamName || !orgFormIsValid}
+                            >
+                                Save
+                            </Button>
+                        )}
+                    </ConfigurationSettingsField>
+
+                    <ConfigurationSettingsField>
+                        <Heading3>Collaboration & Sharing</Heading3>
+
+                        {updateTeamSettings.isError && (
+                            <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
+                                <span>Failed to update organization settings: </span>
+                                <span>{updateTeamSettings.error.message || "unknown error"}</span>
+                            </Alert>
+                        )}
+
+                        <CheckboxInputField
+                            label="Workspace Sharing"
+                            hint="Allow workspaces created within an Organization to share the workspace with any authenticated user."
+                            checked={!settings?.workspaceSharingDisabled}
+                            onChange={(checked) => handleUpdateTeamSettings({ workspaceSharingDisabled: !checked })}
+                            disabled={isLoading || !isOwner}
+                        />
+                    </ConfigurationSettingsField>
+
+                    <ConfigurationSettingsField>
+                        <Heading3>Workspace Images</Heading3>
+                        <Subheading>Choose a default image for all workspaces in the organization.</Subheading>
+
+                        <WorkspaceImageButton
+                            disabled={!isOwner}
+                            settings={settings}
+                            installationDefaultWorkspaceImage={installationDefaultImage}
+                            onClick={() => setShowImageEditModal(true)}
+                        />
+                    </ConfigurationSettingsField>
+
+                    {showImageEditModal && (
+                        <OrgDefaultWorkspaceImageModal
+                            settings={settings}
+                            installationDefaultWorkspaceImage={installationDefaultImage}
+                            onClose={() => setShowImageEditModal(false)}
+                        />
                     )}
-                </form>
 
-                <OrgSettingsForm org={org} isOwner={isOwner} />
+                    {enableOrgWorkspaceClassRestrictions && (
+                        <ConfigurationSettingsField>
+                            <Heading3>Available Workspace Classes</Heading3>
+                            <Subheading>Limit the available workspace classes in your organization.</Subheading>
 
-                {user?.organizationId !== org?.id && isOwner && (
-                    <>
-                        <Heading2 className="pt-12">Delete Organization</Heading2>
-                        <Subheading className="pb-4 max-w-2xl">
-                            Deleting this organization will also remove all associated data, including projects and
-                            workspaces. Deleted organizations cannot be restored!
-                        </Subheading>
+                            {settings && <WorkspaceClassOptions disabled={!isOwner} settings={settings} />}
+                        </ConfigurationSettingsField>
+                    )}
 
-                        <Button variant="destructive" onClick={() => setModal(true)}>
-                            Delete Organization
-                        </Button>
-                    </>
-                )}
+                    {user?.organizationId !== org?.id && isOwner && (
+                        <ConfigurationSettingsField>
+                            <Heading3>Delete Organization</Heading3>
+                            <Subheading className="pb-4 max-w-2xl">
+                                Deleting this organization will also remove all associated data, including projects and
+                                workspaces. Deleted organizations cannot be restored!
+                            </Subheading>
+
+                            <Button variant="destructive" onClick={() => setModal(true)}>
+                                Delete Organization
+                            </Button>
+                        </ConfigurationSettingsField>
+                    )}
+                </div>
             </OrgSettingsPage>
 
             <ConfirmationModal
@@ -170,86 +266,6 @@ export default function TeamSettingsPage() {
                 ></input>
             </ConfirmationModal>
         </>
-    );
-}
-
-function OrgSettingsForm(props: { org?: Organization; isOwner: boolean }) {
-    const { org, isOwner } = props;
-    const { data: settings, isLoading } = useOrgSettingsQuery();
-    const { data: installationDefaultImage } = useInstallationDefaultWorkspaceImageQuery();
-    const updateTeamSettings = useUpdateOrgSettingsMutation();
-
-    const [showImageEditModal, setShowImageEditModal] = useState(false);
-
-    const handleUpdateTeamSettings = useCallback(
-        async (newSettings: Partial<OrganizationSettings>) => {
-            if (!org?.id) {
-                throw new Error("no organization selected");
-            }
-            if (!isOwner) {
-                throw new Error("no organization settings change permission");
-            }
-            try {
-                await updateTeamSettings.mutateAsync({
-                    ...settings,
-                    ...newSettings,
-                });
-            } catch (error) {
-                console.error(error);
-            }
-        },
-        [updateTeamSettings, org?.id, isOwner, settings],
-    );
-
-    return (
-        <form
-            onSubmit={(e) => {
-                e.preventDefault();
-            }}
-        >
-            {props.org && (
-                <InputField label="Organization ID">
-                    <InputWithCopy value={props.org.id} tip="Copy Organization ID" />
-                </InputField>
-            )}
-
-            <Heading2 className="pt-12">Collaboration & Sharing</Heading2>
-
-            {updateTeamSettings.isError && (
-                <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
-                    <span>Failed to update organization settings: </span>
-                    <span>{updateTeamSettings.error.message || "unknown error"}</span>
-                </Alert>
-            )}
-
-            <CheckboxInputField
-                label="Workspace Sharing"
-                hint="Allow workspaces created within an Organization to share the workspace with any authenticated user."
-                checked={!settings?.workspaceSharingDisabled}
-                onChange={(checked) => handleUpdateTeamSettings({ workspaceSharingDisabled: !checked })}
-                disabled={isLoading || !isOwner}
-            />
-
-            <Heading2 className="pt-12">Workspace Images</Heading2>
-            <Subheading className="max-w-2xl">
-                Choose a default image for all workspaces in the organization.
-            </Subheading>
-
-            <WorkspaceImageButton
-                disabled={!isOwner}
-                settings={settings}
-                installationDefaultWorkspaceImage={installationDefaultImage}
-                onClick={() => setShowImageEditModal(true)}
-            />
-
-            {showImageEditModal && (
-                <OrgDefaultWorkspaceImageModal
-                    settings={settings}
-                    installationDefaultWorkspaceImage={installationDefaultImage}
-                    onClose={() => setShowImageEditModal(false)}
-                />
-            )}
-        </form>
     );
 }
 
@@ -397,3 +413,93 @@ function OrgDefaultWorkspaceImageModal(props: OrgDefaultWorkspaceImageModalProps
         </Modal>
     );
 }
+
+interface WorkspaceClassOptionsProps {
+    settings: OrganizationSettings | undefined;
+    disabled: boolean;
+}
+const WorkspaceClassOptions = (props: WorkspaceClassOptionsProps) => {
+    const [validateError, setValidateError] = useState("");
+    const [selectedValue, setSelectedValue] = useState(props.settings?.allowedWorkspaceClasses ?? []);
+    const [isChanged, setIsChanged] = useState(false);
+    const updateTeamSettings = useUpdateOrgSettingsMutation();
+    const { data: classes, isError, isLoading } = useWorkspaceClasses();
+
+    const { toast } = useToast();
+    const handleUpdateTeamSettings = useCallback(
+        async (classes: string[]) => {
+            await updateTeamSettings.mutateAsync(
+                {
+                    ...props.settings,
+                    allowedWorkspaceClasses: classes,
+                },
+                {
+                    onSuccess: () => {
+                        toast({ message: "Available workspace classes updated." });
+                    },
+                },
+            );
+        },
+        [updateTeamSettings, props.settings, toast],
+    );
+
+    const noClassesSelected = useMemo(() => {
+        return (props.settings?.allowedWorkspaceClasses.length ?? 0) === 0;
+    }, [props.settings?.allowedWorkspaceClasses]);
+
+    if (isError || !classes) {
+        return <div>Something went wrong</div>;
+    }
+
+    if (isLoading) {
+        return <LoadingState />;
+    }
+
+    return (
+        <div className="space-y-4">
+            <div>
+                {classes.map((wsClass) => (
+                    <SwitchInputField
+                        className="mt-2"
+                        key={wsClass.id}
+                        id={wsClass.id}
+                        label={wsClass.displayName}
+                        description={wsClass.description}
+                        checked={(!isChanged && noClassesSelected) || selectedValue.includes(wsClass.id)}
+                        onCheckedChange={(checked) => {
+                            const previousValue =
+                                !isChanged && noClassesSelected ? classes.map((e) => e.id) : selectedValue;
+                            setIsChanged(true);
+                            const newVal = (
+                                checked ? [...previousValue, wsClass.id] : previousValue.filter((e) => e !== wsClass.id)
+                            ).filter((id) => classes.find((cls) => cls.id === id));
+                            setValidateError(
+                                newVal.length === 0 ? "At least one workspace class has to be selected." : "",
+                            );
+                            setSelectedValue(newVal);
+                        }}
+                        disabled={props.disabled || updateTeamSettings.isLoading}
+                    />
+                ))}
+            </div>
+
+            <div className="flex gap-2 items-center">
+                {!props.disabled && (
+                    <LoadingButton
+                        disabled={props.disabled || !isChanged || validateError.length > 0}
+                        loading={updateTeamSettings.isLoading}
+                        onClick={() => {
+                            handleUpdateTeamSettings(selectedValue);
+                        }}
+                    >
+                        Save
+                    </LoadingButton>
+                )}
+                {validateError.length > 0 && <span className="text-red-600 dark:text-red-400">{validateError}</span>}
+                {updateTeamSettings.isError && updateTeamSettings.error.message.length > 0 && (
+                    <span className="text-red-600 dark:text-red-400">{updateTeamSettings.error.message}</span>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -49,10 +49,12 @@ import { User_WorkspaceAutostartOption } from "@gitpod/public-api/lib/gitpod/v1/
 import { EditorReference } from "@gitpod/public-api/lib/gitpod/v1/editor_pb";
 import { converter } from "../service/public-api";
 import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutation";
+import { useOrgWorkspaceClassesQuery } from "../data/organizations/org-workspace-classes-query";
 
 export function CreateWorkspacePage() {
     const { user, setUser } = useContext(UserContext);
     const updateUser = useUpdateCurrentUserMutation();
+    const { data: orgWorkspaceClasses } = useOrgWorkspaceClassesQuery();
     const currentOrg = useCurrentOrg().data;
     const projects = useListAllProjectsQuery();
     const workspaces = useListWorkspacesQuery({ limit: 50 });
@@ -70,7 +72,7 @@ export function CreateWorkspacePage() {
     const defaultIde =
         props.ideSettings?.defaultIde !== undefined ? props.ideSettings.defaultIde : user?.editorSettings?.name;
     const [selectedIde, setSelectedIde, selectedIdeIsDirty] = useDirtyState(defaultIde);
-    const defaultWorkspaceClass = props.workspaceClass;
+    const defaultWorkspaceClass = props.workspaceClass ?? orgWorkspaceClasses?.find((e) => e.isDefault)?.id;
     const [selectedWsClass, setSelectedWsClass, selectedWsClassIsDirty] = useDirtyState(defaultWorkspaceClass);
     const [errorWsClass, setErrorWsClass] = useState<string | undefined>(undefined);
     const [contextURL, setContextURL] = useState<string | undefined>(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Blocked by https://github.com/gitpod-io/gitpod/pull/19275

Addition changes are in Fixing commit https://github.com/gitpod-io/gitpod/pull/19276/commits/ec299ea181627163abe76065f22a60895d34244e

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes Project Setting page crash [[internal chat](https://gitpod.slack.com/archives/C06B030LCL8/p1702640968561529)]

## How to test
<!-- Provide steps to test this PR -->

https://hw-revert-d5978ec121.preview.gitpod-dev.com/settings

- It should be able to access Project Setting page
- It should select default workspace class in new workspace page

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
