### PR TITLE
Fix & Refactor Git Integration settings modal

### DIFF
--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -699,10 +699,20 @@ export function GitIntegrationModal(
         let settingsUrl = ``;
         switch (type) {
             case AuthProviderType.GITHUB:
-                settingsUrl = `${host}/settings/developers`;
+                // if host is empty or untouched by user, use the default value
+                if (host === "") {
+                    settingsUrl = "github.com/settings/developers";
+                } else {
+                    settingsUrl = `${host}/settings/developers`;
+                }
                 break;
             case AuthProviderType.GITLAB:
-                settingsUrl = `${host}/-/profile/applications`;
+                // if host is empty or untouched by user, use the default value
+                if (host === "") {
+                    settingsUrl = "gitlab.com/-/profile/applications";
+                } else {
+                    settingsUrl = `${host}/-/profile/applications`;
+                }
                 break;
             default:
                 return undefined;
@@ -750,14 +760,10 @@ export function GitIntegrationModal(
     };
 
     const copyRedirectURI = () => {
-        const el = document.createElement("textarea");
-        el.value = callbackUrl;
-        document.body.appendChild(el);
-        el.select();
         try {
-            document.execCommand("copy");
-        } finally {
-            document.body.removeChild(el);
+            navigator.clipboard.writeText(callbackUrl);
+        } catch (error) {
+            console.error(error);
         }
     };
 
@@ -853,6 +859,7 @@ export function GitIntegrationModal(
                                 className="w-full pr-8"
                             />
                             <div className="cursor-pointer" onClick={() => copyRedirectURI()}>
+                                {/* TODO: Handle 'copied' state to change icon to green check mark for better UX */}
                                 <img
                                     src={copy}
                                     title="Copy the redirect URI to clipboard"

--- a/components/dashboard/src/user-settings/Integrations.tsx
+++ b/components/dashboard/src/user-settings/Integrations.tsx
@@ -17,7 +17,6 @@ import { ItemsList } from "../components/ItemsList";
 import { SpinnerLoader } from "../components/Loader";
 import Modal, { ModalBody, ModalHeader, ModalFooter } from "../components/Modal";
 import { Heading2, Subheading } from "../components/typography/headings";
-import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
 import { openAuthorizeWindow, toAuthProviderLabel } from "../provider-utils";
 import { gitpodHostUrl } from "../service/service";
@@ -41,6 +40,7 @@ import { useUpdateUserAuthProviderMutation } from "../data/auth-providers/update
 import { useDeleteUserAuthProviderMutation } from "../data/auth-providers/delete-user-auth-provider-mutation";
 import { Button } from "@podkit/buttons/Button";
 import { isOrganizationOwned } from "@gitpod/public-api-common/lib/user-utils";
+import { InputWithCopy } from "../components/InputWithCopy";
 
 export default function Integrations() {
     return (
@@ -759,14 +759,6 @@ export function GitIntegrationModal(
         }
     };
 
-    const copyRedirectURI = () => {
-        try {
-            navigator.clipboard.writeText(callbackUrl);
-        } catch (error) {
-            console.error(error);
-        }
-    };
-
     const getNumber = (paramValue: string | null) => {
         if (!paramValue) {
             return 0;
@@ -799,7 +791,7 @@ export function GitIntegrationModal(
                     </span>
                 </div>
 
-                <div className="overscroll-contain max-h-96 overflow-y-auto pr-2">
+                <div className="overscroll-contain max-h-96 space-y-4 overflow-y-auto pr-2">
                     {mode === "new" && (
                         <div className="flex flex-col space-y-2">
                             <label htmlFor="type" className="font-medium">
@@ -849,25 +841,7 @@ export function GitIntegrationModal(
                         <label htmlFor="redirectURI" className="font-medium">
                             Redirect URI
                         </label>
-                        <div className="w-full relative">
-                            <input
-                                id="redirectURI"
-                                disabled={true}
-                                readOnly={true}
-                                type="text"
-                                value={callbackUrl}
-                                className="w-full pr-8"
-                            />
-                            <div className="cursor-pointer" onClick={() => copyRedirectURI()}>
-                                {/* TODO: Handle 'copied' state to change icon to green check mark for better UX */}
-                                <img
-                                    src={copy}
-                                    title="Copy the redirect URI to clipboard"
-                                    className="absolute top-1/3 right-3"
-                                    alt="copy icon"
-                                />
-                            </div>
-                        </div>
+                        <InputWithCopy value={callbackUrl} tip="Copy the redirect URI to clipboard" />
                         <span className="text-gray-500 text-sm">{getRedirectUrlDescription(type, host)}</span>
                     </div>
                     <div className="flex flex-col space-y-2">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR fixes the integration settings URL and improves the copy functionality in the GitI Integration Modal component. Aligned the Copy input component to the modal and performs code cleanup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1182

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment
- Go to user settings
- Go to `Git providers` and Click <kbd>New Integration</kbd>

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-edde7213363</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-edde7213363.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-edde7213363.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-1182-developer-settings-urls-are-broken-in-new-git-integration-gha.22411</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-edde7213363%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
