### PR TITLE
[server] Sync token refresh

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -172,7 +172,7 @@ api.{$GITPOD_DOMAIN} {
 		allowed_origins https://{$GITPOD_DOMAIN}
 	}
 
-	@to_server path /auth/github/callback
+	@to_server path /auth/*/callback
 	handle @to_server {
 		import compression
 


### PR DESCRIPTION
## Description
Attempt two to fix token refresh (attempt one is [here](https://github.com/gitpod-io/gitpod/pull/19452)) using a redis mutex.

Code is guarded with the `sync_refresh_token_exchange` feature flag.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1413

## How to test
 - start a workspace on a repo on gitlab.com :heavy_check_mark: 
 - extended test:
   - invalidate your GitLab token (by changing the expiryDate in the DB)
   - start another workspace on GitLab
   - see how the token got refreshed :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
