### PR TITLE
[usage] track email for free allowance

### DIFF
--- a/components/gitpod-db/go/cost_center.go
+++ b/components/gitpod-db/go/cost_center.go
@@ -157,17 +157,33 @@ func (c *CostCenterManager) getSpendingLimitForNewCostCenter(attributionID Attri
 	// check if the user has already granted free credits to another org
 	type FreeCredit struct {
 		UserID         uuid.UUID `gorm:"primary_key;column:userId;type:char(36)"`
+		Email          string    `gorm:"column:email;type:varchar(255)"`
 		OrganizationID uuid.UUID `gorm:"column:organizationId;type:char(36)"`
+	}
+
+	// fetch primaryEmail from d_b_identity
+	var primaryEmail string
+	db = c.conn.Raw(`
+		SELECT primaryEmail
+		FROM d_b_identity
+		WHERE
+			userid = ?
+		LIMIT 1
+	`, userId).Scan(&primaryEmail)
+	if db.Error != nil {
+		log.WithError(db.Error).WithField("attributionId", attributionID).Error("Failed to get primaryEmail for user.")
+		return c.cfg.ForTeams
 	}
 
 	var freeCredit FreeCredit
 
 	// check if the user has already granted free credits to another org
-	db = c.conn.Table("d_b_free_credits").Where(&FreeCredit{UserID: userUUID}).First(&freeCredit)
+	db = c.conn.Table("d_b_free_credits").Where(&FreeCredit{UserID: userUUID}).Or(
+		&FreeCredit{Email: primaryEmail}).First(&freeCredit)
 	if db.Error != nil {
 		if errors.Is(db.Error, gorm.ErrRecordNotFound) {
 			// no record was found, so let's insert a new one
-			freeCredit = FreeCredit{UserID: userUUID, OrganizationID: orgUUID}
+			freeCredit = FreeCredit{UserID: userUUID, Email: primaryEmail, OrganizationID: orgUUID}
 			db = c.conn.Table("d_b_free_credits").Save(&freeCredit)
 			if db.Error != nil {
 				log.WithError(db.Error).WithField("attributionId", attributionID).Error("Failed to insert free credits.")

--- a/components/gitpod-db/src/typeorm/migration/1704350022475-TrackEmailForFreeCredits.ts
+++ b/components/gitpod-db/src/typeorm/migration/1704350022475-TrackEmailForFreeCredits.ts
@@ -5,7 +5,7 @@
  */
 
 import { MigrationInterface, QueryRunner } from "typeorm";
-import { columnExists } from "./helper/helper";
+import { columnExists, indexExists } from "./helper/helper";
 
 export class TrackEmailForFreeCredits1704350022475 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
@@ -13,6 +13,20 @@ export class TrackEmailForFreeCredits1704350022475 implements MigrationInterface
         const column = "email";
         if (!(await columnExists(queryRunner, table, column))) {
             await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN ${column} varchar(255) NULL`);
+        }
+
+        const indexNameUserId = "ind_userId";
+        const indexNameEmail = "ind_email";
+        if (!(await indexExists(queryRunner, table, indexNameUserId))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${table}\` ADD INDEX \`${indexNameUserId}\` (userId), ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+
+        if (!(await indexExists(queryRunner, table, indexNameEmail))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${table}\` ADD INDEX \`${indexNameEmail}\` (email), ALGORITHM=INPLACE, LOCK=NONE`,
+            );
         }
     }
 

--- a/components/gitpod-db/src/typeorm/migration/1704350022475-TrackEmailForFreeCredits.ts
+++ b/components/gitpod-db/src/typeorm/migration/1704350022475-TrackEmailForFreeCredits.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class TrackEmailForFreeCredits1704350022475 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = "d_b_free_credits";
+        const column = "email";
+        if (!(await columnExists(queryRunner, table, column))) {
+            await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN ${column} varchar(255) NULL`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

adds email tracking to free allowance

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1078

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-trackemail</li>
	<li><b>🔗 URL</b> - <a href="https://se-trackemail.preview.gitpod-dev.com/workspaces" target="_blank">se-trackemail.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-trackemail-gha.22114</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-trackemail%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
