### PR TITLE
[server] fix db tests with test ctx wrap

### DIFF
--- a/components/server/src/auth/auth-provider-service.spec.db.ts
+++ b/components/server/src/auth/auth-provider-service.spec.db.ts
@@ -10,7 +10,7 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { UserService } from "../user/user-service";
 import { AuthProviderService } from "./auth-provider-service";
@@ -20,6 +20,7 @@ import { expectError } from "../test/expect-utils";
 import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
 import { AuthProviderParams } from "./auth-provider";
 import { OrganizationService } from "../orgs/organization-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -320,7 +321,7 @@ describe("AuthProviderService", async () => {
                 },
             });
             const invite = await orgService.getOrCreateInvite(currentUser.id, org.id);
-            await orgService.joinOrganization(member.id, invite.id);
+            await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
 
             const created = await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
             await service.markAsVerified({ userId: currentUser.id, id: created.id });
@@ -350,7 +351,7 @@ describe("AuthProviderService", async () => {
                 },
             });
             const invite = await orgService.getOrCreateInvite(currentUser.id, org.id);
-            await orgService.joinOrganization(member.id, invite.id);
+            await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
 
             const created = await service.createOrgAuthProvider(currentUser.id, newOrgEntry());
             await service.markAsVerified({ userId: currentUser.id, id: created.id });

--- a/components/server/src/orgs/usage-service.spec.db.ts
+++ b/components/server/src/orgs/usage-service.spec.db.ts
@@ -20,12 +20,13 @@ import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
 import { Mock } from "../test/mocks/mock";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { OrganizationService } from "./organization-service";
 import { UsageService } from "./usage-service";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { expectError } from "../test/expect-utils";
 import { UserService } from "../user/user-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -65,7 +66,7 @@ describe("UsageService", async () => {
                 authId: "1234",
             },
         });
-        await os.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => os.joinOrganization(member.id, invite.id));
 
         stranger = await userService.createUser({
             identity: {

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -17,6 +17,7 @@ import { expectError } from "../test/expect-utils";
 import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { OldProjectSettings, ProjectsService } from "./projects-service";
 import { daysBefore } from "@gitpod/gitpod-protocol/lib/util/timeutil";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -46,10 +47,10 @@ describe("ProjectsService", async () => {
         // create and add a member
         member = await userDB.newUser();
         const invite = await orgService.getOrCreateInvite(owner.id, org.id);
-        await orgService.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
 
         const anotherInvite = await orgService.getOrCreateInvite(owner.id, anotherOrg.id);
-        await orgService.joinOrganization(member.id, anotherInvite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, anotherInvite.id));
 
         // create a stranger
         stranger = await userDB.newUser();

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -18,7 +18,7 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
@@ -26,6 +26,7 @@ import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { EnvVarService } from "./env-var-service";
 import { ProjectsService } from "../projects/projects-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -109,7 +110,7 @@ describe("EnvVarService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await orgService.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",

--- a/components/server/src/user/gitpod-token-service.spec.db.ts
+++ b/components/server/src/user/gitpod-token-service.spec.db.ts
@@ -10,13 +10,14 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
 import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { GitpodTokenService } from "./gitpod-token-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -48,7 +49,7 @@ describe("GitpodTokenService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await orgService.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -10,13 +10,14 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { SSHKeyService } from "./sshkey-service";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
 import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -59,7 +60,7 @@ describe("SSHKeyService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await orgService.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",

--- a/components/server/src/workspace/context-service.spec.db.ts
+++ b/components/server/src/workspace/context-service.spec.db.ts
@@ -22,7 +22,7 @@ import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
 import { OrganizationService } from "../orgs/organization-service";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { WorkspaceService } from "./workspace-service";
 import { ProjectsService } from "../projects/projects-service";
 import { UserService } from "../user/user-service";
@@ -35,6 +35,7 @@ import { PrebuildManager } from "../prebuilds/prebuild-manager";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { AuthProvider } from "../auth/auth-provider";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -196,7 +197,7 @@ describe("ContextService", async () => {
                 },
             });
             const invite = await orgService.getOrCreateInvite(owner.id, org.id);
-            await orgService.joinOrganization(member.id, invite.id);
+            await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
 
             // create a project
             const projectService = container.get(ProjectsService);

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -22,11 +22,12 @@ import { Container } from "inversify";
 import "mocha";
 import { OrganizationService } from "../orgs/organization-service";
 import { expectError } from "../test/expect-utils";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
 import { WorkspaceService } from "./workspace-service";
 import { ProjectsService } from "../projects/projects-service";
 import { ConfigProvider } from "./config-provider";
 import { UserService } from "../user/user-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -75,7 +76,7 @@ describe("WorkspaceService", async () => {
             },
         });
         const invite = await orgService.getOrCreateInvite(owner.id, org.id);
-        await orgService.joinOrganization(member.id, invite.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
 
         // create a project
         const projectService = container.get(ProjectsService);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix db test cases

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Open this PR with Gitpod
```
cd components/server
yarn build && yarn test:db
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
