### PR TITLE
Allow running prebuilds on a specific branch

### DIFF
--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -38,7 +38,13 @@ export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", classNa
             />
 
             <Tooltip content={tip} className="absolute top-0 right-0">
-                <Button variant="ghost" size={"icon"} onClick={handleCopyToClipboard} className="ring-inset">
+                <Button
+                    variant="ghost"
+                    size={"icon"}
+                    onClick={handleCopyToClipboard}
+                    type="button"
+                    className="ring-inset"
+                >
                     {copied ? <CheckIcon className="text-green-500 w-5 h-5" /> : <CopyIcon className="w-3.5 h-3.5" />}
                 </Button>
             </Tooltip>

--- a/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
+++ b/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
@@ -79,7 +79,7 @@ export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfig
         <Modal visible onClose={onClose} onSubmit={handleSubmit}>
             <ModalHeader>Run a prebuild</ModalHeader>
             <ModalBody>
-                <div className="w-112 max-w-full flex flex-col gap-8">
+                <div className="w-112 max-w-full flex flex-col">
                     {needsGitAuth ? (
                         <AuthorizeGit />
                     ) : (

--- a/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
+++ b/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
@@ -16,6 +16,7 @@ import { SuggestedRepository } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 import { useConfiguration } from "../../data/configurations/configuration-queries";
 import { Link } from "react-router-dom";
 import { repositoriesRoutes } from "../../repositories/repositories.routes";
+import { TextInputField } from "../../components/forms/TextInputField";
 
 type Props = {
     defaultRepositoryId?: string;
@@ -25,6 +26,8 @@ type Props = {
 export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfigurationId, onClose, onRun }) => {
     const needsGitAuth = useNeedsGitAuthorization();
     const [selectedRepo, setSelectedRepo] = useState<SuggestedRepository>();
+    const [branchName, setBranchName] = useState<string>();
+
     const [createErrorMsg, setCreateErrorMsg] = useState<JSX.Element | undefined>();
     const configurationId = useMemo(
         () => selectedRepo?.configurationId ?? defaultConfigurationId,
@@ -38,7 +41,7 @@ export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfig
         error,
         isRefetching,
         data: prebuildId,
-    } = useTriggerPrebuildQuery(configurationId);
+    } = useTriggerPrebuildQuery(configurationId, branchName);
 
     const { data: configuration } = useConfiguration(configurationId ?? "");
 
@@ -76,12 +79,12 @@ export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfig
         <Modal visible onClose={onClose} onSubmit={handleSubmit}>
             <ModalHeader>Run a prebuild</ModalHeader>
             <ModalBody>
-                <div className="w-112 max-w-full">
+                <div className="w-112 max-w-full flex flex-col gap-8">
                     {needsGitAuth ? (
                         <AuthorizeGit />
                     ) : (
                         <>
-                            <InputField className="mb-8 w-full">
+                            <InputField className="w-full">
                                 <RepositoryFinder
                                     selectedContextURL={selectedRepo?.url}
                                     selectedConfigurationId={configurationId}
@@ -89,6 +92,18 @@ export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfig
                                     onlyProjects
                                 />
                             </InputField>
+                            <TextInputField
+                                label="Branch"
+                                hint={
+                                    <>
+                                        Leaving this blank will result in running your prebuild on the repository's
+                                        default branch.
+                                    </>
+                                }
+                                value={branchName}
+                                onChange={setBranchName}
+                                disabled={isFetching || isRefetching}
+                            />
                         </>
                     )}
                 </div>

--- a/components/server/src/api/prebuild-service-api.ts
+++ b/components/server/src/api/prebuild-service-api.ts
@@ -56,6 +56,7 @@ export class PrebuildServiceAPI implements ServiceImpl<typeof PrebuildServiceInt
         const userId = ctxUserId();
         const user = await this.userService.findUserById(userId, userId);
         const prebuild = await this.prebuildManager.triggerPrebuild({}, user, request.configurationId, request.gitRef);
+
         return new StartPrebuildResponse({
             prebuildId: prebuild.prebuildId,
         });

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -165,17 +165,21 @@ export class PrebuildManager {
 
         const project = await this.projectService.getProject(user.id, projectId);
 
-        const branchDetails = !!branchName
-            ? await this.projectService.getBranchDetails(user, project, branchName)
-            : (await this.projectService.getBranchDetails(user, project)).filter((b) => b.isDefault);
-        if (branchDetails.length !== 1) {
-            log.debug({ userId: user.id }, "Cannot find branch details.", { project, branchName });
-            throw new ApplicationError(
-                ErrorCodes.NOT_FOUND,
-                `Could not find ${!branchName ? "a default branch" : `branch '${branchName}'`} in repository ${
-                    project.cloneUrl
-                }`,
-            );
+        let branchDetails: Project.BranchDetails[] = [];
+        try {
+            branchDetails = branchName
+                ? await this.projectService.getBranchDetails(user, project, branchName)
+                : (await this.projectService.getBranchDetails(user, project)).filter((b) => b.isDefault);
+        } finally {
+            if (branchDetails.length !== 1) {
+                log.debug({ userId: user.id }, "Cannot find branch details.", { project, branchName });
+                throw new ApplicationError(
+                    ErrorCodes.NOT_FOUND,
+                    `Could not find ${!branchName ? "a default branch" : `branch '${branchName}'`} in repository ${
+                        project.cloneUrl
+                    }`,
+                );
+            }
         }
         const contextURL = branchDetails[0].url;
 

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -170,6 +170,8 @@ export class PrebuildManager {
             branchDetails = branchName
                 ? await this.projectService.getBranchDetails(user, project, branchName)
                 : (await this.projectService.getBranchDetails(user, project)).filter((b) => b.isDefault);
+        } catch (e) {
+            log.error(e);
         } finally {
             if (branchDetails.length !== 1) {
                 log.debug({ userId: user.id }, "Cannot find branch details.", { project, branchName });


### PR DESCRIPTION
## Description

Allows you to create prebuilds from any branch your heart desires.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1491

## How to test

https://ft-manual-f41a539ce1.preview.gitpod-dev.com/prebuilds

1. Import a repo and turn prebuilds on
2. Run a prebuild manually

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-manual-f41a539ce1</li>
	<li><b>🔗 URL</b> - <a href="https://ft-manual-f41a539ce1.preview.gitpod-dev.com/workspaces" target="_blank">ft-manual-f41a539ce1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-manual-prebuild-run-with-branches-gha.23481</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-manual-f41a539ce1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
