### PR TITLE
Fix button gap

### DIFF
--- a/components/dashboard/src/components/podkit/buttons/Button.tsx
+++ b/components/dashboard/src/components/podkit/buttons/Button.tsx
@@ -10,7 +10,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@podkit/lib/cn";
 
 export const buttonVariants = cva(
-    "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+    "inline-flex gap-1.5 items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
     {
         variants: {
             variant: {

--- a/components/dashboard/src/components/podkit/buttons/Button.tsx
+++ b/components/dashboard/src/components/podkit/buttons/Button.tsx
@@ -10,7 +10,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@podkit/lib/cn";
 
 export const buttonVariants = cva(
-    "inline-flex gap-1.5 items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+    "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
     {
         variants: {
             variant: {

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -27,7 +27,7 @@ export const EmptyWorkspacesContent = () => {
                         </a>
                     </Subheading>
                     <span>
-                        <LinkButton href={"/new"} className="gap-1">
+                        <LinkButton href={"/new"} className="gap-1.5">
                             New Workspace{" "}
                             <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
                         </LinkButton>

--- a/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
@@ -68,7 +68,7 @@ export const WorkspacesSearchBar: FunctionComponent<WorkspacesSearchBarProps> = 
                 />
             </div>
             <Link to={"/new"}>
-                <Button className="ml-2">
+                <Button className="ml-2 gap-1.5">
                     New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
                 </Button>
             </Link>


### PR DESCRIPTION
## Description

Fixes gap between button children on the New Workspace button

| Before | Now |
|--------|--------|
| <img width="543" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/d84487e0-ab8b-4bef-b13c-7c66c823273b"> |<img width="543" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/01279bb2-be4e-4fc4-a339-f302d1385b66"> | 


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes a [Slack-raised issue](https://gitpod.slack.com/archives/C065C7LC328/p1704455880714019).

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-button-gap-fix</li>
	<li><b>🔗 URL</b> - <a href="https://ft-button-gap-fix.preview.gitpod-dev.com/workspaces" target="_blank">ft-button-gap-fix.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-button-gap-fix-gha.22153</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-button-gap-fix%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
