### PR TITLE
Fix breadcrumb padding

### DIFF
--- a/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
+++ b/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
@@ -43,7 +43,7 @@ export const BreadcrumbNav: FC<BreadcrumbPageNavProps> = ({ pageTitle, pageDescr
                 </LinkButton>
             )}
             <MiddleDot className="font-bold" />
-            <p className="text-pk-content-primary text-lg">{pageDescription}</p>
+            <p className="text-pk-content-primary text-lg pl-1">{pageDescription}</p>
         </section>
     );
 };


### PR DESCRIPTION
## Description

It's not much but it's honest work

| Before | After |
|--------|--------|
| <img width="681" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/fc6fb1d9-4774-4033-8470-9559549d4f28"> | <img width="681" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/f7712db0-4578-4b1d-b602-5b4c41d9e9ee"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1694

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-breb10ee906b1</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-breb10ee906b1.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-breb10ee906b1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-breadcrumb-padding-gha.24018</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-breb10ee906b1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
