### PR TITLE
[preview] update to gen108 VM image

### DIFF
--- a/dev/preview/infrastructure/modules/gce/cloudinit.yaml
+++ b/dev/preview/infrastructure/modules/gce/cloudinit.yaml
@@ -23,6 +23,6 @@ write_files:
         password = "${dockerhub_passwd}"
       EOF
 
-      sudo systemctl restart containerd.service &
+      sudo systemctl restart containerd.service --wait
 runcmd:
  - bash /usr/local/bin/bootstrap.sh

--- a/dev/preview/infrastructure/modules/gce/cloudinit.yaml
+++ b/dev/preview/infrastructure/modules/gce/cloudinit.yaml
@@ -23,6 +23,6 @@ write_files:
         password = "${dockerhub_passwd}"
       EOF
 
-      sudo systemctl restart containerd.service --wait
+      sudo systemctl restart containerd.service &
 runcmd:
  - bash /usr/local/bin/bootstrap.sh

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -44,7 +44,7 @@ variable "harvester_ingress_ip" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402021944"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -33,7 +33,7 @@ variable "ssh_key" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402021944"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -24,7 +24,7 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
 
 # Seems like this is a bit flaky now, with k3s not always being ready, and the labeling
 # failing occasionally. Sleeping for a bit solves it.
-sleep 10
+sleep 60
 
 # shellcheck disable=SC2154
 # shellcheck disable=SC2086

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -15,7 +15,6 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
   --write-kubeconfig-mode 444 \
   --disable traefik \
   --disable metrics-server \
-  --disable local-storage \
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
   --kubelet-arg cgroup-driver=systemd \

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -15,6 +15,7 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
   --write-kubeconfig-mode 444 \
   --disable traefik \
   --disable metrics-server \
+  --disable local-storage \
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
   --kubelet-arg cgroup-driver=systemd \
@@ -24,7 +25,7 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
 
 # Seems like this is a bit flaky now, with k3s not always being ready, and the labeling
 # failing occasionally. Sleeping for a bit solves it.
-sleep 60
+sleep 10
 
 # shellcheck disable=SC2154
 # shellcheck disable=SC2086

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -6,10 +6,12 @@ set -eo pipefail
 
 # Install k3s
 export INSTALL_K3S_SKIP_DOWNLOAD=true
+SERVICE_DNS_IP="$(hostname -I | cut -d ' ' -f1)"
+export SERVICE_DNS_IP
 
 /usr/local/bin/install-k3s.sh \
   --token "1234" \
-  --node-ip "$(hostname -I | cut -d ' ' -f1)" \
+  --node-ip "$SERVICE_DNS_IP" \
   --node-label "cloud.google.com/gke-nodepool=control-plane-pool" \
   --container-runtime-endpoint=/var/run/containerd/containerd.sock \
   --write-kubeconfig-mode 444 \
@@ -54,6 +56,8 @@ sed -i 's/interface=ens/interface=en/g' /var/lib/gitpod/manifests/calico2.yaml
 sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
+kubectl apply -f /var/lib/gitpod/manifests/coredns.yaml
+kubectl apply -f /var/lib/gitpod/manifests/node-local-dns.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
 kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -15,6 +15,7 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
   --write-kubeconfig-mode 444 \
   --disable traefik \
   --disable metrics-server \
+  --disable-network-policy \
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
   --kubelet-arg cgroup-driver=systemd \

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -57,6 +57,7 @@ sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.
 
 kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
 kubectl apply -f /var/lib/gitpod/manifests/coredns.yaml
+kubectl scale deployment/coredns -n kube-system --replicas 1
 kubectl apply -f /var/lib/gitpod/manifests/node-local-dns.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -18,7 +18,6 @@ export SERVICE_DNS_IP
   --disable traefik \
   --disable metrics-server \
   --disable-network-policy \
-  --disable coredns \
   --disable-cloud-controller \
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
@@ -56,9 +55,6 @@ sed -i 's/interface=ens/interface=en/g' /var/lib/gitpod/manifests/calico2.yaml
 sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
-kubectl apply -f /var/lib/gitpod/manifests/coredns.yaml
-kubectl scale deployment/coredns -n kube-system --replicas 1
-kubectl apply -f /var/lib/gitpod/manifests/node-local-dns.yaml
 
 kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
 kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -16,6 +16,8 @@ export INSTALL_K3S_SKIP_DOWNLOAD=true
   --disable traefik \
   --disable metrics-server \
   --disable-network-policy \
+  --disable coredns \
+  --disable-cloud-controller \
   --flannel-backend=none \
   --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
   --kubelet-arg cgroup-driver=systemd \

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202312131438"
+  default     = "gitpod-k3s-202402021944"
 }
 
 variable "cert_issuer" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update to the latest image. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1668

## How to test
<!-- Provide steps to test this PR -->
Start a workspace in preview:
![image](https://github.com/gitpod-io/gitpod/assets/1272076/be4c3f32-a556-49f0-8fd5-2cf894c69ff9) from https://github.com/kylos101/gitpod-custom-image

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-gd9f4c157e2</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-gd9f4c157e2.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-gd9f4c157e2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-gen108-preview-gha.22896</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-gd9f4c157e2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
