### PR TITLE
GitpodWorkspaceTooManyRegularNotActiveMk2: add lower bound of 20

### DIFF
--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -29,11 +29,11 @@ spec:
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceRegularNotActive.md
         summary: too many running but inactive workspaces
-        description: too many running but inactive workspaces.
+        description: too many running but inactive workspaces. lower bound is 20 "regular not active" workspaces to reduce the false-positive rate.
       expr: |
         sum(gitpod_workspace_regular_not_active_percentage_mk2) by(cluster) > 0.08
         AND
-        sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 50
+        sum (gitpod_ws_manager_mk2_workspace_activity_total{active="false"}) by (cluster) > 20
 
     - alert: GitpodWorkspacesNotStartingMk2
       labels:


### PR DESCRIPTION
## Description
GitpodWorkspaceTooManyRegularNotActiveMk2 still triggers too often (false positive): it wakes on-callers up at night, and vanishes after ~2mins, without anybody having a chance to do anything.

Before we had a lower bound of 50 workspaces in a cluster (`sum(gitpod_ws_manager_mk2_workspace_activity_total) by(cluster) > 50`). That was still way to low, because there all sorts of reasons why a handful of workspaces are suddenly appearing in the "regular not active" bucket.

This change alters this lower bound to "at least 20 workspaces regular-not-active stuck for 10 mins", because we don't want to wake up on-call for for individual workspaces.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related: EXP-1392

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
