### PR TITLE
[content-service] revert git config feature.manyFiles true

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -111,11 +111,6 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		}
 
 		// we can only do `git config` stuffs after having a directory that is also git init'd
-		// https://github.blog/2019-11-03-highlights-from-git-2-24/
-		err = ws.Git(ctx, "config", "feature.manyFiles", "true")
-		if err != nil {
-			log.WithError(err).WithField("location", ws.Location).Error("cannot configure feature.manyFiles")
-		}
 		// commit-graph after every git fetch command that downloads a pack-file from a remote
 		err = ws.Git(ctx, "config", "fetch.writeCommitGraph", "true")
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removing because it's causing integration tests to fail.

It's causing integration tests to fail here: https://github.com/gitpod-io/gitpod/blob/c4e2c43ab1acb78fda438be135b4d2bf3ec661df/test/tests/components/ws-manager/prebuild_test.go#L684

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
[TestOpenWorkspaceFromPrebuild is passing now](https://github.com/gitpod-io/gitpod/actions/runs/7223943576/job/19684479806#step:6:789). The run [failed](https://github.com/gitpod-io/gitpod/actions/runs/7223943576/job/19684479806#step:6:1474) due to a flake.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
