### PR TITLE
[redis] Fix readiness probe

### DIFF
--- a/install/installer/pkg/components/redis/deployment.go
+++ b/install/installer/pkg/components/redis/deployment.go
@@ -91,7 +91,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ReadinessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										Exec: &v1.ExecAction{
-											Command: []string{"sh", "-c", "nc -z -w 2 127.0.0.1 6379"},
+											Command: []string{"sh", "-c", "timeout 2 bash -c '</dev/tcp/127.0.0.1/6379'"},
 										},
 									},
 									InitialDelaySeconds: 5,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`nc` got removed from the chainguard redis image

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1677

## How to test
<!-- Provide steps to test this PR -->

Tested by manually running the readiness probe in the latest redis image, with and without a redis running in the background, and checking the exit status code.

Redis also becomes ready in preview env:
<img width="886" alt="image" src="https://github.com/gitpod-io/gitpod/assets/9721064/b47e184a-0800-411f-85d0-d6de9d8be98d">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - wv-fix-red8d54c06ad1</li>
	<li><b>🔗 URL</b> - <a href="https://wv-fix-red8d54c06ad1.preview.gitpod-dev.com/workspaces" target="_blank">wv-fix-red8d54c06ad1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - wv-fix-redisness-probe-gha.22831</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-wv-fix-red8d54c06ad1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
