### PR TITLE
[ws-daemon] Take backup once container has stopped

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -253,6 +253,13 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		return ctrl.Result{}, nil
 	}
 
+	if ws.IsConditionTrue(workspacev1.WorkspaceConditionContainerRunning) {
+		// Container is still running, we need to wait for it to stop.
+		// We should get an event when the condition changes, but requeue
+		// anyways to make sure we act on it in time.
+		return ctrl.Result{RequeueAfter: 500 * time.Millisecond}, nil
+	}
+
 	if wsc.latestWorkspace(ctx, ws) != nil {
 		return ctrl.Result{Requeue: true, RequeueAfter: 100 * time.Millisecond}, nil
 	}

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -261,6 +261,10 @@ const (
 	VolumeMounted WorkspaceCondition = "VolumeMounted"
 	// ThroughputAdjusted is true if the throughput of the workspace volume has been adjusted
 	WorkspaceConditionThroughputAdjusted WorkspaceCondition = "ThroughputAdjusted"
+
+	// WorkspaceContainerRunning is true if the workspace container is running.
+	// Used to determine if a backup can be taken, only once the container is stopped.
+	WorkspaceConditionContainerRunning WorkspaceCondition = "WorkspaceContainerRunning"
 )
 
 func NewWorkspaceConditionDeployed() metav1.Condition {
@@ -394,6 +398,14 @@ func NewWorkspaceConditionThroughputAdjusted() metav1.Condition {
 		Type:               string(WorkspaceConditionThroughputAdjusted),
 		LastTransitionTime: metav1.Now(),
 		Status:             metav1.ConditionTrue,
+	}
+}
+
+func NewWorkspaceConditionContainerRunning(status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(WorkspaceConditionContainerRunning),
+		LastTransitionTime: metav1.Now(),
+		Status:             status,
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Take backup only once workspace container is no longer running.

Introduces a new `WorkspaceContainerRunning` condition on the workspace CRD, which ws-manager-mk2 sets to true/false based on whether the container is running. ws-daemon then checks this condition, and only starts the backup once it is false. (ws-daemon doesn't check the container itself directly, as it doesn't have access to the k8s pod during reconciliation, instead this is communicated through a condition by ws-manager-mk2).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1687

## How to test
<!-- Provide steps to test this PR -->

Tested in a preview env, backup only starts once container is stopped, and the WorkspaceContainerRunning condition is present with the right value during different lifecycles of the workspace.

Also triggered integration tests to run.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
