### PR TITLE
[dashboard] Fix GitHub app integration URL in user settings

### DIFF
--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -97,7 +97,7 @@ function GitProviders() {
         const url = new URL(`https://${ap.host}`);
         switch (ap.type) {
             case AuthProviderType.GITHUB:
-                url.pathname = "settings/connections/applications/484069277e293e6d2a2a";
+                url.pathname = "settings/applications";
                 break;
             case AuthProviderType.GITLAB:
                 url.pathname = "-/profile/applications";

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -97,7 +97,7 @@ function GitProviders() {
         const url = new URL(`https://${ap.host}`);
         switch (ap.type) {
             case AuthProviderType.GITHUB:
-                url.pathname = "settings/developers";
+                url.pathname = "settings/connections/applications/484069277e293e6d2a2a";
                 break;
             case AuthProviderType.GITLAB:
                 url.pathname = "-/profile/applications";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Bug got introduced in #19057 (cc: @AlexTugarev), which confuses the `appRedirectUrl` with GitHub App settings url (which is a constant URL for every user with GitHub App Id). See linked linear issue for more details.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1152

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment & complete setup w/ GitHub as Git provider.
- Go to user integrations settings (`/user/integrations`) and click on three dots in `GitHub` item list.
- Click on <kbd>Manage on github.com</kbd> & see fixed URL.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e7c7afcfb57</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e7c7afcfb57.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e7c7afcfb57.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-1152-github-integration-manage-on-githubcom-button-takes-to-wrong-gha.22319</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e7c7afcfb57%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
