### PR TITLE
[obs] fix alerts for workspace deployments

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -49,5 +49,5 @@ spec:
           summary: Desired number of replicas for image-builder-mk3 are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
-          kube_deployment_spec_replicas{container="image-builder-mk3", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="image-builder-mk3", cluster!~"ephemeral.*"}
+          kube_deployment_spec_replicas{deployment="image-builder-mk3", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{deployment="image-builder-mk3", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
+++ b/operations/observability/mixins/workspace/rules/central/node-labeler.yaml
@@ -33,5 +33,5 @@ spec:
           summary: Desired number of replicas for node-labeler are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
-          kube_deployment_spec_replicas{container="node-labeler", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="node-labeler", cluster!~"ephemeral.*"}
+          kube_deployment_spec_replicas{deployment="node-labeler", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{deployment="node-labeler", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-manager.yaml
@@ -33,5 +33,5 @@ spec:
           summary: Desired number of replicas for ws-manager-mk2 are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
-          kube_deployment_spec_replicas{container="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-manager-mk2", cluster!~"ephemeral.*"}
+          kube_deployment_spec_replicas{deployment="ws-manager-mk2", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{deployment="ws-manager-mk2", cluster!~"ephemeral.*"}
         for: 3m

--- a/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
+++ b/operations/observability/mixins/workspace/rules/central/ws-proxy.yaml
@@ -33,5 +33,5 @@ spec:
           summary: Desired number of replicas for ws-proxy are not available in cluster {{ $labels.cluster }}
           description: The mismatch is {{ printf "%.2f" $value }}
         expr: |
-          kube_deployment_spec_replicas{container="ws-proxy", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{container="ws-proxy", cluster!~"ephemeral.*"}
+          kube_deployment_spec_replicas{deployment="ws-proxy", cluster!~"ephemeral.*"} != kube_deployment_status_replicas_available{deployment="ws-proxy", cluster!~"ephemeral.*"}
         for: 3m


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The proper label to use with `kube_deployment_spec_replicas` is deployment.

`container` is okay with `kube_pod_container_status_restarts_total`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1804

## How to test
<!-- Provide steps to test this PR -->
[Here](https://gitpoddedicatedprod.grafana.net/explore?schemaVersion=1&panes=%7B%224kl%22:%7B%22datasource%22:%22grafanacloud-prom%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22expr%22:%22kube_deployment_spec_replicas%7Bdeployment%3D%5C%22ws-manager-mk2%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%20%21%3D%20kube_deployment_status_replicas_available%7Bdeployment%3D%5C%22ws-manager-mk2%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22grafanacloud-prom%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22,%22hide%22:false%7D%5D,%22range%22:%7B%22from%22:%221709070292652%22,%22to%22:%221709081215735%22%7D%7D%7D&orgId=1) you can see we get data that matches:
![image](https://github.com/gitpod-io/gitpod/assets/1272076/cbd2627f-a5e5-45e7-9500-ed9be92d27f3)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
