### PR TITLE
[code] Update code to 1.85.1

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-dcabd3a05822f5d07c649f5e57bf0a3e9cbd3353" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-1fc02691286b404b664249d7c840cf8c84343741" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
 	CodeWebExtensionVersion     = "commit-49bb715b599dce2356dd02a6ede7ae8cf10d8d12" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Switch to VS Code Browser stable in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-assistant-hamster</li>
	<li><b>🔗 URL</b> - <a href="https://jp-assistant-hamster.preview.gitpod-dev.com/workspaces" target="_blank">jp-assistant-hamster.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-assistant-hamster-gha.22020</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-assistant-hamster%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
