### PR TITLE
[dashboard] update login screen and autostart

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -9,9 +9,6 @@ import { useContext, useEffect, useState, useMemo, useCallback, FC } from "react
 import { UserContext } from "./user-context";
 import { getGitpodService } from "./service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "./provider-utils";
-import gitpod from "./images/gitpod.svg";
-import gitpodDark from "./images/gitpod-dark.svg";
-import gitpodIcon from "./icons/gitpod.svg";
 import exclamation from "./images/exclamation.svg";
 import { getURLHash } from "./utils";
 import ErrorMessage from "./components/ErrorMessage";
@@ -24,6 +21,8 @@ import { AuthProviderDescription } from "@gitpod/public-api/lib/gitpod/v1/authpr
 import { Button, ButtonProps } from "@podkit/buttons/Button";
 import { cn } from "@podkit/lib/cn";
 import { userClient } from "./service/public-api";
+import { ProductLogo } from "./components/ProductLogo";
+import { useIsDataOps } from "./data/featureflag-query";
 
 export function markLoggedIn() {
     document.cookie = GitpodCookie.generateCookie(window.location.hostname);
@@ -38,6 +37,7 @@ type LoginProps = {
 };
 export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
     const { setUser } = useContext(UserContext);
+    const isDataOps = useIsDataOps();
 
     const urlHash = useMemo(() => getURLHash(), []);
 
@@ -133,20 +133,13 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                         <div className="flex-grow h-100 flex flex-row items-center justify-center">
                             <div className="rounded-xl px-10 py-10 mx-auto">
                                 <div className="mx-auto pb-8">
-                                    <img
-                                        src={providerFromContext ? gitpod : gitpodIcon}
-                                        className="h-14 mx-auto block dark:hidden"
-                                        alt="Gitpod's logo"
-                                    />
-                                    <img
-                                        src={providerFromContext ? gitpodDark : gitpodIcon}
-                                        className="h-14 hidden mx-auto dark:block"
-                                        alt="Gitpod dark theme logo"
-                                    />
+                                    <ProductLogo className="h-14 mx-auto block" />
                                 </div>
 
                                 <div className="mx-auto text-center pb-8 space-y-2">
-                                    {providerFromContext ? (
+                                    {isDataOps ? (
+                                        <Heading1>Log in to DataOps.live Develop</Heading1>
+                                    ) : providerFromContext ? (
                                         <>
                                             <Heading2>Open a cloud development environment</Heading2>
                                             <Subheading>for the repository {repoPathname?.slice(1)}</Subheading>

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -119,151 +119,157 @@ export const AppRoutes = () => {
 
     return (
         <Route>
-            <div className="container">
-                <Menu />
-                <AppNotifications />
-                <Switch>
-                    <Route path="/new" exact component={CreateWorkspacePage} />
-                    <Route path="/open">
-                        <Redirect to="/new" />
-                    </Route>
-                    {/* TODO(gpl): Remove once we don't need the redirect anymore */}
-                    <Route
-                        path={[
-                            switchToPAYGPathMain,
-                            settingsPathPlans,
-                            "/old-team-plans",
-                            "/teams",
-                            "/subscription",
-                            "/upgrade-subscription",
-                            "/plans",
-                        ]}
-                        exact
-                    >
-                        <Redirect to={"/billing"} />
-                    </Route>
-                    <Route path={workspacesPathMain} exact component={Workspaces} />
-                    <Route path={settingsPathAccount} exact component={Account} />
-                    <Route path={usagePathMain} exact component={Usage} />
-                    <Route path={settingsPathIntegrations} exact component={Integrations} />
-                    <Route path={settingsPathNotifications} exact component={Notifications} />
-                    <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
-                    <Route path={settingsPathSSHKeys} exact component={SSHKeys} />
-                    <Route path={settingsPathPersonalAccessTokens} exact component={PersonalAccessTokens} />
-                    <Route
-                        path={settingsPathPersonalAccessTokenCreate}
-                        exact
-                        component={PersonalAccessTokenCreateView}
-                    />
-                    <Route
-                        path={settingsPathPersonalAccessTokenEdit + "/:tokenId"}
-                        exact
-                        component={PersonalAccessTokenCreateView}
-                    />
-                    <Route path={settingsPathPreferences} exact component={Preferences} />
-                    <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
-                    <Route path="/from-referrer" exact component={FromReferrer} />
+            <Switch>
+                <Route path="/new" exact component={CreateWorkspacePage} />
+                <Route path="*">
+                    <div className="container">
+                        <Menu />
+                        <AppNotifications />
+                        <Switch>
+                            <Route path="/open">
+                                <Redirect to="/new" />
+                            </Route>
+                            {/* TODO(gpl): Remove once we don't need the redirect anymore */}
+                            <Route
+                                path={[
+                                    switchToPAYGPathMain,
+                                    settingsPathPlans,
+                                    "/old-team-plans",
+                                    "/teams",
+                                    "/subscription",
+                                    "/upgrade-subscription",
+                                    "/plans",
+                                ]}
+                                exact
+                            >
+                                <Redirect to={"/billing"} />
+                            </Route>
+                            <Route path={workspacesPathMain} exact component={Workspaces} />
+                            <Route path={settingsPathAccount} exact component={Account} />
+                            <Route path={usagePathMain} exact component={Usage} />
+                            <Route path={settingsPathIntegrations} exact component={Integrations} />
+                            <Route path={settingsPathNotifications} exact component={Notifications} />
+                            <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
+                            <Route path={settingsPathSSHKeys} exact component={SSHKeys} />
+                            <Route path={settingsPathPersonalAccessTokens} exact component={PersonalAccessTokens} />
+                            <Route
+                                path={settingsPathPersonalAccessTokenCreate}
+                                exact
+                                component={PersonalAccessTokenCreateView}
+                            />
+                            <Route
+                                path={settingsPathPersonalAccessTokenEdit + "/:tokenId"}
+                                exact
+                                component={PersonalAccessTokenCreateView}
+                            />
+                            <Route path={settingsPathPreferences} exact component={Preferences} />
+                            <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
+                            <Route path="/from-referrer" exact component={FromReferrer} />
 
-                    <AdminRoute path="/admin/users" component={UserSearch} />
-                    <AdminRoute path="/admin/orgs" component={TeamsSearch} />
-                    <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
-                    <AdminRoute path="/admin/projects" component={ProjectsSearch} />
-                    <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositories} />
-                    <AdminRoute path="/admin/blocked-email-domains" component={BlockedEmailDomains} />
+                            <AdminRoute path="/admin/users" component={UserSearch} />
+                            <AdminRoute path="/admin/orgs" component={TeamsSearch} />
+                            <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
+                            <AdminRoute path="/admin/projects" component={ProjectsSearch} />
+                            <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositories} />
+                            <AdminRoute path="/admin/blocked-email-domains" component={BlockedEmailDomains} />
 
-                    <Route path={["/", "/login", "/login/:orgSlug"]} exact>
-                        <Redirect to={workspacesPathMain} />
-                    </Route>
-                    <Route path={[settingsPathMain]} exact>
-                        <Redirect to={settingsPathAccount} />
-                    </Route>
-                    <Route path={["/access-control"]} exact>
-                        <Redirect to={settingsPathIntegrations} />
-                    </Route>
-                    <Route path={["/admin"]} exact>
-                        <Redirect to="/admin/users" />
-                    </Route>
-                    <Route path="/sorry" exact>
-                        <div className="mt-48 text-center">
-                            <Heading1>Oh, no! Something went wrong!</Heading1>
-                            <Subheading className="mt-4 text-gitpod-red">{decodeURIComponent(getURLHash())}</Subheading>
-                        </div>
-                    </Route>
-                    <Route exact path="/orgs/new" component={NewTeam} />
-                    <Route exact path="/orgs/join" component={JoinTeam} />
-                    <Route exact path="/projects" component={Projects} />
-
-                    {/* These routes that require a selected organization, otherwise they redirect to "/" */}
-                    <Route exact path="/members" component={Members} />
-                    <Route exact path="/settings" component={TeamSettings} />
-                    <Route exact path="/settings/git" component={TeamGitIntegrations} />
-                    {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
-                    <Route exact path="/billing" component={TeamUsageBasedBilling} />
-                    <Route exact path="/sso" component={SSO} />
-
-                    <Route exact path={`/projects/:projectSlug`} component={Project} />
-                    <Route exact path={`/projects/:projectSlug/prebuilds`} component={Prebuilds} />
-                    <Route exact path={`/projects/:projectSlug/settings`} component={ProjectSettings} />
-                    <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
-                    <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
-
-                    <Route exact path={`/prebuilds`} component={PrebuildListPage} />
-                    <Route path="/prebuilds/:prebuildId" component={PrebuildDetailPage} />
-                    <Route exact path="/repositories" component={ConfigurationListPage} />
-                    {/* Handles all /repositories/:id/* routes in a nested router */}
-                    <Route path="/repositories/:id" component={ConfigurationDetailPage} />
-
-                    {/* basic redirect for old team slugs */}
-                    <Route path={["/t/"]} exact>
-                        <Redirect to="/projects" />
-                    </Route>
-                    {/* redirect for old user settings slugs */}
-                    <Route path="/account" exact>
-                        <Redirect to={settingsPathAccount} />
-                    </Route>
-                    <Route path="/integrations" exact>
-                        <Redirect to={settingsPathIntegrations} />
-                    </Route>
-                    <Route path="/notifications" exact>
-                        <Redirect to={settingsPathNotifications} />
-                    </Route>
-                    <Route path="/user/billing" exact>
-                        <Redirect to={"/billing"} />
-                    </Route>
-                    <Route path="/preferences" exact>
-                        <Redirect to={settingsPathPreferences} />
-                    </Route>
-                    <Route path="/variables" exact>
-                        <Redirect to={settingsPathVariables} />
-                    </Route>
-                    <Route path="/tokens" exact>
-                        <Redirect to={settingsPathPersonalAccessTokens} />
-                    </Route>
-                    <Route path="/tokens/create" exact>
-                        <Redirect to={settingsPathPersonalAccessTokenCreate} />
-                    </Route>
-                    <Route path="/keys" exact>
-                        <Redirect to={settingsPathSSHKeys} />
-                    </Route>
-                    <Route
-                        path="*"
-                        render={(_match) => {
-                            // delegate to our website to handle the request
-                            if (isGitpodIo()) {
-                                window.location.host = "www.gitpod.io";
-                            }
-
-                            return (
+                            <Route path={["/", "/login", "/login/:orgSlug"]} exact>
+                                <Redirect to={workspacesPathMain} />
+                            </Route>
+                            <Route path={[settingsPathMain]} exact>
+                                <Redirect to={settingsPathAccount} />
+                            </Route>
+                            <Route path={["/access-control"]} exact>
+                                <Redirect to={settingsPathIntegrations} />
+                            </Route>
+                            <Route path={["/admin"]} exact>
+                                <Redirect to="/admin/users" />
+                            </Route>
+                            <Route path="/sorry" exact>
                                 <div className="mt-48 text-center">
-                                    <Heading1>404</Heading1>
-                                    <Subheading className="mt-4">Page not found.</Subheading>
+                                    <Heading1>Oh, no! Something went wrong!</Heading1>
+                                    <Subheading className="mt-4 text-gitpod-red">
+                                        {decodeURIComponent(getURLHash())}
+                                    </Subheading>
                                 </div>
-                            );
-                        }}
-                    />
-                </Switch>
-            </div>
-            <WebsocketClients />
+                            </Route>
+                            <Route exact path="/orgs/new" component={NewTeam} />
+                            <Route exact path="/orgs/join" component={JoinTeam} />
+                            <Route exact path="/projects" component={Projects} />
+
+                            {/* These routes that require a selected organization, otherwise they redirect to "/" */}
+                            <Route exact path="/members" component={Members} />
+                            <Route exact path="/settings" component={TeamSettings} />
+                            <Route exact path="/settings/git" component={TeamGitIntegrations} />
+                            {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
+                            <Route exact path="/billing" component={TeamUsageBasedBilling} />
+                            <Route exact path="/sso" component={SSO} />
+
+                            <Route exact path={`/projects/:projectSlug`} component={Project} />
+                            <Route exact path={`/projects/:projectSlug/prebuilds`} component={Prebuilds} />
+                            <Route exact path={`/projects/:projectSlug/settings`} component={ProjectSettings} />
+                            <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
+                            <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
+
+                            <Route exact path={`/prebuilds`} component={PrebuildListPage} />
+                            <Route path="/prebuilds/:prebuildId" component={PrebuildDetailPage} />
+                            <Route exact path="/repositories" component={ConfigurationListPage} />
+                            {/* Handles all /repositories/:id/* routes in a nested router */}
+                            <Route path="/repositories/:id" component={ConfigurationDetailPage} />
+
+                            {/* basic redirect for old team slugs */}
+                            <Route path={["/t/"]} exact>
+                                <Redirect to="/projects" />
+                            </Route>
+                            {/* redirect for old user settings slugs */}
+                            <Route path="/account" exact>
+                                <Redirect to={settingsPathAccount} />
+                            </Route>
+                            <Route path="/integrations" exact>
+                                <Redirect to={settingsPathIntegrations} />
+                            </Route>
+                            <Route path="/notifications" exact>
+                                <Redirect to={settingsPathNotifications} />
+                            </Route>
+                            <Route path="/user/billing" exact>
+                                <Redirect to={"/billing"} />
+                            </Route>
+                            <Route path="/preferences" exact>
+                                <Redirect to={settingsPathPreferences} />
+                            </Route>
+                            <Route path="/variables" exact>
+                                <Redirect to={settingsPathVariables} />
+                            </Route>
+                            <Route path="/tokens" exact>
+                                <Redirect to={settingsPathPersonalAccessTokens} />
+                            </Route>
+                            <Route path="/tokens/create" exact>
+                                <Redirect to={settingsPathPersonalAccessTokenCreate} />
+                            </Route>
+                            <Route path="/keys" exact>
+                                <Redirect to={settingsPathSSHKeys} />
+                            </Route>
+                            <Route
+                                path="*"
+                                render={(_match) => {
+                                    // delegate to our website to handle the request
+                                    if (isGitpodIo()) {
+                                        window.location.host = "www.gitpod.io";
+                                    }
+
+                                    return (
+                                        <div className="mt-48 text-center">
+                                            <Heading1>404</Heading1>
+                                            <Subheading className="mt-4">Page not found.</Subheading>
+                                        </div>
+                                    );
+                                }}
+                            />
+                        </Switch>
+                    </div>
+                    <WebsocketClients />
+                </Route>
+            </Switch>
         </Route>
     );
 };

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -83,7 +83,7 @@ export interface StartPageProps {
     title?: string;
     children?: React.ReactNode;
     showLatestIdeWarning?: boolean;
-    workspaceId: string;
+    workspaceId?: string;
 }
 
 export interface StartWorkspaceError {

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -29,7 +29,7 @@ import { useWorkspaceContext } from "../data/workspaces/resolve-context-query";
 import { useDirtyState } from "../hooks/use-dirty-state";
 import { openAuthorizeWindow } from "../provider-utils";
 import { gitpodHostUrl } from "../service/service";
-import { StartWorkspaceError } from "../start/StartPage";
+import { StartPage, StartWorkspaceError } from "../start/StartPage";
 import { VerifyModal } from "../start/VerifyModal";
 import { StartWorkspaceOptions } from "../start/start-workspace-options";
 import { UserContext, useCurrentUser } from "../user-context";
@@ -50,6 +50,7 @@ import { EditorReference } from "@gitpod/public-api/lib/gitpod/v1/editor_pb";
 import { converter } from "../service/public-api";
 import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutation";
 import { useAllowedWorkspaceClassesMemo } from "../data/workspaces/workspace-classes-query";
+import Menu from "../menu/Menu";
 
 type NextLoadOption = "searchParams" | "autoStart" | "allDone";
 
@@ -419,90 +420,100 @@ export function CreateWorkspacePage() {
         );
     }
 
+    if (
+        (createWorkspaceMutation.isStarting || autostart) &&
+        !(createWorkspaceMutation.error || workspaceContext.error)
+    ) {
+        return <StartPage phase={WorkspacePhase_Phase.PREPARING} />;
+    }
+
     return (
-        <div className="flex flex-col mt-32 mx-auto ">
-            <div className="flex flex-col max-h-screen max-w-xl mx-auto items-center w-full">
-                <Heading1>New Workspace</Heading1>
-                <div className="text-gray-500 text-center text-base">
-                    Create a new workspace in the{" "}
-                    <span className="font-semibold text-gray-600 dark:text-gray-400">{currentOrg?.name}</span>{" "}
-                    organization.
-                </div>
-
-                <div className="-mx-6 px-6 mt-6 w-full">
-                    {createWorkspaceMutation.error || workspaceContext.error ? (
-                        <ErrorMessage
-                            error={
-                                (createWorkspaceMutation.error as StartWorkspaceError) ||
-                                (workspaceContext.error as StartWorkspaceError)
-                            }
-                            setSelectAccountError={setSelectAccountError}
-                            reset={() => {
-                                workspaceContext.refetch();
-                                createWorkspaceMutation.reset();
-                            }}
-                        />
-                    ) : null}
-
-                    <InputField>
-                        <RepositoryFinder
-                            onChange={handleContextURLChange}
-                            selectedContextURL={contextURL}
-                            selectedConfigurationId={selectedProjectID}
-                            expanded={!contextURL}
-                            disabled={createWorkspaceMutation.isStarting}
-                        />
-                    </InputField>
-
-                    <InputField error={errorIde}>
-                        <SelectIDEComponent
-                            onSelectionChange={onSelectEditorChange}
-                            setError={setErrorIde}
-                            selectedIdeOption={selectedIde}
-                            useLatest={useLatestIde}
-                            disabled={createWorkspaceMutation.isStarting}
-                            loading={workspaceContext.isLoading}
-                        />
-                    </InputField>
-
-                    <InputField error={errorWsClass}>
-                        <SelectWorkspaceClassComponent
-                            selectedConfigurationId={selectedProjectID}
-                            onSelectionChange={setSelectedWsClass}
-                            setError={setErrorWsClass}
-                            selectedWorkspaceClass={selectedWsClass}
-                            disabled={createWorkspaceMutation.isStarting}
-                            loading={workspaceContext.isLoading}
-                        />
-                    </InputField>
-                </div>
-                <div className="w-full flex justify-end mt-3 space-x-2 px-6">
-                    <LoadingButton
-                        onClick={onClickCreate}
-                        autoFocus={true}
-                        className="w-full"
-                        loading={createWorkspaceMutation.isStarting || !!autostart}
-                        disabled={continueButtonDisabled}
-                    >
-                        {createWorkspaceMutation.isStarting ? "Opening Workspace ..." : "Continue"}
-                    </LoadingButton>
-                </div>
-                {existingWorkspaces.length > 0 && !createWorkspaceMutation.isStarting && (
-                    <div className="w-full flex flex-col justify-end px-6">
-                        <p className="mt-6 text-center text-base">Running workspaces on this revision</p>
-                        {existingWorkspaces.map((w) => {
-                            return (
-                                <a
-                                    key={w.id}
-                                    href={w.status?.workspaceUrl || `/start/${w.id}}`}
-                                    className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex"
-                                >
-                                    <WorkspaceEntry info={w} shortVersion={true} />
-                                </a>
-                            );
-                        })}
+        <div className="container">
+            <Menu />
+            <div className="flex flex-col mt-32 mx-auto ">
+                <div className="flex flex-col max-h-screen max-w-xl mx-auto items-center w-full">
+                    <Heading1>New Workspace</Heading1>
+                    <div className="text-gray-500 text-center text-base">
+                        Create a new workspace in the{" "}
+                        <span className="font-semibold text-gray-600 dark:text-gray-400">{currentOrg?.name}</span>{" "}
+                        organization.
                     </div>
-                )}
+
+                    <div className="-mx-6 px-6 mt-6 w-full">
+                        {createWorkspaceMutation.error || workspaceContext.error ? (
+                            <ErrorMessage
+                                error={
+                                    (createWorkspaceMutation.error as StartWorkspaceError) ||
+                                    (workspaceContext.error as StartWorkspaceError)
+                                }
+                                setSelectAccountError={setSelectAccountError}
+                                reset={() => {
+                                    workspaceContext.refetch();
+                                    createWorkspaceMutation.reset();
+                                }}
+                            />
+                        ) : null}
+
+                        <InputField>
+                            <RepositoryFinder
+                                onChange={handleContextURLChange}
+                                selectedContextURL={contextURL}
+                                selectedConfigurationId={selectedProjectID}
+                                expanded={!contextURL}
+                                disabled={createWorkspaceMutation.isStarting}
+                            />
+                        </InputField>
+
+                        <InputField error={errorIde}>
+                            <SelectIDEComponent
+                                onSelectionChange={onSelectEditorChange}
+                                setError={setErrorIde}
+                                selectedIdeOption={selectedIde}
+                                useLatest={useLatestIde}
+                                disabled={createWorkspaceMutation.isStarting}
+                                loading={workspaceContext.isLoading}
+                            />
+                        </InputField>
+
+                        <InputField error={errorWsClass}>
+                            <SelectWorkspaceClassComponent
+                                selectedConfigurationId={selectedProjectID}
+                                onSelectionChange={setSelectedWsClass}
+                                setError={setErrorWsClass}
+                                selectedWorkspaceClass={selectedWsClass}
+                                disabled={createWorkspaceMutation.isStarting}
+                                loading={workspaceContext.isLoading}
+                            />
+                        </InputField>
+                    </div>
+                    <div className="w-full flex justify-end mt-3 space-x-2 px-6">
+                        <LoadingButton
+                            onClick={onClickCreate}
+                            autoFocus={true}
+                            className="w-full"
+                            loading={createWorkspaceMutation.isStarting || !!autostart}
+                            disabled={continueButtonDisabled}
+                        >
+                            {createWorkspaceMutation.isStarting ? "Opening Workspace ..." : "Continue"}
+                        </LoadingButton>
+                    </div>
+                    {existingWorkspaces.length > 0 && !createWorkspaceMutation.isStarting && (
+                        <div className="w-full flex flex-col justify-end px-6">
+                            <p className="mt-6 text-center text-base">Running workspaces on this revision</p>
+                            {existingWorkspaces.map((w) => {
+                                return (
+                                    <a
+                                        key={w.id}
+                                        href={w.status?.workspaceUrl || `/start/${w.id}}`}
+                                        className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex"
+                                    >
+                                        <WorkspaceEntry info={w} shortVersion={true} />
+                                    </a>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Show the loading screen when autostart=true

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #EXP-1344
Fixes #EXP-1569

## How to test
<!-- Provide steps to test this PR -->

Try this: https://se-auto-start.preview.gitpod-dev.com/new/?autostart=true#https://github.com/svenefftinge/2048-in-terminal

Unhappy path: https://se-auto-start.preview.gitpod-dev.com/new?autostart=true#https://github.com/svenefftinge/2048-in-terssminal

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
