### PR TITLE
fix: Workspace Timeout Bug: Correctly Apply disabledClosedTimeout Flag for Enhanced User Control

### DIFF
--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -63,7 +63,7 @@ export default function Preferences() {
             try {
                 await getGitpodService().server.updateWorkspaceTimeoutSetting({
                     workspaceTimeout: workspaceTimeout,
-                    disabledClosedTimeout: true,
+                    disabledClosedTimeout: workspaceTimeout === "" ? false : true,
                 });
 
                 // TODO: Once current user is in react-query, we can instead invalidate the query vs. refetching here

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -61,7 +61,10 @@ export default function Preferences() {
 
             // TODO: Convert this to a mutation
             try {
-                await getGitpodService().server.updateWorkspaceTimeoutSetting({ workspaceTimeout: workspaceTimeout });
+                await getGitpodService().server.updateWorkspaceTimeoutSetting({
+                    workspaceTimeout: workspaceTimeout,
+                    disabledClosedTimeout: true,
+                });
 
                 // TODO: Once current user is in react-query, we can instead invalidate the query vs. refetching here
                 const { user } = await userClient.getAuthenticatedUser({});

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1553,7 +1553,17 @@ export class WorkspaceStarter {
                         spec.setTimeout(timeout);
                     } catch (err) {}
                 }
+
+                // if the user has set a timeout, then disabledClosedTimeout would be true
                 if (user.additionalData?.disabledClosedTimeout === true) {
+                    /*
+                     * If disabledClosedTimeout is true, it indicates that the user wishes to prevent the workspace
+                     * from being automatically "stopped" or terminated due to inactivity.
+                     * By setting the closed timeout to "0", we effectively disable this automatic termination feature,
+                     * ensuring that the workspace remains active until it explicitly hits the workspace timeout limits,
+                     * if any are set. This provides users with greater control over their workspace's lifecycle,
+                     * accommodating scenarios where extended activity periods are necessary.
+                     */
                     spec.setClosedTimeout("0");
                 }
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request fixes a bug related to workspace timeout. Previously, when updating the workspace timeout setting, the `disabledClosedTimeout` flag was not being set correctly. This caused the workspace to be automatically stopped or terminated due to inactivity, even if the user had explicitly disabled this feature. This pull request ensures that the `disabledClosedTimeout` flag is set correctly when updating the workspace timeout setting, allowing users to have greater control over their workspace's lifecycle.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1343

## How to test
<!-- Provide steps to test this PR -->

- Create account in preview environment
- Complete billing with mock stripe a/c
- Setup timeout in user settings (let's say 15m)
- create a workspace from any repo in VS Code browser or VS Code desktop
- Now, close the workspace tab (if VS code browser) or VS Code window (if desktop)
- then open `/workspaces` tab back and see workspace status, it would still be running.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-ws-timed68fa0a21</li>
	<li><b>🔗 URL</b> - <a href="https://fix-ws-timed68fa0a21.preview.gitpod-dev.com/workspaces" target="_blank">fix-ws-timed68fa0a21.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-ws-timeout-behaviour-gha.22992</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-ws-timed68fa0a21%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
