### PR TITLE
[server] fix BBS metadata `latest-commit-metadata` not defined cause prebuild trigger failed

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -499,7 +499,7 @@ export namespace BitbucketServer {
     }
 
     export interface BranchWithMeta extends Branch {
-        latestCommitMetadata: Commit;
+        latestCommitMetadata?: Commit;
         htmlUrl: string;
         metadata: {
             "com.atlassian.bitbucket.server.bitbucket-branch:latest-commit-metadata": Commit;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changes are based on:
- Field `latest-commit-metadata` will be undefined for some reason (base on information provided on issue EXP-1058). [[code refer](https://github.com/gitpod-io/gitpod/blob/903fc68587a70f4496a8e4c17a5404d8b0c7ccae/components/server/src/bitbucket-server/bitbucket-server-api.ts#L288-L289)] is not safe on Typescript that meta could be undefined 
- We only need `name` and `htmlUrl` field for prebuild trigger
- We can confirm that respond data must have fields without search params `details=true`, so we can make data based on it
  - https://bitbucket.gitpod-dev.com/rest/api/1.0/projects/MOR/repos/bb-extension-test/branches?details=true
  - https://bitbucket.gitpod-dev.com/rest/api/1.0/projects/MOR/repos/bb-extension-test/branches

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1058

## How to test
<!-- Provide steps to test this PR -->
No way to test. Review the code, and make sure logic will not break anything

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
