### PR TITLE
Unify prebuild status indicators

### DIFF
--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -12,7 +12,6 @@ import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
 import { ThemeContext } from "../theme-context";
 import { cn } from "@podkit/lib/cn";
-import { LoadingState } from "@podkit/loading/LoadingState";
 
 const darkTheme: ITheme = {
     // What written on DevTool dark:bg-gray-800 is
@@ -29,7 +28,6 @@ export interface WorkspaceLogsProps {
     errorMessage?: string;
     classes?: string;
     xtermClasses?: string;
-    isLoading?: boolean;
 }
 
 export default function WorkspaceLogs(props: WorkspaceLogsProps) {
@@ -106,12 +104,6 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
                 "bg-gray-100 dark:bg-gray-800 relative text-left",
             )}
         >
-            {props.isLoading && (
-                <div className="absolute top-2 right-8 flex items-center gap-1 z-10 text-pk-content-tertiary">
-                    <LoadingState delay={false} size={16} />
-                    <span>Fetching logs</span>
-                </div>
-            )}
             <div
                 className={cn(props.xtermClasses || "absolute top-0 left-0 bottom-0 right-0 m-6")}
                 ref={xTermParentRef}

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -107,8 +107,9 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
             )}
         >
             {props.isLoading && (
-                <div className="absolute top-2 right-2">
+                <div className="absolute top-2 right-8 flex items-center gap-1 z-10 text-pk-content-tertiary">
                     <LoadingState delay={false} size={16} />
+                    <span>Fetching logs</span>
                 </div>
             )}
             <div

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -23,6 +23,8 @@ import Alert from "../../components/Alert";
 import { prebuildDisplayProps, prebuildStatusIconComponent } from "../../projects/prebuild-utils";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { MiddleDot } from "../../components/typography/MiddleDot";
+import { TextMuted } from "@podkit/typography/TextMuted";
 
 const WorkspaceLogs = React.lazy(() => import("../../components/WorkspaceLogs"));
 
@@ -219,9 +221,14 @@ export const PrebuildDetailPage: FC = () => {
                                 </div>
                             </div>
                             <div className="px-6 py-4 flex flex-col gap-1 border-pk-border-base">
-                                <div className="flex gap-1 items-center capitalize">
+                                <div className="flex gap-1 items-center">
                                     {prebuildPhase.icon}
-                                    <span>{prebuildPhase.description}</span>
+                                    <span className="capitalize">{prebuildPhase.description}</span>{" "}
+                                    {isStreamingLogs && (
+                                        <TextMuted>
+                                            <MiddleDot /> Fetching logs...
+                                        </TextMuted>
+                                    )}
                                 </div>
                                 {prebuild.status?.message && (
                                     <div className="text-pk-content-secondary truncate">{prebuild.status.message}</div>
@@ -251,7 +258,6 @@ export const PrebuildDetailPage: FC = () => {
                                             classes="h-full w-full"
                                             xtermClasses="absolute top-0 left-0 bottom-0 right-0 ml-6 my-0"
                                             logsEmitter={logEmitter}
-                                            isLoading={isStreamingLogs}
                                         />
                                     )}
                                 </Suspense>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Prebuild, PrebuildPhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
+import { Prebuild } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { BreadcrumbNav } from "@podkit/breadcrumbs/BreadcrumbNav";
 import { Text } from "@podkit/typography/Text";
 import { Button } from "@podkit/buttons/Button";
@@ -128,34 +128,20 @@ export const PrebuildDetailPage: FC = () => {
             };
         }
 
-        const phase = currentPrebuild.status?.phase?.name;
-        if (!phase) {
+        if (!currentPrebuild.status?.phase?.name) {
             return {
                 icon: <CircleSlash size={20} className="text-gray-500" />,
                 description: "Unknown prebuild status.",
             };
         }
 
-        switch (phase) {
-            case PrebuildPhase_Phase.QUEUED:
-                return {
-                    icon: loaderIcon,
-                    description: "Prebuild queued",
-                };
-            case PrebuildPhase_Phase.BUILDING:
-                return {
-                    icon: loaderIcon,
-                    description: "Prebuild in progress",
-                };
-            default:
-                const props = prebuildDisplayProps(currentPrebuild);
-                const Icon = prebuildStatusIconComponent(currentPrebuild);
+        const props = prebuildDisplayProps(currentPrebuild);
+        const Icon = prebuildStatusIconComponent(currentPrebuild);
 
-                return {
-                    description: props.label,
-                    icon: <Icon className={props.className} />,
-                };
-        }
+        return {
+            description: props.label,
+            icon: <Icon className={props.className} />,
+        };
     }, [currentPrebuild]);
 
     if (newPrebuildID) {
@@ -263,7 +249,7 @@ export const PrebuildDetailPage: FC = () => {
                                     ) : (
                                         <WorkspaceLogs
                                             classes="h-full w-full"
-                                            xtermClasses="absolute top-0 left-0 bottom-0 right-0 mx-6 my-0"
+                                            xtermClasses="absolute top-0 left-0 bottom-0 right-0 ml-6 my-0"
                                             logsEmitter={logEmitter}
                                             isLoading={isStreamingLogs}
                                         />


### PR DESCRIPTION
## Description

Make sure that the prebuild statuses we show on the list page reflect those which we show on the detail page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1643

## How to test


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-unify-p53a20bcd2b</li>
	<li><b>🔗 URL</b> - <a href="https://ft-unify-p53a20bcd2b.preview.gitpod-dev.com/workspaces" target="_blank">ft-unify-p53a20bcd2b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-unify-prebuild-statuses-gha.23820</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-unify-p53a20bcd2b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
