### PR TITLE
[gpctl] add `users unblock` command

### DIFF
--- a/dev/gpctl/cmd/users-block.go
+++ b/dev/gpctl/cmd/users-block.go
@@ -8,9 +8,6 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-
-	"github.com/gitpod-io/gitpod/common-go/log"
-	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 )
 
 // usersBlockCmd represents the describe command
@@ -21,25 +18,7 @@ var usersBlockCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
-		client, err := newLegacyAPIConn()
-		if err != nil {
-			log.WithError(err).Fatal("cannot connect")
-		}
-		defer client.Close()
-
-		for _, uid := range args {
-			err = client.AdminBlockUser(ctx, &protocol.AdminBlockUserRequest{
-				UserID:    uid,
-				IsBlocked: true,
-			})
-			if err != nil {
-				log.WithError(err).Error("cannot block user")
-			} else {
-				log.WithField("uid", uid).Info("user blocked")
-			}
-		}
-
+		blockUser(ctx, args, true)
 	},
 }
 

--- a/dev/gpctl/cmd/users-unblock.go
+++ b/dev/gpctl/cmd/users-unblock.go
@@ -8,9 +8,6 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-
-	"github.com/gitpod-io/gitpod/common-go/log"
-	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 )
 
 // usersUnblockCmd represents the describe command
@@ -21,25 +18,7 @@ var usersUnblockCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
-		client, err := newLegacyAPIConn()
-		if err != nil {
-			log.WithError(err).Fatal("cannot connect")
-		}
-		defer client.Close()
-
-		for _, uid := range args {
-			err = client.AdminBlockUser(ctx, &protocol.AdminBlockUserRequest{
-				UserID:    uid,
-				IsBlocked: false,
-			})
-			if err != nil {
-				log.WithError(err).Error("cannot unblock user")
-			} else {
-				log.WithField("uid", uid).Info("user unblocked")
-			}
-		}
-
+		blockUser(ctx, args, false)
 	},
 }
 

--- a/dev/gpctl/cmd/users-unblock.go
+++ b/dev/gpctl/cmd/users-unblock.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+)
+
+// usersUnblockCmd represents the describe command
+var usersUnblockCmd = &cobra.Command{
+	Use:   "unblock <userID> ... <userID>",
+	Short: "unblocks a user",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		client, err := newLegacyAPIConn()
+		if err != nil {
+			log.WithError(err).Fatal("cannot connect")
+		}
+		defer client.Close()
+
+		for _, uid := range args {
+			err = client.AdminBlockUser(ctx, &protocol.AdminBlockUserRequest{
+				UserID:    uid,
+				IsBlocked: false,
+			})
+			if err != nil {
+				log.WithError(err).Error("cannot unblock user")
+			} else {
+				log.WithField("uid", uid).Info("user unblocked")
+			}
+		}
+
+	},
+}
+
+func init() {
+	usersCmd.AddCommand(usersUnblockCmd)
+}

--- a/dev/gpctl/cmd/users.go
+++ b/dev/gpctl/cmd/users.go
@@ -5,11 +5,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	api "github.com/gitpod-io/gitpod/gitpod-protocol"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -55,4 +57,27 @@ func newLegacyAPIConn() (*api.APIoverJSONRPC, error) {
 	}
 
 	return conn, nil
+}
+
+func blockUser(ctx context.Context, args []string, block bool) {
+	client, err := newLegacyAPIConn()
+	if err != nil {
+		log.WithError(err).Fatal("cannot connect")
+	}
+	defer client.Close()
+
+	for _, uid := range args {
+		err = client.AdminBlockUser(ctx, &protocol.AdminBlockUserRequest{
+			UserID:    uid,
+			IsBlocked: block,
+		})
+		if err != nil {
+			log.WithField("uid", uid).WithField("block", block).Errorf("AdminBlockUser failed with: %v", err)
+			return
+		} else {
+			log.WithField("uid", uid).WithField("block", block).Info("AdminBlockUser")
+			return
+		}
+	}
+	log.Fatal("no args")
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To help automate unblocking users

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
Got a preview environment created with `leeway run dev:preview`.

Made myself an admin via `leeway run components:make-user-admin`

Got an access token, and ran the below tests from a workspace in the preview environment from this branch:

```bash
# stops the workspaces and blocks the user
go run . users block --token $TOKEN --address wss://kylos101-u73aa6162e2.preview.gitpod-dev.com/api/v1 f66c4875-42d9-4a51-955e-b80b788cdfcc
# cannot really test w/o another person
go run . users unblock --token $TOKEN --address wss://kylos101-u73aa6162e2.preview.gitpod-dev.com/api/v1 f66c4875-42d9-4a51-955e-b80b788cdfcc
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
