### PR TITLE
[ws-mananger-mk2] fix metrics

### DIFF
--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -125,11 +125,8 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			// Disable the metrics server. We already expose metrics
-			BindAddress: "0",
-		},
+		Scheme:  scheme,
+		Metrics: metricsserver.Options{BindAddress: cfg.Prometheus.Addr},
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				cfg.Manager.Namespace:        {},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ws-mananger-mk2] fix metrics

|  Before | After  |
|---|---|
|  <img width="1865" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/d531e6bf-0a37-4dae-83c9-7abd6c0c3eda"> |  <img width="1932" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/1cd2035a-f9d2-4abc-af0a-e1877aef0cdb"> |



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] with-monitoring
</details>

/hold
