### PR TITLE
[server, dashboard] improve single prebuild view

### DIFF
--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -12,6 +12,7 @@ import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
 import { ThemeContext } from "../theme-context";
 import { cn } from "@podkit/lib/cn";
+import { LoadingState } from "@podkit/loading/LoadingState";
 
 const darkTheme: ITheme = {
     // What written on DevTool dark:bg-gray-800 is
@@ -28,6 +29,7 @@ export interface WorkspaceLogsProps {
     errorMessage?: string;
     classes?: string;
     xtermClasses?: string;
+    isLoading?: boolean;
 }
 
 export default function WorkspaceLogs(props: WorkspaceLogsProps) {
@@ -104,6 +106,11 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
                 "bg-gray-100 dark:bg-gray-800 relative",
             )}
         >
+            {props.isLoading && (
+                <div className="absolute top-2 right-2">
+                    <LoadingState delay={false} size={16} />
+                </div>
+            )}
             <div
                 className={cn(props.xtermClasses || "absolute top-0 left-0 bottom-0 right-0 m-6")}
                 ref={xTermParentRef}

--- a/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
@@ -7,7 +7,7 @@
 import EventEmitter from "events";
 import { prebuildClient } from "../../service/public-api";
 import { useEffect, useState } from "react";
-import { onDownloadPrebuildLogsUrl } from "@gitpod/public-api-common/lib/prebuild-utils";
+import { matchPrebuildError, onDownloadPrebuildLogsUrl } from "@gitpod/public-api-common/lib/prebuild-utils";
 
 export function usePrebuildLogsEmitter(prebuildId: string) {
     const [emitter] = useState(new EventEmitter());
@@ -25,7 +25,12 @@ export function usePrebuildLogsEmitter(prebuildId: string) {
             dispose = onDownloadPrebuildLogsUrl(
                 prebuild.prebuild.status.logUrl,
                 (msg) => {
-                    emitter.emit("logs", msg);
+                    const error = matchPrebuildError(msg);
+                    if (!error) {
+                        emitter.emit("logs", msg);
+                    } else {
+                        emitter.emit("logs-error", error);
+                    }
                 },
                 {
                     includeCredentials: true,

--- a/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
@@ -12,6 +12,11 @@ import { matchPrebuildError, onDownloadPrebuildLogsUrl } from "@gitpod/public-ap
 export function usePrebuildLogsEmitter(prebuildId: string) {
     const [emitter] = useState(new EventEmitter());
     const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        setIsLoading(true);
+    }, [prebuildId]);
+
     useEffect(() => {
         const controller = new AbortController();
         const watch = async () => {

--- a/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
@@ -11,6 +11,7 @@ import { matchPrebuildError, onDownloadPrebuildLogsUrl } from "@gitpod/public-ap
 
 export function usePrebuildLogsEmitter(prebuildId: string) {
     const [emitter] = useState(new EventEmitter());
+    const [isLoading, setIsLoading] = useState(true);
     useEffect(() => {
         const controller = new AbortController();
         const watch = async () => {
@@ -35,6 +36,9 @@ export function usePrebuildLogsEmitter(prebuildId: string) {
                 {
                     includeCredentials: true,
                     maxBackoffTimes: 3,
+                    onEnd: () => {
+                        setIsLoading(false);
+                    },
                 },
             );
         };
@@ -47,5 +51,5 @@ export function usePrebuildLogsEmitter(prebuildId: string) {
             controller.abort();
         };
     }, [emitter, prebuildId]);
-    return { emitter };
+    return { emitter, isLoading };
 }

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -84,7 +84,7 @@ export const PrebuildDetailPage: FC = () => {
             }
         });
         logEmitter.on("logs-error", (err: ApplicationError) => {
-            toast("Fetch logs failed: " + err.message, { autoHide: false });
+            toast("Fetching logs failed: " + err.message, { autoHide: false });
         });
     }, [logEmitter, toast]);
 

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -22,6 +22,7 @@ import Alert from "../../components/Alert";
 import { prebuildDisplayProps, prebuildStatusIconComponent } from "../../projects/prebuild-utils";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { useConfiguration } from "../../data/configurations/configuration-queries";
+import { ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 const WorkspaceLogs = React.lazy(() => import("../../components/WorkspaceLogs"));
 
@@ -81,6 +82,9 @@ export const PrebuildDetailPage: FC = () => {
             if (err?.message) {
                 toast("Failed to fetch logs: " + err.message);
             }
+        });
+        logEmitter.on("logs-error", (err: ApplicationError) => {
+            toast("Fetch logs failed: " + err.message, { autoHide: false });
         });
     }, [logEmitter, toast]);
 

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -55,7 +55,7 @@ export const PrebuildDetailPage: FC = () => {
     const { toast } = useToast();
     const [currentPrebuild, setCurrentPrebuild] = useState<Prebuild | undefined>();
 
-    const { emitter: logEmitter } = usePrebuildLogsEmitter(prebuildId);
+    const { emitter: logEmitter, isLoading: isStreamingLogs } = usePrebuildLogsEmitter(prebuildId);
     const {
         isFetching: isTriggeringPrebuild,
         refetch: triggerPrebuild,
@@ -213,6 +213,7 @@ export const PrebuildDetailPage: FC = () => {
                                         classes="h-full w-full"
                                         xtermClasses="absolute top-0 left-0 bottom-0 right-0 mx-6 my-0"
                                         logsEmitter={logEmitter}
+                                        isLoading={isStreamingLogs}
                                     />
                                 </Suspense>
                             </div>

--- a/components/public-api/typescript-common/src/prebuild-utils.spec.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.spec.ts
@@ -40,7 +40,7 @@ describe("PrebuildUtils", () => {
                 const result = matchPrebuildError(msg);
                 expect(result).to.not.undefined;
                 expect(result?.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
-                expect(result?.message).to.equal(err.message);
+                expect(result?.message).to.equal("unexpected error");
             }
         });
 

--- a/components/public-api/typescript-common/src/prebuild-utils.spec.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { getPrebuildErrorMessage, matchPrebuildError } from "./prebuild-utils";
+
+describe("PrebuildUtils", () => {
+    describe("PrebuildErrorMessage", () => {
+        it("Application Error", async () => {
+            const errorList = [
+                new ApplicationError(ErrorCodes.UNIMPLEMENTED, "not implemented"),
+                new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, "not implemented#"),
+                new ApplicationError(ErrorCodes.NOT_FOUND, "#not implemented#"),
+                new ApplicationError(ErrorCodes.NOT_FOUND, "#not#implemented#"),
+                new ApplicationError(ErrorCodes.NOT_FOUND, "12312#not#implemented#"),
+            ];
+            for (const err of errorList) {
+                const msg = getPrebuildErrorMessage(err);
+                const result = matchPrebuildError(msg);
+                expect(result).to.not.undefined;
+                expect(result?.code).to.equal(err.code);
+                expect(result?.message).to.equal(err.message);
+            }
+        });
+
+        it("Error", async () => {
+            const errorList = [
+                new Error("not implemented"),
+                new Error("not implemented#"),
+                new Error("#not implemented#"),
+                new Error("#not#implemented#"),
+                new Error("12312#not#implemented#"),
+            ];
+            for (const err of errorList) {
+                const msg = getPrebuildErrorMessage(err);
+                const result = matchPrebuildError(msg);
+                expect(result).to.not.undefined;
+                expect(result?.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
+                expect(result?.message).to.equal(err.message);
+            }
+        });
+
+        it("others", async () => {
+            const errorList = [{}, [], Symbol("hello")];
+            for (const err of errorList) {
+                const msg = getPrebuildErrorMessage(err);
+                const result = matchPrebuildError(msg);
+                expect(result).to.not.undefined;
+                expect(result?.code).to.equal(ErrorCodes.INTERNAL_SERVER_ERROR);
+                expect(result?.message).to.equal("unknown error");
+            }
+        });
+    });
+
+    describe("matchPrebuildError", () => {
+        it("happy path", async () => {
+            const result = matchPrebuildError(
+                "X-Prebuild-Error#404#Headless logs for 07f877b5-631c-47c8-82aa-09de2f11fff3 not found#X-Prebuild-Error",
+            );
+            expect(result).to.not.undefined;
+            expect(result?.code).to.be.equal(404);
+            expect(result?.message).to.be.equal("Headless logs for 07f877b5-631c-47c8-82aa-09de2f11fff3 not found");
+        });
+
+        it("not match", async () => {
+            const result = matchPrebuildError("echo hello");
+            expect(result).to.be.undefined;
+        });
+    });
+});

--- a/components/public-api/typescript-common/src/prebuild-utils.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.ts
@@ -45,6 +45,7 @@ const defaultBackoffTimes = 3;
 interface Options {
     includeCredentials: boolean;
     maxBackoffTimes?: number;
+    onEnd?: () => void;
 }
 
 /**
@@ -141,6 +142,9 @@ export function onDownloadPrebuildLogsUrl(
             await retryBackoff("error while listening to stream", err);
         } finally {
             reader?.cancel().catch(console.debug);
+            if (options.onEnd) {
+                options.onEnd();
+            }
         }
     };
     startWatchingLogs().catch(console.error);

--- a/components/public-api/typescript-common/src/prebuild-utils.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.ts
@@ -36,7 +36,7 @@ export function getPrebuildErrorMessage(err: any) {
         code = err.code;
         message = err.message;
     } else if (err instanceof Error) {
-        message = err.message;
+        message = "unexpected error";
     }
     return `${PREBUILD_LOG_STREAM_ERROR}#${code}#${message}#${PREBUILD_LOG_STREAM_ERROR}`;
 }

--- a/components/public-api/typescript-common/src/prebuild-utils.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import { Disposable, DisposableCollection, HEADLESS_LOG_STREAM_STATUS_CODE_REGEX } from "@gitpod/gitpod-protocol";
-import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ApplicationError, ErrorCode, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 /**
  * new entry for the stream prebuild logs, contains logs of imageBuild (if it has) and prebuild tasks(first task only for now) logs
@@ -15,6 +15,30 @@ export const PREBUILD_LOGS_PATH_PREFIX = "/prebuild-logs";
 
 export function getPrebuildLogPath(prebuildId: string): string {
     return PREBUILD_LOGS_PATH_PREFIX + "/" + prebuildId;
+}
+
+/** cmp. @const HEADLESS_LOG_STREAM_ERROR_REGEX */
+const PREBUILD_LOG_STREAM_ERROR = "X-Prebuild-Error";
+const PREBUILD_LOG_STREAM_ERROR_REGEX = /X-Prebuild-Error: (?<code>[0-9]{3}) (?<message>\w+)$/;
+
+export function matchPrebuildError(msg: string): undefined | ApplicationError {
+    const result = PREBUILD_LOG_STREAM_ERROR_REGEX.exec(msg);
+    if (!result || !result.groups) {
+        return;
+    }
+    return new ApplicationError(Number(result.groups.code) as ErrorCode, result.groups.message);
+}
+
+export function getPrebuildErrorMessage(err: any) {
+    let code: ErrorCode = ErrorCodes.INTERNAL_SERVER_ERROR;
+    let message = "unknown error";
+    if (err instanceof ApplicationError) {
+        code = err.code;
+        message = err.message;
+    } else if (err instanceof Error) {
+        message = err.message;
+    }
+    return `${PREBUILD_LOG_STREAM_ERROR}: ${code} ${message}`;
 }
 
 const defaultBackoffTimes = 3;

--- a/components/public-api/typescript-common/src/prebuild-utils.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.ts
@@ -19,7 +19,7 @@ export function getPrebuildLogPath(prebuildId: string): string {
 
 /** cmp. @const HEADLESS_LOG_STREAM_ERROR_REGEX */
 const PREBUILD_LOG_STREAM_ERROR = "X-Prebuild-Error";
-const PREBUILD_LOG_STREAM_ERROR_REGEX = /X-Prebuild-Error: (?<code>[0-9]{3}) (?<message>\w+)$/;
+const PREBUILD_LOG_STREAM_ERROR_REGEX = /X-Prebuild-Error#(?<code>[0-9]+)#(?<message>.*?)#X-Prebuild-Error/;
 
 export function matchPrebuildError(msg: string): undefined | ApplicationError {
     const result = PREBUILD_LOG_STREAM_ERROR_REGEX.exec(msg);
@@ -38,7 +38,7 @@ export function getPrebuildErrorMessage(err: any) {
     } else if (err instanceof Error) {
         message = err.message;
     }
-    return `${PREBUILD_LOG_STREAM_ERROR}: ${code} ${message}`;
+    return `${PREBUILD_LOG_STREAM_ERROR}#${code}#${message}#${PREBUILD_LOG_STREAM_ERROR}`;
 }
 
 const defaultBackoffTimes = 3;

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -631,13 +631,14 @@ export class PrebuildManager {
     }
 
     public async watchPrebuildLogs(userId: string, prebuildId: string, onLog: (message: string) => void) {
-        const workspaceId = await this.waitUntilPrebuildWorkspaceCreated(userId, prebuildId);
-        if (!workspaceId) {
+        const { workspaceId, organizationId } = await this.waitUntilPrebuildWorkspaceCreated(userId, prebuildId);
+        if (!workspaceId || !organizationId) {
             throw new ApplicationError(ErrorCodes.PRECONDITION_FAILED, "prebuild workspace not found");
         }
-
+        await this.auth.checkPermissionOnOrganization(userId, "read_prebuild", organizationId);
         const workspaceStatusIt = this.workspaceService.getAndWatchWorkspaceStatus(userId, workspaceId, {
             signal: ctxSignal(),
+            skipPermissionCheck: true,
         });
         let hasImageBuild = false;
         for await (const itWsInfo of workspaceStatusIt) {
@@ -752,12 +753,14 @@ export class PrebuildManager {
     }
 
     private async waitUntilPrebuildWorkspaceCreated(userId: string, prebuildId: string) {
-        let prebuildWorkspaceId: string | undefined;
+        let workspaceId: string | undefined;
+        let organizationId: string | undefined;
         const prebuildIt = this.getAndWatchPrebuildStatus(userId, { prebuildId }, { signal: ctxSignal() });
 
         for await (const pb of prebuildIt) {
-            prebuildWorkspaceId = pb.info.buildWorkspaceId;
-            if (prebuildWorkspaceId) {
+            workspaceId = pb.info.buildWorkspaceId;
+            organizationId = pb.info.teamId;
+            if (workspaceId) {
                 break;
             }
             if (pb.status === "aborted" || pb.status === "failed" || pb.status === "timeout") {
@@ -765,7 +768,7 @@ export class PrebuildManager {
             }
         }
         await prebuildIt.return();
-        return prebuildWorkspaceId;
+        return { workspaceId, organizationId };
     }
 
     private parsePrebuildLogUrl(url: string) {

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -717,6 +717,9 @@ export class PrebuildManager {
                                         {
                                             includeCredentials: false,
                                             maxBackoffTimes: 3,
+                                            onEnd: () => {
+                                                sink.stop();
+                                            },
                                         },
                                     );
                                     return () => {

--- a/components/server/src/util/request-context.ts
+++ b/components/server/src/util/request-context.ts
@@ -203,6 +203,17 @@ export function runWithSubjectId<T>(subjectId: SubjectId | undefined, fun: () =>
     return runWithContext({ ...parent, subjectId }, fun);
 }
 
+export function runWithSubSignal<T>(abortController: AbortController, fun: () => T): T {
+    const parent = ctxTryGet();
+    if (!parent) {
+        throw new Error("runWithChildContext: No parent context available");
+    }
+    ctxOnAbort(() => {
+        abortController.abort("runWithSubSignal: Parent context signal aborted");
+    });
+    return runWithContext({ ...parent, signal: abortController.signal }, fun);
+}
+
 function runWithContext<C extends RequestContext, T>(context: C, fun: () => T): T {
     return asyncLocalStorage.run(context, fun);
 }

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -244,9 +244,7 @@ export class HeadlessLogController {
                     } catch (e) {
                         log.error(logCtx, "error streaming headless logs", e);
                         TraceContext.setError({ span }, e);
-                        writeToResponse(getPrebuildErrorMessage(e))
-                            .then()
-                            .catch(() => {});
+                        await writeToResponse(getPrebuildErrorMessage(e)).catch(() => {});
                     } finally {
                         span.finish();
                         res.end();

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -217,7 +217,7 @@ export class HeadlessLogController {
                 const writeToResponse = async (chunk: string) =>
                     queue.enqueue(
                         () =>
-                            new Promise<void>(async (resolve, reject) => {
+                            new Promise<void>((resolve) => {
                                 if (ctxIsAborted()) {
                                     return;
                                 }

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -209,7 +209,7 @@ export class HeadlessLogController {
 
                     const prebuildId = req.params.prebuildId;
                     if (!uuidValidate(prebuildId)) {
-                        res.status(400).send("prebuildId is invalidate");
+                        res.status(400).send("prebuildId is invalid");
                         return;
                     }
                     const logCtx = { userId: user.id, prebuildId };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It will show streaming result with toast (auto close disabled) if server respond error
<img width="2048" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/ae46d31b-7c2f-46d9-8c2f-30bc34271908">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1360 EXP-1411

## How to test
<!-- Provide steps to test this PR -->

https://hw-debug-prebuild.preview.gitpod-dev.com/workspaces

1️⃣ Prebuild log works:

- Access preview env, trigger a prebuild
- Access prebuild-logs entry (can be find in DevTool of prebuild log view), it should work like before and Browser tab indicator should stop show loading circle after everything is done
- It should throw and print error on server when

2️⃣ Permission check:
- Should not able to access https://hw-debug-prebuild.preview.gitpod-dev.com/prebuild-logs/d5780885-fbe2-47fb-b748-3d83d4951e24 (it will print X-Prebuild-Error:xxx)
- Join org via https://hw-debug-prebuild.preview.gitpod-dev.com/orgs/join?inviteId=29067092-cd09-4ee0-ba68-5da1e838d9d2, link above should work

3️⃣ Loading indicator is shown and dismissed at proper time
<img width="1503" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/2039623b-d7c6-4396-8d5a-0664117bcf6c">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
