### PR TITLE
Add helper function to process repo URL in create project modal

### DIFF
--- a/components/dashboard/src/projects/create-project-modal/CreateProjectModal.tsx
+++ b/components/dashboard/src/projects/create-project-modal/CreateProjectModal.tsx
@@ -26,6 +26,21 @@ export const CreateProjectModal: FC<Props> = ({ onClose, onCreated }) => {
     const createProject = useCreateProject();
     const [createErrorMsg, setCreateErrorMsg] = useTemporaryState("", 3000);
 
+    // Helper function to process the URL to handle the case where user passed some issues, pulls, branches or files url.
+    const processRepoUrl = (url: string): string => {
+        /**
+         * RegEx explaination:
+         * ^(https?:\/\/)?: This part optionally matches the http or https scheme.
+         * ([\w.-]+): This part matches the hostname (like github.com). \w matches any word character (alphanumeric plus underscore), and . and - match literal periods and hyphens, which are common in domain names.
+         * \/: This matches the forward slash / separator.
+         * ([\w.-]+): This matches the repository owner's username.
+         * \/: Another forward slash as a separator.
+         * ([\w.-]+): This matches the repository name.
+         */
+        const regex = /^(https?:\/\/)?([\w.-]+)\/([\w.-]+)\/([\w.-]+)/;
+        return url.split(regex).slice(1, 5).join("/");
+    };
+
     const handleSubmit = useCallback(() => {
         if (!selectedRepo) {
             setCreateErrorMsg("Please select a repository");
@@ -37,7 +52,7 @@ export const CreateProjectModal: FC<Props> = ({ onClose, onCreated }) => {
             name: "",
             // deprecated
             slug: "",
-            cloneUrl: selectedRepo.url,
+            cloneUrl: processRepoUrl(selectedRepo.url),
             appInstallationId: "",
         };
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**Before**:


https://github.com/gitpod-io/gitpod/assets/55068936/8235e949-fe25-4c17-92b5-df94b9c234e8

**After**:


https://github.com/gitpod-io/gitpod/assets/55068936/0a4f6ee7-d749-484b-bc60-7d3f17d1e61c



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1012

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment
- Connect GitHub/GitLab/Bitbucket
- Try with any GitHub/GitLab/Bitbucket repo's branch/file/pr/issues URL. Example:
    - `https://gitlab.com/Siddhant-K-code/team/-/tree/main/.gitlab?ref_type=heads`
    - `https://github.com/gitpod-io/gitpod/tree/aa/jam-dev-image`
    - `https://bitbucket.org/siddhant_gitpod/example/src/demo/.gitignore`
- See the difference, it would work now 🥳.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-exp-1012</li>
	<li><b>🔗 URL</b> - <a href="https://fix-exp-1012.preview.gitpod-dev.com/workspaces" target="_blank">fix-exp-1012.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-exp-1012-gha.22215</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-exp-1012%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
