### PR TITLE
[code] Update code 1.88

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 0ab7db2c7269dc6711fee21bb9a4c2cc7c08142d
-  codeVersion: 1.87.1
+  codeCommit: 0859efdc73ff89d823efce9288ead6d36080f315
+  codeVersion: 1.88.0
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2023.3.6.tar.gz"

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -37,10 +37,20 @@ RUN mkdir /gp-code \
     && git fetch origin $CODE_COMMIT --depth=1 \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code
+
+RUN apt-get install -y pkg-config dbus xvfb libgtk-3-0 libxkbfile-dev libkrb5-dev libgbm1 rpm \
+    && cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb \
+    && chmod +x /etc/init.d/xvfb \
+    && update-rc.d xvfb defaults \
+    && service xvfb start \
+    # Start dbus session
+    && mkdir -p /var/run/dbus
+
 ENV npm_config_arch=x64
 RUN mkdir -p .build \
-    && yarn --cwd build --frozen-lockfile --network-timeout 180000 \
-    && ./build/azure-pipelines/linux/install.sh
+    && yarn config set registry "$NPM_REGISTRY" \
+    && yarn --cwd build --frozen-lockfile --check-files --network-timeout 180000 \
+    && yarn --frozen-lockfile --check-files --network-timeout 180000
 
 # copy remote dependencies build in dependencies_builder image
 RUN rm -rf remote/node_modules/

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -113,6 +113,14 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					LatestImageLayers: []string{codeWebExtensionImage, codeHelperImage},
 					Versions: []ide_config.IDEVersion{
 						{
+							Version: "1.88.0",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-7721fe825201d4d8d53975f81de0b063d94383cc"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, "commit-4e069a6195f3926ba8b84725bc806228f4cb94ec"),
+								ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, "commit-4f921cd94dfe046097167e177a6e781f3aa00d70"),
+							},
+						},
+						{
 							Version: "1.87.1",
 							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-aaa9aeb1a12870ab8c19ca8a928d76849bc24c84"),
 							ImageLayers: []string{

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                  = "ide/code"
-	CodeIDEImageStableVersion     = "commit-aaa9aeb1a12870ab8c19ca8a928d76849bc24c84" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion     = "commit-7721fe825201d4d8d53975f81de0b063d94383cc" // stable version that will be updated manually on demand
 	Code1_85IDEImageStableVersion = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876"
 	CodeHelperIDEImage            = "ide/code-codehelper"
 	CodeWebExtensionImage         = "ide/gitpod-code-web"


### PR DESCRIPTION
## Description
Update code to `1.88.0`

## Progress

- [x] Update Insiders  (https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml)
- [x] Update Stable (https://github.com/gitpod-io/gitpod/blob/main/install/installer/pkg/components/workspace/ide/constants.go)
- [x] Update code versions array

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [x] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-fancy-urial</li>
	<li><b>🔗 URL</b> - <a href="https://jp-fancy-urial.preview.gitpod-dev.com/workspaces" target="_blank">jp-fancy-urial.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-fancy-urial-gha.24135</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-fancy-urial%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
