### PR TITLE
[UX] Refactor Tab menu styles to highlight active state

### DIFF
--- a/components/dashboard/src/components/TabMenuItem.tsx
+++ b/components/dashboard/src/components/TabMenuItem.tsx
@@ -15,7 +15,7 @@ export default function TabMenuItem(p: {
     const classes =
         "cursor-pointer py-2 px-4 border-b-4 transition ease-in-out " +
         (p.selected
-            ? "text-gray-600 dark:text-gray-400 border-gray-400 dark:border-gray-600"
+            ? "text-gray-600 dark:text-gray-400 border-gray-700 dark:border-gray-400"
             : "text-gray-400 dark:text-gray-600 border-transparent hover:border-gray-400 dark:hover:border-gray-600");
     return !p.link || p.link.startsWith("https://") ? (
         <a className={classes} href={p.link} onClick={p.onClick} data-analytics='{"button_type":"tab_menu"}'>

--- a/components/dashboard/src/components/TabMenuItem.tsx
+++ b/components/dashboard/src/components/TabMenuItem.tsx
@@ -13,10 +13,10 @@ export default function TabMenuItem(p: {
     onClick?: (event: React.MouseEvent) => void;
 }) {
     const classes =
-        "cursor-pointer py-2 px-4 border-b-4 border-transparent transition ease-in-out " +
+        "cursor-pointer py-2 px-4 border-b-4 transition ease-in-out " +
         (p.selected
-            ? "text-gray-600 dark:text-gray-400 border-gray-700 dark:border-gray-400"
-            : "text-gray-400 dark:text-gray-600 hover:border-gray-400 dark:hover:border-gray-600");
+            ? "text-gray-600 dark:text-gray-400 border-gray-400 dark:border-gray-600"
+            : "text-gray-400 dark:text-gray-600 border-transparent hover:border-gray-400 dark:hover:border-gray-600");
     return !p.link || p.link.startsWith("https://") ? (
         <a className={classes} href={p.link} onClick={p.onClick} data-analytics='{"button_type":"tab_menu"}'>
             {p.name}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**Before:**

https://github.com/gitpod-io/gitpod/assets/55068936/8dabbea9-06d7-48e4-80c8-482c78e3f38e

**After:**


https://github.com/gitpod-io/gitpod/assets/55068936/1996ac29-2c9c-4e68-a87e-e306f0903514



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1108

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-efd585fc0b0</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-efd585fc0b0.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-efd585fc0b0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-1108-ux-borders-are-missing-on-selected-tab-menu-state-gha.22193</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-efd585fc0b0%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
