### PR TITLE
[scrubber] Scrub URL path parts separately

### DIFF
--- a/components/scrubber/config.go
+++ b/components/scrubber/config.go
@@ -21,10 +21,14 @@ var (
 
 	// HashedFieldNames name fields whose values we'll hash
 	HashedFieldNames = []string{
-		"contextURL",
 		"metaID",
 		"workspaceID",
 		"username",
+	}
+
+	// HashedURLPathsFieldNames name fields with URLS whose paths we'll hash
+	HashedURLPathsFieldNames = []string{
+		"contextURL",
 	}
 
 	// HashedValues are regular expressions which - when matched - cause the entire value to be hashed

--- a/components/scrubber/sanitisation_test.go
+++ b/components/scrubber/sanitisation_test.go
@@ -24,6 +24,8 @@ func TestSanitiser(t *testing.T) {
 		{Func: SanitiseHash, Name: "hash empty string", Expectation: "[redacted:md5:d41d8cd98f00b204e9800998ecf8427e]"},
 		{Func: SanitiseHash, Name: "hash sensitive string", Input: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8]"},
 		{Func: SanitiseHash, Name: "hash key name", Opts: []SanitiserOption{SanitiseWithKeyName("foo")}, Input: "foo@bar.com", Expectation: "[redacted:md5:f3ada405ce890b6f8204094deb12d8a8:foo]"},
+		{Func: SanitiseHashURLPathSegments, Name: "hash contextURL", Input: "https://github.com/gitpod-io/gitpod/pull/19402", Expectation: "[redacted:md5:3097fca9b1ec8942c4305e550ef1b50a]/[redacted:md5:308cb0f82b8a4966a32f7c360315c160]/[redacted:md5:5bc8d0354fba47db774b70d2a9161bbb]/pull/19402"},
+		{Func: SanitiseHashURLPathSegments, Name: "hash contextURL with query", Input: "https://github.com/gitpod-io/gitpod/pull/19402?foo=bar&foo=baz", Expectation: "[redacted:md5:3097fca9b1ec8942c4305e550ef1b50a]/[redacted:md5:308cb0f82b8a4966a32f7c360315c160]/[redacted:md5:5bc8d0354fba47db774b70d2a9161bbb]/pull/19402?[redacted:md5:d76c5fb536a9f4866aed3c0d7a0d0f76]"},
 	}
 
 	for _, test := range tests {
@@ -31,6 +33,7 @@ func TestSanitiser(t *testing.T) {
 			act := test.Func(test.Input, test.Opts...)
 
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("act: %s", act)
 				t.Errorf("sanitiser mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -112,16 +112,18 @@ func TestStruct(t *testing.T) {
 				Email        string
 				Password     string
 				WorkspaceID  string
+				ContextURL   string
 				LeaveMeAlone string
-			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
+			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", ContextURL: "https://github.com/gitpod-io/gitpod/pull/19402", LeaveMeAlone: "foo"},
 			Expectation: Expectation{
 				Result: &struct {
 					Username     string
 					Email        string
 					Password     string
 					WorkspaceID  string
+					ContextURL   string
 					LeaveMeAlone string
-				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", ContextURL: "[redacted:md5:3097fca9b1ec8942c4305e550ef1b50a]/[redacted:md5:308cb0f82b8a4966a32f7c360315c160]/[redacted:md5:5bc8d0354fba47db774b70d2a9161bbb]/pull/19402", LeaveMeAlone: "foo"},
 			},
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This change hashes the URL path parts separately instead of the whole context URL. Is does not hash specific keywords (as “pull”, “tree”) and does not hash URL path parts that consist of numbers only.

Example:
```
https://github.com/gitpod-io/gitpod/pull/19402
```

becomes:
```
[redacted:md5:3097fca9b1ec8942c4305e550ef1b50a]/[redacted:md5:d41d8cd98f00b204e9800998ecf8427e]/[redacted:md5:308cb0f82b8a4966a32f7c360315c160]/[redacted:md5:5bc8d0354fba47db774b70d2a9161bbb]/pull/19402
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENG-363/only-scrub-parts-of-a-string-for-context-url-in-analytics-events

## How to test
<!-- Provide steps to test this PR -->
Use the go test files to test it.


#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
