### PR TITLE
Align design to editor icon and breadcrumb

### DIFF
--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -39,7 +39,7 @@ export const IdeOptions = (props: IdeOptionsProps) => {
             {props.ideOptions &&
                 props.ideOptions.map((ide) => (
                     <div key={ide.id} className="flex gap-2 items-center">
-                        <img className="w-8 h-8 self-center" src={ide.logo} alt="" />
+                        <img className="w-5 h-5 self-center" src={ide.logo} alt="" />
                         <span>
                             <span className="font-medium text-pk-content-primary">{ide.title}</span>
                             {ide.imageVersion && (
@@ -215,7 +215,7 @@ const IdeOptionSwitch = ({
     const contentColor = ideOption.isDisabledInScope ? "text-pk-content-disabled" : "text-pk-content-primary";
     const label = (
         <>
-            <img className="w-8 h-8 self-center mr-2" src={ideOption.logo} alt="" />
+            <img className="w-5 h-5 self-center mr-2" src={ideOption.logo} alt="" />
             <span className={cn("font-medium", contentColor)}>{ideOption.title}</span>
         </>
     );

--- a/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
+++ b/components/dashboard/src/components/podkit/breadcrumbs/BreadcrumbNav.tsx
@@ -33,7 +33,7 @@ export const BreadcrumbNav: FC<BreadcrumbPageNavProps> = ({ pageTitle, pageDescr
             {backLink && (
                 <LinkButton
                     variant={"ghost"}
-                    className="py-1 pl-0 pr-2 text-content-primary hover:bg-pk-surface-tertiary flex flex-row gap-1 items-center"
+                    className="py-1 pl-0 pr-1 text-content-primary hover:bg-pk-surface-tertiary flex flex-row gap-1 items-center"
                     href={backLink}
                 >
                     <ChevronLeft size={24} />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

|Breadcrumb|
|:-:|
|<img width="543" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/eb1822c6-8c24-4535-b37e-4cdd1223034a">|


|Before| After|
|:-:|:-:|
|<img width="1541" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/c016b904-6a20-4ddb-b680-c4ca1348c4fc">|<img width="1582" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/51f309a7-1e15-42ab-b742-6b765d0a7ee5">|


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1712
Relates EXP-1694

## How to test
<!-- Provide steps to test this PR -->

- Check org settings and repo settings's editor icon size, it should be 20px
- Breadcrumb's gap should be the same

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-exp-1712</li>
	<li><b>🔗 URL</b> - <a href="https://hw-exp-1712.preview.gitpod-dev.com/workspaces" target="_blank">hw-exp-1712.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-EXP-1712-gha.24031</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-exp-1712%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
