### PR TITLE
[observability] update dashboard not all ready alert

### DIFF
--- a/operations/observability/mixins/meta/rules/dashboard.yaml
+++ b/operations/observability/mixins/meta/rules/dashboard.yaml
@@ -22,3 +22,14 @@ spec:
         summary: Dashboard has excessive CPU usage.
         description: Dashboard is consumming too much CPU. Please investigate.
         dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default
+    - alert: DashboardPodsAreNotAllInReadyState
+      expr: sum(kube_deployment_status_replicas_unavailable{deployment="dashboard"}) > 0
+      for: 5m
+      labels:
+        severity: critical
+        team: webapp
+        dedicated: included
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/DashboardStuckInPodInitState.md
+        summary: Dashboard stuck in PodInitializing state {{ $labels.cluster }}.
+        description: Dashboard is stuck in PodInitializing for at least 5 minutes

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -97,20 +97,6 @@ spec:
         description: Server is consumming too much CPU. Please investigate.
         dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default
 
-    - alert: DashboardStuckInPodInitState
-      # Reasoning: alert if dashboard is stuck in init more than 5 minute.
-      expr: sum(kube_pod_container_status_waiting_reason{container="dashboard", reason="PodInitializing"}) by (container) > 0
-      # Five minutes sound high, but that's the only value that's higher than recent history
-      for: 5m
-      labels:
-        severity: critical
-        team: webapp
-        dedicated: included
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/DashboardStuckInPodInitState.md
-        summary: Dashboard stuck in PodInitializing state {{ $labels.cluster }}.
-        description: Dashboard is stuck in PodInitializing for at least 5 minutes
-
     - alert: WebAppServicesCrashlooping
       # Reasoning: alert if any pod is stuck in crashlooping more than 5 minute.
       expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster, pod) > 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Switch to use `unavailable`, because `unavailable` are more common metric for alerts and has been exported already. [more context](https://github.com/gitpod-io/gitpod-dedicated/pull/2673#discussion_r1447972971)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [EXP-1049](https://linear.app/gitpod/issue/EXP-1049)
Relates https://github.com/gitpod-io/gitpod-dedicated/pull/2726

## How to test
<!-- Provide steps to test this PR -->

<img width="1913" alt="SCR-20240112-oqhn" src="https://github.com/gitpod-io/gitpod/assets/20944364/d3d3bc9e-d02d-4956-9198-e52fd453d582">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
