### PR TITLE
Fix configuration input with preset value

### DIFF
--- a/components/dashboard/src/prebuilds/configuration-input/ConfigurationInput.tsx
+++ b/components/dashboard/src/prebuilds/configuration-input/ConfigurationInput.tsx
@@ -34,8 +34,8 @@ export const ConfigurationDropdown = ({ selectedConfigurationId, disabled, expan
             return config.id === selectedConfigurationId;
         });
 
-        return match;
-    }, [configurations, selectedConfigurationId]);
+        return match ?? selectedConfiguration;
+    }, [configurations, selectedConfiguration, selectedConfigurationId]);
 
     const getElements = useCallback(() => {
         const resetFilterItem: ComboboxElement = {


### PR DESCRIPTION
## Description

Fixes the default state of the configuration select component when we feed an initial value into it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1420

## How to test

1. Import a repo and enable prebuilds
2. Run a prebuild
3. Go to the repo's prebuild settings again, click <kbd>View prebuild history</kbd>.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
