### PR TITLE
Fix prebuild logs race condition

### DIFF
--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -630,7 +630,7 @@ export class PrebuildManager {
         return false;
     }
 
-    public async watchPrebuildLogs(userId: string, prebuildId: string, onLog: (message: string) => void) {
+    public async watchPrebuildLogs(userId: string, prebuildId: string, onLog: (message: string) => Promise<void>) {
         const { workspaceId, organizationId } = await this.waitUntilPrebuildWorkspaceCreated(userId, prebuildId);
         if (!workspaceId || !organizationId) {
             throw new ApplicationError(ErrorCodes.PRECONDITION_FAILED, "prebuild workspace not found");
@@ -654,7 +654,7 @@ export class PrebuildManager {
                             },
                         );
                         for await (const message of imageBuildIt) {
-                            onLog(message);
+                            await onLog(message);
                         }
                     }
                     break;
@@ -739,7 +739,7 @@ export class PrebuildManager {
                     );
 
                     for await (const message of it) {
-                        onLog(message);
+                        await onLog(message);
                     }
                     // we don't care the case phase updates from `running` to `stopped` because their logs are the same
                     // this may cause some logs lost, but better than duplicate?


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1483

## How to test
<!-- Provide steps to test this PR -->
Hot deploy server with a setTimeout, logs should be incomplete
<img width="2020" alt="SCR-20240305-prul" src="https://github.com/gitpod-io/gitpod/assets/20944364/8d620976-3f97-4c11-99eb-cb48ac9e5b63">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
