### PR TITLE
Do not flash unknown prebuild status

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -105,7 +105,7 @@ export const PrebuildDetailPage: FC = () => {
     const prebuildPhase = useMemo(() => {
         if (!currentPrebuild) {
             return {
-                icon: <></>,
+                icon: <LoadingState size={20} delay={false} />,
                 description: "",
             };
         }

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -103,9 +103,11 @@ export const PrebuildDetailPage: FC = () => {
     }, [isTriggerError, triggerError, toast]);
 
     const prebuildPhase = useMemo(() => {
+        const loaderIcon = <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
+
         if (!currentPrebuild) {
             return {
-                icon: <LoadingState size={20} delay={false} />,
+                icon: loaderIcon,
                 description: "",
             };
         }
@@ -118,7 +120,6 @@ export const PrebuildDetailPage: FC = () => {
             };
         }
 
-        const loaderIcon = <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
         switch (phase) {
             case PrebuildPhase_Phase.QUEUED:
                 return {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -110,7 +110,7 @@ export const PrebuildDetailPage: FC = () => {
             };
         }
 
-        const name = currentPrebuild?.status?.phase?.name;
+        const name = currentPrebuild.status?.phase?.name;
         if (!name) {
             return {
                 icon: <CircleSlash size={20} className="text-gray-500" />,

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -103,6 +103,13 @@ export const PrebuildDetailPage: FC = () => {
     }, [isTriggerError, triggerError, toast]);
 
     const prebuildPhase = useMemo(() => {
+        if (!currentPrebuild) {
+            return {
+                icon: <></>,
+                description: "",
+            };
+        }
+
         const name = currentPrebuild?.status?.phase?.name;
         if (!name) {
             return {
@@ -112,7 +119,7 @@ export const PrebuildDetailPage: FC = () => {
         }
 
         const loaderIcon = <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
-        switch (currentPrebuild?.status?.phase?.name) {
+        switch (name) {
             case PrebuildPhase_Phase.QUEUED:
                 return {
                     icon: loaderIcon,

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -110,8 +110,8 @@ export const PrebuildDetailPage: FC = () => {
             };
         }
 
-        const name = currentPrebuild.status?.phase?.name;
-        if (!name) {
+        const phase = currentPrebuild.status?.phase?.name;
+        if (!phase) {
             return {
                 icon: <CircleSlash size={20} className="text-gray-500" />,
                 description: "Unknown prebuild status.",
@@ -119,7 +119,7 @@ export const PrebuildDetailPage: FC = () => {
         }
 
         const loaderIcon = <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
-        switch (name) {
+        switch (phase) {
             case PrebuildPhase_Phase.QUEUED:
                 return {
                     icon: loaderIcon,
@@ -150,10 +150,12 @@ export const PrebuildDetailPage: FC = () => {
             <BreadcrumbNav
                 pageTitle="Prebuild history"
                 pageDescription={
-                    <>
-                        <span className="font-semibold">{prebuild?.configurationName ?? "unknown repository"}</span>{" "}
-                        <span className="text-pk-content-secondary">{prebuild?.ref ?? ""}</span>
-                    </>
+                    !isInfoLoading && (
+                        <>
+                            <span className="font-semibold">{prebuild?.configurationName ?? "unknown repository"}</span>{" "}
+                            <span className="text-pk-content-secondary">{prebuild?.ref ?? ""}</span>
+                        </>
+                    )
                 }
                 backLink={repositoriesRoutes.Prebuilds()}
             />


### PR DESCRIPTION
## Description

When there is no prebuild yet, do not assume the status is not available. Instead, wait for a prebuild to load first.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1427

## How to test

Go to a prebuild's page and observe the phase's first state is the correct one and not unknown.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-exp-1427</li>
	<li><b>🔗 URL</b> - <a href="https://ft-exp-1427.preview.gitpod-dev.com/workspaces" target="_blank">ft-exp-1427.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-EXP-1427-gha.23449</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-exp-1427%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
