### PR TITLE
[installer] use image digest for redis image

### DIFF
--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -63,6 +63,14 @@ jobs:
             fi
           done < <(find "$(pwd)" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "Dockerfile*" -o -name "leeway.Dockerfile" \) -print0)
 
+          # update for chainguard redis
+          redisImageDigest=$(crane digest cgr.dev/chainguard/redis:latest)
+          redisExporterDigest=$(crane digest cgr.dev/chainguard/prometheus-redis-exporter:latest)
+
+
+          sed -i -e "s/^\(\s*ImageDigest\s*=\s*\)\".*\"/\1\"$redisImageDigest\"/" install/installer/pkg/components/redis/constants.go
+          sed -i -e "s/^\(\s*ExporterImageDigest\s*=\s*\)\".*\"/\1\"$redisExporterDigest\"/" install/installer/pkg/components/redis/constants.go
+          go fmt install/installer/pkg/components/redis/constants.go
       - name: Check workspace
         id: create_pr
         shell: bash

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -89,9 +89,20 @@ jobs:
           body: |
             Update images digests using the latest version available for image/s
 
-            ```release-note
-            NONE
-            ```
+            ## How to test
+            - [ ] Start a workspace in the preview environment and verify that it functions properly.
+
+            <details>
+            <summary>Preview Environment / Integration Tests</summary>
+
+            - [x] /werft with-preview
+            - [x] /werft with-gce-vm
+                  If enabled this will create the environment on GCE infra
+            - [x] /werft preemptible
+                  Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
+            - [x] with-integration-tests=ssh
+                  Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
+            </details>
           labels: automated pr, kind/cleanup, release-note-none
           branch: update-digests
           delete-branch: true

--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/spf13/cobra"

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cert-manager/trust-manager v0.9.1
-	github.com/docker/distribution v2.8.3+incompatible
+	github.com/distribution/reference v0.5.0
 	github.com/fatih/structtag v1.2.0
 	github.com/gitpod-io/gitpod/agent-smith v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/blobserve v0.0.0-00010101000000-000000000000
@@ -108,8 +108,8 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/install/installer/pkg/common/render.go
+++ b/install/installer/pkg/common/render.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -120,6 +120,18 @@ func (r *RenderContext) ImageName(repo, name, tag string) string {
 		panic(fmt.Sprintf("image ref %s has no tag: %v", ref, err))
 	}
 
+	return ref
+}
+
+func (r *RenderContext) ImageDigest(repo, name, digest string) string {
+	ref := fmt.Sprintf("%s@%s", r.RepoName(repo, name), digest)
+	pref, err := reference.ParseNamed(ref)
+	if err != nil {
+		panic(fmt.Sprintf("cannot parse image ref %s: %v", ref, err))
+	}
+	if _, ok := pref.(reference.Digested); !ok {
+		panic(fmt.Sprintf("image ref %s has no digest: %v", ref, err))
+	}
 	return ref
 }
 

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -14,10 +14,10 @@ const (
 	RegistryImage = "chainguard/redis"
 
 	ContainerName = "redis"
-	ImageTag      = "latest"
+	ImageDigest   = "sha256:cd0eb6030e86577bbf24c18e7d6ff1f84b2bce4b9f1d74f2bd0fba170e728165"
 
 	ExporterRegistryImage = "chainguard/prometheus-redis-exporter"
-	ExporterImageTag      = "latest"
+	ExporterImageDigest   = "sha256:68eeec479c749ffb9b9a3ac8913cedc8cb067040675570d721bc1d2f39051a02"
 
 	ExporterContainerName = "exporter"
 	ExporterPortName      = "exporter"

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -14,10 +14,10 @@ const (
 	RegistryImage = "chainguard/redis"
 
 	ContainerName = "redis"
-	ImageDigest   = "sha256:cd0eb6030e86577bbf24c18e7d6ff1f84b2bce4b9f1d74f2bd0fba170e728165"
+	ImageDigest   = "sha256:faafcc4f149997127c3402565fcaf018980e2a1803ef0ef2256ee6b11c1972b9"
 
 	ExporterRegistryImage = "chainguard/prometheus-redis-exporter"
-	ExporterImageDigest   = "sha256:68eeec479c749ffb9b9a3ac8913cedc8cb067040675570d721bc1d2f39051a02"
+	ExporterImageDigest   = "sha256:ca22acb4dd6046bec280361a7ad262fee8d69a5beb7dc1ea2f9009f53b0773b5"
 
 	ExporterContainerName = "exporter"
 	ExporterPortName      = "exporter"

--- a/install/installer/pkg/components/redis/deployment.go
+++ b/install/installer/pkg/components/redis/deployment.go
@@ -58,7 +58,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Containers: []corev1.Container{
 							{
 								Name:            ContainerName,
-								Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
+								Image:           ctx.ImageDigest(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageDigest),
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command: []string{
 									"redis-server",
@@ -104,7 +104,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							{
 								Name:            ExporterContainerName,
-								Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), ExporterRegistryImage, ExporterImageTag),
+								Image:           ctx.ImageDigest(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), ExporterRegistryImage, ExporterImageDigest),
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 									[]v1.EnvVar{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[installer] use image digest for redis image

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1717

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-image-dbfcbfa4290</li>
	<li><b>🔗 URL</b> - <a href="https://pd-image-dbfcbfa4290.preview.gitpod-dev.com/workspaces" target="_blank">pd-image-dbfcbfa4290.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-image-digest-redis-gha.23350</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-image-dbfcbfa4290%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
