### PR TITLE
[obs] tune GitpodWorkspaceStuckOnStoppingMk2 alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -18,12 +18,16 @@ spec:
       labels:
         severity: critical
         dedicated: included
-      for: 30m
+      for: 20m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
-        summary: 15 or more workspaces are stuck on stopping in cluster {{ $labels.cluster }}.
-        description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.'
+        summary: '{{ printf "%.2f" $value }}% of Regular workspaces stopping in {{ $labels.cluster }}'
+        description: '{{ printf "%.2f" $value }}% of Regular workspaces stopping in {{ $labels.cluster }} is too high.'
       expr: |
+        sum(
+          gitpod_ws_manager_mk2_workspace_phase_total{type="Regular", phase="Stopping", cluster!~"ephemeral.*"}) / sum(gitpod_ws_manager_mk2_workspace_phase_total{type="Regular", cluster!~"ephemeral.*"}
+        ) >= .2
+        and
         sum(
           gitpod_ws_manager_mk2_workspace_phase_total{type="Regular", phase="Stopping", cluster!~"ephemeral.*"}
         ) without(phase) > 15


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This alert fired 8 times for us107 since Dec 23, each time the operator followed the run book, but, no action was required. Let's make it more difficult for the alert to fire, to avoid unnecessary escalations to on-call.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
[Compare](https://grafana.gitpod.io/explore?panes=%7B%22Mkx%22:%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%28cluster%29%28gitpod_ws_manager_mk2_workspace_phase_total%7Btype%3D%5C%22Regular%5C%22,%20phase%3D%5C%22Stopping%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%29%20%2F%20sum%20by%28cluster%29%20%28gitpod_ws_manager_mk2_workspace_phase_total%7Btype%3D%5C%22Regular%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%29%20%3E%20.2%5Cr%5Cnand%5Cr%5Cn%20sum%20by%28cluster%29%28%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20gitpod_ws_manager_mk2_workspace_phase_total%7Btype%3D%5C%22Regular%5C%22,%20phase%3D%5C%22Stopping%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%29%20%3E%3D%2015%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D,%22hqW%22:%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%20sum%20by%28cluster%29%28%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20gitpod_ws_manager_mk2_workspace_phase_total%7Btype%3D%5C%22Regular%5C%22,%20phase%3D%5C%22Stopping%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%29%20%3E%3D%2015%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1) how there are less eligible data points. This change brings it down to one, and the one did not last for 20m, so, the alert would not have fired.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
