### PR TITLE
[server] fix unit test

### DIFF
--- a/components/server/src/auth/auth-provider-service.spec.db.ts
+++ b/components/server/src/auth/auth-provider-service.spec.db.ts
@@ -128,6 +128,8 @@ describe("AuthProviderService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     describe("createAuthProviderOfUser", async () => {

--- a/components/server/src/auth/bearer-authenticator.spec.db.ts
+++ b/components/server/src/auth/bearer-authenticator.spec.db.ts
@@ -72,6 +72,8 @@ describe("BearerAuth", () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("authExpressRequest should successfully authenticate BearerToken (PAT)", async () => {

--- a/components/server/src/authorization/authorizer.spec.db.ts
+++ b/components/server/src/authorization/authorizer.spec.db.ts
@@ -36,6 +36,8 @@ describe("Authorizer", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should removeUser", async () => {

--- a/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
+++ b/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
@@ -51,7 +51,7 @@ describe("CachingSpiceDBAuthorizer", async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
 
-        container.unbindAll();
+        await container.unbindAllAsync();
     });
 
     it("should avoid new-enemy after removal", async () => {

--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -52,6 +52,8 @@ describe("RelationshipUpdater", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should update a simple user", async () => {

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -78,6 +78,8 @@ describe("OrganizationService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should deleteOrganization", async () => {
@@ -302,21 +304,27 @@ describe("OrganizationService", async () => {
 
         await assertUpdateSettings(
             "should update allowed workspace classes",
-            { allowedWorkspaceClasses: ["foo"] },
+            { allowedWorkspaceClasses: ["default"] },
             {
                 workspaceSharingDisabled: true,
                 defaultWorkspaceImage: "ubuntu",
-                allowedWorkspaceClasses: ["foo"],
+                allowedWorkspaceClasses: ["default"],
             },
         );
 
+        try {
+            await os.updateSettings(adminId, myOrg.id, { allowedWorkspaceClasses: ["foo"] });
+            expect.fail("should have failed");
+        } catch (err) {
+            expect(err.message).to.equal("items in allowedWorkspaceClasses are not all allowed", "invalid classes");
+        }
+
         await assertUpdateSettings(
-            "should update empty allowed workspace classes",
+            "empty allowed workspace classes should allow all (null)",
             { allowedWorkspaceClasses: [] },
             {
                 workspaceSharingDisabled: true,
                 defaultWorkspaceImage: "ubuntu",
-                allowedWorkspaceClasses: [],
             },
         );
 

--- a/components/server/src/orgs/organization-service.spec.ts
+++ b/components/server/src/orgs/organization-service.spec.ts
@@ -14,6 +14,8 @@ import { ProjectsService } from "../projects/projects-service";
 import { Authorizer } from "../authorization/authorizer";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { DefaultWorkspaceImageValidator } from "./default-workspace-image-validator";
+import { UserService } from "../user/user-service";
+import { Config } from "../config";
 
 const expect = chai.expect;
 
@@ -33,6 +35,8 @@ describe("OrganizationService", async () => {
         ];
         beforeEach(async () => {
             container = testContainer.createChild();
+            container.bind(Config).toConstantValue({} as any as Config);
+            container.bind(UserService).toConstantValue({} as any as UserService);
             container.bind(OrganizationService).toSelf().inSingletonScope();
             container.bind(ProjectsService).toConstantValue({} as any as ProjectsService);
             container.bind(Authorizer).toConstantValue({

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -394,17 +394,25 @@ export class OrganizationService {
                 settings = { ...settings, defaultWorkspaceImage: null };
             }
         }
-        if (settings.allowedWorkspaceClasses && settings.allowedWorkspaceClasses.length > 0) {
-            const allClasses = await this.installationService.getInstallationWorkspaceClasses(userId);
-            const availableClasses = allClasses.filter((e) => settings.allowedWorkspaceClasses!.includes(e.id));
-            if (availableClasses.length !== settings.allowedWorkspaceClasses.length) {
-                throw new ApplicationError(
-                    ErrorCodes.BAD_REQUEST,
-                    "items in allowedWorkspaceClasses are not all allowed",
-                );
-            }
-            if (availableClasses.length === 0) {
-                throw new ApplicationError(ErrorCodes.BAD_REQUEST, "at least one workspace class has to be selected.");
+        if (settings.allowedWorkspaceClasses) {
+            if (settings.allowedWorkspaceClasses.length === 0) {
+                // Pass an empty array to allow all workspace classes
+                settings.allowedWorkspaceClasses = null;
+            } else {
+                const allClasses = await this.installationService.getInstallationWorkspaceClasses(userId);
+                const availableClasses = allClasses.filter((e) => settings.allowedWorkspaceClasses!.includes(e.id));
+                if (availableClasses.length !== settings.allowedWorkspaceClasses.length) {
+                    throw new ApplicationError(
+                        ErrorCodes.BAD_REQUEST,
+                        `items in allowedWorkspaceClasses are not all allowed`,
+                    );
+                }
+                if (availableClasses.length === 0) {
+                    throw new ApplicationError(
+                        ErrorCodes.BAD_REQUEST,
+                        "at least one workspace class has to be selected.",
+                    );
+                }
             }
         }
         return this.toSettings(await this.teamDB.setOrgSettings(orgId, settings));
@@ -418,7 +426,9 @@ export class OrganizationService {
         if (typeof settings.defaultWorkspaceImage === "string") {
             result.defaultWorkspaceImage = settings.defaultWorkspaceImage;
         }
-        result.allowedWorkspaceClasses = settings.allowedWorkspaceClasses;
+        if (settings.allowedWorkspaceClasses) {
+            result.allowedWorkspaceClasses = settings.allowedWorkspaceClasses;
+        }
         return result;
     }
 

--- a/components/server/src/orgs/usage-service.spec.db.ts
+++ b/components/server/src/orgs/usage-service.spec.db.ts
@@ -98,6 +98,8 @@ describe("UsageService", async () => {
         // Clean-up database
         const typeorm = container.get(TypeORM);
         await resetDB(typeorm);
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("getCostCenter permissions", async () => {

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -58,6 +58,8 @@ describe("ProjectsService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should getProject and getProjects", async () => {

--- a/components/server/src/scm/scm-service.spec.db.ts
+++ b/components/server/src/scm/scm-service.spec.db.ts
@@ -58,6 +58,8 @@ describe("ScmService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     describe("getToken", async () => {

--- a/components/server/src/session-handler.spec.db.ts
+++ b/components/server/src/session-handler.spec.db.ts
@@ -77,6 +77,8 @@ describe("SessionHandler", () => {
     afterEach(async () => {
         const typeorm = container.get(TypeORM);
         await resetDB(typeorm);
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     describe("verify", () => {

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -136,6 +136,8 @@ describe("EnvVarService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should add and update env variable", async () => {

--- a/components/server/src/user/gitpod-token-service.spec.db.ts
+++ b/components/server/src/user/gitpod-token-service.spec.db.ts
@@ -63,6 +63,8 @@ describe("GitpodTokenService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("should generate a new gitpod token", async () => {

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -74,7 +74,7 @@ describe("SSHKeyService", async () => {
     afterEach(async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
-        container.unbindAll();
+        await container.unbindAllAsync();
     });
 
     it("should add ssh key", async () => {

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -75,6 +75,8 @@ describe("UserService", async () => {
     afterEach(async () => {
         const typeorm = container.get(TypeORM);
         await resetDB(typeorm);
+        // Deactivate all services
+        await container.unbindAllAsync();
     });
 
     it("createUser", async () => {

--- a/components/server/src/workspace/context-service.spec.db.ts
+++ b/components/server/src/workspace/context-service.spec.db.ts
@@ -256,7 +256,7 @@ describe("ContextService", async () => {
 
     afterEach(async () => {
         await resetDB(container.get(TypeORM));
-        container.unbindAll();
+        await container.unbindAllAsync();
     });
 
     it("should parse normal context", async () => {

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -104,7 +104,7 @@ describe("WorkspaceService", async () => {
         // Clean-up database
         await resetDB(container.get(TypeORM));
         // Deactivate all services
-        container.unbindAll();
+        await container.unbindAllAsync();
     });
 
     it("should createWorkspace", async () => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1702917379651279)

## How to test
<!-- Provide steps to test this PR -->

- Open this PR with Gitpod
- Exec `cd components/server && yarn build && yarn test:unit` should work and pass

<img width="983" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/1d527af6-797b-4875-9786-060234352986">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
