### PR TITLE
 Remove ability to edit repository variables

### DIFF
--- a/components/dashboard/src/repositories/detail/variables/ConfigurationAddVariableModal.tsx
+++ b/components/dashboard/src/repositories/detail/variables/ConfigurationAddVariableModal.tsx
@@ -10,10 +10,7 @@ import Modal, { ModalHeader, ModalBody, ModalFooter, ModalFooterAlert } from "..
 import { CheckboxInputField } from "../../../components/forms/CheckboxInputField";
 import { Button } from "@podkit/buttons/Button";
 import { EnvironmentVariableAdmission } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
-import {
-    useCreateConfigurationVariable,
-    useUpdateConfigurationVariable,
-} from "../../../data/configurations/configuration-queries";
+import { useCreateConfigurationVariable } from "../../../data/configurations/configuration-queries";
 import { useToast } from "../../../components/toasts/Toasts";
 import { TextInputField } from "../../../components/forms/TextInputField";
 
@@ -21,14 +18,13 @@ type Props = {
     configurationId: string;
     onClose: () => void;
 };
-export const ModifyVariableModal = ({ configurationId, onClose }: Props) => {
+export const AddVariableModal = ({ configurationId, onClose }: Props) => {
     const { toast } = useToast();
 
     const [name, setName] = useState("");
     const [value, setValue] = useState("");
     const [admission, setAdmission] = useState<EnvironmentVariableAdmission>(EnvironmentVariableAdmission.EVERYWHERE);
     const createVariable = useCreateConfigurationVariable();
-    const updateVariable = useUpdateConfigurationVariable();
 
     const addVariable = useCallback(() => {
         createVariable.mutateAsync(
@@ -87,12 +83,9 @@ export const ModifyVariableModal = ({ configurationId, onClose }: Props) => {
             </ModalBody>
             <ModalFooter
                 alert={
-                    createVariable.isError || updateVariable.isError ? (
+                    createVariable.isError ? (
                         <ModalFooterAlert type="danger">
-                            {String(createVariable.error || updateVariable.error).replace(
-                                /Error: Request \w+ failed with message: /,
-                                "",
-                            )}
+                            {String(createVariable.error).replace(/Error: Request \w+ failed with message: /, "")}
                         </ModalFooterAlert>
                     ) : null
                 }

--- a/components/dashboard/src/repositories/detail/variables/ConfigurationModifyVariableModal.tsx
+++ b/components/dashboard/src/repositories/detail/variables/ConfigurationModifyVariableModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */

--- a/components/dashboard/src/repositories/detail/variables/ConfigurationVariableItem.tsx
+++ b/components/dashboard/src/repositories/detail/variables/ConfigurationVariableItem.tsx
@@ -13,7 +13,6 @@ import { TableRow, TableCell } from "@podkit/tables/Table";
 import { useState } from "react";
 import { ConfigurationDeleteVariableModal } from "./ConfigurationRemoveVariableModal";
 import { DropdownMenuItem } from "@podkit/dropdown/DropDown";
-import { ModifyVariableModal } from "./ConfigurationModifyVariableModal";
 
 type Props = {
     configurationId: string;
@@ -21,17 +20,9 @@ type Props = {
 };
 export const ConfigurationVariableItem = ({ variable, configurationId }: Props) => {
     const [showRemoveModal, setShowRemoveModal] = useState<boolean>(false);
-    const [showEditModal, setShowEditModal] = useState<boolean>(false);
 
     return (
         <>
-            {showEditModal && (
-                <ModifyVariableModal
-                    configurationId={configurationId}
-                    variable={variable}
-                    onClose={() => setShowEditModal(false)}
-                />
-            )}
             {showRemoveModal && (
                 <ConfigurationDeleteVariableModal
                     variable={variable}
@@ -48,7 +39,6 @@ export const ConfigurationVariableItem = ({ variable, configurationId }: Props) 
                 </TableCell>
                 <TableCell className="flex justify-end">
                     <DropdownActions>
-                        <DropdownMenuItem onSelect={() => setShowEditModal(true)}>Edit</DropdownMenuItem>
                         <DropdownMenuItem
                             className="text-red-600 dark:text-red-400 focus:text-red-800 dark:focus:text-red-300"
                             onSelect={() => {

--- a/components/dashboard/src/repositories/detail/variables/ConfigurationVariableList.tsx
+++ b/components/dashboard/src/repositories/detail/variables/ConfigurationVariableList.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
 import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { Button } from "@podkit/buttons/Button";
-import { ModifyVariableModal } from "./ConfigurationModifyVariableModal";
+import { AddVariableModal } from "./ConfigurationAddVariableModal";
 import { Heading3, Subheading } from "@podkit/typography/Headings";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@podkit/tables/Table";
 import { useListConfigurationVariables } from "../../../data/configurations/configuration-queries";
@@ -29,7 +29,7 @@ export const ConfigurationVariableList = ({ configuration }: Props) => {
     return (
         <ConfigurationSettingsField>
             {showAddVariableModal && (
-                <ModifyVariableModal
+                <AddVariableModal
                     configurationId={configuration.id}
                     onClose={() => {
                         setShowAddVariableModal(false);


### PR DESCRIPTION
## Description

Removed the ability to edit repository-level environment variables, since the omission of the previous value was causing confusion.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1397

## How to test

1. Create a repo configuration
2. Add an environment variable
3. `¯\_(ツ)_/¯`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-disablefa53d263a6</li>
	<li><b>🔗 URL</b> - <a href="https://ft-disablefa53d263a6.preview.gitpod-dev.com/workspaces" target="_blank">ft-disablefa53d263a6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-disable-config-env-var-editing-gha.23207</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-disablefa53d263a6%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold