### PR TITLE
Increase initial healthcheck start

### DIFF
--- a/components/node-labeler/cmd/run.go
+++ b/components/node-labeler/cmd/run.go
@@ -232,6 +232,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 			log.WithError(err).Error("checking registry-facade")
 			return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
 		}
+
+		time.Sleep(1 * time.Second)
 	}
 
 	err = updateLabel(labelToUpdate, true, nodeName, r)

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -246,7 +246,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 									Port: intstr.IntOrString{IntVal: ReadinessPort},
 								},
 							},
-							InitialDelaySeconds: 5,
+							InitialDelaySeconds: 10,
 							PeriodSeconds:       5,
 							TimeoutSeconds:      2,
 							SuccessThreshold:    2,


### PR DESCRIPTION
## Description

Delay initial registry-facade health checks to avoid nodeport issues

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-delay</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-delay.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-delay.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-delay-gha.24125</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-delay%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
