### PR TITLE
Ensure valid repository tie when listing prebuilds

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -152,6 +152,8 @@ export const PrebuildDetailPage: FC = () => {
         }
     }, [currentPrebuild]);
 
+    const notFoundError = error instanceof ApplicationError && error.code === ErrorCodes.NOT_FOUND;
+
     if (newPrebuildID) {
         return <Redirect to={repositoriesRoutes.PrebuildDetail(newPrebuildID)} />;
     }
@@ -177,20 +179,29 @@ export const PrebuildDetailPage: FC = () => {
                     </div>
                 )}
                 {error ? (
-                    <div className="flex flex-col gap-4">
-                        <Alert type="error">
-                            <span>Failed to load prebuild</span>
-                            <pre>{error.message}</pre>
-                        </Alert>
-                        <Button
-                            variant="destructive"
-                            onClick={() => {
-                                refetch();
-                            }}
-                        >
-                            Retry
-                        </Button>
-                    </div>
+                    notFoundError ? (
+                        <div className="flex flex-col gap-4">
+                            <Alert type="error">
+                                <span>Failed to load prebuild</span>
+                                <pre>Prebuild not found</pre>
+                            </Alert>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-4">
+                            <Alert type="error">
+                                <span>Failed to load prebuild</span>
+                                <pre>{error.message}</pre>
+                            </Alert>
+                            <Button
+                                variant="destructive"
+                                onClick={() => {
+                                    refetch();
+                                }}
+                            >
+                                Retry
+                            </Button>
+                        </div>
+                    )
                 ) : (
                     prebuild && (
                         <div className={"border border-pk-border-base rounded-xl py-6 divide-y"}>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -183,19 +183,12 @@ export const PrebuildDetailPage: FC = () => {
                     </div>
                 )}
                 {error ? (
-                    notFoundError ? (
-                        <div className="flex flex-col gap-4">
-                            <Alert type="error">
-                                <span>Failed to load prebuild</span>
-                                <pre>Prebuild not found</pre>
-                            </Alert>
-                        </div>
-                    ) : (
-                        <div className="flex flex-col gap-4">
-                            <Alert type="error">
-                                <span>Failed to load prebuild</span>
-                                <pre>{error.message}</pre>
-                            </Alert>
+                    <div className="flex flex-col gap-4">
+                        <Alert type="error">
+                            <span>Failed to load prebuild</span>
+                            <pre>{notFoundError ? "Prebuild not found" : error.message}</pre>
+                        </Alert>
+                        {!notFoundError && (
                             <Button
                                 variant="destructive"
                                 onClick={() => {
@@ -204,8 +197,8 @@ export const PrebuildDetailPage: FC = () => {
                             >
                                 Retry
                             </Button>
-                        </div>
-                    )
+                        )}
+                    </div>
                 ) : (
                     prebuild && (
                         <div className={"border border-pk-border-base rounded-xl py-6 divide-y"}>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -87,9 +87,15 @@ export const PrebuildDetailPage: FC = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const notFoundError = error instanceof ApplicationError && error.code === ErrorCodes.NOT_FOUND;
+
     useEffect(() => {
         logEmitter.on("error", (err: Error) => {
             if (err?.name === "AbortError") {
+                return;
+            }
+            if (err instanceof ApplicationError && err.code === ErrorCodes.NOT_FOUND) {
+                // We don't want to show a toast for this error, because it's handled by `notFoundError`.
                 return;
             }
             if (err?.message) {
@@ -151,8 +157,6 @@ export const PrebuildDetailPage: FC = () => {
                 };
         }
     }, [currentPrebuild]);
-
-    const notFoundError = error instanceof ApplicationError && error.code === ErrorCodes.NOT_FOUND;
 
     if (newPrebuildID) {
         return <Redirect to={repositoriesRoutes.PrebuildDetail(newPrebuildID)} />;

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.spec.db.ts
@@ -12,11 +12,13 @@ import { resetDB } from "../test/reset-db";
 import { WorkspaceDB } from "../workspace-db";
 import { randomUUID } from "crypto";
 import { PrebuiltWorkspaceState } from "@gitpod/gitpod-protocol";
+import { ProjectDB } from "../project-db";
 const expect = chai.expect;
 
 @suite(timeout(10000))
 export class WorkspaceSpec {
     private readonly wsDB = testContainer.get<WorkspaceDB>(WorkspaceDB);
+    private readonly projectDB = testContainer.get<ProjectDB>(ProjectDB);
 
     readonly org = randomUUID();
     readonly strangerOrg = randomUUID();
@@ -63,6 +65,15 @@ export class WorkspaceSpec {
             "failed",
         ];
         const errors = [undefined, undefined, undefined, undefined, "failed", undefined, undefined];
+
+        await this.projectDB.storeProject({
+            id: this.configuration.id,
+            name: "gitpod",
+            cloneUrl: this.configuration.cloneUrl,
+            teamId: this.org,
+            appInstallationId: randomUUID(),
+            creationTime: now,
+        });
 
         // Mock all possible states (including two possible states for "available" with and without an error value)
         for (let i = 0; i < states.length; i++) {

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.spec.db.ts
@@ -75,57 +75,66 @@ export class WorkspaceSpec {
             creationTime: now,
         });
 
-        // Mock all possible states (including two possible states for "available" with and without an error value)
-        for (let i = 0; i < states.length; i++) {
-            const prebuildId = randomUUID();
-            const workspaceId = randomUUID();
-            const state = states[i];
-            const error = errors[i];
+        const fakeConfiguration = {
+            id: randomUUID(),
+            cloneUrl: "https://github.com/gitpod-io/gitpod",
+            branch: "main",
+            commit: "1676c9001cdf291d27f48bd18b40b773dd24748b",
+        };
 
-            const ws = await this.wsDB.store({
-                id: workspaceId,
-                type: "prebuild",
-                creationTime: now,
-                organizationId: this.org,
-                contextURL: this.configuration.cloneUrl,
-                description: "Gitpod",
-                ownerId: randomUUID(),
-                projectId: this.configuration.id,
-                context: {
-                    title: "Gitpod",
-                    ref: this.configuration.branch,
-                },
-                config: {},
-            });
+        for (const configuration of [this.configuration, fakeConfiguration]) {
+            // Mock all possible states (including two possible states for "available" with and without an error value)
+            for (let i = 0; i < states.length; i++) {
+                const prebuildId = randomUUID();
+                const workspaceId = randomUUID();
+                const state = states[i];
+                const error = errors[i];
 
-            await this.wsDB.storePrebuiltWorkspace({
-                id: prebuildId,
-                cloneURL: this.configuration.cloneUrl,
-                commit: this.configuration.commit,
-                projectId: this.configuration.id,
-                buildWorkspaceId: ws.id,
-                creationTime: now,
-                branch: this.configuration.branch,
-                state,
-                error,
-                statusVersion: 1,
-            });
+                const ws = await this.wsDB.store({
+                    id: workspaceId,
+                    type: "prebuild",
+                    creationTime: now,
+                    organizationId: this.org,
+                    contextURL: configuration.cloneUrl,
+                    description: "Gitpod",
+                    ownerId: randomUUID(),
+                    projectId: configuration.id,
+                    context: {
+                        title: "Gitpod",
+                        ref: configuration.branch,
+                    },
+                    config: {},
+                });
 
-            await this.wsDB.storePrebuildInfo({
-                teamId: this.org,
-                id: randomUUID(),
-                buildWorkspaceId: ws.id,
-                projectId: this.configuration.id,
-                projectName: "gitpod",
-                cloneUrl: this.configuration.cloneUrl,
-                branch: this.configuration.branch,
-                startedAt: now,
-                startedBy: "me",
-                changeTitle: "Change this",
-                changeDate: now,
-                changeAuthor: "me again",
-                changeHash: this.configuration.commit,
-            });
+                await this.wsDB.storePrebuiltWorkspace({
+                    id: prebuildId,
+                    cloneURL: configuration.cloneUrl,
+                    commit: configuration.commit,
+                    projectId: configuration.id,
+                    buildWorkspaceId: ws.id,
+                    creationTime: now,
+                    branch: configuration.branch,
+                    state,
+                    error,
+                    statusVersion: 1,
+                });
+
+                await this.wsDB.storePrebuildInfo({
+                    teamId: this.org,
+                    id: randomUUID(),
+                    buildWorkspaceId: ws.id,
+                    projectId: configuration.id,
+                    projectName: "gitpod",
+                    cloneUrl: configuration.cloneUrl,
+                    branch: configuration.branch,
+                    startedAt: now,
+                    startedBy: "me",
+                    changeTitle: "Change this",
+                    changeDate: now,
+                    changeAuthor: "me again",
+                    changeHash: configuration.commit,
+                });
+            }
         }
     }
 

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -1074,6 +1074,9 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                 "pws.buildWorkspaceId = ws.id AND ws.organizationId = :organizationId",
                 { organizationId },
             )
+            .innerJoinAndMapOne("pws.project", DBProject, "project", "pws.projectId = project.id")
+            .where("project.markedDeleted = false")
+            .andWhere("project.id IS NOT NULL")
             .skip(pagination.offset)
             .take(pagination.limit)
             .orderBy("pws.creationTime", sort.order); // todo: take sort field into account
@@ -1122,7 +1125,6 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
 
         const normalizedSearchTerm = filter.searchTerm?.trim();
         if (normalizedSearchTerm) {
-            query.innerJoinAndMapOne("pws.project", DBProject, "project", "pws.projectId = project.id");
             query.andWhere(
                 new Brackets((qb) => {
                     qb.where("project.cloneUrl LIKE :searchTerm", {


### PR DESCRIPTION
## Description

This is an effort to clean up orphaned prebuilds from the prebuilds page. It ensures we do not return any prebuilds of deleted projects and therefore also not showing them in the UI.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1377

## How to test
1. [Join my org](https://ft-hide-orbc251e49cc.preview.gitpod-dev.com/orgs/join?inviteId=e4b0fa57-9ecb-4342-9cac-d3e63ba37d11)
2. Go to /prebuilds on the preview env
3. Try to find [this prebuild,](https://ft-hide-orbc251e49cc.preview.gitpod-dev.com/prebuilds/5088f4c1-4936-4a2d-81d7-cb7e1f680f8b) you should not be able to.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-hide-orbc251e49cc</li>
	<li><b>🔗 URL</b> - <a href="https://ft-hide-orbc251e49cc.preview.gitpod-dev.com/workspaces" target="_blank">ft-hide-orbc251e49cc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-hide-orphaned-prebuilds-gha.23740</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-hide-orbc251e49cc%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
