### PR TITLE
[papi] better grpc code for application unimplemented

### DIFF
--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -95,7 +95,9 @@ import { ContextURL } from "@gitpod/gitpod-protocol/lib/context-url";
 import {
     Prebuild,
     PrebuildStatus,
-    PrebuildPhase, PrebuildPhase_Phase} from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
+    PrebuildPhase,
+    PrebuildPhase_Phase,
+} from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { InvalidGitpodYMLError, RepositoryNotFoundError, UnauthorizedRepositoryAccessError } from "./public-api-errors";
 import {
@@ -594,6 +596,9 @@ export class PublicAPIConverter {
             if (reason.code === ErrorCodes.PERMISSION_DENIED) {
                 return new ConnectError(reason.message, Code.PermissionDenied, undefined, undefined, reason);
             }
+            if (reason.code === ErrorCodes.UNIMPLEMENTED) {
+                return new ConnectError(reason.message, Code.Unimplemented, undefined, undefined, reason);
+            }
             if (reason.code === ErrorCodes.CONFLICT) {
                 return new ConnectError(reason.message, Code.AlreadyExists, undefined, undefined, reason);
             }
@@ -668,6 +673,9 @@ export class PublicAPIConverter {
                     return new ApplicationError(ErrorCodes.TOO_MANY_RUNNING_WORKSPACES, reason.rawMessage);
             }
             return new ApplicationError(ErrorCodes.PRECONDITION_FAILED, reason.rawMessage);
+        }
+        if (reason.code === Code.Unimplemented) {
+            return new ApplicationError(ErrorCodes.UNIMPLEMENTED, reason.rawMessage);
         }
         if (reason.code === Code.ResourceExhausted) {
             return new ApplicationError(ErrorCodes.TOO_MANY_REQUESTS, reason.rawMessage);
@@ -1139,7 +1147,7 @@ export class PublicAPIConverter {
         return PrebuildPhase_Phase.UNSPECIFIED;
     }
 
-    fromPrebuildPhase (status: PrebuildPhase_Phase): PrebuiltWorkspaceState | undefined {
+    fromPrebuildPhase(status: PrebuildPhase_Phase): PrebuiltWorkspaceState | undefined {
         switch (status) {
             case PrebuildPhase_Phase.QUEUED:
                 return "queued";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When server throw Unimplemented ApplicationError, gRPC clients will receive gRPC code `Unknown`. This PR is about to improve it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
https://hw-papi-unimplement.preview.gitpod-dev.com/workspaces

Generate PAT token in preview env and use it in https://github.com/mustard-mh/test/tree/gp/papi-example error message should include `unimplemented`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
