### PR TITLE
fix: components/gitpod-db/leeway.Dockerfile to reduce vulnerabilities

### DIFF
--- a/components/gitpod-db/leeway.Dockerfile
+++ b/components/gitpod-db/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:18.17.1-slim as builder
+FROM node:18.18.2-slim as builder
 COPY components-gitpod-db--migrations /installer/
 WORKDIR /app
 RUN /installer/install.sh
@@ -11,7 +11,7 @@ FROM node:18.17.1 as proxy
 RUN wget https://storage.googleapis.com/cloudsql-proxy/v1.23.0/cloud_sql_proxy.linux.amd64 -O /bin/cloud_sql_proxy \
  && chmod +x /bin/cloud_sql_proxy
 
-FROM node:18.17.1-slim
+FROM node:18.18.2-slim
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 COPY migrate.sh /app/migrate.sh
 COPY migrate_gcp.sh /app/migrate_gcp.sh


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-DEBIAN12-GLIBC-5927132
- https://snyk.io/vuln/SNYK-DEBIAN12-GLIBC-5927132
- https://snyk.io/vuln/SNYK-DEBIAN12-GLIBC-6210098
- https://snyk.io/vuln/SNYK-DEBIAN12-GLIBC-6210098
- https://snyk.io/vuln/SNYK-DEBIAN12-GNUTLS28-6159418

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
