### PR TITLE
[billing] fix: stripe service for their address parameters

### DIFF
--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -451,8 +451,13 @@ func (c *Client) SetDefaultPaymentForCustomer(ctx context.Context, customerID st
 		InvoiceSettings: &stripe.CustomerInvoiceSettingsParams{
 			DefaultPaymentMethod: stripe.String(paymentMethod.ID)},
 		Address: &stripe.AddressParams{
-			Line1:   stripe.String(paymentMethod.BillingDetails.Address.Line1),
-			Country: stripe.String(paymentMethod.BillingDetails.Address.Country)}})
+			Line1:      stripe.String(paymentMethod.BillingDetails.Address.Line1),
+			Line2:      stripe.String(paymentMethod.BillingDetails.Address.Line2),
+			City:       stripe.String(paymentMethod.BillingDetails.Address.City),
+			PostalCode: stripe.String(paymentMethod.BillingDetails.Address.PostalCode),
+			Country:    stripe.String(paymentMethod.BillingDetails.Address.Country),
+			State:      stripe.String(paymentMethod.BillingDetails.Address.State),
+		}})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to update customer with id %s", customerID)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request fixes an issue with the stripe service where the address parameters were not being set correctly. The `SetDefaultPaymentForCustomer` function now includes all the necessary address fields such as Line1, Line2, City, PostalCode, Country, and State. This ensures that the customer's address is properly updated when setting the default payment method.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1359

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-stripe-ip-bug</li>
	<li><b>🔗 URL</b> - <a href="https://fix-stripe-ip-bug.preview.gitpod-dev.com/workspaces" target="_blank">fix-stripe-ip-bug.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-stripe-ip-bug-gha.23045</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-stripe-ip-bug%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
