### PR TITLE
[dashboard] ux improvement on pat list

### DIFF
--- a/components/dashboard/src/user-settings/TokenEntry.tsx
+++ b/components/dashboard/src/user-settings/TokenEntry.tsx
@@ -67,7 +67,7 @@ function TokenEntry(props: TokenEntryProps) {
                 <span className="truncate whitespace-pre-line">{getScopes()}</span>
             </div>
             <div className="flex items-center w-3/12 text-gray-400">
-                <span className={"flex items-center gap-1 truncate" + (expiredInfo.expired ? " text-orange-600" : "")}>
+                <span className={"flex items-center gap-2 truncate" + (expiredInfo.expired ? " text-orange-600" : "")}>
                     {expiredInfo.tooltip && (
                         <Tooltip content={expiredInfo.tooltip.content}>{expiredInfo.tooltip.icon}</Tooltip>
                     )}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

change gap between icon to description to `8px`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1706112416774419?thread_ts=1705433151.541559&cid=C05H5UQBW6Q)

## How to test
<!-- Provide steps to test this PR -->
<img width="1397" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/f02a0697-eeca-41fa-bed4-5ce38327e278">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
