### PR TITLE
[server] Missing SCM access: Filter out user error on workspace start

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -172,7 +172,7 @@ api.{$GITPOD_DOMAIN} {
 		allowed_origins https://{$GITPOD_DOMAIN}
 	}
 
-	@to_server path /auth/github/callback
+	@to_server path /auth/*/callback
 	handle @to_server {
 		import compression
 

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -203,6 +203,7 @@ export type FailedInstanceStartReason =
     | "startOnClusterFailed"
     | "imageBuildFailed"
     | "imageBuildFailedUser"
+    | "scmAccessFailed"
     | "resourceExhausted"
     | "workspaceClusterMaintenance"
     | "other";

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -35,7 +35,7 @@ spec:
 
     - alert: InstanceStartFailures
       # Reasoning: 1 failure every 120s should not trigger an incident: 1/120 = 0.00833.. => 0.01
-      expr: sum(irate(gitpod_server_instance_starts_failed_total{reason!~"imageBuildFailed|imageBuildFailedUser"}[2m])) by (reason) > 0.01
+      expr: sum(irate(gitpod_server_instance_starts_failed_total{reason!~"imageBuildFailed|imageBuildFailedUser|scmAccessFailed"}[2m])) by (reason) > 0.01
       for: 30s
       labels:
         severity: critical


### PR DESCRIPTION
to prevent false alerts (EXP-1434)

## Description
We some cases where we got paged last week for this very error. This PR labels and filters them out.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1434

## How to test
 - start a workspace on a repo on gitlab.com
 - create a snapshot
 - login with another user that is _not_ linked to GitLab
   - try to open the workspace: it fails :heavy_check_mark: 
 - do:
   - `kubectl port-forward deployment/server 9500 &`
   - `curl server:9500/metrics | grep gitpod_server_instance_starts_failed_total` and see that:
     - `reason: "scmAccessFailed"` +1
     - `reason: "other"` = 0
![image](https://github.com/gitpod-io/gitpod/assets/32448529/df31b3ff-cd3d-4a57-81f7-e246bcd6f559)


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
