### PR TITLE
Add pinnedEditorVersions db migration

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-team-settings.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-settings.ts
@@ -24,6 +24,9 @@ export class DBOrgSettings implements OrganizationSettings {
     @Column("json", { nullable: true })
     allowedWorkspaceClasses?: string[] | null;
 
+    @Column("json", { nullable: true })
+    pinnedEditorVersions?: { [key: string]: string } | null;
+
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/migration/1709626232691-AddPinnedEditorVersions.ts
+++ b/components/gitpod-db/src/typeorm/migration/1709626232691-AddPinnedEditorVersions.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const table = "d_b_org_settings";
+const newColumn = "pinnedEditorVersions";
+
+export class AddPinnedEditorVersions1709626232691 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, table, newColumn))) {
+            await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN ${newColumn} JSON NULL`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, table, newColumn)) {
+            await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN ${newColumn}`);
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -360,7 +360,13 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
         const repo = await this.getOrgSettingsRepo();
         return repo.findOne({
             where: { orgId, deleted: false },
-            select: ["orgId", "workspaceSharingDisabled", "defaultWorkspaceImage", "allowedWorkspaceClasses"],
+            select: [
+                "orgId",
+                "workspaceSharingDisabled",
+                "defaultWorkspaceImage",
+                "allowedWorkspaceClasses",
+                "pinnedEditorVersions",
+            ],
         });
     }
 

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -199,6 +199,8 @@ export interface OrganizationSettings {
 
     // empty array to allow all kind of workspace classes
     allowedWorkspaceClasses?: string[] | null;
+
+    pinnedEditorVersions?: { [key: string]: string } | null;
 }
 
 export type TeamMemberRole = OrgMemberRole;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add pinnedEditorVersions db migration

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
