### PR TITLE
[papi,server] implement `restricted_workspace_classes` in server

### DIFF
--- a/components/public-api-server/pkg/apiv1/project.go
+++ b/components/public-api-server/pkg/apiv1/project.go
@@ -180,6 +180,9 @@ func projectSettingsToAPIResponse(s *protocol.ProjectSettings) *v1.ProjectSettin
 		settings.Prebuild.PrebuildInterval = s.PrebuildSettings.PrebuildInterval
 		settings.Prebuild.WorkspaceClass = s.PrebuildSettings.WorkspaceClass
 	}
+	if s.RestrictedWorkspaceClasses != nil {
+		settings.Workspace.RestrictedWorkspaceClasses = *s.RestrictedWorkspaceClasses
+	}
 
 	return settings
 }

--- a/components/public-api-server/pkg/apiv1/project_test.go
+++ b/components/public-api-server/pkg/apiv1/project_test.go
@@ -341,6 +341,7 @@ func newProject(p *protocol.Project) *protocol.Project {
 				Regular:  "default",
 				Prebuild: "default",
 			},
+			RestrictedWorkspaceClasses: &[]string{"default"},
 			PrebuildSettings: &protocol.PrebuildSettings{
 				Enable: &b_false,
 			},

--- a/components/public-api/typescript-common/fixtures/fromPartialConfiguration_1.golden
+++ b/components/public-api/typescript-common/fixtures/fromPartialConfiguration_1.golden
@@ -1,6 +1,7 @@
 {
     "result": {
         "id": "123",
+        "settings": {},
         "name": "My Config"
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.golden
+++ b/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.golden
@@ -1,0 +1,19 @@
+{
+    "result": {
+        "id": "123",
+        "settings": {
+            "prebuilds": {
+                "enable": true,
+                "prebuildInterval": 5
+            },
+            "workspaceClasses": {
+                "regular": "huge"
+            },
+            "restrictedWorkspaceClasses": [
+                "huge",
+                "large"
+            ]
+        }
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.json
+++ b/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.json
@@ -1,0 +1,11 @@
+{
+  "id": "123",
+  "workspaceSettings": {
+      "workspaceClass": "huge",
+      "restrictedWorkspaceClasses": ["huge", "large"]
+  },
+  "prebuildSettings": {
+      "enabled": true,
+      "prebuildInterval": 5
+  }
+}

--- a/components/public-api/typescript-common/fixtures/toConfiguration_2.golden
+++ b/components/public-api/typescript-common/fixtures/toConfiguration_2.golden
@@ -1,0 +1,24 @@
+{
+    "result": {
+        "id": "123",
+        "organizationId": "456",
+        "name": "My Project",
+        "cloneUrl": "https://github.com/myorg/myproject.git",
+        "creationTime": "2023-11-29T17:52:27.467Z",
+        "prebuildSettings": {
+            "enabled": true,
+            "branchMatchingPattern": "main",
+            "branchStrategy": "BRANCH_MATCHING_STRATEGY_DEFAULT_BRANCH",
+            "prebuildInterval": 20,
+            "workspaceClass": "dev"
+        },
+        "workspaceSettings": {
+            "workspaceClass": "dev",
+            "restrictedWorkspaceClasses": [
+                "cls-1",
+                "cls-2"
+            ]
+        }
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/toConfiguration_2.json
+++ b/components/public-api/typescript-common/fixtures/toConfiguration_2.json
@@ -1,0 +1,21 @@
+{
+  "id": "123",
+  "teamId": "456",
+  "name": "My Project",
+  "cloneUrl": "https://github.com/myorg/myproject.git",
+  "appInstallationId": "",
+  "creationTime": "2023-11-29T17:52:27.467Z",
+  "settings": {
+    "workspaceClasses": {
+      "regular": "dev"
+    },
+    "prebuilds": {
+      "enable": true,
+      "branchMatchingPattern": "main",
+      "branchStrategy": "default-branch",
+      "prebuildInterval": 20,
+      "workspaceClass": "dev"
+    },
+    "restrictedWorkspaceClasses": ["cls-1", "cls-2"]
+  }
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
@@ -1,6 +1,6 @@
 {
     "result": {
-        "workspaceClass": "dev",
+        "workspaceClass": "",
         "restrictedWorkspaceClasses": []
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
@@ -1,6 +1,6 @@
 {
     "result": {
-        "workspaceClass": "",
+        "workspaceClass": "dev",
         "restrictedWorkspaceClasses": []
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.json
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.json
@@ -1,1 +1,3 @@
-"dev"
+{
+  "workspaceClasses": { "regular": "dev" }
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.golden
@@ -1,0 +1,10 @@
+{
+    "result": {
+        "workspaceClass": "test",
+        "restrictedWorkspaceClasses": [
+            "g1",
+            "g2"
+        ]
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.json
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.json
@@ -1,0 +1,4 @@
+{
+  "workspaceClasses": { "regular": "test" },
+  "restrictedWorkspaceClasses": ["g1", "g2"]
+}

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -19,7 +19,6 @@ import {
     ListConfigurationsResponse,
     PrebuildSettings,
     UpdateConfigurationRequest,
-    WorkspaceSettings,
 } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
 import { PaginationResponse } from "@gitpod/public-api/lib/gitpod/v1/pagination_pb";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -187,7 +186,18 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
         }
 
         if (req.workspaceSettings !== undefined) {
-            update.workspaceSettings = buildUpdateObject<DeepPartial<WorkspaceSettings>>(req.workspaceSettings);
+            update.workspaceSettings = {};
+            if (req.workspaceSettings.workspaceClass !== undefined) {
+                update.workspaceSettings.workspaceClass = req.workspaceSettings.workspaceClass;
+            }
+            if (req.workspaceSettings.updateRestrictedWorkspaceClasses) {
+                update.workspaceSettings.restrictedWorkspaceClasses = req.workspaceSettings.restrictedWorkspaceClasses;
+            } else if (req.workspaceSettings.restrictedWorkspaceClasses.length > 0) {
+                throw new ApplicationError(
+                    ErrorCodes.BAD_REQUEST,
+                    "updateRestrictedWorkspaceClasses is required to be true to update restrictedWorkspaceClasses",
+                );
+            }
         }
 
         if (Object.keys(update).length <= 1) {

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -454,18 +454,6 @@ export class OrganizationService {
         return result;
     }
 
-    public async hasAllowedWorkspaceClassesInInstallation(userId: string, orgId: string): Promise<boolean> {
-        const allClasses = await this.installationService.getInstallationWorkspaceClasses(userId);
-        const settings = await this.getSettings(userId, orgId);
-        if (settings.allowedWorkspaceClasses && settings.allowedWorkspaceClasses.length > 0) {
-            return (
-                settings.allowedWorkspaceClasses.filter((e) => allClasses.findIndex((cls) => cls.id === e) !== -1)
-                    .length > 0
-            );
-        }
-        return allClasses.length > 0;
-    }
-
     public async listWorkspaceClasses(userId: string, orgId: string): Promise<SupportedWorkspaceClass[]> {
         const allClasses = await this.installationService.getInstallationWorkspaceClasses(userId);
         const settings = await this.getSettings(userId, orgId);

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -147,7 +147,7 @@ export class WorkspaceService {
             if (project.settings.restrictedWorkspaceClasses.includes(workspaceClass)) {
                 throw new ApplicationError(
                     ErrorCodes.PRECONDITION_FAILED,
-                    "Selected workspace class is restricted in current configuration.",
+                    "Selected workspace class is restricted in current repository.",
                 );
             }
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Part of https://github.com/gitpod-io/gitpod/pull/19410
- Blocked by https://github.com/gitpod-io/gitpod/pull/19480
- Need to be rebased after blocked PR merged

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Should be tested in https://github.com/gitpod-io/gitpod/pull/19410

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
