### PR TITLE
Use custom runner for JetBrains auto update GHA

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -43,7 +43,6 @@ jobs:
         if: ${{ steps.ide-version.outputs.ideBuildVersion }}
         env:
           LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: "8388608"
-          LEEWAY_REMOTE_CACHE_BUCKET: '${{ needs.configuration.outputs.leeway_cache_bucket }}'
         run: |
           leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.ideBuildVersion }} components/ide/jetbrains/image:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideVersion }}
       - name: Get previous job's status

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -7,51 +7,28 @@ on:
       productCode:
         type: string
         required: true
-    secrets:
-      projectId:
-        required: true
-      serviceAccountKey:
-        required: true
-      slackWebhook:
-        required: true
-      gcp_credentials:
-        required: true
-      runner_token:
-        required: true
 
 jobs:
   create-runner:
     uses: gitpod-io/gce-github-runner/.github/workflows/create-vm.yml@main
     secrets:
-      runner_token: ${{ secrets.runner_token }}
-      gcp_credentials: ${{ secrets.gcp_credentials }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    with:
+      task: ${{ inputs.productId }}
 
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-user-getauthenticated-dashboard-gha.20954
     needs: [ create-runner ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
         with:
-          go-version: "1.19"
-      - name: Download leeway
-        run: cd /usr/local/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.7.3/leeway_0.7.3_Linux_x86_64.tar.gz | tar xz
-      - name: Download golangci-lint
-        run: cd /usr/local && curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
-      - name: Download GoKart
-        run: cd /usr/local/bin && curl -L https://github.com/praetorian-inc/gokart/releases/download/v0.4.0/gokart_0.4.0_linux_x86_64.tar.gz | tar xzv gokart
-      - name: Auth Google Cloud SDK
-        uses: google-github-actions/auth@v0
-        with:
-          credentials_json: ${{ secrets.serviceAccountKey }}
-      - uses: actions/setup-java@v2
-        with:
-          distribution: zulu
-          java-version: "11"
-      - name: Setup Google Cloud
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: ${{ secrets.projectId }}
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          leeway_segment_key: ${{ secrets.LEEWAY_SEGMENT_KEY }}
       - name: Find IDE version to download
         id: ide-version
         run: |
@@ -68,10 +45,7 @@ jobs:
           LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: "8388608"
           LEEWAY_REMOTE_CACHE_BUCKET: '${{ needs.configuration.outputs.leeway_cache_bucket }}'
         run: |
-          gcloud auth configure-docker --quiet
-          export LEEWAY_WORKSPACE_ROOT=$(pwd)
-          cd components/ide/jetbrains/image
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.ideBuildVersion }} .:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideVersion }}
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.ideBuildVersion }} components/ide/jetbrains/image:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideVersion }}
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main
@@ -79,7 +53,7 @@ jobs:
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+          SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_TITLE: ${{ inputs.productId }}
           SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
@@ -91,7 +65,7 @@ jobs:
       - update-jetbrains
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@main
     secrets:
-      gcp_credentials: ${{ secrets.gcp_credentials }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -21,9 +21,6 @@ jobs:
     secrets:
       runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
       gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
-    concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-create-runner
-      cancel-in-progress: false
 
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -16,8 +16,18 @@ on:
         required: true
 
 jobs:
+  create-runner:
+    uses: gitpod-io/gce-github-runner/.github/workflows/create-vm.yml@main
+    secrets:
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    concurrency:
+      group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-create-runner
+      cancel-in-progress: false
+
   update-jetbrains:
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.create-runner.outputs.label }}
+    needs: [ create-runner ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -72,3 +82,15 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_TITLE: ${{ inputs.productId }}
           SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
+
+  delete-runner:
+    if: always()
+    needs:
+      - create-runner
+      - update-jetbrains
+    uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@main
+    secrets:
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    with:
+      runner-label: ${{ needs.create-runner.outputs.label }}
+      machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -14,13 +14,17 @@ on:
         required: true
       slackWebhook:
         required: true
+      gcp_credentials:
+        required: true
+      runner_token:
+        required: true
 
 jobs:
   create-runner:
     uses: gitpod-io/gce-github-runner/.github/workflows/create-vm.yml@main
     secrets:
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+      runner_token: ${{ secrets.runner_token }}
+      gcp_credentials: ${{ secrets.gcp_credentials }}
 
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}
@@ -87,7 +91,7 @@ jobs:
       - update-jetbrains
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@main
     secrets:
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+      gcp_credentials: ${{ secrets.gcp_credentials }}
     with:
       runner-label: ${{ needs.create-runner.outputs.label }}
       machine-zone: ${{ needs.create-runner.outputs.machine-zone }}

--- a/.github/workflows/jetbrains-auto-update.yml
+++ b/.github/workflows/jetbrains-auto-update.yml
@@ -20,6 +20,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   goland:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -29,6 +31,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   pycharm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -38,6 +42,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   phpstorm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -47,6 +53,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   rubymine:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -56,6 +64,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   webstorm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -65,6 +75,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   rider:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -74,6 +86,8 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   clion:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
@@ -83,3 +97,5 @@ jobs:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
       slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
+      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}

--- a/.github/workflows/jetbrains-auto-update.yml
+++ b/.github/workflows/jetbrains-auto-update.yml
@@ -16,86 +16,46 @@ jobs:
     with:
       productId: intellij
       productCode: IIU
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   goland:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: goland
       productCode: GO
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   pycharm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: pycharm
       productCode: PCP
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   phpstorm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: phpstorm
       productCode: PS
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   rubymine:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: rubymine
       productCode: RM
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   webstorm:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: webstorm
       productCode: WS
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   rider:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: rider
       productCode: RD
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit
   clion:
     uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: clion
       productCode: CL
-    secrets:
-      projectId: ${{ secrets.GCP_PROJECT_ID }}
-      serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
-      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
-      runner_token: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_TOKEN }}
-      gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
+    secrets: inherit


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

May need to update https://github.com/gitpod-io/gitpod/pull/19572

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

See https://github.com/gitpod-io/gitpod/actions/runs/8416187349

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
