### PR TITLE
Fix context missing for test cases

### DIFF
--- a/components/server/src/auth/bearer-authenticator.spec.db.ts
+++ b/components/server/src/auth/bearer-authenticator.spec.db.ts
@@ -99,18 +99,18 @@ describe("BearerAuth", () => {
                 authorization: `Bearer `, // missing
             },
         } as Request;
-        await expectError(async () => bearerAuth.authExpressRequest(req), "missing bearer token header");
+        await expectError(async () => bearerAuth.authExpressRequest(req), "missing Bearer token");
     });
 
     it("authExpressRequest should fail to authenticate with missing BearerToken from DB (PAT)", async () => {
-        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4";
+        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4.value";
 
         const req = {
             headers: {
                 authorization: `Bearer ${patNotStored}`,
             },
         } as Request;
-        await expectError(async () => bearerAuth.authExpressRequest(req), "cannot find token");
+        await expectError(async () => bearerAuth.authExpressRequest(req), "Invalid personal access token");
     });
 
     it("tryAuthFromHeaders should successfully authenticate BearerToken (PAT)", async () => {
@@ -132,17 +132,19 @@ describe("BearerAuth", () => {
     });
 
     it("tryAuthFromHeaders should fail to authenticate with missing BearerToken from DB (PAT)", async () => {
-        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4";
+        const patNotStored = "gitpod_pat_GrvGthczSRf3ypqFhNtcRiN5fK6CV7rdCkkPLfpbc_4.value";
 
         const headers = new Headers();
         headers.set("authorization", `Bearer ${patNotStored}`);
-        await expectError(async () => bearerAuth.tryAuthFromHeaders(headers), "cannot find token");
+        await expectError(async () => bearerAuth.tryAuthFromHeaders(headers), "Invalid personal access token");
     });
 
     async function expectError(fun: () => Promise<any>, message: string) {
         try {
             await fun();
             fail(`Expected error: ${message}`);
-        } catch (err) {}
+        } catch (err) {
+            expect(err.message).to.include(message);
+        }
     }
 });

--- a/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
+++ b/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
@@ -179,7 +179,7 @@ describe("CachingSpiceDBAuthorizer", async () => {
         const ws1 = await withTestCtx(userA, () => createTestWorkspace(org1, userA));
 
         expect(
-            await withTestCtx(SYSTEM_USER, () => authorizer.hasPermissionOnWorkspace(userA.id, "read_info", ws1.id)),
+            await withTestCtx(userA, () => authorizer.hasPermissionOnWorkspace(userA.id, "read_info", ws1.id)),
             "userA should have read_info after removal of userB",
         ).to.be.true;
         expect(

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -11,7 +11,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx, withTestCtxProxy } from "../test/service-testing-container-module";
 import { OrganizationService } from "./organization-service";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { expectError } from "../test/expect-utils";
@@ -48,7 +48,21 @@ describe("OrganizationService", async () => {
                     await validateDefaultWorkspaceImage(userId, imageRef);
                 }
             });
-        os = container.get(OrganizationService);
+        const realOs = container.get(OrganizationService);
+        os = withTestCtxProxy(realOs, {
+            0: [
+                "getSettings",
+                "updateSettings",
+                "listMembers",
+                "getOrganization",
+                "addOrUpdateMember",
+                "getOrCreateInvite",
+                "listOrganizations",
+                "removeOrganizationMember",
+                "resetInvite",
+                "deleteOrganization",
+            ],
+        });
         userService = container.get<UserService>(UserService);
         owner = await userService.createUser({
             identity: {

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -27,6 +27,7 @@ import { InstallationService } from "../auth/installation-service";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { runWithSubjectId } from "../util/request-context";
 import { IDEService } from "../ide-service";
+import { SubjectId } from "../auth/subject-id";
 
 @injectable()
 export class OrganizationService {
@@ -319,7 +320,9 @@ export class OrganizationService {
                 // we can remove the built-in installation admin if we have added an owner
                 if (!hasOtherRegularOwners && members.some((m) => m.userId === BUILTIN_INSTLLATION_ADMIN_USER_ID)) {
                     try {
-                        await this.removeOrganizationMember(memberId, orgId, BUILTIN_INSTLLATION_ADMIN_USER_ID, txCtx);
+                        await runWithSubjectId(SubjectId.fromUserId(memberId), () =>
+                            this.removeOrganizationMember(memberId, orgId, BUILTIN_INSTLLATION_ADMIN_USER_ID, txCtx),
+                        );
                     } catch (error) {
                         log.warn("Failed to remove built-in installation admin from organization.", error);
                     }

--- a/components/server/src/scm/scm-service.spec.db.ts
+++ b/components/server/src/scm/scm-service.spec.db.ts
@@ -10,7 +10,7 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtxProxy } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { UserService } from "../user/user-service";
 import { Config } from "../config";
@@ -43,7 +43,10 @@ describe("ScmService", async () => {
         Experiments.configureTestingClient({
             centralizedPermissions: true,
         });
-        service = container.get(ScmService);
+        const realService = container.get(ScmService);
+        service = withTestCtxProxy(realService, {
+            0: ["getToken"],
+        });
         userService = container.get<UserService>(UserService);
         currentUser = await userService.createUser({
             identity: {

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -10,14 +10,13 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { createTestContainer, withTestCtx, withTestCtxProxy } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { SSHKeyService } from "./sshkey-service";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
 import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -48,9 +47,19 @@ describe("SSHKeyService", async () => {
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
-        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
+        const invite = await withTestCtx(BUILTIN_INSTLLATION_ADMIN_USER_ID, () =>
+            orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id),
+        );
 
         const userService = container.get<UserService>(UserService);
+        const owner = await userService.createUser({
+            identity: {
+                authId: "foo",
+                authName: "bar",
+                authProviderId: "github",
+                primaryEmail: "yolo@yolo.com",
+            },
+        });
         member = await userService.createUser({
             organizationId: org.id,
             identity: {
@@ -60,7 +69,8 @@ describe("SSHKeyService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
+        await withTestCtx(owner, () => orgService.joinOrganization(owner.id, invite.id));
+        await withTestCtx(member, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",
@@ -69,7 +79,10 @@ describe("SSHKeyService", async () => {
             },
         });
 
-        ss = container.get(SSHKeyService);
+        const realSs = container.get(SSHKeyService);
+        ss = withTestCtxProxy(realSs, {
+            0: ["hasSSHPublicKey", "getSSHPublicKeys", "addSSHPublicKey", "deleteSSHPublicKey"],
+        });
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**There're some places will print `mismatch`**
- `authorizaer`: it's testing mismatch cases
- `organization-service`: testing PERMISSION_DENIED / NOT_FOUND (i.e. member update settings, stranger find org)

**Important logic change:**
- `organization-service`: `addOrUpdateMember` with a new owner it will delete BUILT_IN one from org, add a `runWithSubjectId` to make sure it's the new owner going to delete the member.
- `workspace-starter`: `failInstanceStart` it can happend no instance (at least in test case)

**Others**
- `bearer-authxxx.spec.ts`: logic of expectError is not complete
- Test cases to create orgniaztion via BUILT IN users, first joiner should be owner

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixed [[internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1709835458123889)]

## How to test
<!-- Provide steps to test this PR -->
Check changes of test cases (there're some note for changes on the Description section)
- Run test in server
- Should have no error like `SubjectId mismatch` except what described on PR Description section

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
