### PR TITLE
Fix failed prebuild reruns

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -68,9 +68,13 @@ export const PrebuildDetailPage: FC = () => {
 
     useEffect(() => {
         setLogNotFound(false);
-        watchPrebuild(prebuildId, (prebuild) => {
+        const disposable = watchPrebuild(prebuildId, (prebuild) => {
             setCurrentPrebuild(prebuild);
         });
+
+        return () => {
+            disposable.dispose();
+        };
     }, [prebuildId]);
 
     useEffect(() => {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -71,7 +71,7 @@ export const PrebuildDetailPage: FC = () => {
         watchPrebuild(prebuildId, (prebuild) => {
             setCurrentPrebuild(prebuild);
         });
-    }, [prebuildId, setCurrentPrebuild]);
+    }, [prebuildId]);
 
     useEffect(() => {
         logEmitter.on("error", (err: Error) => {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -67,6 +67,7 @@ export const PrebuildDetailPage: FC = () => {
     const triggeredString = useMemo(() => formatDate(triggeredDate), [triggeredDate]);
 
     useEffect(() => {
+        setLogNotFound(false);
         watchPrebuild(prebuildId, (prebuild) => {
             setCurrentPrebuild(prebuild);
         });


### PR DESCRIPTION
## Description

Fixes an itty bitty regression I created in https://github.com/gitpod-io/gitpod/pull/19460, where rerunning a prebuild would not get rid of the log not found overlay.

## How to test

Start a prebuild which should fail and rerun it. The no logs screen should reset with the rerun.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-rere75871d56c</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-rere75871d56c.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-rere75871d56c.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-rerunning-failed-prebuilds-gha.23292</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-rere75871d56c%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
