### PR TITLE
[JetBrains] make plugin support other platforms

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
@@ -18,6 +18,8 @@
     see https://jetbrains.slack.com/archives/C02BRJLGPGF/p1643369943314119?thread_ts=1643358812.185799&cid=C02BRJLGPGF
     <depends>com.jetbrains.gateway</depends> -->
 
+    <depends optional="true">com.jetbrains.gateway</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <httpRequestHandler implementation="io.gitpod.jetbrains.auth.GitpodAuthCallbackHandler"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.gateway.GitpodSettingsState"/>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
show GitPod Plugin In IDEA
IDEA's remote development have released . the interface in IDEA will be more and more important .
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
https://github.com/gitpod-io/gitpod/issues/19296
## How to test
<!-- Provide steps to test this PR -->
install the plugin in IDEA 
![image](https://github.com/gitpod-io/gitpod/assets/54702578/8fd0df08-a025-4b94-882a-42623168db16)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
