### PR TITLE
[db] add migration to alter pat table allow null expirationTime

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-personal-access-token.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-personal-access-token.ts
@@ -53,7 +53,7 @@ export class DBPersonalAccessToken {
     scopes: string[];
 
     @Column("datetime")
-    expirationTime: Date;
+    expirationTime: Date | null;
 
     @Column("datetime")
     createdAt: Date;

--- a/components/gitpod-db/src/typeorm/migration/1705393804800-PersonalAccessTokenAllowNullExpireDateonPAT.ts
+++ b/components/gitpod-db/src/typeorm/migration/1705393804800-PersonalAccessTokenAllowNullExpireDateonPAT.ts
@@ -10,12 +10,12 @@ const table = "d_b_personal_access_token";
 
 export class PersonalAccessTokenAllowNullExpireDateonPAT1705393804800 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE ${table} MODIFY expirationTime expirationTime timestamp(6) NULL`);
+        await queryRunner.query(`ALTER TABLE ${table} MODIFY expirationTime timestamp(6) NULL`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `ALTER TABLE ${table} CHANGE expirationTime expirationTime timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
+            `ALTER TABLE ${table} CHANGE expirationTime timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
         );
     }
 }

--- a/components/gitpod-db/src/typeorm/migration/1705393804800-PersonalAccessTokenAllowNullExpireDateonPAT.ts
+++ b/components/gitpod-db/src/typeorm/migration/1705393804800-PersonalAccessTokenAllowNullExpireDateonPAT.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const table = "d_b_personal_access_token";
+
+export class PersonalAccessTokenAllowNullExpireDateonPAT1705393804800 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE ${table} MODIFY expirationTime expirationTime timestamp(6) NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE ${table} CHANGE expirationTime expirationTime timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
+        );
+    }
+}

--- a/components/gitpod-db/src/typeorm/personal-access-token-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/personal-access-token-db-impl.ts
@@ -29,7 +29,7 @@ export class PersonalAccessTokenDBImpl implements PersonalAccessTokenDB {
         const pat = await repo
             .createQueryBuilder("pat")
             .where(`pat.hash = :hash`, { hash })
-            .andWhere(`pat.expirationTime > :expirationTime`, { expirationTime })
+            .andWhere(`pat.expirationTime > :expirationTime OR pat.expirationTime IS NULL`, { expirationTime })
             .andWhere(`pat.deleted = false`)
             .getOne();
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
DB migration part of https://github.com/gitpod-io/gitpod/pull/19327, split in case we need to do revert / rollback

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates EXP-1084

## How to test
<!-- Provide steps to test this PR -->
Should be tested in https://github.com/gitpod-io/gitpod/pull/19327

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
