### PR TITLE
[server] Improve behavior and reporting around "refreshToken"

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -381,3 +381,27 @@ type AuthorizerSubjectIdMatch = "ctx-user-id-missing" | "passed-subject-id-missi
 export function reportAuthorizerSubjectId(match: AuthorizerSubjectIdMatch) {
     authorizerSubjectId.labels(match).inc();
 }
+
+export const scmTokenRefreshRequestsTotal = new prometheusClient.Counter({
+    name: "gitpod_scm_token_refresh_requests_total",
+    help: "Counter for the number of token refresh requests we issue against SCM systems",
+    labelNames: ["host", "result"],
+});
+export type ScmTokenRefreshResult =
+    | "success"
+    | "timeout"
+    | "error"
+    | "still_valid"
+    | "no_token"
+    | "not_refreshable"
+    | "success_after_timeout";
+export function reportScmTokenRefreshRequest(host: string, result: ScmTokenRefreshResult) {
+    scmTokenRefreshRequestsTotal.labels(host, result).inc();
+}
+
+export const scmTokenRefreshLatencyHistogram = new prometheusClient.Histogram({
+    name: "gitpod_scm_token_refresh_latency_seconds",
+    help: "SCM token refresh latency in seconds",
+    labelNames: ["host"],
+    buckets: [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+});

--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -104,9 +104,10 @@ export class TokenService implements TokenProvider {
             } finally {
                 stopTimer({ host });
             }
-            reportScmTokenRefreshRequest(host, "success");
 
-            return await this.userDB.findTokenForIdentity(identity);
+            const freshToken = await this.userDB.findTokenForIdentity(identity);
+            reportScmTokenRefreshRequest(host, "success");
+            return freshToken;
         };
 
         try {

--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -15,6 +15,7 @@ import { GarbageCollectedCache } from "@gitpod/gitpod-protocol/lib/util/garbage-
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { RedisMutex } from "../redis/mutex";
+import { reportScmTokenRefreshRequest, scmTokenRefreshLatencyHistogram } from "../prometheus-metrics";
 
 @injectable()
 export class TokenService implements TokenProvider {
@@ -80,20 +81,31 @@ export class TokenService implements TokenProvider {
             // Check: Current token so we can actually refresh?
             const token = await this.userDB.findTokenForIdentity(identity);
             if (!token) {
+                reportScmTokenRefreshRequest(host, "no_token");
                 return undefined;
             }
 
             if (isValid(token)) {
+                reportScmTokenRefreshRequest(host, "still_valid");
                 return token;
             }
 
             // Can we refresh these kind of tokens?
             const { authProvider } = this.hostContextProvider.get(host)!;
             if (!authProvider.refreshToken) {
+                reportScmTokenRefreshRequest(host, "not_refreshable");
                 return undefined;
             }
 
-            await authProvider.refreshToken(user);
+            // Perform actual refresh
+            const stopTimer = scmTokenRefreshLatencyHistogram.startTimer({ host });
+            try {
+                await authProvider.refreshToken(user);
+            } finally {
+                stopTimer({ host });
+            }
+            reportScmTokenRefreshRequest(host, "success");
+
             return await this.userDB.findTokenForIdentity(identity);
         };
 
@@ -112,12 +124,15 @@ export class TokenService implements TokenProvider {
                 const token = await this.userDB.findTokenForIdentity(identity);
                 if (token && isValid(token)) {
                     log.debug({ userId }, `Token refresh timed out, but still successful`, { host });
+                    reportScmTokenRefreshRequest(host, "success_after_timeout");
                     return token;
                 }
 
                 log.error({ userId }, `Failed to refresh token (timeout waiting on lock)`, err, { host });
+                reportScmTokenRefreshRequest(host, "timeout");
                 throw new Error(`Failed to refresh token (timeout waiting on lock)`);
             }
+            reportScmTokenRefreshRequest(host, "error");
             throw err;
         }
     }


### PR DESCRIPTION
## Description
This PR improves two things around token refresh:
 1. [[server] Check token even in case of timeout](https://github.com/gitpod-io/gitpod/commit/c253faf6c74c26e133a2628bb6828b8a9ffdc273)
   - in prod we observed suspiciously high latencies on `Authprovider.refreshToken` (10s+) even though in some cases (we inspected) the token seemed to already be present in our database (?). This case should improve those cases. 
 1. https://github.com/gitpod-io/gitpod/commit/4149ccd3e3a49867f224620921f4810c02d6761e
   - these metrics should help better discern the cases we observed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1413

## How to test
 - sign in https://gpl-1413-improve.preview.gitpod-dev.com/workspaces
 - Create a workspace from a repo on gitlab.com , e.g. https://gpl-1413-improve.preview.gitpod-dev.com/#https://gitlab.com/geropl/gitpod-test :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
