### PR TITLE
[JetBrains] fix EAP backend-plugin not start issue

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -63,6 +63,7 @@ $GITPOD_PLUGIN_DIR/gradlew -PenvironmentName="$JB_QUALIFIER" buildPlugin
 # TODO(ak) actually should be gradle task to make use of output
 GITPOD_PLUGIN_DIST="$GITPOD_PLUGIN_DIR/build/distributions/gitpod-remote.zip"
 unzip $GITPOD_PLUGIN_DIST -d $TEST_PLUGINS_DIR
+rm -rf "$TEST_PLUGINS_DIR/plugin-classpath.txt"
 
 TEST_REPO_NAME=$(basename "$TEST_REPO")
 TEST_DIR=/workspace/$TEST_REPO_NAME

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodMetricControlProvider.kt
@@ -19,14 +19,10 @@ import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.perform
 abstract class AbstractGitpodMetricControlProvider : MetricControlProvider {
     override val id: String = "gitpodMetricsControl"
 
-    private fun getMargin(left: Int, top: Int, right: Int, bottom: Int): BeMarginsBuilder.() -> BeMargin {
-        val result: BeMarginsBuilder.() -> BeMargin = { margin(left, top, right, bottom) }
-        return result
-    }
+    abstract fun setMargin(element: BeControl, left: Int, top: Int, right: Int, bottom: Int): BeControl;
 
     override fun getControl(lifetime: Lifetime): BeControl {
         val backendDiagnosticsService = BackendDiagnosticsService.Companion.getInstance()
-        val self = this
         return verticalGrid {
             row {
                 horizontalGrid {
@@ -37,17 +33,18 @@ abstract class AbstractGitpodMetricControlProvider : MetricControlProvider {
             }
             createWorkspaceHeaderRow(this, backendDiagnosticsService, lifetime)
             row {
-                verticalGrid {
+                setMargin(verticalGrid {
                     createCpuControl(this, backendDiagnosticsService, lifetime)
                     createMemoryControl(this, backendDiagnosticsService, lifetime)
-                }.withMargin(self.getMargin(0, 15, 0, 25))
+                }, 0, 15, 0, 25)
             }
+
             row {
-                horizontalGrid {
+                setMargin(horizontalGrid {
                     column {
                         label("Shared Node Resources")
                     }
-                }.withMargin(self.getMargin(0, 0, 0, 15)).withHelpTooltip("Shared Node Resources", "The shared metrics represent the used and available resources of the cluster node on which your workspace is running")
+                }, 0, 0, 0, 15).withHelpTooltip("Shared Node Resources", "The shared metrics represent the used and available resources of the cluster node on which your workspace is running")
             }
         }
     }
@@ -72,13 +69,12 @@ abstract class AbstractGitpodMetricControlProvider : MetricControlProvider {
         if (workspaceClass == "") {
             return
         }
-        val self = this
         return ctx.row {
-            horizontalGrid {
+            setMargin(horizontalGrid {
                 column {
                     label(workspaceClass)
                 }
-            }.withMargin(self.getMargin(0, 15, 0, 0))
+            },0, 15, 0, 0)
         }
     }
 

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
@@ -97,15 +97,15 @@ class GitpodManager : Disposable {
             // Heap usage at any time in the last 5 minutes:
             // max_over_time(gitpod_jb_backend_memory_used_bytes[5m:])/max_over_time(gitpod_jb_backend_memory_max_bytes[5m:])
             val allocatedGauge = Gauge.build()
-                    .name("gitpod_jb_backend_memory_max_bytes")
-                    .help("Total allocated memory of JB backend in bytes.")
-                    .labelNames("product", "qualifier")
-                    .register(registry)
+                .name("gitpod_jb_backend_memory_max_bytes")
+                .help("Total allocated memory of JB backend in bytes.")
+                .labelNames("product", "qualifier")
+                .register(registry)
             val usedGauge = Gauge.build()
-                    .name("gitpod_jb_backend_memory_used_bytes")
-                    .help("Used memory of JB backend in bytes.")
-                    .labelNames("product", "qualifier")
-                    .register(registry)
+                .name("gitpod_jb_backend_memory_used_bytes")
+                .help("Used memory of JB backend in bytes.")
+                .labelNames("product", "qualifier")
+                .register(registry)
 
             while (isActive) {
                 val totalMemory = Runtime.getRuntime().totalMemory()

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/GitpodCopyWebUrlAction.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/GitpodCopyWebUrlAction.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.ide.CopyPasteManager
 import com.jetbrains.rd.platform.codeWithMe.portForwarding.PerClientPortForwardingManager
 import com.jetbrains.rd.platform.codeWithMe.portForwarding.PortConfiguration
 import com.jetbrains.rd.platform.codeWithMe.portForwarding.PortForwardingDataKeys
-import io.gitpod.jetbrains.remote.internal.GitpodPortForwardingServiceImpl
+import io.gitpod.jetbrains.remote.AbstractGitpodPortForwardingService
 import java.awt.datatransfer.StringSelection
 
 @Suppress("ComponentNotRegistered", "UnstableApiUsage")
@@ -21,7 +21,7 @@ class GitpodCopyWebUrlAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         e.dataContext.getData(PortForwardingDataKeys.SUGGESTION)?.getSuggestedHostPort()?.let { hostPort ->
             (service<PerClientPortForwardingManager>().getPorts(hostPort).firstOrNull {
-                it.labels.contains(GitpodPortForwardingServiceImpl.EXPOSED_PORT_LABEL)
+                it.labels.contains(AbstractGitpodPortForwardingService.EXPOSED_PORT_LABEL)
             }?.configuration as PortConfiguration.UrlExposure?)?.exposedUrl?.let {
                 CopyPasteManager.getInstance().setContents(StringSelection(it))
             }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricControlProvider.kt
@@ -1,0 +1,23 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.jetbrains.ide.model.uiautomation.BeControl
+import com.jetbrains.ide.model.uiautomation.DefiniteProgress
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
+import com.jetbrains.rd.ui.bedsl.dsl.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
+import io.gitpod.jetbrains.remote.AbstractGitpodMetricControlProvider
+
+class GitpodMetricControlProvider: AbstractGitpodMetricControlProvider() {
+    override fun setMargin(element: BeControl, left: Int, top: Int, right: Int, bottom: Int) = element.withMargin(left, top, right, bottom)
+
+    override fun createProgressControl(ctx: VerticalGridBuilder, lifetime: Lifetime, label: String, cpuPercentage: Metric, labelProperty: Property<String>, cpuPercentageProperty: Property<String>, progressBar: DefiniteProgress) {
+        createProgressRow(ctx, id, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+    }
+
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingServiceImpl.kt
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.threading.coroutines.launch
+import io.gitpod.jetbrains.remote.AbstractGitpodPortForwardingService
+import kotlinx.coroutines.CoroutineScope
+
+@Suppress("UnstableApiUsage")
+class GitpodPortForwardingServiceImpl : AbstractGitpodPortForwardingService() {
+    override fun runJob(lifetime: Lifetime, block: suspend CoroutineScope.() -> Unit) = lifetime.launch { block() }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodTerminalService.kt
@@ -1,26 +1,31 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote.internal
+package io.gitpod.jetbrains.remote.latest
 
+import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.threading.coroutines.launch
 import com.jetbrains.rdserver.terminal.BackendTerminalManager
 import io.gitpod.jetbrains.remote.AbstractGitpodTerminalService
+import kotlinx.coroutines.CoroutineScope
 import org.jetbrains.plugins.terminal.ShellTerminalWidget
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager
 import java.util.*
 
 @Suppress("UnstableApiUsage")
-class GitpodTerminalService(project: Project): AbstractGitpodTerminalService(project) {
+class GitpodTerminalService(val project: Project): AbstractGitpodTerminalService(project) {
 
     private val terminalToolWindowManager = TerminalToolWindowManager.getInstance(project)
     private val backendTerminalManager = BackendTerminalManager.getInstance(project)
 
+    override fun runJob(lifetime: Lifetime, block: suspend CoroutineScope.() -> Unit) = lifetime.launch { block() }
+
     override fun createSharedTerminal(title: String): ShellTerminalWidget {
-        val shellTerminalWidget = terminalToolWindowManager.createLocalShellWidget(null, title, true, false)
+        val shellTerminalWidget = ShellTerminalWidget.toShellJediTermWidgetOrThrow(terminalToolWindowManager.createShellWidget(null, title, true, false))
         backendTerminalManager.shareTerminal(shellTerminalWidget.asNewWidget(), UUID.randomUUID().toString())
         return shellTerminalWidget
     }
-
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/ControllerStatusService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/ControllerStatusService.kt
@@ -39,7 +39,7 @@ object ControllerStatusService {
                 .GET()
                 .build()
             val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
-            if (response.statusCode() !== 200) {
+            if (response.statusCode() != 200) {
                 throw IOException("gitpod: failed to retrieve controller status: ${response.statusCode()}")
             }
             val status = with(jacksonMapper) {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodMetricControlProvider.kt
@@ -1,18 +1,26 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote.internal
+package io.gitpod.jetbrains.remote.stable
 
+import com.jetbrains.ide.model.uiautomation.BeControl
+import com.jetbrains.ide.model.uiautomation.BeMargin
 import com.jetbrains.ide.model.uiautomation.DefiniteProgress
 import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
 import com.jetbrains.rd.ui.bedsl.dsl.*
+import com.jetbrains.rd.ui.bedsl.dsl.util.BeMarginsBuilder
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.reactive.Property
 import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
 import io.gitpod.jetbrains.remote.AbstractGitpodMetricControlProvider
 
 class GitpodMetricControlProvider: AbstractGitpodMetricControlProvider() {
+    override fun setMargin(element: BeControl, left: Int, top: Int, right: Int, bottom: Int): BeControl {
+        val result: BeMarginsBuilder.() -> BeMargin = { margin(left, top, right, bottom) }
+        element.withMargin(result)
+        return element
+    }
 
     override fun createProgressControl(ctx: VerticalGridBuilder, lifetime: Lifetime, label: String, cpuPercentage: Metric, labelProperty: Property<String>, cpuPercentageProperty: Property<String>, progressBar: DefiniteProgress) {
         createProgressRow(ctx, id, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodPortForwardingServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodPortForwardingServiceImpl.kt
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.framework.util.launch
+import io.gitpod.jetbrains.remote.AbstractGitpodPortForwardingService
+import kotlinx.coroutines.CoroutineScope
+
+@Suppress("UnstableApiUsage")
+class GitpodPortForwardingServiceImpl : AbstractGitpodPortForwardingService() {
+    override fun runJob(lifetime: Lifetime, block: suspend CoroutineScope.() -> Unit) = lifetime.launch { block() }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalService.kt
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rd.framework.util.launch
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rdserver.terminal.BackendTerminalManager
+import io.gitpod.jetbrains.remote.AbstractGitpodTerminalService
+import kotlinx.coroutines.CoroutineScope
+import org.jetbrains.plugins.terminal.ShellTerminalWidget
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class GitpodTerminalService(val project: Project): AbstractGitpodTerminalService(project) {
+
+    private val terminalToolWindowManager = TerminalToolWindowManager.getInstance(project)
+    private val backendTerminalManager = BackendTerminalManager.getInstance(project)
+
+    override fun runJob(lifetime: Lifetime, block: suspend CoroutineScope.() -> Unit) = lifetime.launch { block() }
+
+    override fun createSharedTerminal(title: String): ShellTerminalWidget {
+        val shellTerminalWidget = terminalToolWindowManager.createLocalShellWidget(null, title, true, false)
+        backendTerminalManager.shareTerminal(shellTerminalWidget.asNewWidget(), UUID.randomUUID().toString())
+        return shellTerminalWidget
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -6,5 +6,12 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodTerminalService" client="controller"
+                        preload="true"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingServiceImpl"
+                            client="controller" preload="true"/>
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
+                                           implementation="io.gitpod.jetbrains.remote.latest.GitpodMetricControlProvider"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -6,5 +6,12 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodTerminalService" client="controller"
+                        preload="true"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodPortForwardingServiceImpl"
+                            client="controller" preload="true"/>
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
+                                           implementation="io.gitpod.jetbrains.remote.stable.GitpodMetricControlProvider"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -26,9 +26,6 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService"
                             preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
-        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
-                            serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodPortForwardingServiceImpl"
-                            client="controller" preload="true"/>
 
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false"/>
 
@@ -46,12 +43,6 @@
                      description="Disable the forced update of Maven projects when IDE opens."
                      restartRequired="true"/>
 
-
-        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
-                                           implementation="io.gitpod.jetbrains.remote.internal.GitpodMetricControlProvider"/>
-
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodTerminalService" client="controller"
-                        preload="true"/>
 
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
                             serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodIgnoredPortsForNotificationServiceImpl"

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1067,10 +1067,17 @@ func getProductConfig(config *gitpod.GitpodConfig, alias string) *gitpod.Jetbrai
 }
 
 func linkRemotePlugin(launchCtx *LaunchContext) error {
-	remotePluginDir := launchCtx.configDir + "/plugins/gitpod-remote"
+	remotePluginsFolder := launchCtx.configDir + "/plugins"
+	remotePluginDir := remotePluginsFolder + "/gitpod-remote"
 	_, err := os.Stat(remotePluginDir)
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		// plugins parent folder must exists, if not, return error
+		if err := os.Mkdir(remotePluginsFolder, 0755); err != nil {
+			return err
+		}
 	}
 
 	// added for backwards compatibility, can be removed in the future

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1067,7 +1067,7 @@ func getProductConfig(config *gitpod.GitpodConfig, alias string) *gitpod.Jetbrai
 }
 
 func linkRemotePlugin(launchCtx *LaunchContext) error {
-	remotePluginDir := launchCtx.backendDir + "/plugins/gitpod-remote"
+	remotePluginDir := launchCtx.configDir + "/plugins/gitpod-remote"
 	_, err := os.Stat(remotePluginDir)
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		return nil

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -46,6 +46,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	*/
 	intellijPrevious := "intellij-previous"
 	jbPluginPrevious := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f")
+	jbLauncherPrevious := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9")
 
 	intellij := "intellij"
 	goland := "goland"
@@ -174,7 +175,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:        ide_config.IDETypeDesktop,
 					Logo:        getIdeLogoPath("intellijIdeaLogo"),
 					Image:       ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "2022.3.3"),
-					ImageLayers: []string{jbPluginPrevious, jbLauncherImage},
+					ImageLayers: []string{jbPluginPrevious, jbLauncherPrevious},
 				},
 				goland: {
 					OrderKey:          "050",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

JetBrains will load plugins if it’s bundled in `/home/gitpod/.local/share/JetBrains/<product_name_and_version>` and listed on [plugin-classpath.txt](https://github.com/JetBrains/intellij-community/blob/c5e6a820cfb3d1d0d3bec91743db0442fb8e792d/platform/core-impl/src/com/intellij/ide/plugins/ProductLoadingStrategy.kt#L107). 

But we’d better not modify plugin-classpath.txt, so make plugin locate on configDir will make it works because we customized it [here](https://github.com/gitpod-io/gitpod/blob/hw/jb/components/ide/jetbrains/launcher/main.go#L672)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1722

## How to test
<!-- Provide steps to test this PR -->

- Open workspace with stable and latest IntelliJ https://github.com/Gitpod-Samples/spring-petclinic
- It should work on versions (`stable`, `latest` and `2022.3.3`) with features below
  - Port-forwarding
  - Terminal tasks attached
  - Command like `gp open README.md` works
  - `gp preview --external https://google.com`
  - Remote indicator is correct on thin client

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-gha.24061</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
