### PR TITLE
[proxy] add a liveness check

### DIFF
--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -216,6 +216,19 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								RunAsNonRoot: pointer.Bool(true),
 								RunAsUser:    pointer.Int64(65532),
 							},
+							LivenessProbe: &corev1.Probe{
+								InitialDelaySeconds: int32(5),
+								PeriodSeconds:       int32(5),
+								FailureThreshold:    int32(10),
+								SuccessThreshold:    int32(1),
+								TimeoutSeconds:      int32(2),
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/live",
+										Port: intstr.IntOrString{IntVal: ReadinessPort},
+									},
+								},
+							},
 						}, {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Proxy.Version),
@@ -259,19 +272,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								TimeoutSeconds:      1,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							LivenessProbe: &corev1.Probe{
-								InitialDelaySeconds: int32(5),
-								PeriodSeconds:       int32(5),
-								FailureThreshold:    int32(10),
-								SuccessThreshold:    int32(1),
-								TimeoutSeconds:      int32(2),
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/live",
-										Port: intstr.IntOrString{IntVal: ReadinessPort},
-									},
-								},
 							},
 							VolumeMounts: volumeMounts,
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -216,19 +216,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								RunAsNonRoot: pointer.Bool(true),
 								RunAsUser:    pointer.Int64(65532),
 							},
-							LivenessProbe: &corev1.Probe{
-								InitialDelaySeconds: int32(5),
-								PeriodSeconds:       int32(5),
-								FailureThreshold:    int32(10),
-								SuccessThreshold:    int32(1),
-								TimeoutSeconds:      int32(2),
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/live",
-										Port: intstr.IntOrString{IntVal: ReadinessPort},
-									},
-								},
-							},
 						}, {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Proxy.Version),
@@ -272,6 +259,19 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								TimeoutSeconds:      1,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
+							},
+							LivenessProbe: &corev1.Probe{
+								InitialDelaySeconds: int32(5),
+								PeriodSeconds:       int32(5),
+								FailureThreshold:    int32(10),
+								SuccessThreshold:    int32(1),
+								TimeoutSeconds:      int32(2),
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/live",
+										Port: intstr.IntOrString{IntVal: ReadinessPort},
+									},
+								},
 							},
 							VolumeMounts: volumeMounts,
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -260,6 +260,19 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
 							},
+							LivenessProbe: &corev1.Probe{
+								InitialDelaySeconds: int32(5),
+								PeriodSeconds:       int32(5),
+								FailureThreshold:    int32(10),
+								SuccessThreshold:    int32(1),
+								TimeoutSeconds:      int32(2),
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/live",
+										Port: intstr.IntOrString{IntVal: ReadinessPort},
+									},
+								},
+							},
 							VolumeMounts: volumeMounts,
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is an initial iteration, to setup a liveness check for caddy using the existing `/live` endpoint on the [readiness port](https://github.com/gitpod-io/gitpod/blob/c7bbff5aceee1e7870a3feac1441a75083bb63b7/components/proxy/conf/Caddyfile#L138). If the problem continues, where new cells sometimes fail the `installation` because all `proxy` pods never become ready, we'll want to add a more complex liveness check, perhaps using `wait4x`, where we check 8003 and 9545 and other ports for "liveness".

E.g.
```go
ProbeHandler: corev1.ProbeHandler{
		Exec: &v1.ExecAction{
			Command: []string{"wait4x", "http", "http://127.0.0.1:9545", "&&", "wait4x", "http", "http://127.0.0.1:8003"},
		},
	},
```

Reference for the `wait4x` idea: https://github.com/gitpod-io/gitpod/pull/8777

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-1889

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-eng-1889</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-eng-1889.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-eng-1889.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-ENG-1889-gha.23578</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-eng-1889%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
