### PR TITLE
Enable vscode 1.85 for older linux distros

### DIFF
--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -101,7 +101,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Options: map[string]ide_config.IDEOption{
 				"code": {
-					OrderKey:          "00",
+					OrderKey:          "010",
 					Title:             "VS Code",
 					Type:              ide_config.IDETypeBrowser,
 					Label:             "Browser",
@@ -110,6 +110,15 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					ImageLayers:       []string{codeWebExtensionImage, codeHelperImage},
 					LatestImage:       resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
 					LatestImageLayers: []string{codeWebExtensionImage, codeHelperImage},
+				},
+				"code1_85": {
+					OrderKey:    "011",
+					Title:       "VS Code",
+					Type:        ide_config.IDETypeBrowser,
+					Label:       "Browser",
+					Logo:        getIdeLogoPath("vscode"),
+					Image:       ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.Code1_85IDEImageStableVersion),
+					ImageLayers: []string{codeWebExtensionImage, codeHelperImage},
 				},
 				codeDesktop: {
 					OrderKey:    "02",

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -121,7 +121,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					ImageLayers: []string{codeWebExtensionImage, codeHelperImage},
 				},
 				codeDesktop: {
-					OrderKey:    "02",
+					OrderKey:    "020",
 					Title:       "VS Code",
 					Type:        ide_config.IDETypeDesktop,
 					Logo:        getIdeLogoPath("vscode"),
@@ -151,7 +151,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					ImageLayers: []string{jbPluginPrevious, jbLauncherImage},
 				},
 				goland: {
-					OrderKey:          "05",
+					OrderKey:          "050",
 					Title:             "GoLand",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("golandLogo"),
@@ -163,7 +163,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				pycharm: {
-					OrderKey:          "06",
+					OrderKey:          "060",
 					Title:             "PyCharm",
 					Label:             "Professional",
 					Type:              ide_config.IDETypeDesktop,
@@ -176,7 +176,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				phpstorm: {
-					OrderKey:          "07",
+					OrderKey:          "070",
 					Title:             "PhpStorm",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("phpstormLogo"),
@@ -188,7 +188,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				rubymine: {
-					OrderKey:          "08",
+					OrderKey:          "080",
 					Title:             "RubyMine",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("rubymineLogo"),
@@ -200,7 +200,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				webstorm: {
-					OrderKey:          "09",
+					OrderKey:          "090",
 					Title:             "WebStorm",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("webstormLogo"),
@@ -212,7 +212,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				rider: {
-					OrderKey:          "10",
+					OrderKey:          "100",
 					Title:             "Rider",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("riderLogo"),
@@ -224,7 +224,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				clion: {
-					OrderKey:          "11",
+					OrderKey:          "110",
 					Title:             "CLion",
 					Type:              ide_config.IDETypeDesktop,
 					Logo:              getIdeLogoPath("clionLogo"),
@@ -236,7 +236,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
 				},
 				xterm: {
-					OrderKey: "12",
+					OrderKey: "120",
 					Title:    "Terminal",
 					Type:     ide_config.IDETypeBrowser,
 					Logo:     getIdeLogoPath("terminal"),

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                  = "ide/code"
-	CodeIDEImageStableVersion     = "commit-feb0bf14bc9ad538f748dbfcc4ba30361d2c38b3" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion     = "commit-fc97f55eae648b06f4cbd03e67c52f229de17023" // stable version that will be updated manually on demand
 	Code1_85IDEImageStableVersion = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876"
 	CodeHelperIDEImage            = "ide/code-codehelper"
 	CodeWebExtensionImage         = "ide/gitpod-code-web"

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -5,22 +5,23 @@
 package ide
 
 const (
-	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876" // stable version that will be updated manually on demand
-	CodeHelperIDEImage          = "ide/code-codehelper"
-	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-127d8686824d65c06a75e16d23052ebfbd8bc6a7" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
-	CodeDesktopIDEImage         = "ide/code-desktop"
-	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
-	XtermIDEImage               = "ide/xterm-web"
-	IntelliJDesktopIDEImage     = "ide/intellij"
-	GoLandDesktopIdeImage       = "ide/goland"
-	PyCharmDesktopIdeImage      = "ide/pycharm"
-	PhpStormDesktopIdeImage     = "ide/phpstorm"
-	RubyMineDesktopIdeImage     = "ide/rubymine"
-	WebStormDesktopIdeImage     = "ide/webstorm"
-	RiderDesktopIdeImage        = "ide/rider"
-	CLionDesktopIdeImage        = "ide/clion"
-	JetBrainsBackendPluginImage = "ide/jb-backend-plugin"
-	JetBrainsLauncherImage      = "ide/jb-launcher"
+	CodeIDEImage                  = "ide/code"
+	CodeIDEImageStableVersion     = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876" // stable version that will be updated manually on demand
+	Code1_85IDEImageStableVersion = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876"
+	CodeHelperIDEImage            = "ide/code-codehelper"
+	CodeWebExtensionImage         = "ide/gitpod-code-web"
+	CodeWebExtensionVersion       = "commit-127d8686824d65c06a75e16d23052ebfbd8bc6a7" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeDesktopIDEImage           = "ide/code-desktop"
+	CodeDesktopInsidersIDEImage   = "ide/code-desktop-insiders"
+	XtermIDEImage                 = "ide/xterm-web"
+	IntelliJDesktopIDEImage       = "ide/intellij"
+	GoLandDesktopIdeImage         = "ide/goland"
+	PyCharmDesktopIdeImage        = "ide/pycharm"
+	PhpStormDesktopIdeImage       = "ide/phpstorm"
+	RubyMineDesktopIdeImage       = "ide/rubymine"
+	WebStormDesktopIdeImage       = "ide/webstorm"
+	RiderDesktopIdeImage          = "ide/rider"
+	CLionDesktopIdeImage          = "ide/clion"
+	JetBrainsBackendPluginImage   = "ide/jb-backend-plugin"
+	JetBrainsLauncherImage        = "ide/jb-launcher"
 )

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                  = "ide/code"
-	CodeIDEImageStableVersion     = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion     = "commit-feb0bf14bc9ad538f748dbfcc4ba30361d2c38b3" // stable version that will be updated manually on demand
 	Code1_85IDEImageStableVersion = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876"
 	CodeHelperIDEImage            = "ide/code-codehelper"
 	CodeWebExtensionImage         = "ide/gitpod-code-web"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Enable vscode 1.85 for older linux distros
- Update stable vscode to 1.86

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/EXP-1315

## How to test
<!-- Provide steps to test this PR -->
- Preview env https://jp-reasonable-skink.preview.gitpod-dev.com/workspaces
- Flag https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853
- Check vscode 1.85 is shown in ide list and workspace can be started

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
