### PR TITLE
Disable Workspace creation directly from prebuilds

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -15,7 +15,6 @@ import { useCurrentProject } from "./project-context";
 import { shortCommitMessage } from "./render-utils";
 import { prebuildClient, watchPrebuild } from "../service/public-api";
 import { Prebuild, PrebuildPhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
-import { gitpodHostUrl } from "../service/service";
 import { Button } from "@podkit/buttons/Button";
 
 export default function PrebuildPage() {
@@ -157,22 +156,14 @@ export default function PrebuildPage() {
                                 onClick={rerunPrebuild}
                             >
                                 {isRerunningPrebuild && (
-                                    <img alt="" className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
+                                    <img
+                                        alt="loading"
+                                        className="h-4 w-4 animate-spin filter brightness-150"
+                                        src={Spinner}
+                                    />
                                 )}
                                 <span>Rerun Prebuild ({prebuild?.ref})</span>
                             </Button>
-                            {prebuild?.status?.phase?.name === PrebuildPhase_Phase.AVAILABLE ? (
-                                <a
-                                    className="my-auto"
-                                    href={gitpodHostUrl
-                                        .withContext(`open-prebuild/${prebuild?.id}/${prebuild?.contextUrl}`)
-                                        .toString()}
-                                >
-                                    <Button>New Workspace (with this prebuild)</Button>
-                                </a>
-                            ) : (
-                                <Button disabled={true}>New Workspace (with this prebuild)</Button>
-                            )}
                         </>
                     )}
                 </PrebuildLogs>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces to avoid the direct workspace creation based on prebuilds. This change addresses a critical issue where workspaces could previously be initiated based on outdated git information, leading to potential discrepancies and sync issues with the latest repository state.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1072

## How to test
<!-- Provide steps to test this PR -->

- Go to `Projects` tab
- Add a project, Enable prebuilds
- Open project's prebuilds & Hit prebuild
- Open prebuild page of that repo. and see `New workspace (from this prebuild)` is not there anymore 👀 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e7a3f8f68b9</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e7a3f8f68b9.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e7a3f8f68b9.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-exp-1072-remove-the-options-to-directly-start-workspaces-on-prebuilds-gha.22856</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e7a3f8f68b9%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
