### PR TITLE
[IdP] add `user_id` claim and allow to customize OIDC subject via FF

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -4,7 +4,10 @@
 
 package experiments
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 const (
 	PersonalAccessTokensEnabledFlag                = "personalAccessTokensEnabled"
@@ -12,10 +15,19 @@ const (
 	SupervisorPersistServerAPIChannelWhenStartFlag = "supervisor_persist_serverapi_channel_when_start"
 	SupervisorUsePublicAPIFlag                     = "supervisor_experimental_publicapi"
 	ServiceWaiterSkipComponentsFlag                = "service_waiter_skip_components"
+	IdPClaimKeysFlag                               = "idp_claim_keys"
 )
 
 func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, PersonalAccessTokensEnabledFlag, false, attributes)
+}
+
+func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) []string {
+	value := client.GetStringValue(ctx, IdPClaimKeysFlag, "", attributes)
+	if value == "" {
+		return []string{}
+	}
+	return strings.Split(value, ";")
 }
 
 func IsOIDCServiceEnabled(ctx context.Context, client Client, attributes Attributes) bool {

--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -27,7 +27,7 @@ func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) 
 	if value == "" || value == "undefined" {
 		return []string{}
 	}
-	return strings.Split(value, ";")
+	return strings.Split(value, ",")
 }
 
 func IsOIDCServiceEnabled(ctx context.Context, client Client, attributes Attributes) bool {

--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -23,8 +23,8 @@ func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attribute
 }
 
 func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) []string {
-	value := client.GetStringValue(ctx, IdPClaimKeysFlag, "", attributes)
-	if value == "" {
+	value := client.GetStringValue(ctx, IdPClaimKeysFlag, "undefined", attributes)
+	if value == "" || value == "undefined" {
 		return []string{}
 	}
 	return strings.Split(value, ";")

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -88,6 +88,7 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo := oidc.NewUserInfo()
 	userInfo.SetName(user.Name)
 	userInfo.SetSubject(subject)
+	userInfo.AppendClaims("user_id", user.ID)
 	userInfo.AppendClaims("org_id", workspace.Workspace.OrganizationId)
 
 	if email != "" {

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -298,14 +298,20 @@ func TestGetOIDCSubject(t *testing.T) {
 			Subject: contextUrl,
 		},
 		{
+			Name:    "happy path 2",
+			Keys:    "undefined",
+			Claims:  map[string]interface{}{},
+			Subject: contextUrl,
+		},
+		{
 			Name:    "with custom keys",
-			Keys:    "key1;key3;key2",
+			Keys:    "key1,key3,key2",
 			Claims:  map[string]interface{}{"key1": 1, "key2": "hello"},
 			Subject: "key1:1:key3::key2:hello",
 		},
 		{
 			Name:    "with custom keys",
-			Keys:    "key1;key3;key2",
+			Keys:    "key1,key3,key2",
 			Claims:  map[string]interface{}{"key1": 1, "key3": errors.New("test")},
 			Subject: "key1:1:key3:test:key2:",
 		},

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -203,7 +203,7 @@ func register(srv *baseserver.Server, deps *registerDependencies) error {
 	rootHandler.Mount(v1connect.NewIDEClientServiceHandler(apiv1.NewIDEClientService(deps.connPool), handlerOptions...))
 	rootHandler.Mount(v1connect.NewProjectsServiceHandler(apiv1.NewProjectsService(deps.connPool), handlerOptions...))
 	rootHandler.Mount(v1connect.NewOIDCServiceHandler(apiv1.NewOIDCService(deps.connPool, deps.expClient, deps.dbConn, deps.cipher), handlerOptions...))
-	rootHandler.Mount(v1connect.NewIdentityProviderServiceHandler(apiv1.NewIdentityProviderService(deps.connPool, deps.idpService), handlerOptions...))
+	rootHandler.Mount(v1connect.NewIdentityProviderServiceHandler(apiv1.NewIdentityProviderService(deps.connPool, deps.idpService, deps.expClient), handlerOptions...))
 
 	if deps.signer != nil {
 		rootHandler.Mount(v1connect.NewTokensServiceHandler(apiv1.NewTokensService(deps.connPool, deps.expClient, deps.dbConn, deps.signer), handlerOptions...))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1389

## How to test
<!-- Provide steps to test this PR -->

https://hw-exp-1389.preview.gitpod-dev.com/workspaces

1️⃣  user_id should be in token you generate
- Exec `gp idp token --audience hello` in preview env workspace
- Decode in jwt.io, there should have a `user_id` field

2️⃣ customize subject
- Update FF https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=290994 with your team to proper value
- Check with `gp idp token --audience hello`
- Decode in jwt.io and you should see subject field `sub` changed according to your setting

<img width="622" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/2861759e-2220-4ae3-b362-6f494dca51ec">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
