### PR TITLE
Misc UI fixes for configs and prebuilds

### DIFF
--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -87,6 +87,10 @@ export const useConfiguration = (configurationId: string) => {
     return useQuery<Configuration | undefined, Error>(
         getConfigurationQueryKey(configurationId),
         async () => {
+            if (!configurationId) {
+                throw new Error("No configurationId provided");
+            }
+
             const { configuration } = await configurationClient.getConfiguration({
                 configurationId,
             });

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -28,6 +28,7 @@ const featureFlags = {
     repositoryFinderSearch: false,
     createProjectModal: false,
     configurationsAndPrebuilds: false,
+    showPrebuildsMenuItem: false,
     /**
      * Whether to enable org-level workspace class restrictions
      */

--- a/components/dashboard/src/data/prebuilds/prebuild-query.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-query.ts
@@ -26,9 +26,6 @@ export function usePrebuildAndConfigurationQuery(prebuildId: string) {
                 configuration,
             };
         },
-        {
-            retry: 1,
-        },
     );
 }
 

--- a/components/dashboard/src/data/prebuilds/prebuild-query.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-query.ts
@@ -9,7 +9,7 @@ import { prebuildClient, stream } from "../../service/public-api";
 import { Prebuild } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
-export function usePrebuilQuery(prebuildId: string) {
+export function usePrebuildQuery(prebuildId: string) {
     return useQuery<Prebuild, Error>(prebuildQueryKey(prebuildId), async () => {
         const prebuild = await prebuildClient.getPrebuild({ prebuildId }).then((response) => response.prebuild);
         if (!prebuild) {

--- a/components/dashboard/src/data/prebuilds/prebuild-query.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-query.ts
@@ -5,32 +5,23 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { configurationClient, prebuildClient, stream } from "../../service/public-api";
-import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { prebuildClient, stream } from "../../service/public-api";
 import { Prebuild } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
-export function usePrebuildAndConfigurationQuery(prebuildId: string) {
-    return useQuery<{ prebuild?: Prebuild; configuration?: Configuration }, Error>(
-        prebuildQueryKey(prebuildId),
-        async () => {
-            const prebuild = await prebuildClient.getPrebuild({ prebuildId }).then((d) => d.prebuild);
-            let configuration: Configuration | undefined;
-            if (prebuild?.configurationId) {
-                configuration = await configurationClient
-                    .getConfiguration({ configurationId: prebuild.configurationId })
-                    .then((d) => d.configuration);
-            }
-            return {
-                prebuild,
-                configuration,
-            };
-        },
-    );
+export function usePrebuilQuery(prebuildId: string) {
+    return useQuery<Prebuild, Error>(prebuildQueryKey(prebuildId), async () => {
+        const prebuild = await prebuildClient.getPrebuild({ prebuildId }).then((response) => response.prebuild);
+        if (!prebuild) {
+            throw new Error("Prebuild not found");
+        }
+
+        return prebuild;
+    });
 }
 
 function prebuildQueryKey(prebuildId: string) {
-    return ["prebuild-and-configuration", prebuildId];
+    return ["prebuild", prebuildId];
 }
 
 export function watchPrebuild(prebuildId: string, cb: (data: Prebuild) => void) {

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -11,7 +11,7 @@ import { useCurrentUser } from "../user-context";
 import { useCurrentOrg, useOrganizations } from "../data/organizations/orgs-query";
 import { useLocation } from "react-router";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
-import { useHasConfigurationsAndPrebuildsEnabled } from "../data/featureflag-query";
+import { useFeatureFlag, useHasConfigurationsAndPrebuildsEnabled } from "../data/featureflag-query";
 import { useIsOwner, useListOrganizationMembers, useHasRolePermission } from "../data/organizations/members-query";
 import { isOrganizationOwned } from "@gitpod/public-api-common/lib/user-utils";
 import { OrganizationRole } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
@@ -26,6 +26,7 @@ export default function OrganizationSelector() {
     const { data: billingMode } = useOrgBillingMode();
     const getOrgURL = useGetOrgURL();
     const configurationsAndPrebuilds = useHasConfigurationsAndPrebuildsEnabled();
+    const showPrebuildMenuItem = useFeatureFlag("showPrebuildsMenuItem");
 
     // we should have an API to ask for permissions, until then we duplicate the logic here
     const canCreateOrgs = user && !isOrganizationOwned(user);
@@ -68,13 +69,15 @@ export default function OrganizationSelector() {
                     separator: false,
                     link: "/repositories",
                 });
-                linkEntries.push({
-                    title: "Prebuilds",
-                    customContent: <LinkEntry>Prebuilds</LinkEntry>,
-                    active: false,
-                    separator: false,
-                    link: "/prebuilds",
-                });
+                if (showPrebuildMenuItem) {
+                    linkEntries.push({
+                        title: "Prebuilds",
+                        customContent: <LinkEntry>Prebuilds</LinkEntry>,
+                        active: false,
+                        separator: false,
+                        link: "/prebuilds",
+                    });
+                }
             }
             linkEntries.push({
                 title: "Members",

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -36,7 +36,7 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
         <TableRow>
             <TableCell>
                 <div className="flex flex-col gap-1">
-                    <Text className="text-sm text-pk-content-primary text-semibold">
+                    <Text className="text-sm text-pk-content-primary text-semibold break-all">
                         <ConfigurationField
                             configuration={configuration}
                             isError={isConfigurationError}

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -36,14 +36,14 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
         <TableRow>
             <TableCell>
                 <div className="flex flex-col gap-1">
-                    <Text className="text-sm text-pk-content-primary text-semibold break-all">
+                    <Text className="text-sm text-pk-content-primary text-semibold break-words">
                         <ConfigurationField
                             configuration={configuration}
                             isError={isConfigurationError}
                             isLoading={isConfigurationLoading}
                         />
                     </Text>
-                    <TextMuted className="text-xs break-all">{prebuild.ref}</TextMuted>
+                    <TextMuted className="text-xs break-words">{prebuild.ref}</TextMuted>
                 </div>
             </TableCell>
 

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -35,7 +35,7 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
     return (
         <TableRow>
             <TableCell>
-                <div className="flex flex-col gap-1">
+                <div className="flex flex-col gap-1 w-52">
                     <Text className="text-sm text-pk-content-primary text-semibold break-words">
                         <ConfigurationField
                             configuration={configuration}

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { TextMuted } from "@podkit/typography/TextMuted";
 import { Text } from "@podkit/typography/Text";
 import { LinkButton } from "@podkit/buttons/LinkButton";
@@ -19,11 +19,28 @@ import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb
 import { LoadingState } from "@podkit/loading/LoadingState";
 import { prebuildDisplayProps, prebuildStatusIconComponent } from "../../projects/prebuild-utils";
 
+/**
+ * Formats a date. For today, it returns the time. For this year, it returns the month and day. Otherwise, it returns the full date.
+ */
+const formatDate = (date: dayjs.Dayjs): string => {
+    if (date.isSame(dayjs(), "day")) {
+        return date.format("[Today at] h:mm A");
+    }
+
+    if (date.isSame(dayjs(), "year")) {
+        return date.format("MMM D");
+    }
+
+    return date.format("MMM D, YYYY");
+};
+
 type Props = {
     prebuild: Prebuild;
 };
 export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
-    const created = dayjs(prebuild.status?.startTime?.toDate()).fromNow();
+    const triggeredDate = useMemo(() => dayjs(prebuild.status?.startTime?.toDate()), [prebuild.status?.startTime]);
+    const triggeredString = useMemo(() => formatDate(triggeredDate), [triggeredDate]);
+
     const {
         data: configuration,
         isError: isConfigurationError,
@@ -64,7 +81,14 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
             </TableCell>
 
             <TableCell hideOnSmallScreen>
-                <Text className="text-sm break-all text-pk-content-secondary">{created}</Text>
+                <Text className="text-sm break-all text-pk-content-secondary">
+                    <time
+                        dateTime={prebuild.status?.startTime?.toDate().toISOString()}
+                        title={triggeredDate.toString()}
+                    >
+                        {triggeredString}
+                    </time>
+                </Text>
             </TableCell>
 
             <TableCell>

--- a/components/dashboard/src/projects/prebuild-utils.tsx
+++ b/components/dashboard/src/projects/prebuild-utils.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Prebuild, PrebuildPhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
-import { PauseCircle, LucideProps, Clock, CheckCircle2, XCircle, CircleSlash2 } from "lucide-react";
+import { PauseCircle, LucideProps, Clock, CheckCircle2, XCircle } from "lucide-react";
 import type { ForwardRefExoticComponent } from "react";
 
 import StatusDone from "../icons/StatusDone.svg";
@@ -52,7 +52,7 @@ export const prebuildStatusIconComponent = (prebuild: Prebuild): ForwardRefExoti
         case PrebuildPhase_Phase.ABORTED:
         case PrebuildPhase_Phase.TIMEOUT:
         case PrebuildPhase_Phase.FAILED:
-            return CircleSlash2;
+            return XCircle;
         case PrebuildPhase_Phase.AVAILABLE:
             if (prebuild?.status?.message) {
                 return XCircle;
@@ -60,7 +60,7 @@ export const prebuildStatusIconComponent = (prebuild: Prebuild): ForwardRefExoti
             return CheckCircle2;
     }
 
-    return CircleSlash2;
+    return XCircle;
 };
 
 export const prebuildStatusIcon = (prebuild?: Prebuild) => {

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
@@ -37,10 +37,10 @@ const formatDate = (date: dayjs.Dayjs): string => {
     }
 
     if (date.isSame(dayjs(), "year")) {
-        return date.format("MMM D h:mm A");
+        return date.format("MMM D [at] h:mm A");
     }
 
-    return date.format("MMM D, YYYY h:mm A");
+    return date.format("MMM D, YYYY [at] h:mm A");
 };
 
 interface Props {

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
@@ -135,7 +135,9 @@ export const PrebuildDetailPage: FC = () => {
                 pageTitle="Prebuild history"
                 pageDescription={
                     <>
-                        <span className="font-semibold">{info?.configuration?.name ?? "unknown repository"}</span>{" "}
+                        <span className="font-semibold">
+                            {!infoIsLoading ? info?.configuration?.name : "" ?? "unknown repository"}
+                        </span>{" "}
                         <span className="text-pk-content-secondary">{info?.prebuild?.ref ?? ""}</span>
                     </>
                 }

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
@@ -158,11 +158,11 @@ export const PrebuildDetailPage: FC = () => {
                                             </div>
                                         )}
                                     </div>
-                                    <div className="flex gap-1">
+                                    <div className="flex gap-1 items-center">
                                         <img
                                             className="w-5 h-5 rounded-full"
                                             src={info.prebuild.commit?.author?.avatarUrl}
-                                            alt={info.prebuild.commit?.author?.name}
+                                            alt=""
                                         />
                                         <span className="text-pk-content-secondary">
                                             {info.prebuild.commit?.author?.name}

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
@@ -14,7 +14,7 @@ import dayjs from "dayjs";
 import { usePrebuildLogsEmitter } from "../../../data/prebuilds/prebuild-logs-emitter";
 import React from "react";
 import { useToast } from "../../../components/toasts/Toasts";
-import { usePrebuilQuery, useTriggerPrebuildQuery, watchPrebuild } from "../../../data/prebuilds/prebuild-query";
+import { usePrebuildQuery, useTriggerPrebuildQuery, watchPrebuild } from "../../../data/prebuilds/prebuild-query";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 import { repositoriesRoutes } from "../../repositories.routes";
 import { LoadingState } from "@podkit/loading/LoadingState";
@@ -46,8 +46,8 @@ interface Props {
 export const PrebuildDetailPage: FC = () => {
     const { prebuildId } = useParams<Props>();
 
-    const { data: prebuild, isLoading: infoIsLoading, error, refetch } = usePrebuilQuery(prebuildId);
-    const { data: configuration, isLoading: configurationIsLoading } = useConfiguration(
+    const { data: prebuild, isLoading: isInfoLoading, error, refetch } = usePrebuildQuery(prebuildId);
+    const { data: configuration, isLoading: isConfigurationLoading } = useConfiguration(
         prebuild?.configurationId ?? "",
     );
 
@@ -134,7 +134,7 @@ export const PrebuildDetailPage: FC = () => {
                 pageDescription={
                     <>
                         <span className="font-semibold">
-                            {!configurationIsLoading ? configuration?.name : "" ?? "unknown repository"}
+                            {!isConfigurationLoading ? configuration?.name : "" ?? "unknown repository"}
                         </span>{" "}
                         <span className="text-pk-content-secondary">{prebuild?.ref ?? ""}</span>
                     </>
@@ -142,7 +142,7 @@ export const PrebuildDetailPage: FC = () => {
                 backLink={repositoriesRoutes.Prebuilds()}
             />
             <div className="app-container mb-8">
-                {infoIsLoading && (
+                {isInfoLoading && (
                     <div className="flex justify-center">
                         <LoadingState />
                     </div>

--- a/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/prebuilds/PrebuildDetailPage.tsx
@@ -9,7 +9,7 @@ import { BreadcrumbNav } from "@podkit/breadcrumbs/BreadcrumbNav";
 import { Button } from "@podkit/buttons/Button";
 import { FC, Suspense, useEffect, useMemo, useState } from "react";
 import { Redirect, useParams } from "react-router";
-import { CircleSlash2, Loader2Icon } from "lucide-react";
+import { CircleSlash, Loader2Icon } from "lucide-react";
 import dayjs from "dayjs";
 import { usePrebuildLogsEmitter } from "../../../data/prebuilds/prebuild-logs-emitter";
 import React from "react";
@@ -95,7 +95,7 @@ export const PrebuildDetailPage: FC = () => {
         const name = currentPrebuild?.status?.phase?.name;
         if (!name) {
             return {
-                icon: <CircleSlash2 size={20} className="text-gray-500" />,
+                icon: <CircleSlash size={20} className="text-gray-500" />,
                 description: "Unknown prebuild status.",
             };
         }

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -27,7 +27,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     return (
         <TableRow>
             <TableCell>
-                <div className="flex flex-col gap-1">
+                <div className="flex flex-col gap-1 break-all">
                     <Text className="font-semibold">{configuration.name}</Text>
                     {/* We show the url on a 2nd line for smaller screens since we hide the column */}
                     <TextMuted className="inline md:hidden text-sm break-all">{url}</TextMuted>

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -27,7 +27,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     return (
         <TableRow>
             <TableCell>
-                <div className="flex flex-col gap-1 break-all">
+                <div className="flex flex-col gap-1 break-words">
                     <Text className="font-semibold">{configuration.name}</Text>
                     {/* We show the url on a 2nd line for smaller screens since we hide the column */}
                     <TextMuted className="inline md:hidden text-sm break-all">{url}</TextMuted>

--- a/components/dashboard/src/repositories/list/RepoListItem.tsx
+++ b/components/dashboard/src/repositories/list/RepoListItem.tsx
@@ -27,7 +27,7 @@ export const RepositoryListItem: FC<Props> = ({ configuration }) => {
     return (
         <TableRow>
             <TableCell>
-                <div className="flex flex-col gap-1 break-words">
+                <div className="flex flex-col gap-1 break-words w-52">
                     <Text className="font-semibold">{configuration.name}</Text>
                     {/* We show the url on a 2nd line for smaller screens since we hide the column */}
                     <TextMuted className="inline md:hidden text-sm break-all">{url}</TextMuted>


### PR DESCRIPTION
## Description

Fixes some small issues with prebuilds and configs:
- in lists, fix layouts where the configuration name is super long 
- fixed prebuild status icons to be consistent and similar to the rest

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-repo-pr16276b329d</li>
	<li><b>🔗 URL</b> - <a href="https://ft-repo-pr16276b329d.preview.gitpod-dev.com/workspaces" target="_blank">ft-repo-pr16276b329d.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-repo-prebuilds-fixes-gha.22946</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-repo-pr16276b329d%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
