### PR TITLE
[workspace-cluster] update image for gen108

### DIFF
--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.2-gitpod.1
+FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.5-gitpod.0
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202402010208"
+  default     = "gitpod-k3s-202402020033"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402010208"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402010208"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202402010208"
+  default     = "gitpod-k3s-202402020033"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -26,6 +26,8 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
 # failing occasionally. Sleeping for a bit solves it.
 sleep 10
 
+# shellcheck disable=SC2154
+# shellcheck disable=SC2086
 kubectl label nodes ${vm_name} \
   gitpod.io/workload_meta=true \
   gitpod.io/workload_ide=true \
@@ -37,15 +39,9 @@ kubectl label nodes ${vm_name} \
   gitpod.io/workspace_1=true \
   gitpod.io/workspace_2=true
 
-# apply fix from https://github.com/k3s-io/klipper-lb/issues/6 so we can use the klipper servicelb
-# this can be removed if https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/20 gets merged
-cat /var/lib/gitpod/manifests/calico.yaml | sed s/__KUBERNETES_NODE_NAME__\"\,/__KUBERNETES_NODE_NAME__\",\ \"container_settings\"\:\ \{\ \"allow_ip_forwarding\"\:\ true\ \}\,/ >/var/lib/gitpod/manifests/calico2.yaml
+  sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico.yaml
 
-sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico2.yaml
-sed -i 's/interface=ens/interface=en/g' /var/lib/gitpod/manifests/calico2.yaml
-sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.yaml
-
-kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
+kubectl apply -f /var/lib/gitpod/manifests/calico.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
 kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -39,7 +39,7 @@ kubectl label nodes ${vm_name} \
   gitpod.io/workspace_1=true \
   gitpod.io/workspace_2=true
 
-sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico.yaml
+  sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/calico.yaml
 

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -39,7 +39,7 @@ kubectl label nodes ${vm_name} \
   gitpod.io/workspace_1=true \
   gitpod.io/workspace_2=true
 
-  sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico.yaml
+sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/calico.yaml
 

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402010208"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202402010208"
+  default     = "gitpod-k3s-202402020033"
 }
 
 variable "cert_issuer" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] with-monitoring
</details>

/hold
