### PR TITLE
[installer] Use experimental config properly for openvsx-proxy

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 )
 
 func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -67,8 +68,9 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	const redisContainerName = "redis"
 
 	var proxyEnvVars []v1.EnvVar
-	if ctx.Config.Experimental != nil && ctx.Config.Experimental.WebApp != nil {
-		proxyConfig := ctx.Config.Experimental.WebApp.ProxySettings
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		proxyConfig := cfg.WebApp.ProxySettings
 		if proxyConfig != nil {
 			proxyEnvVars = []v1.EnvVar{
 				{
@@ -84,10 +86,9 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Value: proxyConfig.NoProxy,
 				},
 			}
-
 		}
-
-	}
+		return nil
+	})
 
 	return []runtime.Object{&appsv1.StatefulSet{
 		TypeMeta: common.TypeMetaStatefulSet,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I tried to use the experimental config directly without using using `WithExperiment` method. Currently the installer doesn't add the proxy settings to openvsx-proxy. With this change it, it is working fine.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
