### PR TITLE
Improve dashboard editor restriction settings

### DIFF
--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -120,7 +120,9 @@ export const IdeOptionsModifyModal = ({
         if (!ideOptionsArr) {
             return;
         }
-        const leftOptions = ideOptionsArr.filter((i) => !restrictedEditors.has(i.id));
+        const leftOptions = ideOptionsArr
+            .filter((e) => !e.isDisabledInScope)
+            .filter((i) => !restrictedEditors.has(i.id));
         if (leftOptions.length === 0) {
             return "At least one Editor has to be selected.";
         }

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useEffect } from "react";
+import { FC, useCallback, useEffect, useMemo } from "react";
 import { Combobox, ComboboxElement, ComboboxSelectedItem } from "./podkit/combobox/Combobox";
 import Editor from "../icons/Editor.svg";
 import { AllowedWorkspaceEditor, useAllowedWorkspaceEditorsMemo } from "../data/ide-options/ide-options-query";
@@ -89,6 +89,28 @@ export default function SelectIDEComponent({
             setError(undefined);
         }
     };
+    const helpMessage = useMemo(() => {
+        const repoSetting = selectedConfigurationId && repositoriesRoutes.EditorSettings(selectedConfigurationId);
+        const orgSetting = "/settings";
+        return (
+            <>
+                Please contact an admin to update{" "}
+                <Link className="underline" to={orgSetting}>
+                    organization settings
+                </Link>
+                {repoSetting && (
+                    <>
+                        {" or "}
+                        <Link className="underline" to={repoSetting}>
+                            repository settings
+                        </Link>
+                    </>
+                )}
+                .
+            </>
+        );
+    }, [selectedConfigurationId]);
+
     const ide = selectedIdeOption || computedDefault || "";
     useEffect(() => {
         if (!availableOptions || loading || disabled || ideOptionsLoading) {
@@ -96,35 +118,20 @@ export default function SelectIDEComponent({
             return;
         }
         if (availableOptions.length === 0) {
-            const settingLink = selectedConfigurationId && repositoriesRoutes.EditorSettings(selectedConfigurationId);
-            const teamSettingsLink = "/settings";
-            setError?.(
-                <>
-                    No available editors for this repository.
-                    {settingLink && (
-                        <>
-                            {" "}
-                            Please contact an admin to update{" "}
-                            <Link className="underline" to={teamSettingsLink}>
-                                organization settings
-                            </Link>
-                            {" or "}
-                            <Link className="underline" to={settingLink}>
-                                repository settings
-                            </Link>
-                            .
-                        </>
-                    )}
-                </>,
-            );
+            setError?.(<>No available editors for this repository. {helpMessage}</>);
             return;
         }
         if (!availableOptions.includes(ide)) {
-            setError?.(`The editor '${ide}' is not supported.`);
+            setError?.(
+                <>
+                    The editor '{ide}' is not supported. {helpMessage}
+                </>,
+            );
         } else {
             setError?.(undefined);
         }
-    }, [ide, availableOptions, setError, selectedConfigurationId, loading, disabled, ideOptionsLoading]);
+    }, [ide, availableOptions, setError, loading, disabled, ideOptionsLoading, helpMessage]);
+
     return (
         <Combobox
             getElements={getElements}

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -481,7 +481,10 @@ const OrgWorkspaceClassesOptions = ({
     return (
         <ConfigurationSettingsField>
             <Heading3>Available workspace classes</Heading3>
-            <Subheading>Limit the available workspace classes in your organization.</Subheading>
+            <Subheading>
+                Limit the available workspace classes in your organization. Requires{" "}
+                <span className="font-medium">Owner</span> permissions to change.
+            </Subheading>
 
             <WorkspaceClassesOptions
                 isLoading={isLoadingClsInOrg}
@@ -550,7 +553,10 @@ const EditorOptions = ({ isOwner, settings, handleUpdateTeamSettings }: EditorOp
     return (
         <ConfigurationSettingsField>
             <Heading3>Available editors</Heading3>
-            <Subheading>Limit the available editors in your organization.</Subheading>
+            <Subheading>
+                Limit the available editors in your organization. Requires <span className="font-medium">Owner</span>{" "}
+                permissions to change.
+            </Subheading>
 
             <IdeOptions
                 isLoading={orgOptionsIsLoading}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Add message to show that only owner can update org settings
- Better error messages when user select an unsupported editor (via url search param `editor`)
- Fix repo-level editor restriction allows to block all editors bug

‼️ not sure about first point, as all settings on org-level only allow `owner` to update it
<img width="1090" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/3cc1f3d8-e5f2-4156-9d08-62608f111e22">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1671, EXP-1672, EXP-1674

## How to test
<!-- Provide steps to test this PR -->
https://hw-restric6410a20100.preview.gitpod-dev.com/workspaces

Check points on PR description

Join an org as a member https://hw-restric6410a20100.preview.gitpod-dev.com/orgs/join?inviteId=46fa8597-ed0a-4997-8260-068c736121b9

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
