### PR TITLE
Rebuild dev-image for go v1.22

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     outputs:
       previewctl_hash: ${{ steps.build.outputs.previewctl_hash }}
     steps:
@@ -161,7 +161,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
       env:
         DB_HOST: "mysql"
         DB_PORT: "23306"
@@ -401,7 +401,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     if: needs.configuration.outputs.with_integration_tests != ''
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -101,7 +101,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/lacework-inline-scanner.yml
+++ b/.github/workflows/lacework-inline-scanner.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [configuration,create-runner]
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     steps:
       # Most of this is taken over from the Build workflow/preview-env-check-regressions workflow
       - uses: actions/checkout@v4

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -86,7 +86,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -136,7 +136,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     steps:
       - uses: actions/checkout@v4
       - id: auth
@@ -167,7 +167,7 @@ jobs:
     if: inputs.skip_delete != 'true' && always()
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
     steps:
       - uses: actions/checkout@v4
       - name: Delete preview environment

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/components/public-api/typescript-common/fixtures/toWorkspace2_2.json
+++ b/components/public-api/typescript-common/fixtures/toWorkspace2_2.json
@@ -30,7 +30,7 @@
     },
     "cloneUrl": "https://github.com/gitpod-io/gitpod.git",
     "config": {
-      "image": "eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954",
+      "image": "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879",
       "workspaceLocation": "gitpod/gitpod-ws.code-workspace",
       "checkoutLocation": "gitpod",
       "ports": [
@@ -77,7 +77,7 @@
       "ideCredentials": "ideCredentials"
     },
     "imageSource": {
-      "baseImageResolved": "eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954"
+      "baseImageResolved": "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go-122-gha.23879"
     },
     "imageNameResolved": "877922613839.dkr.ecr.eu-central-1.amazonaws.com/image-build/workspace-images:adb73357f7e48abcb1210a0fad039618a8156bb5de667a2ae7acb98ff5244b5e",
     "baseImageNameResolved": "eu.gcr.io/gitpod-core-dev/dev/dev-environment@sha256:1107ae38187802fd784467529d9cc0b98e720f0980e3ec2fcbcecb4d7916da5e",

--- a/components/supervisor/openssh/BUILD.yaml
+++ b/components/supervisor/openssh/BUILD.yaml
@@ -5,7 +5,7 @@ packages:
       - :docker-build
     config:
       commands:
-        - ["sh", "-c", "find . | grep layer.tar | while read f; do tar xfv $f; done"]
+        - ["sh", "-c","TARFILE=$(cat ./components-supervisor-openssh--docker-build/manifest.json | jq -r '.[].Layers[]') && tar xvf ./components-supervisor-openssh--docker-build/$TARFILE"]
         - ["rm", "-rf", "components-supervisor-openssh--docker-build"]
   - name: docker-build
     type: docker

--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -22,7 +22,7 @@
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
 FROM alpine:3.19 AS builder
 
-ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_6_P1.tar.gz
+ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_7_P1.tar.gz
 
 WORKDIR /build
 

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-gitpod-dev:latest
 
-ENV TRIGGER_REBUILD 40
+ENV TRIGGER_REBUILD 41
 
 USER root
 


### PR DESCRIPTION
## Description

Update go to v1.22.1.

As a side effect of the update of the image, docker now generates an OCI image, requiring an update to extract content from the ssh container image.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
