### PR TITLE
[image-builder-bob] update buildkit version

### DIFF
--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.2-gitpod.1
+FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.5-gitpod.0
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -26,6 +26,8 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
 # failing occasionally. Sleeping for a bit solves it.
 sleep 10
 
+# shellcheck disable=SC2154
+# shellcheck disable=SC2086
 kubectl label nodes ${vm_name} \
   gitpod.io/workload_meta=true \
   gitpod.io/workload_ide=true \
@@ -39,10 +41,13 @@ kubectl label nodes ${vm_name} \
 
 # apply fix from https://github.com/k3s-io/klipper-lb/issues/6 so we can use the klipper servicelb
 # this can be removed if https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/20 gets merged
+# shellcheck disable=SC2002
+# shellcheck disable=SC1001
 cat /var/lib/gitpod/manifests/calico.yaml | sed s/__KUBERNETES_NODE_NAME__\"\,/__KUBERNETES_NODE_NAME__\",\ \"container_settings\"\:\ \{\ \"allow_ip_forwarding\"\:\ true\ \}\,/ >/var/lib/gitpod/manifests/calico2.yaml
 
 sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico2.yaml
 sed -i 's/interface=ens/interface=en/g' /var/lib/gitpod/manifests/calico2.yaml
+# shellcheck disable=SC2016
 sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update to our latest buildkit [fork](https://github.com/gitpod-io/buildkit/pull/1), which is on v0.12.5.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1639

## How to test
<!-- Provide steps to test this PR -->
Using this test repo: https://github.com/kylos101/gitpod-custom-image

1. Do an image build from this preview environment and start a workspace:
   * ![image](https://github.com/gitpod-io/gitpod/assets/1272076/354dabcf-fe23-4d9e-b34c-e2d429b8aae4)
2. Do the same image build from a Gitpod workspace in this preview environment using `gp validate` and open the debug workspace
   * ![image](https://github.com/gitpod-io/gitpod/assets/1272076/204f9878-e553-4ba2-aeec-7216465f117f)


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-g330ce40b86</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-g330ce40b86.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-g330ce40b86.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-gen108-image-2-gha.22720</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-g330ce40b86%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
