### PR TITLE
[server] Fix handling of multiple session cookies with the same name

### DIFF
--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -61,14 +61,20 @@ export class SessionHandler {
 
                 // Was the token issued more than threshold ago?
                 if (issuedAtMs + SessionHandler.JWT_REFRESH_THRESHOLD < now.getTime()) {
-                    // issue a new one, to refresh it
-                    const cookie = await this.createJWTSessionCookie(user.id);
-                    res.cookie(cookie.name, cookie.value, cookie.opts);
+                    try {
+                        // issue a new one, to refresh it
+                        const cookie = await this.createJWTSessionCookie(user.id);
+                        res.cookie(cookie.name, cookie.value, cookie.opts);
 
-                    reportJWTCookieIssued();
-                    res.status(200);
-                    res.send("Refreshed JWT cookie issued.");
-                    return;
+                        reportJWTCookieIssued();
+                        res.status(200);
+                        res.send("Refreshed JWT cookie issued.");
+                        return;
+                    } catch (err) {
+                        res.status(401);
+                        res.send("JWT Session can't be signed");
+                        return;
+                    }
                 }
 
                 res.status(200);


### PR DESCRIPTION
## Description
Previously, we would pick the last cookie (with the same name) the browser sends us, which is "random": browser-dependent, and complex/different for every call.
This makes us pick the first valid JWT cookie from the list of correctly named cookies.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1415

## How to test 
 - [tests](https://github.com/gitpod-io/gitpod/blob/32fa7aa4ca80e68291112a4c0a9a1e7f41504a5d/components/server/src/session-handler.spec.db.ts#L107-L146) are :green_circle: 

 - go to https://gpl-ood-cookie.preview.gitpod-dev.com/workspaces
 - sign up
 - go to "Storage/Cookies", and add another cookie:
   - with some random value
   - domain should be automatically be set to "gpl-ood-cookie.preview.gitpod-dev.com" (without the dot)
   - name: "_gpl_ood_cookie_preview_gitpod_dev_com_jwt2_"
 -  navigate around (especially [/projects](https://gpl-ood-cookie.preview.gitpod-dev.com/projects)) and observe on the network tab:
   - all requests carry the two cookies (in different orders) :heavy_check_mark: 
   - all requests work (no 401s) :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
