### PR TITLE
[lacework] Use 'installer mirror list' and include Docker Hub images

### DIFF
--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -71,8 +71,6 @@ jobs:
         env:
           VERSION: ${{needs.configuration.outputs.version}}
           LW_ACCESS_TOKEN: "${{ steps.secrets.outputs.lacework-access-token }}"
-          # TODO(gpl) See docker.io access above
-          EXCLUDE_DOCKER_IO: true
         run: |
           $GITHUB_WORKSPACE/scripts/lw-scan-images.sh
 

--- a/scripts/lw-scan-images.sh
+++ b/scripts/lw-scan-images.sh
@@ -51,6 +51,7 @@ echo "=== Found $TOTAL_IMAGES images to scan"
 # There, we can see the results in the "Vulnerabilities" tab, by searching for the Gitpod version
 # Note: Does not fail on CVEs!
 COUNTER=0
+FAILED=0
 while IFS= read -r IMAGE_REF; do
   ((COUNTER=COUNTER+1))
   # TODO(gpl) Unclear why we can't access the docker.io images the GitHub workflow; it works from a workspace?
@@ -71,5 +72,11 @@ while IFS= read -r IMAGE_REF; do
     --ci-build=true \
     --disable-library-package-scanning=false \
     --save=true \
-    --tags version="$VERSION" > /dev/null
+    --tags version="$VERSION" > /dev/null || ((FAILED=FAILED+1))
+  echo ""
 done < "$TMP/images.txt"
+
+echo "number of failed image scans: $FAILED of $COUNTER"
+if (( FAILED > 0 )); then
+  exit 1
+fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change uses the `installer mirror list` command to get the list of all used images for the Lacework scan. It also fixes the issues that lacework cannot scan images from Docker Hub. For some reason, removing the `docker.io/` prefix did the trick.

As an additional improvement, it does not stop scanning when there is an error with an image. It continues and returns an error exit code at the end.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENG-1591/scan-workspace-images-for-cves

## How to test
<!-- Provide steps to test this PR -->
I started a manual GitHub action run: https://github.com/gitpod-io/gitpod/actions/runs/7805409193/job/21289613547

For some reason, the `xterm-web` image fails to scan:

```
= Scanning eu.gcr.io/gitpod-core-dev/build/ide/xterm-web : latest [49 / 66]
Pulling image: Done!
Saving image: Done!
Getting image manifest: Done!
Gathering packages: Done!
Packaging image data: Done!
ERROR: Scanned manifest has no packages. Aborting..
```

However, this seems to be independent of this change.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
