### PR TITLE
[ws-manager-mk2] Add workspace reconciler tracing

### DIFF
--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/constants"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/maintenance"
 	config "github.com/gitpod-io/gitpod/ws-manager/api/config"
@@ -91,11 +92,14 @@ type WorkspaceReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
-func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	span, ctx := tracing.FromContext(ctx, "WorkspaceReconciler.Reconcile")
+	defer tracing.FinishSpan(span, &err)
 	log := log.FromContext(ctx)
 
 	var workspace workspacev1.Workspace
-	if err := r.Get(ctx, req.NamespacedName, &workspace); err != nil {
+	err = r.Get(ctx, req.NamespacedName, &workspace)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "unable to fetch workspace")
 		}
@@ -140,7 +144,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return errorResultLogConflict(log, fmt.Errorf("failed to update workspace status: %w", err))
 	}
 
-	result, err := r.actOnStatus(ctx, &workspace, workspacePods)
+	result, err = r.actOnStatus(ctx, &workspace, workspacePods)
 	if err != nil {
 		return errorResultLogConflict(log, fmt.Errorf("failed to act on status: %w", err))
 	}
@@ -148,9 +152,12 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return result, nil
 }
 
-func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspacev1.Workspace) (*corev1.PodList, error) {
+func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspacev1.Workspace) (list *corev1.PodList, err error) {
+	span, ctx := tracing.FromContext(ctx, "listWorkspacePods")
+	defer tracing.FinishSpan(span, &err)
+
 	var workspacePods corev1.PodList
-	err := r.List(ctx, &workspacePods, client.InNamespace(ws.Namespace), client.MatchingFields{wsOwnerKey: ws.Name})
+	err = r.List(ctx, &workspacePods, client.InNamespace(ws.Namespace), client.MatchingFields{wsOwnerKey: ws.Name})
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +165,9 @@ func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspa
 	return &workspacePods, nil
 }
 
-func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (ctrl.Result, error) {
+func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (result ctrl.Result, err error) {
+	span, ctx := tracing.FromContext(ctx, "actOnStatus")
+	defer tracing.FinishSpan(span, &err)
 	log := log.FromContext(ctx)
 
 	if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped && !r.metrics.containsWorkspace(workspace) {
@@ -409,10 +418,13 @@ func (r *WorkspaceReconciler) emitPhaseEvents(ctx context.Context, ws *workspace
 	}
 }
 
-func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev1.Pod, reason string) (ctrl.Result, error) {
+func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev1.Pod, reason string) (result ctrl.Result, err error) {
+	span, ctx := tracing.FromContext(ctx, "deleteWorkspacePod")
+	defer tracing.FinishSpan(span, &err)
+
 	// Workspace was requested to be deleted, propagate by deleting the Pod.
 	// The Pod deletion will then trigger workspace disposal steps.
-	err := r.Client.Delete(ctx, pod)
+	err = r.Client.Delete(ctx, pod)
 	if apierrors.IsNotFound(err) {
 		// pod is gone - nothing to do here
 	} else {
@@ -422,13 +434,15 @@ func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev
 	return ctrl.Result{}, nil
 }
 
-func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) error {
+func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) (err error) {
+	span, ctx := tracing.FromContext(ctx, "deleteWorkspaceSecrets")
+	defer tracing.FinishSpan(span, &err)
 	log := log.FromContext(ctx)
 
 	// if a secret cannot be deleted we do not return early because we want to attempt
 	// the deletion of the remaining secrets
 	var errs []string
-	err := r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "env"), r.Config.Namespace)
+	err = r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "env"), r.Config.Namespace)
 	if err != nil {
 		errs = append(errs, err.Error())
 		log.Error(err, "could not delete environment secret", "workspace", ws.Name)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add tracing to the workspace reconciler, and additional tracing to the API service, especially around k8s operations.

Gives us better visibility into how much time is spent on what during reconciliations and API handlers.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

https://gitpod.slack.com/archives/C06PTBSE59N/p1710269657251179

## How to test
<!-- Provide steps to test this PR -->

I've tested in a preview env that workspaces still start and stop. But haven't been able to verify the tracing works, there's no tracing configured in preview envs as far as I know. Changes should be low risk though?

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - wv-add-mk261c2ed1f6b</li>
	<li><b>🔗 URL</b> - <a href="https://wv-add-mk261c2ed1f6b.preview.gitpod-dev.com/workspaces" target="_blank">wv-add-mk261c2ed1f6b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - wv-add-mk2-ws-reconciler-tracing-gha.23731</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-wv-add-mk261c2ed1f6b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
