### PR TITLE
Fix stripe API rate limit error

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -89,7 +89,6 @@ export function AppNotifications() {
     const [topNotification, setTopNotification] = useState<Notification | undefined>(undefined);
     const { user, loading } = useUserLoader();
     const { mutateAsync } = useUpdateCurrentUserMutation();
-    const [stripePortalUrl, setStripePortalUrl] = useState<string | undefined>();
 
     const currentOrg = useCurrentOrg().data;
     const attrId = currentOrg ? AttributionId.createFromOrganizationId(currentOrg.id) : undefined;
@@ -113,10 +112,10 @@ export function AppNotifications() {
                     const [subscriptionId, invalidBillingAddress] = await Promise.all([
                         getGitpodService().server.findStripeSubscriptionId(attributionId),
                         getGitpodService().server.isCustomerBillingAddressInvalid(attributionId),
-                        getGitpodService().server.getStripePortalUrl(attributionId).then(setStripePortalUrl),
                     ]);
+                    const stripePortalUrl = getGitpodService().server.getStripePortalUrl(attributionId);
                     if (subscriptionId && invalidBillingAddress) {
-                        notifications.push(INVALID_BILLING_ADDRESS(stripePortalUrl));
+                        notifications.push(INVALID_BILLING_ADDRESS(await stripePortalUrl));
                     }
                 }
             }
@@ -132,7 +131,7 @@ export function AppNotifications() {
         return () => {
             ignore = true;
         };
-    }, [stripePortalUrl, loading, mutateAsync, user, attributionId]);
+    }, [loading, mutateAsync, user, attributionId]);
 
     const dismissNotification = useCallback(() => {
         if (!topNotification) {

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -109,13 +109,13 @@ export function AppNotifications() {
                 }
 
                 if (isGitpodIo() && attributionId) {
-                    const [subscriptionId, invalidBillingAddress] = await Promise.all([
+                    const [subscriptionId, invalidBillingAddress, stripePortalUrl] = await Promise.all([
                         getGitpodService().server.findStripeSubscriptionId(attributionId),
                         getGitpodService().server.isCustomerBillingAddressInvalid(attributionId),
+                        getGitpodService().server.getStripePortalUrl(attributionId),
                     ]);
-                    const stripePortalUrl = getGitpodService().server.getStripePortalUrl(attributionId);
                     if (subscriptionId && invalidBillingAddress) {
-                        notifications.push(INVALID_BILLING_ADDRESS(await stripePortalUrl));
+                        notifications.push(INVALID_BILLING_ADDRESS(stripePortalUrl));
                     }
                 }
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request fixes a regression issue where hitting the stripe API rate limit would result in an error. The issue has been resolved by removing the unnecessary `stripePortalUrl` state and updating the code accordingly.

regression but introduced in #19417

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
