### PR TITLE
[service-waiter] add addition image condition in annotation

### DIFF
--- a/components/common-go/kubernetes/kubernetes.go
+++ b/components/common-go/kubernetes/kubernetes.go
@@ -78,6 +78,9 @@ const (
 
 	// workspacePressureStallInfo indicates if pressure stall information should be retrieved for the workspace
 	WorkspacePressureStallInfoAnnotation = "gitpod.io/psi"
+
+	// ImageNameAnnotation indicates the original format of the main image of the pod
+	ImageNameAnnotation = "gitpod.io/image_name"
 )
 
 // GetOWIFromObject finds the owner, workspace and instance information on a Kubernetes object using labels

--- a/components/service-waiter/cmd/component.go
+++ b/components/service-waiter/cmd/component.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const AnnotationImageName = "gitpod.io/image_name"
+
 var componentCmdOpt struct {
 	image          string
 	namespace      string
@@ -81,7 +83,7 @@ func checkPodsImage(ctx context.Context, k8sClient *kubernetes.Clientset) (bool,
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
 			if container.Name == componentCmdOpt.component {
-				if container.Image != componentCmdOpt.image {
+				if container.Image != componentCmdOpt.image && pod.Annotations[AnnotationImageName] != componentCmdOpt.image {
 					return false, fmt.Errorf("image is not the same: %s != %s", container.Image, componentCmdOpt.image)
 				}
 				for _, condition := range pod.Status.Conditions {

--- a/components/service-waiter/cmd/component.go
+++ b/components/service-waiter/cmd/component.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gitpod-io/gitpod/common-go/experiments"
+	k8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/service-waiter/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
@@ -22,8 +23,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
-
-const AnnotationImageName = "gitpod.io/image_name"
 
 var componentCmdOpt struct {
 	image          string
@@ -81,19 +80,15 @@ func checkPodsImage(ctx context.Context, k8sClient *kubernetes.Clientset) (bool,
 	}
 	readyCount := 0
 	for _, pod := range pods.Items {
-		for _, container := range pod.Spec.Containers {
-			if container.Name == componentCmdOpt.component {
-				if container.Image != componentCmdOpt.image && pod.Annotations[AnnotationImageName] != componentCmdOpt.image {
-					return false, fmt.Errorf("image is not the same: %s != %s", container.Image, componentCmdOpt.image)
-				}
-				for _, condition := range pod.Status.Conditions {
-					if condition.Type == corev1.PodReady {
-						if condition.Status == corev1.ConditionTrue {
-							readyCount += 1
-						} else {
-							return false, fmt.Errorf("pod is not ready")
-						}
-					}
+		if pod.Annotations[k8s.ImageNameAnnotation] != componentCmdOpt.image {
+			return false, fmt.Errorf("image is not the same: %s != %s", pod.Annotations[k8s.ImageNameAnnotation], componentCmdOpt.image)
+		}
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady {
+				if condition.Status == corev1.ConditionTrue {
+					readyCount += 1
+				} else {
+					return false, fmt.Errorf("pod is not ready")
 				}
 			}
 		}

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -22,10 +22,7 @@ RUN mkdir -p /tmp/helm/ \
     && helm completion bash > /usr/share/bash-completion/completions/helm
 
 ### kubectl ###
-RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-    # really 'xenial'
-    && add-apt-repository -yu "deb https://apt.kubernetes.io/ kubernetes-xenial main" \
-    && install-packages kubectl=1.27.1-00 \
+RUN curl -fsSL -o /usr/bin/kubectl "https://dl.k8s.io/release/v1.27.11/bin/linux/amd64/kubectl" && chmod +x /usr/bin/kubectl \
     && kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 
 RUN curl -fsSL -o /usr/bin/kubectx https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx && chmod +x /usr/bin/kubectx \

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -58,6 +58,7 @@ const (
 	DBCaPath                    = DBCaBasePath + "/" + DBCaFileName
 	WorkspaceSecretsNamespace   = "workspace-secrets"
 	AnnotationConfigChecksum    = "gitpod.io/checksum_config"
+	AnnotationImageName         = "gitpod.io/image_name"
 	DatabaseConfigMountPath     = "/secrets/database-config"
 	AuthPKISecretName           = "auth-pki"
 	IDEServiceComponent         = "ide-service"

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -58,7 +58,6 @@ const (
 	DBCaPath                    = DBCaBasePath + "/" + DBCaFileName
 	WorkspaceSecretsNamespace   = "workspace-secrets"
 	AnnotationConfigChecksum    = "gitpod.io/checksum_config"
-	AnnotationImageName         = "gitpod.io/image_name"
 	DatabaseConfigMountPath     = "/secrets/database-config"
 	AuthPKISecretName           = "auth-pki"
 	IDEServiceComponent         = "ide-service"

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -110,7 +111,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
 							return map[string]string{
 								common.AnnotationConfigChecksum: configHash,
-								common.AnnotationImageName:      imageName,
+								kubernetes.ImageNameAnnotation:  imageName,
 							}
 						}),
 					},

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -22,6 +22,7 @@ import (
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
+	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -308,7 +309,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
 							return map[string]string{
 								common.AnnotationConfigChecksum: configHash,
-								common.AnnotationImageName:      imageName,
+								kubernetes.ImageNameAnnotation:  imageName,
 							}
 						}),
 					},

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -285,6 +285,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	volumes = append(volumes, authVolumes...)
 	volumeMounts = append(volumeMounts, authMounts...)
 
+	imageName := ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Server.Version)
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -306,6 +308,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
 							return map[string]string{
 								common.AnnotationConfigChecksum: configHash,
+								common.AnnotationImageName:      imageName,
 							}
 						}),
 					},
@@ -336,7 +339,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 						Containers: []corev1.Container{{
 							Name:            Component,
-							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Server.Version),
+							Image:           imageName,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[service-waiter] add addition image condition in annotation

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1817

## How to test
<!-- Provide steps to test this PR -->
1. use `kubectl` to check `server` and `public-api-server` pods, the pod's annotation `gitpod.io/image_name` should be the same as pod image
2. change `server` image in deployment, then restart the `dashboard`, it should be fine
## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-api-for-commit</li>
	<li><b>🔗 URL</b> - <a href="https://pd-api-for-commit.preview.gitpod-dev.com/workspaces" target="_blank">pd-api-for-commit.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-api-for-commit-gha.23412</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-api-for-commit%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
