### PR TITLE
Alert for high load average on headless nodes

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -30,10 +30,21 @@ spec:
                     team: engine
                 for: 60m
                 annotations:
-                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodePoolLoad.md
                     summary: Workspace node's normalized load average is higher than 10 for more than 60 minutes. Check for abuse.
                     description: Node {{ $labels.node }} in {{ $labels.cluster }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.
                 expr: nodepool:node_load1:normalized{nodepool=~".*workspace.*", cluster!~"ephemeral.*"} > 10
+
+              - alert: GitpodHeadlessNodeHighNormalizedLoadAverage
+                labels:
+                    severity: warning
+                    team: engine
+                for: 60m
+                annotations:
+                    runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodePoolLoad.md
+                    summary: Workspace node's normalized load average is higher than 10 for more than 60 minutes. Check for abuse.
+                    description: Node {{ $labels.node }} in {{ $labels.cluster }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.
+                expr: nodepool:node_load1:normalized{nodepool=~".*headless.*", cluster!~"ephemeral.*"} > 10
 
               - alert: AutoscalerAddsNodesTooFast
                 labels:


### PR DESCRIPTION
## Description
Alert for high load average on headless nodes. [Context](https://gitpod.slack.com/archives/C06NF8LBSRY)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1864

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
