### PR TITLE
Add repo-level editor restriction

### DIFF
--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -158,8 +158,7 @@ export const IdeOptionsModifyModal = ({
                         <IdeOptionSwitch
                             key={ide.id}
                             ideOption={ide}
-                            ideVersions={editorVersions?.[ide.id]}
-                            hidePinEditorInputs={hidePinEditorInputs}
+                            ideVersions={hidePinEditorInputs ? undefined : editorVersions?.[ide.id]}
                             pinnedIdeVersion={pinnedEditorVersions.get(ide.id)}
                             checked={!restrictedEditors.has(ide.id)}
                             onPinnedIdeVersionChange={(version) => {
@@ -198,7 +197,6 @@ export const IdeOptionsModifyModal = ({
 interface IdeOptionSwitchProps {
     ideOption: AllowedWorkspaceEditor;
     ideVersions: string[] | undefined;
-    hidePinEditorInputs?: boolean;
     pinnedIdeVersion: string | undefined;
     checked: boolean;
     onPinnedIdeVersionChange: (version: string | undefined) => void;
@@ -207,7 +205,6 @@ interface IdeOptionSwitchProps {
 const IdeOptionSwitch = ({
     ideOption,
     ideVersions,
-    hidePinEditorInputs,
     pinnedIdeVersion,
     checked,
     onCheckedChange,
@@ -221,7 +218,7 @@ const IdeOptionSwitch = ({
         </>
     );
 
-    const versionSelector = !!pinnedIdeVersion && !!ideVersions && (
+    const versionSelector = !!pinnedIdeVersion && !!ideVersions && ideVersions.length > 0 && (
         <select
             className="py-0 pl-2 pr-7 w-auto"
             name="Editor version"
@@ -241,13 +238,13 @@ const IdeOptionSwitch = ({
                 <>
                     <MiddleDot />
                     <PinIcon size={16} />
-                    {hidePinEditorInputs ? <span>{pinnedIdeVersion}</span> : versionSelector}
+                    {versionSelector}
                 </>
             ) : (
-                ideOption.imageVersion && (
+                (pinnedIdeVersion || ideOption.imageVersion) && (
                     <>
                         <MiddleDot />
-                        <span>{ideOption.imageVersion}</span>
+                        <span>{pinnedIdeVersion || ideOption.imageVersion}</span>
                     </>
                 )
             )}
@@ -283,7 +280,7 @@ const IdeOptionSwitch = ({
                 title={computedState.title}
                 className={computedState.classes}
             />
-            {!hidePinEditorInputs && ideOption.pinnable && !!ideVersions && (
+            {ideOption.pinnable && !!ideVersions && ideVersions.length > 0 && (
                 <Button
                     type="button"
                     onClick={() => onPinnedIdeVersionChange(pinnedIdeVersion ? undefined : ideVersions[0])}

--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -234,19 +234,12 @@ const IdeOptionSwitch = ({
     );
     const description = (
         <div className={cn("inline-flex items-center", contentColor)}>
-            {versionSelector ? (
+            {(ideOption.imageVersion || pinnedIdeVersion || versionSelector) && (
                 <>
                     <MiddleDot />
-                    <PinIcon size={16} />
-                    {versionSelector}
+                    {(pinnedIdeVersion || versionSelector) && <PinIcon size={16} />}
+                    {versionSelector || <span>{pinnedIdeVersion || ideOption.imageVersion}</span>}
                 </>
-            ) : (
-                (pinnedIdeVersion || ideOption.imageVersion) && (
-                    <>
-                        <MiddleDot />
-                        <span>{pinnedIdeVersion || ideOption.imageVersion}</span>
-                    </>
-                )
             )}
             <MiddleDot />
             <span className="capitalize">{ideOption.type}</span>

--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -15,12 +15,12 @@ import { MiddleDot } from "./typography/MiddleDot";
 import { useToast } from "./toasts/Toasts";
 import Modal, { ModalBaseFooter, ModalBody, ModalHeader } from "./Modal";
 import { LoadingState } from "@podkit/loading/LoadingState";
-import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { useIDEVersionsQuery } from "../data/ide-options/ide-options-query";
+import { useFeatureFlag } from "../data/featureflag-query";
+import { AllowedWorkspaceEditor, IdeOptionsSorter, LocalIDEOptions } from "../data/ide-options/ide-options-query";
 
 interface IdeOptionsProps {
-    ideOptions: IDEOptions | undefined;
+    ideOptions: LocalIDEOptions | undefined;
     pinnedEditorVersions: Map<string, string>;
     className?: string;
     emptyState?: React.ReactNode;
@@ -28,12 +28,21 @@ interface IdeOptionsProps {
 }
 
 export const IdeOptions = (props: IdeOptionsProps) => {
+    const options = useMemo(() => {
+        return Object.values(props.ideOptions?.options ?? [])
+            .filter((x) => !x.hidden)
+            .sort(IdeOptionsSorter);
+    }, [props.ideOptions]);
+
     if (props.isLoading) {
         return <LoadingState />;
     }
+    if (options.length === 0 && props.emptyState) {
+        return <>{props.emptyState}</>;
+    }
     return (
         <div className={cn("space-y-2", props.className)}>
-            {sortedIdeOptions(props.ideOptions!).map((ide) => (
+            {options.map((ide) => (
                 <div key={ide.id} className="flex gap-2 items-center">
                     <img className="w-8 h-8 self-center" src={ide.logo} alt="" />
                     <span>
@@ -60,8 +69,9 @@ export const IdeOptions = (props: IdeOptionsProps) => {
 
 export interface IdeOptionsModifyModalProps {
     isLoading: boolean;
-    ideOptions: IDEOptions | undefined;
+    ideOptions: LocalIDEOptions | undefined;
     restrictedEditors: Set<string>;
+    hidePinEditorInputs?: boolean;
     pinnedEditorVersions: Map<string, string>;
     updateMutation: UseMutationResult<
         void,
@@ -75,11 +85,20 @@ export const IdeOptionsModifyModal = ({
     onClose,
     updateMutation,
     ideOptions,
+    hidePinEditorInputs,
     ...props
 }: IdeOptionsModifyModalProps) => {
     const orgLevelEditorVersionPinningEnabled = useFeatureFlag("org_level_editor_version_pinning_enabled");
 
-    const ideOptionsArr = useMemo(() => (ideOptions ? sortedIdeOptions(ideOptions) : undefined), [ideOptions]);
+    const ideOptionsArr = useMemo(
+        () =>
+            ideOptions?.options
+                ? Object.values(ideOptions.options)
+                      .filter((x) => !x.hidden)
+                      .sort(IdeOptionsSorter)
+                : undefined,
+        [ideOptions],
+    );
     const pinnableIdes = useMemo(
         () => ideOptionsArr?.filter((i) => orgLevelEditorVersionPinningEnabled && !!i.pinnable),
         [ideOptionsArr, orgLevelEditorVersionPinningEnabled],
@@ -153,6 +172,7 @@ export const IdeOptionsModifyModal = ({
                             key={ide.id}
                             ideOption={ide}
                             ideVersions={editorVersions?.[ide.id]}
+                            hidePinEditorInputs={hidePinEditorInputs}
                             pinnedIdeVersion={pinnedEditorVersions.get(ide.id)}
                             checked={!restrictedEditors.has(ide.id)}
                             onPinnedIdeVersionChange={(version) => {
@@ -189,8 +209,9 @@ export const IdeOptionsModifyModal = ({
 };
 
 interface IdeOptionSwitchProps {
-    ideOption: IDEOption & { id: string };
+    ideOption: AllowedWorkspaceEditor;
     ideVersions: string[] | undefined;
+    hidePinEditorInputs?: boolean;
     pinnedIdeVersion: string | undefined;
     checked: boolean;
     onPinnedIdeVersionChange: (version: string | undefined) => void;
@@ -199,19 +220,21 @@ interface IdeOptionSwitchProps {
 const IdeOptionSwitch = ({
     ideOption,
     ideVersions,
+    hidePinEditorInputs,
     pinnedIdeVersion,
     checked,
     onCheckedChange,
     onPinnedIdeVersionChange,
 }: IdeOptionSwitchProps) => {
+    const contentColor = ideOption.isDisabledInScope ? "text-pk-content-disabled" : "text-pk-content-primary";
     const label = (
         <>
             <img className="w-8 h-8 self-center mr-2" src={ideOption.logo} alt="" />
-            <span className="font-medium text-pk-content-primary">{ideOption.title}</span>
+            <span className={cn("font-medium", contentColor)}>{ideOption.title}</span>
         </>
     );
 
-    const versionSelector = !!pinnedIdeVersion && !!ideVersions && (
+    let versionSelector = !!pinnedIdeVersion && !!ideVersions && (
         <select
             className="py-0 pl-2 pr-7 w-auto"
             name="Editor version"
@@ -225,8 +248,11 @@ const IdeOptionSwitch = ({
             ))}
         </select>
     );
+    if (versionSelector && hidePinEditorInputs) {
+        versionSelector = <span>{pinnedIdeVersion}</span>;
+    }
     const description = (
-        <div className="inline-flex items-center text-pk-content-primary">
+        <div className={cn("inline-flex items-center", contentColor)}>
             {versionSelector ? (
                 <>
                     <MiddleDot />
@@ -237,27 +263,43 @@ const IdeOptionSwitch = ({
                 ideOption.imageVersion && (
                     <>
                         <MiddleDot />
-                        <span className="text-pk-content-primary">{ideOption.imageVersion}</span>
+                        <span>{ideOption.imageVersion}</span>
                     </>
                 )
             )}
             <MiddleDot />
-            <span className="text-pk-content-primary capitalize">{ideOption.type}</span>
+            <span className="capitalize">{ideOption.type}</span>
         </div>
     );
+
+    const computedState = useMemo(() => {
+        if (ideOption.isDisabledInScope && ideOption.disableScope === "organization") {
+            return {
+                title: "Your organization has disabled this editor",
+                classes: "cursor-not-allowed",
+            };
+        }
+        return {
+            title: ideOption.title,
+            classes: "",
+        };
+    }, [ideOption]);
+
     return (
-        <div className="flex w-full justify-between items-center mt-2">
+        <div className={cn("flex w-full justify-between items-center mt-2", contentColor, computedState.classes)}>
             <SwitchInputField
                 key={ideOption.id}
                 id={ideOption.id}
                 label={label}
+                disabled={ideOption.isDisabledInScope}
                 description={description}
                 labelLayout="row"
-                checked={checked}
+                checked={!ideOption.isDisabledInScope && checked}
                 onCheckedChange={onCheckedChange}
-                title={ideOption.title}
+                title={computedState.title}
+                className={computedState.classes}
             />
-            {ideOption.pinnable && !!ideVersions && (
+            {!hidePinEditorInputs && ideOption.pinnable && !!ideVersions && (
                 <Button
                     type="button"
                     onClick={() => onPinnedIdeVersionChange(pinnedIdeVersion ? undefined : ideVersions[0])}
@@ -270,25 +312,3 @@ const IdeOptionSwitch = ({
         </div>
     );
 };
-
-function filteredIdeOptions(ideOptions: IDEOptions) {
-    return IDEOptions.asArray(ideOptions).filter((x) => !x.hidden);
-}
-
-function sortedIdeOptions(ideOptions: IDEOptions) {
-    return filteredIdeOptions(ideOptions).sort((a, b) => {
-        // Prefer experimental options
-        if (a.experimental && !b.experimental) {
-            return -1;
-        }
-        if (!a.experimental && b.experimental) {
-            return 1;
-        }
-
-        if (!a.orderKey || !b.orderKey) {
-            return 0;
-        }
-
-        return parseInt(a.orderKey, 10) - parseInt(b.orderKey, 10);
-    });
-}

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -24,6 +24,7 @@ interface SelectIDEComponentProps {
     disabled?: boolean;
     loading?: boolean;
     ignoreRestrictionScopes: DisableScope[] | undefined;
+    availableOptions?: string[];
 }
 
 function filteredIdeOptions(ideOptions: IDEOptions) {
@@ -44,12 +45,9 @@ export default function SelectIDEComponent({
     setError,
     onSelectionChange,
     ignoreRestrictionScopes,
+    availableOptions,
 }: SelectIDEComponentProps) {
-    const {
-        data: ideOptions,
-        isLoading: ideOptionsLoading,
-        availableOptions,
-    } = useAllowedWorkspaceEditorsMemo(selectedConfigurationId, {
+    const { data: ideOptions, isLoading: ideOptionsLoading } = useAllowedWorkspaceEditorsMemo(selectedConfigurationId, {
         filterOutDisabled: true,
         ignoreScope: ignoreRestrictionScopes,
     });
@@ -99,6 +97,7 @@ export default function SelectIDEComponent({
     const ide = selectedIdeOption || ideOptions?.defaultIde || "";
     useEffect(() => {
         if (!availableOptions || loading || disabled || ideOptionsLoading) {
+            setError?.(undefined);
             return;
         }
         if (availableOptions.length === 0) {

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -94,7 +94,7 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
         orgSettings,
         configuration?.workspaceSettings?.restrictedEditorNames,
     ]);
-    return { ...data, isLoading };
+    return { ...data, isLoading, usingConfigurationId: configuration?.id };
 };
 
 const getAllowedWorkspaceEditors = (
@@ -149,7 +149,7 @@ const getAllowedWorkspaceEditors = (
     }
 
     let computedDefault = options?.userDefault;
-    const allowedList = data.filter((d) => !d.isDisabledInScope);
+    const allowedList = data.filter((e) => !e.isDisabledInScope);
     if (!allowedList.some((d) => d.id === options?.userDefault && !d.isDisabledInScope)) {
         computedDefault = allowedList.length > 0 ? allowedList[0].id : baseDefault;
     }
@@ -159,9 +159,9 @@ const getAllowedWorkspaceEditors = (
         }
         return e;
     });
-    const availableOptions = data.filter((e) => !e.isDisabledInScope).map((e) => e.id);
+    const availableOptions = allowedList.map((e) => e.id);
     if (options?.filterOutDisabled) {
-        return { data: data.filter((e) => !e.isDisabledInScope), scope, computedDefault, availableOptions };
+        return { data: allowedList, scope, computedDefault, availableOptions };
     }
     return { data, scope, computedDefault, availableOptions };
 };

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -77,16 +77,12 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
         isLoading = isLoadingInstallationCls || isLoadingConfiguration;
     }
     const data = useMemo(() => {
-        const result = getAllowedWorkspaceEditors(
+        return getAllowedWorkspaceEditors(
             installationOptions,
             orgSettings,
             configuration?.workspaceSettings?.restrictedEditorNames,
             options,
         );
-        return {
-            ...result,
-            data: toIDEOptions(installationOptions, result.data),
-        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         installationOptions,
@@ -166,22 +162,7 @@ const getAllowedWorkspaceEditors = (
     return { data, scope, computedDefault, availableOptions };
 };
 
-export type LocalIDEOptions = Omit<IDEOptions, "options"> & { options: { [key: string]: AllowedWorkspaceEditor } };
-
-const toIDEOptions = (
-    installationOptions: IDEOptions | undefined,
-    allowedList: AllowedWorkspaceEditor[],
-): LocalIDEOptions | undefined => {
-    if (!installationOptions) {
-        return undefined;
-    }
-    return {
-        ...installationOptions,
-        options: Object.fromEntries(allowedList.map((e) => [e.id, e])),
-    };
-};
-
-export function IdeOptionsSorter(
+function IdeOptionsSorter(
     a: Pick<IDEOption, "experimental" | "orderKey">,
     b: Pick<IDEOption, "experimental" | "orderKey">,
 ) {

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailEditors.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailEditors.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { ConfigurationWorkspaceEditorsOptions } from "./editors/ConfigurationWorkspaceEditorsOptions";
+
+interface Props {
+    configuration: Configuration;
+}
+export const ConfigurationDetailEditors: FC<Props> = ({ configuration }) => {
+    return <ConfigurationWorkspaceEditorsOptions configuration={configuration} />;
+};

--- a/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationDetailPage.tsx
@@ -19,6 +19,8 @@ import { ConfigurationDetailPrebuilds } from "./ConfigurationDetailPrebuilds";
 import { ConfigurationVariableList } from "./variables/ConfigurationVariableList";
 import { useWorkspaceClasses } from "../../data/workspaces/workspace-classes-query";
 import { LoadingState } from "@podkit/loading/LoadingState";
+import { ConfigurationDetailEditors } from "./ConfigurationDetailEditors";
+import { useFeatureFlag } from "../../data/featureflag-query";
 
 type PageRouteParams = {
     id: string;
@@ -32,6 +34,7 @@ const ConfigurationDetailPage: FC = () => {
 
     const { data, error, isLoading, refetch } = useConfiguration(id);
     const prebuildsEnabled = !!data?.prebuildSettings?.enabled;
+    const orgLevelEditorRestrictionEnabled = useFeatureFlag("org_level_editor_restriction_enabled");
 
     const settingsMenu = useMemo(() => {
         const menu: SubmenuItemProps[] = [
@@ -53,8 +56,14 @@ const ConfigurationDetailPage: FC = () => {
                 link: [`${url}/workspaces`],
             },
         ];
+        if (orgLevelEditorRestrictionEnabled) {
+            menu.push({
+                title: "Workspace editors",
+                link: [`${url}/editors`],
+            });
+        }
         return menu;
-    }, [prebuildsEnabled, url]);
+    }, [prebuildsEnabled, url, orgLevelEditorRestrictionEnabled]);
 
     return (
         <div className="w-full">
@@ -89,6 +98,9 @@ const ConfigurationDetailPage: FC = () => {
                                 </Route>
                                 <Route exact path={`${path}/workspaces`}>
                                     <ConfigurationDetailWorkspaces configuration={data} />
+                                </Route>
+                                <Route exact path={`${path}/editors`}>
+                                    <ConfigurationDetailEditors configuration={data} />
                                 </Route>
                                 <Route exact path={`${path}/prebuilds`}>
                                     <ConfigurationDetailPrebuilds configuration={data} />

--- a/components/dashboard/src/repositories/detail/editors/ConfigurationWorkspaceEditorsOptions.tsx
+++ b/components/dashboard/src/repositories/detail/editors/ConfigurationWorkspaceEditorsOptions.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import type { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
+import { useState } from "react";
+import { Heading3, Subheading } from "@podkit/typography/Headings";
+import { ConfigurationSettingsField } from "../ConfigurationSettingsField";
+import { useConfigurationMutation } from "../../../data/configurations/configuration-queries";
+import { Button } from "@podkit/buttons/Button";
+import { useMutation } from "@tanstack/react-query";
+import { useAllowedWorkspaceEditorsMemo } from "../../../data/ide-options/ide-options-query";
+import { IdeOptions, IdeOptionsModifyModal, IdeOptionsModifyModalProps } from "../../../components/IdeOptions";
+import { useOrgSettingsQuery } from "../../../data/organizations/org-settings-query";
+import { AlertTriangleIcon } from "lucide-react";
+
+export const ConfigurationWorkspaceEditorsOptions = ({ configuration }: { configuration: Configuration }) => {
+    const configurationMutation = useConfigurationMutation();
+    const { data: orgSettings } = useOrgSettingsQuery();
+    const [showModal, setShowModal] = useState(false);
+    const { data: orgOptions, isLoading: orgOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(configuration.id, {
+        filterOutDisabled: false,
+        ignoreScope: ["configuration"],
+    });
+    const { data: repoOptions, isLoading: repoOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(configuration.id, {
+        filterOutDisabled: true,
+    });
+
+    const updateMutation: IdeOptionsModifyModalProps["updateMutation"] = useMutation({
+        mutationFn: async ({ restrictedEditors }) => {
+            const updatedRestrictedEditors = [...restrictedEditors.keys()];
+            await configurationMutation.mutateAsync({
+                configurationId: configuration.id,
+                workspaceSettings: {
+                    restrictedEditorNames: updatedRestrictedEditors,
+                    updateRestrictedEditorNames: true,
+                },
+            });
+        },
+    });
+
+    const pinnedEditorVersions = new Map<string, string>(Object.entries(orgSettings?.pinnedEditorVersions || {}));
+    const restrictedEditors = new Set<string>(configuration.workspaceSettings?.restrictedEditorNames || []);
+
+    return (
+        <ConfigurationSettingsField>
+            <Heading3>Available editors</Heading3>
+            <Subheading>Limit the available editors for this repository.</Subheading>
+
+            <div className="mt-4">
+                <IdeOptions
+                    isLoading={repoOptionsIsLoading}
+                    emptyState={
+                        <div className="font-semibold text-pk-content-primary flex gap-2 items-center">
+                            <AlertTriangleIcon size={20} className="text-red-500" />
+                            <span>This repository doesn't have any available editor.</span>
+                        </div>
+                    }
+                    ideOptions={repoOptions}
+                    pinnedEditorVersions={pinnedEditorVersions}
+                />
+            </div>
+
+            <Button className="mt-6" onClick={() => setShowModal(true)}>
+                Manage Editors
+            </Button>
+
+            {showModal && (
+                <IdeOptionsModifyModal
+                    hidePinEditorInputs
+                    isLoading={orgOptionsIsLoading}
+                    ideOptions={orgOptions}
+                    restrictedEditors={restrictedEditors}
+                    pinnedEditorVersions={pinnedEditorVersions}
+                    updateMutation={updateMutation}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/repositories/repositories.routes.ts
+++ b/components/dashboard/src/repositories/repositories.routes.ts
@@ -10,6 +10,7 @@ export const repositoriesRoutes = {
     Configuration: (id: string) => `/repositories/${id}/configuration`,
     PrebuildsSettings: (id: string) => `/repositories/${id}/prebuilds`,
     WorkspaceSettings: (id: string) => `/repositories/${id}/workspaces`,
+    EditorSettings: (id: string) => `/repositories/${id}/editors`,
     Prebuilds: () => `/prebuilds`,
     PrebuildDetail: (prebuildId: string) => `/prebuilds/${prebuildId}`,
 };

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -520,11 +520,14 @@ interface EditorOptionsProps {
 }
 const EditorOptions = ({ isOwner, settings, handleUpdateTeamSettings }: EditorOptionsProps) => {
     const [showModal, setShowModal] = useState(false);
-    const { data: installationOptions, isLoading: installationOptionsIsLoading } = useAllowedWorkspaceEditorsMemo({
-        filterOutDisabled: true,
-        ignoreScope: ["organization", "configuration"],
-    });
-    const { data: orgOptions, isLoading: orgOptionsIsLoading } = useAllowedWorkspaceEditorsMemo({
+    const { data: installationOptions, isLoading: installationOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(
+        undefined,
+        {
+            filterOutDisabled: true,
+            ignoreScope: ["organization", "configuration"],
+        },
+    );
+    const { data: orgOptions, isLoading: orgOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(undefined, {
         filterOutDisabled: true,
         ignoreScope: ["configuration"],
     });

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -173,6 +173,8 @@ export function CreateWorkspacePage() {
             setSelectedProjectID(repo?.configurationId);
             // TOOD: consider dropping this - it's a lossy conversion
             history.replace(`#${repo?.url}`);
+            // reset load options
+            setNextLoadOption("searchParams");
         },
         [history],
     );

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -78,7 +78,15 @@ export function CreateWorkspacePage() {
             ? props.ideSettings.useLatestVersion
             : user?.editorSettings?.version === "latest";
     const [useLatestIde, setUseLatestIde] = useState(defaultLatestIde);
-    const { computedDefault: computedDefaultEditor } = useAllowedWorkspaceEditorsMemo(selectedProjectID, {
+    // Note: it has data fetching and UI rendering race between the updating of `selectedProjectId` and `selectedIde`
+    // We have to stored the using repositoryId locally so that we can know selectedIde is updated because if which repo
+    // so that it doesn't show ide error messages in middle state
+    const [defaultIdeSource, setDefaultIdeSource] = useState<string | undefined>(selectedProjectID);
+    const {
+        computedDefault: computedDefaultEditor,
+        usingConfigurationId,
+        availableOptions: availableEditorOptions,
+    } = useAllowedWorkspaceEditorsMemo(selectedProjectID, {
         userDefault: user?.editorSettings?.name,
         filterOutDisabled: true,
     });
@@ -348,6 +356,7 @@ export function CreateWorkspacePage() {
                 }
             }
         }
+        setDefaultIdeSource(usingConfigurationId);
         setNextLoadOption("allDone");
         // we only update the remembered options when the workspaceContext changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -477,6 +486,9 @@ export function CreateWorkspacePage() {
                         <InputField error={errorIde}>
                             <SelectIDEComponent
                                 onSelectionChange={onSelectEditorChange}
+                                availableOptions={
+                                    defaultIdeSource === selectedProjectID ? availableEditorOptions : undefined
+                                }
                                 setError={setErrorIde}
                                 selectedIdeOption={selectedIde}
                                 selectedConfigurationId={selectedProjectID}

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -78,7 +78,7 @@ export function CreateWorkspacePage() {
             ? props.ideSettings.useLatestVersion
             : user?.editorSettings?.version === "latest";
     const [useLatestIde, setUseLatestIde] = useState(defaultLatestIde);
-    const { computedDefault: computedDefaultEditor } = useAllowedWorkspaceEditorsMemo({
+    const { computedDefault: computedDefaultEditor } = useAllowedWorkspaceEditorsMemo(selectedProjectID, {
         userDefault: user?.editorSettings?.name,
         filterOutDisabled: true,
     });
@@ -89,6 +89,7 @@ export function CreateWorkspacePage() {
     const { data: orgSettings } = useOrgSettingsQuery();
     const [selectedWsClass, setSelectedWsClass, selectedWsClassIsDirty] = useDirtyState(defaultWorkspaceClass);
     const [errorWsClass, setErrorWsClass] = useState<React.ReactNode | undefined>(undefined);
+    const [errorIde, setErrorIde] = useState<React.ReactNode | undefined>(undefined);
     const [contextURL, setContextURL] = useState<string | undefined>(
         StartWorkspaceOptions.parseContextUrl(location.hash),
     );
@@ -175,7 +176,6 @@ export function CreateWorkspacePage() {
         },
         [setSelectedIde, setUseLatestIde],
     );
-    const [errorIde, setErrorIde] = useState<string | undefined>(undefined);
 
     const existingWorkspaces = useMemo(() => {
         if (!workspaces.data || !workspaceContext.data) {
@@ -479,6 +479,7 @@ export function CreateWorkspacePage() {
                                 onSelectionChange={onSelectEditorChange}
                                 setError={setErrorIde}
                                 selectedIdeOption={selectedIde}
+                                selectedConfigurationId={selectedProjectID}
                                 pinnedEditorVersions={
                                     orgSettings?.pinnedEditorVersions &&
                                     new Map<string, string>(Object.entries(orgSettings.pinnedEditorVersions))

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -25,6 +25,8 @@ export interface ProjectSettings {
      * Controls workspace class restriction for this project, the list is a NOT ALLOW LIST. Empty array to allow all kind of workspace classes
      */
     restrictedWorkspaceClasses?: string[];
+
+    restrictedEditorNames?: string[];
 }
 export namespace PrebuildSettings {
     export type BranchStrategy = "default-branch" | "all-branches" | "matched-branches";

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -927,7 +927,9 @@ export class PublicAPIConverter {
     }
 
     fromWorkspaceSettings(settings?: DeepPartial<WorkspaceSettings>) {
-        const result: Partial<Pick<ProjectSettings, "workspaceClasses" | "restrictedWorkspaceClasses">> = {};
+        const result: Partial<
+            Pick<ProjectSettings, "workspaceClasses" | "restrictedWorkspaceClasses" | "restrictedEditorNames">
+        > = {};
         if (settings?.workspaceClass) {
             result.workspaceClasses = {
                 regular: settings.workspaceClass,
@@ -936,6 +938,10 @@ export class PublicAPIConverter {
 
         if (settings?.restrictedWorkspaceClasses) {
             result.restrictedWorkspaceClasses = settings.restrictedWorkspaceClasses.filter((e) => !!e) as string[];
+        }
+
+        if (settings?.restrictedEditorNames) {
+            result.restrictedEditorNames = settings.restrictedEditorNames.filter((e) => !!e) as string[];
         }
         return result;
     }
@@ -976,7 +982,7 @@ export class PublicAPIConverter {
 
     fromPartialConfiguration(configuration: PartialConfiguration): PartialProject {
         const prebuilds = this.fromPartialPrebuildSettings(configuration.prebuildSettings);
-        const { workspaceClasses, restrictedWorkspaceClasses } = this.fromWorkspaceSettings(
+        const { workspaceClasses, restrictedWorkspaceClasses, restrictedEditorNames } = this.fromWorkspaceSettings(
             configuration.workspaceSettings,
         );
 
@@ -997,6 +1003,9 @@ export class PublicAPIConverter {
         }
         if (restrictedWorkspaceClasses) {
             result.settings!.restrictedWorkspaceClasses = restrictedWorkspaceClasses;
+        }
+        if (restrictedEditorNames) {
+            result.settings!.restrictedEditorNames = restrictedEditorNames;
         }
 
         return result;
@@ -1055,6 +1064,9 @@ export class PublicAPIConverter {
         }
         if (projectSettings?.restrictedWorkspaceClasses) {
             result.restrictedWorkspaceClasses = projectSettings.restrictedWorkspaceClasses;
+        }
+        if (projectSettings?.restrictedEditorNames) {
+            result.restrictedEditorNames = projectSettings.restrictedEditorNames;
         }
         return result;
     }

--- a/components/server/src/api/configuration-service-api.ts
+++ b/components/server/src/api/configuration-service-api.ts
@@ -206,6 +206,14 @@ export class ConfigurationServiceAPI implements ServiceImpl<typeof Configuration
                     "updateRestrictedWorkspaceClasses is required to be true to update restrictedWorkspaceClasses",
                 );
             }
+            if (req.workspaceSettings.updateRestrictedEditorNames) {
+                update.workspaceSettings.restrictedEditorNames = req.workspaceSettings.restrictedEditorNames;
+            } else if (req.workspaceSettings.restrictedEditorNames.length > 0) {
+                throw new ApplicationError(
+                    ErrorCodes.BAD_REQUEST,
+                    "updateRestrictedEditorNames is required to be true to update restrictedEditorNames",
+                );
+            }
         }
 
         if (Object.keys(update).length <= 1) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- [x] Need to be rebased after https://github.com/gitpod-io/gitpod/pull/19542

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1484, EXP-1262, EXP-1264

## How to test
<!-- Provide steps to test this PR -->
- Try to update both repo and org-level available editors
- Test on create workspace page if the option and error message is expected

Examples to load create workspace pages:
- Change contextUrl on browser manually
- Add search param `editor` on url manually
- Update selected repo
- Update selected editor then update selected repo
- ...

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-repo-editor</li>
	<li><b>🔗 URL</b> - <a href="https://hw-repo-editor.preview.gitpod-dev.com/workspaces" target="_blank">hw-repo-editor.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-repo-editor-gha.23804</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-repo-editor%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
