### PR TITLE
Fix freshly authed SCMs on the new workspace page

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -439,6 +439,7 @@ export function CreateWorkspacePage() {
                             setSelectAccountError={setSelectAccountError}
                             reset={() => {
                                 createWorkspaceMutation.reset();
+                                workspaceContext.refetch();
                             }}
                         />
                     ) : null}
@@ -557,9 +558,10 @@ const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({ error, reset, setS
                     title="You are not authenticated."
                     linkText={`Authorize with ${error.data?.host}`}
                     linkOnClick={() => {
-                        tryAuthorize(error.data?.host, error.data?.scopes).then((payload) =>
-                            setSelectAccountError(payload),
-                        );
+                        tryAuthorize(error.data?.host, error.data?.scopes).then((payload) => {
+                            setSelectAccountError(payload);
+                            reset();
+                        });
                     }}
                 />
             );

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -438,8 +438,8 @@ export function CreateWorkspacePage() {
                             }
                             setSelectAccountError={setSelectAccountError}
                             reset={() => {
-                                createWorkspaceMutation.reset();
                                 workspaceContext.refetch();
+                                createWorkspaceMutation.reset();
                             }}
                         />
                     ) : null}


### PR DESCRIPTION
## Description

Previously, when creating a workspace from a context URL of an unauthorized provider and clicking `Authorize` from the error alert, one would have to refresh to allow themselves to proceed with workspace creation. This change refetches the provider state when you complete the authentication.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1516

## How to test

As instructed in EXP-1516:
> go to user setings and make sure no gitlab.com git provider is enabled (remove if you have it)
open [contextLink](https://gitlab.com/jeanphi-baconnais-experiments/gitpod-terminal/-/tree/main?ref_type=heads)
click "Authorize with Gitlab.com"  and proceed.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-exp-1516</li>
	<li><b>🔗 URL</b> - <a href="https://ft-exp-1516.preview.gitpod-dev.com/workspaces" target="_blank">ft-exp-1516.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-EXP-1516-gha.23529</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-exp-1516%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
