### PR TITLE
Fix new workspace page re-render loop and false negative error message for ws class

### DIFF
--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -50,7 +50,7 @@ export default function SelectWorkspaceClassComponent({
     }, [workspaceClasses]);
 
     useEffect(() => {
-        if (!workspaceClasses) {
+        if (!workspaceClasses || loading || disabled || workspaceClassesLoading) {
             return;
         }
 
@@ -82,6 +82,9 @@ export default function SelectWorkspaceClassComponent({
             setError?.(`The workspace class '${selectedWorkspaceClass}' is not supported.`);
         }
     }, [
+        loading,
+        workspaceClassesLoading,
+        disabled,
         workspaceClasses,
         selectedWorkspaceClass,
         setError,

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -34,9 +34,12 @@ export default function SelectWorkspaceClassComponent({
     const enabledWorkspaceClassRestrictionOnConfiguration = useFeatureFlag(
         "configuration_workspace_class_restrictions",
     );
-    const { data: workspaceClasses } = useAllowedWorkspaceClassesMemo(selectedConfigurationId, {
-        filterOutDisabled: true,
-    });
+    const { data: workspaceClasses, isLoading: workspaceClassesLoading } = useAllowedWorkspaceClassesMemo(
+        selectedConfigurationId,
+        {
+            filterOutDisabled: true,
+        },
+    );
 
     const getElements = useCallback((): ComboboxElement[] => {
         return (workspaceClasses || [])?.map((c) => ({
@@ -108,9 +111,12 @@ export default function SelectWorkspaceClassComponent({
             searchPlaceholder="Select class"
             disableSearch={true}
             initialValue={selectedWsClass?.id}
-            disabled={workspaceClasses.length === 0 || loading || disabled}
+            disabled={workspaceClassesLoading || loading || disabled}
         >
-            <WorkspaceClassDropDownElementSelected wsClass={selectedWsClass} loading={loading} />
+            <WorkspaceClassDropDownElementSelected
+                wsClass={selectedWsClass}
+                loading={workspaceClassesLoading || loading}
+            />
         </Combobox>
     );
 }

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -116,12 +116,14 @@ export const useAllowedWorkspaceClassesMemo = (
     configurationId?: Configuration["id"],
     options?: { filterOutDisabled: boolean; ignoreScope?: DisableScope[] },
 ) => {
-    const { data: orgSettings } = useOrgSettingsQuery();
-    const { data: installationClasses } = useWorkspaceClasses();
+    const { data: orgSettings, isLoading: isLoadingOrgSettings } = useOrgSettingsQuery();
+    const { data: installationClasses, isLoading: isLoadingInstallationCls } = useWorkspaceClasses();
     // empty configurationId will return undefined
-    const { data: configuration } = useConfiguration(configurationId ?? "");
+    const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId ?? "");
 
-    return useMemo(() => {
+    const isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
+
+    const data = useMemo(() => {
         return getAllowedWorkspaceClasses(
             installationClasses,
             orgSettings,
@@ -136,4 +138,5 @@ export const useAllowedWorkspaceClassesMemo = (
         configuration?.workspaceSettings?.restrictedWorkspaceClasses,
         configuration?.workspaceSettings?.workspaceClass,
     ]);
+    return { ...data, isLoading };
 };

--- a/components/dashboard/src/repositories/detail/workspaces/ConfigurationWorkspaceClassesOptions.tsx
+++ b/components/dashboard/src/repositories/detail/workspaces/ConfigurationWorkspaceClassesOptions.tsx
@@ -23,13 +23,19 @@ export const ConfigurationWorkspaceClassesOptions = ({ configuration }: { config
     const [showModal, setShowModal] = useState(false);
     const configurationMutation = useConfigurationMutation();
 
-    const { data: allowedClassesInConfiguration } = useAllowedWorkspaceClassesMemo(configuration.id, {
-        filterOutDisabled: true,
-    });
-    const { data: allowedClassesInOrganization } = useAllowedWorkspaceClassesMemo(undefined, {
-        filterOutDisabled: false,
-        ignoreScope: ["configuration"],
-    });
+    const { data: allowedClassesInConfiguration, isLoading: isLoadingInConfig } = useAllowedWorkspaceClassesMemo(
+        configuration.id,
+        {
+            filterOutDisabled: true,
+        },
+    );
+    const { data: allowedClassesInOrganization, isLoading: isLoadingInOrg } = useAllowedWorkspaceClassesMemo(
+        undefined,
+        {
+            filterOutDisabled: false,
+            ignoreScope: ["configuration"],
+        },
+    );
 
     const updateMutation: WorkspaceClassesModifyModalProps["updateMutation"] = useMutation({
         mutationFn: async ({ restrictedWorkspaceClasses, defaultClass }) => {
@@ -50,21 +56,22 @@ export const ConfigurationWorkspaceClassesOptions = ({ configuration }: { config
             <Subheading>Limit the available workspace classes for this repository.</Subheading>
 
             <div className="mt-4">
-                {allowedClassesInConfiguration.length === 0 ? (
-                    <div className="font-semibold text-pk-content-primary flex gap-2 items-center">
-                        <AlertTriangleIcon size={20} className="text-red-500" />
-                        <span>This repository doesn't have any available workspace classes.</span>
-                    </div>
-                ) : (
-                    <WorkspaceClassesOptions
-                        classes={allowedClassesInConfiguration}
-                        defaultClass={configuration.workspaceSettings?.workspaceClass}
-                    />
-                )}
+                <WorkspaceClassesOptions
+                    isLoading={isLoadingInConfig}
+                    emptyState={
+                        <div className="font-semibold text-pk-content-primary flex gap-2 items-center">
+                            <AlertTriangleIcon size={20} className="text-red-500" />
+                            <span>This repository doesn't have any available workspace classes.</span>
+                        </div>
+                    }
+                    classes={allowedClassesInConfiguration}
+                    defaultClass={configuration.workspaceSettings?.workspaceClass}
+                />
             </div>
 
             {showModal && (
                 <WorkspaceClassesModifyModal
+                    isLoading={isLoadingInOrg}
                     showSetDefaultButton
                     defaultClass={configuration.workspaceSettings?.workspaceClass}
                     restrictedWorkspaceClasses={configuration.workspaceSettings?.restrictedWorkspaceClasses ?? []}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- https://hw-cls-fix.preview.gitpod-dev.com/new is accessible
- Use Browser Extension to create ws in preview env should not show `no allowed workspace classes...` under class selector

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
