### PR TITLE
Make `gitpod org get` use the context's org by default

### DIFF
--- a/components/local-app/CHANGELOG.md
+++ b/components/local-app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated list of notable changes to the Gitpod CLI.
 
+## v1.0.5
+
+-  When getting the information about an org with `gitpod organization get`, use the currently active one from the context by default
+
 ## v1.0.4
 
 -  When opening / sshing into a stopped workspace, it will now be started automatically

--- a/components/local-app/cmd/organization-get.go
+++ b/components/local-app/cmd/organization-get.go
@@ -19,7 +19,7 @@ import (
 var organizationGetCmd = &cobra.Command{
 	Use:   "get [organization-id]",
 	Short: "Retrieves metadata about a given organization",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			cfg := config.FromContext(cmd.Context())


### PR DESCRIPTION
## Description

Previously, you would have to provide an organization ID for the `gitpod org get` command, which was quite impractical. With this change, the ID is inferred from the active context.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1074

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
