### PR TITLE
[installer] fix mirror list get empty image

### DIFF
--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -225,6 +225,10 @@ func generateMirrorList(cfgVersion string, cfg *configv1.Config) ([]mirrorListRe
 		if img == common.GitpodContainerRegistry {
 			continue
 		}
+		// Ignore empty image
+		if img == "" {
+			continue
+		}
 		// Dedupe
 		if _, ok := allImages[img]; ok {
 			continue


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[installer] fix mirror list get empty image

<img width="1447" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/9b07703e-6260-47bb-b0b9-af951203a57f">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
