### PR TITLE
Fix inconsistent autostart data on ws creation

### DIFF
--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -57,7 +57,7 @@ import { useAllowedWorkspaceEditorsMemo } from "../data/ide-options/ide-options-
 type NextLoadOption = "searchParams" | "autoStart" | "allDone";
 
 export function CreateWorkspacePage() {
-    const { user, setUser } = useContext(UserContext);
+    const { setUser, user } = useContext(UserContext);
     const updateUser = useUpdateCurrentUserMutation();
     const currentOrg = useCurrentOrg().data;
     const projects = useListAllProjectsQuery();
@@ -316,7 +316,7 @@ export function CreateWorkspacePage() {
 
     // when workspaceContext is available, we look up if options are remembered
     useEffect(() => {
-        if (!workspaceContext.data || !user || !currentOrg) {
+        if (!workspaceContext.data || !user?.workspaceAutostartOptions || !currentOrg) {
             return;
         }
         const cloneURL = workspaceContext.data.cloneUrl;
@@ -326,7 +326,7 @@ export function CreateWorkspacePage() {
         if (nextLoadOption !== "autoStart") {
             return;
         }
-        const rememberedOptions = (user?.workspaceAutostartOptions || []).find(
+        const rememberedOptions = user.workspaceAutostartOptions.find(
             (e) => e.cloneUrl === cloneURL && e.organizationId === currentOrg?.id,
         );
         if (rememberedOptions) {
@@ -362,7 +362,7 @@ export function CreateWorkspacePage() {
         setNextLoadOption("allDone");
         // we only update the remembered options when the workspaceContext changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [workspaceContext.data, nextLoadOption, setNextLoadOption, project]);
+    }, [workspaceContext.data, nextLoadOption, project, user?.workspaceAutostartOptions]);
 
     // Need a wrapper here so we call createWorkspace w/o any arguments
     const onClickCreate = useCallback(() => createWorkspace(), [createWorkspace]);

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -92,7 +92,11 @@ export function CreateWorkspacePage() {
     });
     const defaultIde = computedDefaultEditor;
     const [selectedIde, setSelectedIde, selectedIdeIsDirty] = useDirtyState<string | undefined>(defaultIde);
-    const { computedDefaultClass, data: allowedWorkspaceClasses } = useAllowedWorkspaceClassesMemo(selectedProjectID);
+    const {
+        computedDefaultClass,
+        data: allowedWorkspaceClasses,
+        isLoading: isLoadingWorkspaceClasses,
+    } = useAllowedWorkspaceClassesMemo(selectedProjectID);
     const defaultWorkspaceClass = props.workspaceClass ?? computedDefaultClass;
     const { data: orgSettings } = useOrgSettingsQuery();
     const [selectedWsClass, setSelectedWsClass, selectedWsClassIsDirty] = useDirtyState(defaultWorkspaceClass);
@@ -326,6 +330,9 @@ export function CreateWorkspacePage() {
         if (nextLoadOption !== "autoStart") {
             return;
         }
+        if (isLoadingWorkspaceClasses) {
+            return;
+        }
         const rememberedOptions = user.workspaceAutostartOptions.find(
             (e) => e.cloneUrl === cloneURL && e.organizationId === currentOrg?.id,
         );
@@ -362,7 +369,14 @@ export function CreateWorkspacePage() {
         setNextLoadOption("allDone");
         // we only update the remembered options when the workspaceContext changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [workspaceContext.data, nextLoadOption, project, user?.workspaceAutostartOptions]);
+    }, [
+        workspaceContext.data,
+        nextLoadOption,
+        project,
+        user?.workspaceAutostartOptions,
+        isLoadingWorkspaceClasses,
+        allowedWorkspaceClasses,
+    ]);
 
     // Need a wrapper here so we call createWorkspace w/o any arguments
     const onClickCreate = useCallback(() => createWorkspace(), [createWorkspace]);

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -330,7 +330,7 @@ export function CreateWorkspacePage() {
         if (nextLoadOption !== "autoStart") {
             return;
         }
-        if (isLoadingWorkspaceClasses) {
+        if (isLoadingWorkspaceClasses || allowedWorkspaceClasses.length === 0) {
             return;
         }
         const rememberedOptions = user.workspaceAutostartOptions.find(
@@ -369,14 +369,7 @@ export function CreateWorkspacePage() {
         setNextLoadOption("allDone");
         // we only update the remembered options when the workspaceContext changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-        workspaceContext.data,
-        nextLoadOption,
-        project,
-        user?.workspaceAutostartOptions,
-        isLoadingWorkspaceClasses,
-        allowedWorkspaceClasses,
-    ]);
+    }, [workspaceContext.data, nextLoadOption, project, isLoadingWorkspaceClasses, allowedWorkspaceClasses]);
 
     // Need a wrapper here so we call createWorkspace w/o any arguments
     const onClickCreate = useCallback(() => createWorkspace(), [createWorkspace]);

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -57,7 +57,7 @@ import { useAllowedWorkspaceEditorsMemo } from "../data/ide-options/ide-options-
 type NextLoadOption = "searchParams" | "autoStart" | "allDone";
 
 export function CreateWorkspacePage() {
-    const { setUser, user } = useContext(UserContext);
+    const { user, setUser } = useContext(UserContext);
     const updateUser = useUpdateCurrentUserMutation();
     const currentOrg = useCurrentOrg().data;
     const projects = useListAllProjectsQuery();


### PR DESCRIPTION
## Description

Sometimes, if you had a preferred workspace class saved, this preference wouldn't be applied when creating a new workspace. Instead, the system would revert to the default setting. The root cause of this issue was that the code didn't properly wait for the query fetching the allowed workspace classes to finish. As a result, when it tried to verify if your saved preference was permitted according to the allowlist, it found the list to be empty, leading to the default setting being applied.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1502

## How to test

1. Start a workspace with context URL A on a non-default workspace class
2. Block `/public-api/gitpod.v1.OrganizationService/GetOrganizationSettings` and `/public-api/gitpod.v1.WorkspaceService/ListWorkspaceClasses`
3. Clear the indexed db so that the caches are not used (can be done in the devtools)
4. Open the create workspace page with the context URL A again
5. Wait until the first requests to the above method fail and unblock them
6. Observe that even after recovering from the blocked requests, the UI shows the previously stored class.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-aut1567c71b22</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-aut1567c71b22.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-aut1567c71b22.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-autostart-races-gha.23993</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-aut1567c71b22%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
