### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -11,14 +11,14 @@ defaultArgs:
   codeVersion: 1.86.0
   codeQuality: stable
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2023.3.2.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2023.3.2.tar.gz"
-  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2023.3.2.tar.gz"
-  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2023.3.2.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2023.3.3.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2023.3.3.tar.gz"
+  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2023.3.3.tar.gz"
+  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2023.3.3.tar.gz"
   rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2023.3.2.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2023.3.2.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2023.3.3.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2023.3.3.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2023.3.2.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2023.3.3.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "20.10.24"
   dockerComposeVersion: "2.23.3-gitpod.1"


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [x] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_