### PR TITLE
Fix line heights for `<h1>`s

### DIFF
--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -21,7 +21,7 @@ export const Heading1: FC<HeadingProps> = ({ id, color, tracking, className, chi
             className={classNames(
                 getHeadingColor(color),
                 getTracking(tracking),
-                "font-bold text-4xl leading-normal truncate",
+                "font-bold text-4xl leading-normal",
                 className,
             )}
         >

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -21,7 +21,7 @@ export const Heading1: FC<HeadingProps> = ({ id, color, tracking, className, chi
             className={classNames(
                 getHeadingColor(color),
                 getTracking(tracking),
-                "font-bold text-4xl truncate",
+                "font-bold text-4xl leading-normal truncate",
                 className,
             )}
         >


### PR DESCRIPTION
## Description

Segoe UI fonts on Windows act funny and require bigger line heights than their SF UI counterparts on macOS. This is a hotfix to a problem we should solve with a consistent, unified typeface.

| Before | After |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/29888641/2057037c-8b73-4e78-bb73-3823169f9335) | ![image](https://github.com/gitpod-io/gitpod/assets/29888641/a0e4423d-96ad-425f-8d4d-81c2964f6b9b) | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1632

## How to test

1. Use Windows
2. Go to the login screen and see no clips

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-line-heights</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-line-heights.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-line-heights.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-line-heights-gha.23777</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-line-heights%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
