### PR TITLE
Remove projects from nav depending on ff

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -23,6 +23,7 @@ import { User, RoleOrPermission } from "@gitpod/public-api/lib/gitpod/v1/user_pb
 import { getPrimaryEmail } from "@gitpod/public-api-common/lib/user-utils";
 import { useHasRolePermission } from "../data/organizations/members-query";
 import { OrganizationRole } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
+import { useHasConfigurationsAndPrebuildsEnabled } from "../data/featureflag-query";
 
 interface Entry {
     title: string;
@@ -130,6 +131,7 @@ type OrgPagesNavProps = {
 const OrgPagesNav: FC<OrgPagesNavProps> = ({ className }) => {
     const location = useLocation();
     const hasMemberPermission = useHasRolePermission(OrganizationRole.MEMBER);
+    const configurationsEnabled = useHasConfigurationsAndPrebuildsEnabled();
 
     const leftMenu: Entry[] = useMemo(() => {
         const menus = [
@@ -139,8 +141,8 @@ const OrgPagesNav: FC<OrgPagesNavProps> = ({ className }) => {
                 alternatives: ["/"],
             },
         ];
-        // collaborator can't access projects
-        if (hasMemberPermission) {
+        // collaborators can't access projects
+        if (hasMemberPermission && !configurationsEnabled) {
             menus.push({
                 title: "Projects",
                 link: `/projects`,
@@ -148,7 +150,7 @@ const OrgPagesNav: FC<OrgPagesNavProps> = ({ className }) => {
             });
         }
         return menus;
-    }, [hasMemberPermission]);
+    }, [configurationsEnabled, hasMemberPermission]);
 
     return (
         <div


### PR DESCRIPTION
## Description

Makes it so that projects don't appear in the UI if you have the `configurationsAndPrebuilds` feature flag.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1322

## How to test

Should make the top-level menu item invisible in the preview environment. You can try flipping it for yourself in Configcat to verify its effect.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
