### PR TITLE
Revert "Redirect on workspace stop"

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -221,7 +221,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         this.workspace = workspaceResponse.workspace!;
         this.user = user;
         this.ideCredentials = ideCredentials;
-        const reconcile = async (status?: WorkspaceStatus) => {
+        const reconcile = (status?: WorkspaceStatus) => {
             const info = this.parseInfo(status ?? this.workspace.status!);
             this.latestInfo = info;
             const oldInstanceID = this.instanceID;
@@ -231,15 +231,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             if (info.instanceId && oldInstanceID !== info.instanceId) {
                 this.auth();
             }
-
-            // Redirect to custom url
-            if (
-                (info.statusPhase === "stopping" || info.statusPhase === "stopped") &&
-                info.workspaceType === "regular"
-            ) {
-                await this.redirectToCustomUrl(info);
-            }
-
             this.sendInfoUpdate(this.latestInfo);
         };
         reconcile();
@@ -262,37 +253,6 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             credentialsToken: this.ideCredentials,
             ownerId: this.workspace.metadata?.ownerId ?? "",
         };
-    }
-
-    private async redirectToCustomUrl(info: IDEFrontendDashboardService.Info) {
-        const isDataOps = await getExperimentsClient().getValueAsync("dataops", false, {
-            user: { id: this.user!.id },
-            gitpodHost: gitpodHostUrl.toString(),
-        });
-        const dataOpsRedirectUrl = await getExperimentsClient().getValueAsync("dataops_redirect_url", "undefined", {
-            user: { id: this.user!.id },
-            gitpodHost: gitpodHostUrl.toString(),
-        });
-
-        if (!isDataOps) {
-            return;
-        }
-
-        try {
-            const params: Record<string, string> = { workspaceID: info.workspaceID };
-            let redirectURL: string;
-            if (dataOpsRedirectUrl === "undefined") {
-                redirectURL = this.workspace.metadata?.originalContextUrl ?? "";
-            } else {
-                redirectURL = dataOpsRedirectUrl;
-                params.contextURL = this.workspace.metadata?.originalContextUrl ?? "";
-            }
-            const url = new URL(redirectURL);
-            url.search = new URLSearchParams(params).toString();
-            this.relocate(url.toString());
-        } catch {
-            console.error("Invalid redirect URL");
-        }
     }
 
     // implements

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -63,8 +63,8 @@ IDEWebSocket.install();
 const ideService = IDEFrontendService.create();
 const loadingIDE = new Promise((resolve) => window.addEventListener("DOMContentLoaded", resolve, { once: true }));
 const toStop = new DisposableCollection();
-let willRedirect = false;
 
+document.body.style.visibility = "hidden";
 LoadingFrame.load().then(async (loading) => {
     const frontendDashboardServiceClient = loading.frontendDashboardServiceClient;
     await frontendDashboardServiceClient.initialize();
@@ -72,10 +72,6 @@ LoadingFrame.load().then(async (loading) => {
     if (frontendDashboardServiceClient.latestInfo.workspaceType !== "regular") {
         return;
     }
-
-    frontendDashboardServiceClient.onWillRedirect(() => {
-        willRedirect = true;
-    });
 
     document.title = frontendDashboardServiceClient.latestInfo.workspaceDescription ?? "gitpod";
     window.gitpod.loggedUserID = frontendDashboardServiceClient.latestInfo.loggedUserId;
@@ -163,11 +159,11 @@ LoadingFrame.load().then(async (loading) => {
         };
         const updateCurrentFrame = () => {
             const newCurrent = nextFrame();
-            if (current === newCurrent || willRedirect) {
+            if (current === newCurrent) {
                 return;
             }
-            current.classList.toggle("hidden", true);
-            newCurrent.classList.toggle("hidden", false);
+            current.style.visibility = "hidden";
+            newCurrent.style.visibility = "visible";
             if (current === document.body) {
                 while (document.body.firstChild && document.body.firstChild !== newCurrent) {
                     document.body.removeChild(document.body.firstChild);

--- a/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
+++ b/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
@@ -21,9 +21,6 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
     private readonly onOpenBrowserIDEEmitter = new Emitter<void>();
     readonly onOpenBrowserIDE = this.onOpenBrowserIDEEmitter.event;
 
-    private readonly onWillRedirectEmitter = new Emitter<void>();
-    readonly onWillRedirect = this.onWillRedirectEmitter.event;
-
     private resolveInit!: () => void;
     private initPromise = new Promise<void>((resolve) => (this.resolveInit = resolve));
 
@@ -53,7 +50,6 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
                 this.onDidChangeEmitter.fire(this.latestInfo);
             }
             if (IDEFrontendDashboardService.isRelocateEventData(event.data)) {
-                this.onWillRedirectEmitter.fire();
                 window.location.href = event.data.url;
             }
             if (IDEFrontendDashboardService.isOpenBrowserIDE(event.data)) {

--- a/components/supervisor/frontend/src/shared/index.css
+++ b/components/supervisor/frontend/src/shared/index.css
@@ -15,8 +15,3 @@
   border: 0px;
   overflow: hidden;
 }
-
-.gitpod-frame.hidden {
-  width: 0px;
-  height: 0px;
-}

--- a/components/supervisor/frontend/src/shared/loading-frame.ts
+++ b/components/supervisor/frontend/src/shared/loading-frame.ts
@@ -14,6 +14,7 @@ export function load(): Promise<{
     return new Promise((resolve) => {
         const frame = document.createElement("iframe");
         frame.src = startUrl.toString();
+        frame.style.visibility = "visible";
         frame.className = "gitpod-frame loading";
         document.body.prepend(frame);
 


### PR DESCRIPTION
#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - revert-193adcb124071</li>
	<li><b>🔗 URL</b> - <a href="https://revert-193adcb124071.preview.gitpod-dev.com/workspaces" target="_blank">revert-193adcb124071.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - revert-19314-jp-relaxed-canidae-gha.22280</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-revert-193adcb124071%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>


<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>