### PR TITLE
[dashboard] add route without FF checking

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -207,11 +207,11 @@ export const AppRoutes = () => {
                     <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
                     <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
 
-                    {/* Handles all /repositories/:id/* routes in a nested router */}
-                    <Route path="/repositories/:id" component={ConfigurationDetailPage} />
                     <Route exact path={`/prebuilds`} component={PrebuildListPage} />
                     <Route path="/prebuilds/:prebuildId" component={PrebuildDetailPage} />
                     <Route exact path="/repositories" component={ConfigurationListPage} />
+                    {/* Handles all /repositories/:id/* routes in a nested router */}
+                    <Route path="/repositories/:id" component={ConfigurationDetailPage} />
 
                     {/* basic redirect for old team slugs */}
                     <Route path={["/t/"]} exact>

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -36,7 +36,6 @@ import { CreateWorkspacePage } from "../workspaces/CreateWorkspacePage";
 import { WebsocketClients } from "./WebsocketClients";
 import { BlockedEmailDomains } from "../admin/BlockedEmailDomains";
 import { AppNotifications } from "../AppNotifications";
-import { useHasConfigurationsAndPrebuildsEnabled } from "../data/featureflag-query";
 import { projectsPathInstallGitHubApp } from "../projects/projects.routes";
 import { Heading1, Subheading } from "@podkit/typography/Headings";
 import { PrebuildDetailPage } from "../prebuilds/detail/PrebuildDetailPage";
@@ -86,7 +85,6 @@ const PrebuildListPage = React.lazy(() => import(/* webpackPrefetch: true */ "..
 export const AppRoutes = () => {
     const hash = getURLHash();
     const location = useLocation();
-    const configurationsAndPrebuilds = useHasConfigurationsAndPrebuildsEnabled();
 
     // TODO: Add a Route for this instead of inspecting location manually
     if (location.pathname.startsWith("/blocked")) {
@@ -209,17 +207,12 @@ export const AppRoutes = () => {
                     <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
                     <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
 
-                    {configurationsAndPrebuilds && <Route exact path={`/prebuilds`} component={PrebuildListPage} />}
-                    {configurationsAndPrebuilds && (
-                        <Route path="/prebuilds/:prebuildId" component={PrebuildDetailPage} />
-                    )}
-                    {configurationsAndPrebuilds && (
-                        <Route exact path="/repositories" component={ConfigurationListPage} />
-                    )}
                     {/* Handles all /repositories/:id/* routes in a nested router */}
-                    {configurationsAndPrebuilds && (
-                        <Route path="/repositories/:id" component={ConfigurationDetailPage} />
-                    )}
+                    <Route path="/repositories/:id" component={ConfigurationDetailPage} />
+                    <Route exact path={`/prebuilds`} component={PrebuildListPage} />
+                    <Route path="/prebuilds/:prebuildId" component={PrebuildDetailPage} />
+                    <Route exact path="/repositories" component={ConfigurationListPage} />
+
                     {/* basic redirect for old team slugs */}
                     <Route path={["/t/"]} exact>
                         <Redirect to="/projects" />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1418

## How to test
<!-- Provide steps to test this PR -->
https://hw-exp-1418.preview.gitpod-dev.com/workspaces

Related pages are still working

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
