### PR TITLE
[dashboard] fix workspace start options ordering

### DIFF
--- a/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
+++ b/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
@@ -9,6 +9,7 @@ import { Button, ButtonProps } from "@podkit/buttons/Button";
 import React from "react";
 
 export interface LinkButtonProps extends ButtonProps {
+    asChild?: false;
     href: string;
 }
 
@@ -18,11 +19,9 @@ export interface LinkButtonProps extends ButtonProps {
 export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
     ({ asChild, children, href, ...props }, ref) => {
         return (
-            <Link to={href}>
-                <Button ref={ref} {...props}>
-                    {children}
-                </Button>
-            </Link>
+            <Button ref={ref} {...props} asChild>
+                <Link to={href}>{children}</Link>
+            </Button>
         );
     },
 );

--- a/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
+++ b/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
@@ -9,7 +9,6 @@ import { Button, ButtonProps } from "@podkit/buttons/Button";
 import React from "react";
 
 export interface LinkButtonProps extends ButtonProps {
-    asChild?: false;
     href: string;
 }
 
@@ -19,9 +18,11 @@ export interface LinkButtonProps extends ButtonProps {
 export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
     ({ asChild, children, href, ...props }, ref) => {
         return (
-            <Button ref={ref} {...props} asChild>
-                <Link to={href}>{children}</Link>
-            </Button>
+            <Link to={href}>
+                <Button ref={ref} {...props}>
+                    {children}
+                </Button>
+            </Link>
         );
     },
 );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1433

## How to test
<!-- Provide steps to test this PR -->

https://hw-exp-1433.preview.gitpod-dev.com/workspaces

Test with via https://github.com/gitpod-io/dashboard-playwright-tests/blob/main/tests/workspace.spec.ts, or test manually:
- Start workspace with custom options
- Stop workspace
- Goes to workspace start page with the same context
- It should show previous options you started
- Add search params to URL with `editor`, `workspaceClass`
- It should show correct options in UX
- Try add `autostart` options, priorities should be the same

<img width="607" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/11f0d31d-cd7f-43a5-b5ee-a499794d148f">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
