### PR TITLE
Fix start workspace button alignment

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -229,6 +229,7 @@ const LoginButton: FC<LoginButtonProps> = ({ children, onClick }) => {
             className={cn(
                 "border-none bg-gray-100 hover:bg-gray-200 text-gray-500 dark:text-gray-200 dark:bg-gray-800 dark:hover:bg-gray-600 hover:opacity-100",
                 "flex-none w-56 h-10 p-0 inline-flex rounded-xl",
+                "justify-normal",
             )}
             onClick={onClick}
         >

--- a/components/dashboard/src/components/podkit/buttons/Button.tsx
+++ b/components/dashboard/src/components/podkit/buttons/Button.tsx
@@ -10,7 +10,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@podkit/lib/cn";
 
 export const buttonVariants = cva(
-    "inline-flex items-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+    "inline-flex items-center whitespace-nowrap rounded-lg text-sm justify-center font-medium transition-colors focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
     {
         variants: {
             variant: {

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -451,7 +451,7 @@ export function CreateWorkspacePage() {
                     <LoadingButton
                         onClick={onClickCreate}
                         autoFocus={true}
-                        className="w-full justify-center"
+                        className="w-full"
                         loading={createWorkspaceMutation.isStarting || !!autostart}
                         disabled={continueButtonDisabled}
                     >

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -451,7 +451,7 @@ export function CreateWorkspacePage() {
                     <LoadingButton
                         onClick={onClickCreate}
                         autoFocus={true}
-                        className="w-full"
+                        className="w-full justify-center"
                         loading={createWorkspaceMutation.isStarting || !!autostart}
                         disabled={continueButtonDisabled}
                     >


### PR DESCRIPTION
## Description

Fix the new workspace modal button to be aligned properly. 

A regression introduced in https://github.com/gitpod-io/gitpod/pull/19361/commits/241ed478d2bb46d1afde56e10f5f4da8c8a6dade

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-new-ws-btn</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-new-ws-btn.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-new-ws-btn.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-new-ws-btn-gha.22939</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-new-ws-btn%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
