### PR TITLE
Improve queries on workspace start page

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -57,6 +57,7 @@
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "url": "^0.11.1",
+    "use-deep-compare-effect": "^1.8.1",
     "util": "^0.11.1",
     "validator": "^13.9.0",
     "xterm": "^5.4.0-beta.37",

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -80,6 +80,8 @@ export default function SelectWorkspaceClassComponent({
         // if the selected workspace class is not supported, we set an error and ask the user to pick one
         if (selectedWorkspaceClass && !workspaceClasses?.find((c) => c.id === selectedWorkspaceClass)) {
             setError?.(`The workspace class '${selectedWorkspaceClass}' is not supported.`);
+        } else {
+            setError?.(undefined);
         }
     }, [
         loading,

--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -108,6 +108,8 @@ export const useConfiguration = (configurationId: string) => {
                 }
                 return true;
             },
+            cacheTime: 1000 * 60 * 10, // 10m
+            staleTime: 1000 * 60 * 10, // 10m
         },
     );
 };

--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -108,8 +108,8 @@ export const useConfiguration = (configurationId: string) => {
                 }
                 return true;
             },
-            cacheTime: 1000 * 60 * 10, // 10m
-            staleTime: 1000 * 60 * 10, // 10m
+            cacheTime: 1000 * 60 * 5, // 5m
+            staleTime: 1000 * 30, // 30s
         },
     );
 };

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -13,6 +13,7 @@ import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organizat
 import { useMemo } from "react";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { useConfiguration } from "../configurations/configuration-queries";
+import { useDeepCompareMemoize } from "use-deep-compare-effect";
 
 const DEFAULT_WS_EDITOR = "code";
 
@@ -91,10 +92,9 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
         );
         // react useMemo is using `Object.is` to compare dependencies so array / object will make re-render re-call useMemo,
         // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
-        // we only use basic types like string here
         //
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify(depItems)]);
+    }, [useDeepCompareMemoize(depItems)]);
     return { ...data, isLoading, usingConfigurationId: configuration?.id };
 };
 

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -76,6 +76,12 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
         // So we will filter it out
         isLoading = isLoadingInstallationCls || isLoadingConfiguration;
     }
+    const depItem = {
+        t1: installationOptions,
+        t2: options?.ignoreScope,
+        t3: orgSettings,
+        t4: configuration?.workspaceSettings?.restrictedEditorNames,
+    };
     const data = useMemo(() => {
         return getAllowedWorkspaceEditors(
             installationOptions,
@@ -83,13 +89,13 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
             configuration?.workspaceSettings?.restrictedEditorNames,
             options,
         );
+
+        // react useMemo is using `Object.is` to compare dependencies so array / object will cause re-render here
+        // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
+        // we only use basic types like string here
+        //
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-        installationOptions,
-        options?.ignoreScope,
-        orgSettings,
-        configuration?.workspaceSettings?.restrictedEditorNames,
-    ]);
+    }, [JSON.stringify(depItem)]);
     return { ...data, isLoading, usingConfigurationId: configuration?.id };
 };
 

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -76,12 +76,12 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
         // So we will filter it out
         isLoading = isLoadingInstallationCls || isLoadingConfiguration;
     }
-    const depItem = {
-        t1: installationOptions,
-        t2: options?.ignoreScope,
-        t3: orgSettings,
-        t4: configuration?.workspaceSettings?.restrictedEditorNames,
-    };
+    const depItems = [
+        installationOptions,
+        options?.ignoreScope,
+        orgSettings,
+        configuration?.workspaceSettings?.restrictedEditorNames,
+    ];
     const data = useMemo(() => {
         return getAllowedWorkspaceEditors(
             installationOptions,
@@ -89,13 +89,12 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
             configuration?.workspaceSettings?.restrictedEditorNames,
             options,
         );
-
         // react useMemo is using `Object.is` to compare dependencies so array / object will make re-render re-call useMemo,
         // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
         // we only use basic types like string here
         //
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify(depItem)]);
+    }, [JSON.stringify(depItems)]);
     return { ...data, isLoading, usingConfigurationId: configuration?.id };
 };
 

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -90,7 +90,7 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
             options,
         );
 
-        // react useMemo is using `Object.is` to compare dependencies so array / object will cause re-render here
+        // react useMemo is using `Object.is` to compare dependencies so array / object will make re-render re-call useMemo,
         // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
         // we only use basic types like string here
         //

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -123,6 +123,13 @@ export const useAllowedWorkspaceClassesMemo = (
 
     const isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
 
+    const depItem = {
+        t1: installationClasses,
+        t2: orgSettings,
+        t3: options,
+        t4: configuration?.workspaceSettings?.restrictedWorkspaceClasses,
+        t5: configuration?.workspaceSettings?.workspaceClass,
+    };
     const data = useMemo(() => {
         return getAllowedWorkspaceClasses(
             installationClasses,
@@ -131,12 +138,11 @@ export const useAllowedWorkspaceClassesMemo = (
             configuration?.workspaceSettings?.workspaceClass,
             options,
         );
-    }, [
-        installationClasses,
-        orgSettings,
-        options,
-        configuration?.workspaceSettings?.restrictedWorkspaceClasses,
-        configuration?.workspaceSettings?.workspaceClass,
-    ]);
+        // react useMemo is using `Object.is` to compare dependencies so array / object will cause re-render here
+        // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
+        // we only use basic types like string here
+        //
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [JSON.stringify(depItem)]);
     return { ...data, isLoading };
 };

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -123,13 +123,13 @@ export const useAllowedWorkspaceClassesMemo = (
 
     const isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
 
-    const depItem = {
-        t1: installationClasses,
-        t2: orgSettings,
-        t3: options,
-        t4: configuration?.workspaceSettings?.restrictedWorkspaceClasses,
-        t5: configuration?.workspaceSettings?.workspaceClass,
-    };
+    const depItems = [
+        installationClasses,
+        orgSettings,
+        options,
+        configuration?.workspaceSettings?.restrictedWorkspaceClasses,
+        configuration?.workspaceSettings?.workspaceClass,
+    ];
     const data = useMemo(() => {
         return getAllowedWorkspaceClasses(
             installationClasses,
@@ -143,6 +143,6 @@ export const useAllowedWorkspaceClassesMemo = (
         // we only use basic types like string here
         //
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify(depItem)]);
+    }, [JSON.stringify(depItems)]);
     return { ...data, isLoading };
 };

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -13,6 +13,7 @@ import { useMemo } from "react";
 import { PlainMessage } from "@bufbuild/protobuf";
 import { useConfiguration } from "../configurations/configuration-queries";
 import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
+import { useDeepCompareMemoize } from "use-deep-compare-effect";
 
 export const DEFAULT_WS_CLASS = "g1-standard";
 
@@ -140,9 +141,8 @@ export const useAllowedWorkspaceClassesMemo = (
         );
         // react useMemo is using `Object.is` to compare dependencies so array / object will make re-render re-call useMemo,
         // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
-        // we only use basic types like string here
         //
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify(depItems)]);
+    }, [useDeepCompareMemoize(depItems)]);
     return { ...data, isLoading };
 };

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -138,7 +138,7 @@ export const useAllowedWorkspaceClassesMemo = (
             configuration?.workspaceSettings?.workspaceClass,
             options,
         );
-        // react useMemo is using `Object.is` to compare dependencies so array / object will cause re-render here
+        // react useMemo is using `Object.is` to compare dependencies so array / object will make re-render re-call useMemo,
         // see also https://react.dev/reference/react/useMemo#every-time-my-component-renders-the-calculation-in-usememo-re-runs
         // we only use basic types like string here
         //

--- a/yarn.lock
+++ b/yarn.lock
@@ -6555,7 +6555,7 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
-dequal@^2.0.3:
+dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -15151,6 +15151,14 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
+
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I checked *How to test* section, only `useConfiguration` needs care, which is caused by no `cacheTime`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Add logs on dashboard for queries on create workspace page, like `useConfiguration` `useOrgSettingsQuery` `useIDEOptions` `useWorkspaceClasses`

Make sure they're called in only when needed when you change options on create page

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-query-improve</li>
	<li><b>🔗 URL</b> - <a href="https://hw-query-improve.preview.gitpod-dev.com/workspaces" target="_blank">hw-query-improve.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-query-improve-gha.24080</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-query-improve%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
