### PR TITLE
[dashboard] restrict workspace classes on repo-level

### DIFF
--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -213,6 +213,16 @@ export const ModalFooter: FC<ModalFooterProps> = ({ className, alert, children }
     );
 };
 
+export const ModalBaseFooter: FC<{ className?: string; children: ReactNode }> = ({ className, children }) => {
+    return (
+        <div
+            className={classNames("flex items-start space-x-2 pt-6 bg-white dark:bg-gray-900 rounded-b-xl", className)}
+        >
+            {children}
+        </div>
+    );
+};
+
 // Wrapper around Alert to ensure it's used correctly in a Modal
 export const ModalFooterAlert: FC<AlertProps> = ({
     closable = true,

--- a/components/dashboard/src/components/WorkspaceClassesOptions.tsx
+++ b/components/dashboard/src/components/WorkspaceClassesOptions.tsx
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMemo, useState } from "react";
+import { LoadingButton } from "@podkit/buttons/LoadingButton";
+import { Button } from "@podkit/buttons/Button";
+import { SwitchInputField } from "@podkit/switch/Switch";
+import { cn } from "@podkit/lib/cn";
+import { CpuIcon } from "lucide-react";
+import { UseMutationResult } from "@tanstack/react-query";
+import { AllowedWorkspaceClass, DEFAULT_WS_CLASS } from "../data/workspaces/workspace-classes-query";
+import { MiddleDot } from "./typography/MiddleDot";
+import { useToast } from "./toasts/Toasts";
+import Modal, { ModalBaseFooter, ModalBody, ModalHeader } from "./Modal";
+
+interface WorkspaceClassesOptionsProps {
+    classes: AllowedWorkspaceClass[];
+    defaultClass?: string;
+    className?: string;
+}
+
+export const WorkspaceClassesOptions = (props: WorkspaceClassesOptionsProps) => {
+    return (
+        <div className={cn("space-y-2", props.className)}>
+            {props.classes.map((cls) => (
+                <div className="flex gap-2 items-center">
+                    <CpuIcon size={20} />
+                    <div>
+                        <span className="font-medium text-pk-content-primary">{cls.displayName}</span>
+                        <MiddleDot />
+                        <span className="text-pk-content-primary">{cls.description}</span>
+                        {props.defaultClass === cls.id && (
+                            <>
+                                <MiddleDot className="text-pk-content-tertiary" />
+                                <span className="text-pk-content-tertiary">default</span>
+                            </>
+                        )}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export interface WorkspaceClassesModifyModalProps {
+    defaultClass?: string;
+    restrictedWorkspaceClasses: string[];
+    showSetDefaultButton: boolean;
+
+    allowedClasses: AllowedWorkspaceClass[];
+    updateMutation: UseMutationResult<void, Error, { restrictedWorkspaceClasses: string[]; defaultClass?: string }>;
+
+    onClose: () => void;
+}
+
+export const WorkspaceClassesModifyModal = ({
+    onClose,
+    updateMutation,
+    allowedClasses,
+    showSetDefaultButton,
+    ...props
+}: WorkspaceClassesModifyModalProps) => {
+    const [defaultClass, setDefaultClass] = useState(props.defaultClass || DEFAULT_WS_CLASS);
+    const [restrictedClasses, setRestrictedClasses] = useState(props.restrictedWorkspaceClasses ?? []);
+    const { toast } = useToast();
+
+    const handleUpdate = async () => {
+        if (computedError) {
+            return;
+        }
+        updateMutation.mutate(
+            { restrictedWorkspaceClasses: restrictedClasses, defaultClass },
+            {
+                onSuccess: () => {
+                    toast({ message: "Workspace class updated" });
+                    onClose();
+                },
+            },
+        );
+    };
+
+    const computedError = useMemo(() => {
+        const leftOptions =
+            allowedClasses.filter((c) => !c.isDisabledInScope && !restrictedClasses.includes(c.id)) ?? [];
+        if (leftOptions.length === 0) {
+            return "At least one workspace class has to be selected.";
+        }
+        if (!defaultClass || !leftOptions.find((cls) => cls.id === defaultClass)) {
+            return "A default workspace class is required.";
+        }
+        return;
+    }, [restrictedClasses, allowedClasses, defaultClass]);
+
+    return (
+        <Modal visible onClose={onClose} onSubmit={handleUpdate}>
+            <ModalHeader>Available workspace classes</ModalHeader>
+            <ModalBody>
+                {allowedClasses.map((wsClass) => (
+                    <WorkspaceClassSwitch
+                        showSetDefaultButton={showSetDefaultButton}
+                        restrictedClasses={restrictedClasses}
+                        wsClass={wsClass}
+                        isDefault={defaultClass === wsClass.id}
+                        checked={!restrictedClasses.includes(wsClass.id)}
+                        onSetDefault={() => {
+                            setDefaultClass(wsClass.id);
+                        }}
+                        onCheckedChange={(checked) => {
+                            const newVal = !checked
+                                ? restrictedClasses.includes(wsClass.id)
+                                    ? [...restrictedClasses]
+                                    : [...restrictedClasses, wsClass.id]
+                                : restrictedClasses.filter((id) => id !== wsClass.id);
+                            setRestrictedClasses(newVal);
+                        }}
+                    />
+                ))}
+            </ModalBody>
+            <ModalBaseFooter className="justify-between">
+                <div className="text-red-500">
+                    {(computedError || updateMutation.isError) && (computedError || String(updateMutation.error))}
+                </div>
+                <div className="flex gap-2">
+                    <Button variant="secondary" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <LoadingButton disabled={!!computedError} type="submit" loading={updateMutation.isLoading}>
+                        Save
+                    </LoadingButton>
+                </div>
+            </ModalBaseFooter>
+        </Modal>
+    );
+};
+
+interface WorkspaceClassSwitchProps {
+    wsClass: AllowedWorkspaceClass;
+    restrictedClasses: string[];
+    checked: boolean;
+    isDefault: boolean;
+    showSetDefaultButton?: boolean;
+    onSetDefault: () => void;
+    onCheckedChange: (checked: boolean) => void;
+}
+const WorkspaceClassSwitch = ({
+    wsClass,
+    checked,
+    isDefault,
+    onCheckedChange,
+    ...props
+}: WorkspaceClassSwitchProps) => {
+    const computedState = useMemo(() => {
+        if (wsClass.isDisabledInScope) {
+            let descriptionScope = "";
+            switch (wsClass.disableScope!) {
+                case "organization":
+                    descriptionScope = "Your organization";
+                    break;
+                case "configuration":
+                    descriptionScope = "Current configuration";
+                    break;
+            }
+            return {
+                title: "Unavailable",
+                classes: "cursor-not-allowed",
+                disabled: true,
+                switchDescription: `${descriptionScope} has disabled this class`,
+            };
+        }
+        if (props.restrictedClasses.includes(wsClass.id)) {
+            return {
+                title: "Unavailable",
+                classes: "cursor-not-allowed",
+                disabled: true,
+                switchDescription: "Current configuration has disabled this class",
+            };
+        }
+        if (isDefault) {
+            return {
+                title: "Default",
+                classes: "text-pk-surface",
+                disabled: true,
+            };
+        }
+        return {
+            title: "Set default",
+            classes: "cursor-pointer text-blue-500",
+            disabled: false,
+        };
+    }, [props.restrictedClasses, isDefault, wsClass]);
+
+    return (
+        <div
+            className={cn(
+                "flex w-full justify-between items-center mt-2",
+                wsClass.isDisabledInScope ? "text-pk-content-disabled" : "",
+            )}
+        >
+            <SwitchInputField
+                key={wsClass.id}
+                id={wsClass.id}
+                label={wsClass.displayName}
+                description={wsClass.description}
+                checked={checked}
+                disabled={wsClass.isDisabledInScope}
+                onCheckedChange={onCheckedChange}
+                title={computedState.switchDescription}
+            />
+            {!props.showSetDefaultButton ? undefined : (
+                <Button
+                    title={computedState.switchDescription}
+                    onClick={() => {
+                        props.onSetDefault();
+                    }}
+                    variant="ghost"
+                    disabled={wsClass.isDisabledInScope || computedState.disabled}
+                    className={cn("text-sm select-none font-normal", computedState.classes)}
+                >
+                    {computedState.title}
+                </Button>
+            )}
+        </div>
+    );
+};

--- a/components/dashboard/src/components/podkit/switch/Switch.tsx
+++ b/components/dashboard/src/components/podkit/switch/Switch.tsx
@@ -54,19 +54,20 @@ export interface SwitchInputFieldProps extends React.ComponentPropsWithoutRef<ty
 }
 
 export const SwitchInputField = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, SwitchInputFieldProps>(
-    ({ className, checked, onCheckedChange, label, id, description, ...props }, ref) => {
+    ({ className, checked, onCheckedChange, title, label, id, description, ...props }, ref) => {
+        const disabledClassName = props.disabled ? "text-pk-content-disabled" : "";
         const switchProps = {
             ...props,
             className: "",
         };
         return (
-            <div className={cn("flex gap-4", className)}>
+            <div className={cn("flex gap-4", className)} title={title}>
                 <Switch checked={checked} onCheckedChange={onCheckedChange} id={id} {...switchProps} ref={ref} />
                 <div className="flex flex-col">
-                    <label className="font-semibold cursor-pointer" htmlFor={id}>
+                    <label className={cn("font-semibold cursor-pointer", disabledClassName)} htmlFor={id}>
                         {label}
                     </label>
-                    <TextMuted>{description}</TextMuted>
+                    <TextMuted className={disabledClassName}>{description}</TextMuted>
                 </div>
             </div>
         );

--- a/components/dashboard/src/components/podkit/typography/Headings.tsx
+++ b/components/dashboard/src/components/podkit/typography/Headings.tsx
@@ -64,7 +64,7 @@ export const Heading3: FC<HeadingProps> = ({ id, tracking, className, children, 
  */
 export const Subheading: FC<HeadingProps> = ({ id, tracking, className, children }) => {
     return (
-        <p id={id} className={cn("text-base text-pk-content-secondary", getTracking(tracking), className)}>
+        <p id={id} className={cn("text-base text-pk-content-tertiary", getTracking(tracking), className)}>
             {children}
         </p>
     );

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -33,6 +33,8 @@ const featureFlags = {
      * Whether to enable org-level workspace class restrictions
      */
     org_workspace_class_restrictions: false,
+    // Whether to enable workspace class restrictions for configurations
+    configuration_workspace_class_restrictions: false,
     // dummy specified dataops feature, default false
     dataops: false,
     // Logging tracing for added for investigate hanging issue

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.test.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AllowedWorkspaceClass, getNextDefaultClass } from "./workspace-classes-query";
+
+test("getNextDefaultClass", async () => {
+    const allClasses: AllowedWorkspaceClass[] = [
+        { id: "cls-1" },
+        { id: "cls-2", isDisabledInScope: true },
+        { id: "cls-3" },
+        { id: "cls-4", isDisabledInScope: true },
+        { id: "cls-5" },
+        { id: "cls-6" },
+        { id: "cls-7" },
+    ] as any;
+    type ArgsType = Parameters<typeof getNextDefaultClass>;
+    const testCases: {
+        args: ArgsType;
+        expected: ReturnType<typeof getNextDefaultClass>;
+    }[] = [
+        { args: [allClasses, undefined], expected: undefined },
+        { args: [allClasses, "cls-2"], expected: "cls-1" },
+        { args: [allClasses, "cls-4"], expected: "cls-3" },
+        { args: [allClasses, "cls-5"], expected: "cls-5" },
+        { args: [[], "cls-3"], expected: undefined },
+        { args: [allClasses.map((e) => ({ ...e, isDisabledInScope: true })), "cls-3"], expected: undefined },
+    ];
+
+    for (const t of testCases) {
+        const actual = getNextDefaultClass(...t.args);
+        expect(actual).toBe(t.expected);
+    }
+});

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -7,6 +7,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { workspaceClient } from "../../service/public-api";
 import { WorkspaceClass } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { useOrgSettingsQuery } from "../organizations/org-settings-query";
+import { Configuration, WorkspaceSettings } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { useMemo } from "react";
+import { PlainMessage } from "@bufbuild/protobuf";
+import { useConfiguration } from "../configurations/configuration-queries";
+import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
 
 export const DEFAULT_WS_CLASS = "g1-standard";
 
@@ -20,4 +26,114 @@ export const useWorkspaceClasses = () => {
         cacheTime: 1000 * 60 * 60, // 1h
         staleTime: 1000 * 60 * 60, // 1h
     });
+};
+
+type Scope = "organization" | "configuration" | "installation";
+type DisableScope = "organization" | "configuration";
+export type AllowedWorkspaceClass = PlainMessage<WorkspaceClass> & {
+    isDisabledInScope?: boolean;
+    disableScope?: DisableScope;
+    isComputedDefaultClass?: boolean;
+};
+
+// getNextDefaultClass returns smaller closest one if or larger closest one if there's no smaller ones
+export const getNextDefaultClass = (allClasses: AllowedWorkspaceClass[], defaultClass?: string) => {
+    const availableClasses = allClasses.filter((e) => !e.isDisabledInScope);
+    if (availableClasses.length === 0) {
+        return undefined;
+    }
+    if (defaultClass) {
+        if (availableClasses.some((cls) => cls.id === defaultClass)) {
+            return defaultClass;
+        }
+    }
+    const defaultIndexInAll = allClasses.findIndex((cls) => cls.id === defaultClass);
+    if (defaultIndexInAll === -1) {
+        return undefined;
+    }
+    // remove unavailable default class
+    const sortedClasses = [
+        ...allClasses.slice(0, defaultIndexInAll).reverse(),
+        ...allClasses.slice(defaultIndexInAll, allClasses.length),
+    ].filter((cls) => !cls.isDisabledInScope);
+    if (sortedClasses.length > 0) {
+        return sortedClasses[0].id;
+    }
+    return undefined;
+};
+
+export const getAllowedWorkspaceClasses = (
+    installationClasses: WorkspaceClass[] | undefined,
+    orgSettings: Pick<OrganizationSettings, "allowedWorkspaceClasses"> | undefined,
+    repoRestrictedClass: WorkspaceSettings["restrictedWorkspaceClasses"] | undefined,
+    repoDefaultClass: WorkspaceSettings["workspaceClass"] | undefined,
+    options?: { filterOutDisabled: boolean; ignoreScope?: DisableScope[] },
+) => {
+    let data: AllowedWorkspaceClass[] = installationClasses ?? [];
+    let scope: Scope = "installation";
+    if (data.length === 0) {
+        return { data, scope, computedDefaultClass: DEFAULT_WS_CLASS };
+    }
+    if (
+        !options?.ignoreScope?.includes("organization") &&
+        orgSettings?.allowedWorkspaceClasses &&
+        orgSettings.allowedWorkspaceClasses.length > 0
+    ) {
+        data = data.map((cls) => ({
+            ...cls,
+            isDisabledInScope: !orgSettings.allowedWorkspaceClasses.includes(cls.id),
+            disableScope: "organization",
+        }));
+        scope = "organization";
+    }
+    if (!options?.ignoreScope?.includes("configuration") && repoRestrictedClass && repoRestrictedClass.length > 0) {
+        data = data.map((cls) => {
+            if (cls.isDisabledInScope) {
+                return cls;
+            }
+            return {
+                ...cls,
+                isDisabledInScope: repoRestrictedClass.includes(cls.id),
+                disableScope: "configuration",
+            };
+        });
+        scope = "configuration";
+    }
+    const computedDefaultClass = getNextDefaultClass(data, repoDefaultClass ?? DEFAULT_WS_CLASS) ?? DEFAULT_WS_CLASS;
+    data = data.map((e) => {
+        if (e.id === computedDefaultClass) {
+            e.isComputedDefaultClass = true;
+        }
+        return e;
+    });
+    if (options?.filterOutDisabled) {
+        return { data: data.filter((e) => !e.isDisabledInScope), scope, computedDefaultClass };
+    }
+    return { data, scope, computedDefaultClass };
+};
+
+export const useAllowedWorkspaceClassesMemo = (
+    configurationId?: Configuration["id"],
+    options?: { filterOutDisabled: boolean; ignoreScope?: DisableScope[] },
+) => {
+    const { data: orgSettings } = useOrgSettingsQuery();
+    const { data: installationClasses } = useWorkspaceClasses();
+    // empty configurationId will return undefined
+    const { data: configuration } = useConfiguration(configurationId ?? "");
+
+    return useMemo(() => {
+        return getAllowedWorkspaceClasses(
+            installationClasses,
+            orgSettings,
+            configuration?.workspaceSettings?.restrictedWorkspaceClasses,
+            configuration?.workspaceSettings?.workspaceClass,
+            options,
+        );
+    }, [
+        installationClasses,
+        orgSettings,
+        options,
+        configuration?.workspaceSettings?.restrictedWorkspaceClasses,
+        configuration?.workspaceSettings?.workspaceClass,
+    ]);
 };

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -49,7 +49,7 @@ const ConfigurationDetailPage: FC = () => {
                 link: [`${url}/variables`],
             },
             {
-                title: "Workspace defaults",
+                title: "Workspace classes",
                 link: [`${url}/workspaces`],
             },
         ];

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailWorkspaces.tsx
@@ -7,10 +7,18 @@
 import { FC } from "react";
 import { ConfigurationWorkspaceSizeOptions } from "./workspaces/WorkpaceSizeOptions";
 import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { ConfigurationWorkspaceClassesOptions } from "./workspaces/ConfigurationWorkspaceClassesOptions";
+import { useFeatureFlag } from "../../data/featureflag-query";
 
 type Props = {
     configuration: Configuration;
 };
 export const ConfigurationDetailWorkspaces: FC<Props> = ({ configuration }) => {
+    const enabledWorkspaceClassRestrictionOnConfiguration = useFeatureFlag(
+        "configuration_workspace_class_restrictions",
+    );
+    if (enabledWorkspaceClassRestrictionOnConfiguration) {
+        return <ConfigurationWorkspaceClassesOptions configuration={configuration} />;
+    }
     return <ConfigurationWorkspaceSizeOptions configuration={configuration} />;
 };

--- a/components/dashboard/src/repositories/detail/workspaces/ConfigurationWorkspaceClassesOptions.tsx
+++ b/components/dashboard/src/repositories/detail/workspaces/ConfigurationWorkspaceClassesOptions.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { useState } from "react";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
+import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
+import { useConfigurationMutation } from "../../../data/configurations/configuration-queries";
+import { useAllowedWorkspaceClassesMemo } from "../../../data/workspaces/workspace-classes-query";
+import { Button } from "@podkit/buttons/Button";
+import { AlertTriangleIcon } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
+import {
+    WorkspaceClassesModifyModal,
+    WorkspaceClassesModifyModalProps,
+    WorkspaceClassesOptions,
+} from "../../../components/WorkspaceClassesOptions";
+
+export const ConfigurationWorkspaceClassesOptions = ({ configuration }: { configuration: Configuration }) => {
+    const [showModal, setShowModal] = useState(false);
+    const configurationMutation = useConfigurationMutation();
+
+    const { data: allowedClassesInConfiguration } = useAllowedWorkspaceClassesMemo(configuration.id, {
+        filterOutDisabled: true,
+    });
+    const { data: allowedClassesInOrganization } = useAllowedWorkspaceClassesMemo(undefined, {
+        filterOutDisabled: false,
+        ignoreScope: ["configuration"],
+    });
+
+    const updateMutation: WorkspaceClassesModifyModalProps["updateMutation"] = useMutation({
+        mutationFn: async ({ restrictedWorkspaceClasses, defaultClass }) => {
+            await configurationMutation.mutateAsync({
+                configurationId: configuration.id,
+                workspaceSettings: {
+                    workspaceClass: defaultClass,
+                    restrictedWorkspaceClasses,
+                    updateRestrictedWorkspaceClasses: true,
+                },
+            });
+        },
+    });
+
+    return (
+        <ConfigurationSettingsField>
+            <Heading3>Available workspace classes</Heading3>
+            <Subheading>Limit the available workspace classes for this repository.</Subheading>
+
+            <div className="mt-4">
+                {allowedClassesInConfiguration.length === 0 ? (
+                    <div className="font-semibold text-pk-content-primary flex gap-2 items-center">
+                        <AlertTriangleIcon size={20} className="text-red-500" />
+                        <span>This repository doesn't have any available workspace classes.</span>
+                    </div>
+                ) : (
+                    <WorkspaceClassesOptions
+                        classes={allowedClassesInConfiguration}
+                        defaultClass={configuration.workspaceSettings?.workspaceClass}
+                    />
+                )}
+            </div>
+
+            {showModal && (
+                <WorkspaceClassesModifyModal
+                    showSetDefaultButton
+                    defaultClass={configuration.workspaceSettings?.workspaceClass}
+                    restrictedWorkspaceClasses={configuration.workspaceSettings?.restrictedWorkspaceClasses ?? []}
+                    allowedClasses={allowedClassesInOrganization}
+                    updateMutation={updateMutation}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
+
+            <Button className="mt-8" onClick={() => setShowModal(true)}>
+                Manage Classes
+            </Button>
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/repositories/repositories.routes.ts
+++ b/components/dashboard/src/repositories/repositories.routes.ts
@@ -9,6 +9,7 @@ export const repositoriesRoutes = {
     Detail: (id: string) => `/repositories/${id}`,
     Configuration: (id: string) => `/repositories/${id}/configuration`,
     PrebuildsSettings: (id: string) => `/repositories/${id}/prebuilds`,
+    WorkspaceSettings: (id: string) => `/repositories/${id}/workspaces`,
     Prebuilds: () => `/prebuilds`,
     PrebuildDetail: (prebuildId: string) => `/prebuilds/${prebuildId}`,
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Blocked by https://github.com/gitpod-io/gitpod/pull/19480
- Blocked by https://github.com/gitpod-io/gitpod/pull/19481
- Need to be rebased after blocked PRs merged

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related [project](https://linear.app/gitpod/project/gitpod-now-restrict-workspace-classes-5514537102b4)

## How to test
<!-- Provide steps to test this PR -->

https://exp-project-ws-cls.preview.gitpod-dev.com/workspaces

- Import a configuration, update its workspace classes setting
- Update organization workspace classes settings

0️⃣ both restricted ws class and default ws class needs to be tested
1️⃣ org-level settings should affect config-level settings
2️⃣ both org and config level settings should affect create workspace page
3️⃣ (nit as old project view may be deleted) old project settings page, default workspace classes should work as before

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - exp-project-ws-cls</li>
	<li><b>🔗 URL</b> - <a href="https://exp-project-ws-cls.preview.gitpod-dev.com/workspaces" target="_blank">exp-project-ws-cls.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - exp-project-ws-cls-gha.23218</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-exp-project-ws-cls%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
