### PR TITLE
[JetBrains] fix mk plugin dir failed

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1073,11 +1073,8 @@ func linkRemotePlugin(launchCtx *LaunchContext) error {
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
-	if errors.Is(err, os.ErrNotExist) {
-		// plugins parent folder must exists, if not, return error
-		if err := os.Mkdir(remotePluginsFolder, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(remotePluginsFolder, 0755); err != nil {
+		return err
 	}
 
 	// added for backwards compatibility, can be removed in the future


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1722

## How to test
<!-- Provide steps to test this PR -->

✅ https://github.com/gitpod-io/gitpod/pull/19595#issuecomment-2033863079

Test with repo
- `https://github.com/Gitpod-Samples/spring-petclinic`
- `https://github.com/gitpod-io/empty`

With steps

- Open workspace with stable and latest IntelliJ
- It should work on versions (`stable`, `latest`) with features below
  - Command like `gp open README.md` works
  - Remote indicator is correct on thin client
  - Restart workspace, restarted one should work well like before

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-jb2</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-jb2.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-jb2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-jb2-gha.24119</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-jb2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
