### PR TITLE
Make sure to refetch ws ctx after `AuthorizeGit`

### DIFF
--- a/components/dashboard/src/components/AuthorizeGit.tsx
+++ b/components/dashboard/src/components/AuthorizeGit.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useContext } from "react";
+import { useCallback, useContext } from "react";
 import { Link } from "react-router-dom";
 import { useAuthProviderDescriptions } from "../data/auth-providers/auth-provider-descriptions-query";
 import { openAuthorizeWindow } from "../provider-utils";
@@ -26,7 +26,11 @@ export function useNeedsGitAuthorization() {
     return !authProviders.some((ap) => user.identities.some((i) => ap.id === i.authProviderId));
 }
 
-export const AuthorizeGit: FC<{ className?: string }> = ({ className }) => {
+type Props = {
+    className?: string;
+    refetch?: () => void;
+};
+export const AuthorizeGit = ({ className, refetch }: Props) => {
     const { setUser } = useContext(UserContext);
     const owner = useIsOwner();
     const { data: authProviders } = useAuthProviderDescriptions();
@@ -35,7 +39,9 @@ export const AuthorizeGit: FC<{ className?: string }> = ({ className }) => {
         if (response.user) {
             setUser(response.user);
         }
-    }, [setUser]);
+
+        refetch?.();
+    }, [refetch, setUser]);
 
     const connect = useCallback(
         (ap: AuthProviderDescription) => {

--- a/components/dashboard/src/components/AuthorizeGit.tsx
+++ b/components/dashboard/src/components/AuthorizeGit.tsx
@@ -96,7 +96,7 @@ export const AuthorizeGit = ({ className, refetch }: Props) => {
                                     key={"button" + ap.host}
                                     className="mt-3 btn-login flex-none w-56 px-0 py-0.5 inline-flex"
                                 >
-                                    <div className="flex relative -left-4 w-56">
+                                    <div className="flex relative w-56">
                                         {iconForAuthProvider(ap.type)}
                                         <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">
                                             Continue with {simplifyProviderName(ap.host)}

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -413,7 +413,10 @@ export function CreateWorkspacePage() {
                     <div className="text-gray-500 text-center text-base">
                         Start a new workspace with the following options.
                     </div>
-                    <AuthorizeGit className="mt-12 border-2 border-gray-100 dark:border-gray-800 rounded-lg" />
+                    <AuthorizeGit
+                        refetch={workspaceContext.refetch}
+                        className="mt-12 border-2 border-gray-100 dark:border-gray-800 rounded-lg"
+                    />
                 </div>
             </div>
         );


### PR DESCRIPTION
## Description

Following on an edge case I did not cover in https://github.com/gitpod-io/gitpod/pull/19517, this PR makes sure to refetch the workspace context after one authorizes their git integration via the dedicated view instead of the banner.

## Related Issue(s)
<!-- List the issue(s) this PR 
Follow-up to EXP-1516.

## How to test

Working on it....

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-refetchd7ab1f88ad</li>
	<li><b>🔗 URL</b> - <a href="https://ft-refetchd7ab1f88ad.preview.gitpod-dev.com/workspaces" target="_blank">ft-refetchd7ab1f88ad.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-refetch-after-git-authorize-gha.23685</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-refetchd7ab1f88ad%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
