### PR TITLE
[dashboard] add dashboard UX load state metric

### DIFF
--- a/components/dashboard/src/app/AppBlockingFlows.tsx
+++ b/components/dashboard/src/app/AppBlockingFlows.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, lazy } from "react";
+import { ReactNode, lazy, useEffect } from "react";
 import { useShowDedicatedSetup } from "../dedicated-setup/use-show-dedicated-setup";
 import { useCurrentUser } from "../user-context";
 import { useShowUserOnboarding } from "../onboarding/use-show-user-onboarding";
@@ -17,12 +17,19 @@ const DedicatedSetup = lazy(() => import(/* webpackPrefetch: true */ "../dedicat
 
 // This component handles any flows that should come after we've loaded the user/orgs, but before we render the normal app chrome.
 // Since this runs before the app is rendered, we should avoid adding any lengthy async calls that would delay the app from loading.
-export const AppBlockingFlows: FC = ({ children }) => {
+export const AppBlockingFlows = ({ children, onReady }: { children: ReactNode; onReady?: () => void }) => {
     const history = useHistory();
     const user = useCurrentUser();
     const org = useCurrentOrg();
     const showDedicatedSetup = useShowDedicatedSetup();
     const showUserOnboarding = useShowUserOnboarding();
+
+    useEffect(() => {
+        // once user is loaded, page is not blocking
+        if (onReady && user) {
+            onReady();
+        }
+    }, [user, onReady]);
 
     // This shouldn't happen, but if it does don't render anything yet
     if (!user) {

--- a/components/dashboard/src/data/performance/measure-app-loading.ts
+++ b/components/dashboard/src/data/performance/measure-app-loading.ts
@@ -92,6 +92,7 @@ function observeHistogramWithBeacon(name: string, labels: Record<string, string>
     if (DEBUG) {
         console.log("====observeHistogramWithBeacon", name, labels, value);
     }
+    labels.source = "beacon";
     return navigator.sendBeacon(`${metricsUrl}/metrics/histogram/observe/${name}`, JSON.stringify({ labels, value }));
 }
 
@@ -99,6 +100,7 @@ async function observeHistogram(name: string, labels: Record<string, string>, va
     if (DEBUG) {
         console.log("====observeHistogram", name, labels, value);
     }
+    labels.source = "fetch";
     const url = `${metricsUrl}/metrics/histogram/observe/${name}`;
     try {
         const response = await fetch(url, {

--- a/components/dashboard/src/data/performance/measure-app-loading.ts
+++ b/components/dashboard/src/data/performance/measure-app-loading.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+
+const metricName = "gitpod_dashboard_page_navigation_duration_seconds";
+const metricsUrl = new GitpodHostUrl(window.location.href).withoutWorkspacePrefix().asIDEMetrics().toString();
+const maxDuration = 30000; // 30 seconds
+const DEBUG = true;
+
+type ProcessEvent = "userLoaded" | "orgsLoaded" | "appLoaded";
+interface Result {
+    complete: () => void;
+    setShouldSend: (shouldSend: boolean) => void;
+}
+const eventState: Record<ProcessEvent, { sent: boolean; started: boolean; storedResult?: Result }> = {
+    userLoaded: { sent: false, started: false },
+    orgsLoaded: { sent: false, started: false },
+    appLoaded: { sent: false, started: false },
+};
+
+// firstScreenLoggedIn is used to determine if the user is logged in on the first screen.
+// if the user is not logged in, we don't report orgsLoaded and appLoaded because <Login> can cost a lot of time.
+let _firstScreenLoggedIn: undefined | boolean = undefined;
+export const firstScreenLoggedIn = {
+    get value() {
+        return _firstScreenLoggedIn;
+    },
+    set value(val: undefined | boolean) {
+        if (_firstScreenLoggedIn === undefined) {
+            _firstScreenLoggedIn = val;
+        }
+    },
+};
+
+export function measureProcessCompleteMetric(event: ProcessEvent, baseShouldSend: boolean = true): Result {
+    if (eventState[event].started) {
+        return eventState[event].storedResult!;
+    }
+    let shouldSend = baseShouldSend;
+    eventState[event].started = true;
+
+    let timer: NodeJS.Timeout | null;
+
+    // Must send after 10 seconds, 10 should be the max bucket of the histogram too.
+    timer = setTimeout(() => complete(), maxDuration);
+
+    const listener = () => {
+        if (!shouldSend || eventState[event].sent) {
+            return;
+        }
+        observeHistogramWithBeacon(metricName, { event }, getDuration());
+    };
+    window.addEventListener("unload", listener);
+
+    const clean = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+        window.removeEventListener("unload", listener);
+    };
+
+    const complete = async () => {
+        if (!shouldSend || eventState[event].sent) {
+            return;
+        }
+        const duration = getDuration();
+        clean();
+        eventState[event].sent = true;
+        await observeHistogram(metricName, { event }, duration);
+    };
+
+    const setShouldSend = (should: boolean) => {
+        shouldSend = should;
+    };
+
+    eventState[event].storedResult = { complete, setShouldSend };
+
+    return { complete, setShouldSend };
+}
+
+function getDuration() {
+    // peformance.now() returns the ms since navigation startTime (0)
+    return performance.now() / 1000;
+}
+
+function observeHistogramWithBeacon(name: string, labels: Record<string, string>, value: number) {
+    if (DEBUG) {
+        console.log("====observeHistogramWithBeacon", name, labels, value);
+    }
+    return navigator.sendBeacon(`${metricsUrl}/metrics/histogram/observe/${name}`, JSON.stringify({ labels, value }));
+}
+
+async function observeHistogram(name: string, labels: Record<string, string>, value: number) {
+    if (DEBUG) {
+        console.log("====observeHistogram", name, labels, value);
+    }
+    const url = `${metricsUrl}/metrics/histogram/observe/${name}`;
+    try {
+        const response = await fetch(url, {
+            method: "POST",
+            body: JSON.stringify({ labels, value }),
+            credentials: "omit",
+        });
+        if (!response.ok) {
+            const data = await response.json(); // { code: number; message: string; }
+            console.error(
+                `Cannot report metrics with observeHistogram: ${response.status} ${response.statusText}`,
+                data,
+            );
+            return false;
+        }
+        return true;
+    } catch (err) {
+        console.error("Cannot report metrics with observeHistogram, error:", err);
+        return false;
+    }
+}

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -397,6 +397,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			Buckets: []float64{0.1, 0.5, 1, 5, 10, 15, 30},
+		}, {
+			Name: "gitpod_dashboard_page_navigation_duration_seconds",
+			Help: "Duration of dashboard process loaded in seconds",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "event",
+					AllowValues: []string{"*"},
+				},
+			},
+			Buckets: []float64{0.1, 0.5, 1, 3, 5, 10, 15, 30},
 		},
 	}
 

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -405,6 +405,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Name:        "event",
 					AllowValues: []string{"*"},
 				},
+				{
+					Name:        "source",
+					AllowValues: []string{"beacon", "fetch"},
+				},
 			},
 			Buckets: []float64{0.1, 0.5, 1, 3, 5, 10, 15, 30},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**TODO**
- [ ] Remove debug loggings
- [ ] Export metric on Cloud and Dedicated

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1703242904484589?thread_ts=1703225279.650859&cid=C05H5UQBW6Q)

## How to test
<!-- Provide steps to test this PR -->

Preview env https://hw-dashboard-metric.preview.gitpod-dev.com/workspaces
- It should report metric when user load / reload / refresh dashboard (check via `DevTools.Console` with `preserve log`(beacon) checked)
- Open this PR with Gitpod, exec command to open prometheus `./dev/preview/portforward-monitoring-satellite.sh`
- There should be metric like `gitpod_dashboard_page_navigation_duration_seconds_bucket` recored
- You can check with P95 bucket too `histogram_quantile(0.95, sum(rate(gitpod_dashboard_page_navigation_duration_seconds_bucket[5m])) by (le))`

**Test Results** 🧑‍💻 

- Before logged in, we only send userLoaded (loaded with not logged in state), other metrics will not send because <Login> can stuck by user behaviors

Metric is affecting by `ListOrganizations` API, so we can change server to sleep 4 seconds or 44 seconds to see the behaviors of dashboard

**Not Sleep**

- Dashboard looks good and report metrics
<img width="813" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/613c905c-61c7-47a9-bdb3-f73f794d6ce9">

**Sleep 4 seconds**

- Dashboard shows hanging page for seconds then report
<img width="873" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/db404e14-ed50-45c3-bbe0-a7d836c0c377">

**Sleep 44 seconds**
- Dashboard stuck in hanging page for 44+ seconds, metrics are reported after around 30 performance seconds, that's because we force report after 30s

<img width="872" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/d8a65038-420d-4b06-ad54-51214c8d5cd6">

**Sleep 44 seconds and refresh dashboard before force 30s reporting**

- Refresh page before 30s force metric reporting, will send false positive metrics via [Beacon](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API)
- `ide-metric` received requests from Beacon
<img width="879" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/e484e46b-e1ca-470f-a4d7-c1ed6fa7349d">
<img width="1866" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/0bdcc0df-efaf-49f6-9629-5d97aaed9396">



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
