### PR TITLE
[openvsx-proxy] Pass in proxy settings as env vars

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -66,6 +66,29 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	const redisContainerName = "redis"
 
+	var proxyEnvVars []v1.EnvVar
+	if ctx.Config.Experimental != nil && ctx.Config.Experimental.WebApp != nil {
+		proxyConfig := ctx.Config.Experimental.WebApp.ProxySettings
+		if proxyConfig != nil {
+			proxyEnvVars = []v1.EnvVar{
+				{
+					Name:  "HTTP_PROXY",
+					Value: proxyConfig.HttpProxy,
+				},
+				{
+					Name:  "HTTPS_PROXY",
+					Value: proxyConfig.HttpsProxy,
+				},
+				{
+					Name:  "NO_PROXY",
+					Value: proxyConfig.HttpsProxy,
+				},
+			}
+
+		}
+
+	}
+
 	return []runtime.Object{&appsv1.StatefulSet{
 		TypeMeta: common.TypeMetaStatefulSet,
 		ObjectMeta: metav1.ObjectMeta{
@@ -136,6 +159,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
 							common.ConfigcatEnv(ctx),
+							proxyEnvVars,
 						)),
 					}, {
 						Name:  redisContainerName,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -209,6 +209,15 @@ type WebAppConfig struct {
 	SpiceDB                      *SpiceDBConfig         `json:"spicedb,omitempty"`
 	CertmanagerNamespaceOverride string                 `json:"certmanagerNamespaceOverride,omitempty"`
 	Redis                        *RedisConfig           `json:"redis"`
+
+	// ProxySettings is used if the gitpod cell uses some proxy for connectivity
+	ProxySettings *ProxySettings `json:"proxySettings"`
+}
+
+type ProxySettings struct {
+	HttpProxy  string `json:"http_proxy"`
+	HttpsProxy string `json:"https_proxy"`
+	NoProxy    string `json:"no_proxy"`
 }
 
 type WorkspaceDefaults struct {
@@ -342,6 +351,7 @@ type IDEMetricsConfig struct {
 // @deprecated
 type VSXProxyConfig struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
+	ExtraEnvVars       map[string]string `json:"extraEnvVars"`
 }
 
 type TracingSampleType string

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -351,7 +351,6 @@ type IDEMetricsConfig struct {
 // @deprecated
 type VSXProxyConfig struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
-	ExtraEnvVars       map[string]string `json:"extraEnvVars"`
 }
 
 type TracingSampleType string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the openvsx-proxy environment variable to have extra proxy settings if the cell is using a proxy
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
