### PR TITLE
Clean up SCM connections of installation admin

### DIFF
--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { TeamDB } from "@gitpod/gitpod-db/lib";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TeamDB } from "@gitpod/gitpod-db/lib";
 import { User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import express from "express";
@@ -219,6 +219,13 @@ export class Authenticator {
         if (!req.isAuthenticated() || !User.is(user)) {
             log.info(`User is not authenticated.`, { "authorize-flow": true });
             res.redirect(this.getSorryUrl(`Not authenticated. Please login.`));
+            return;
+        }
+        if (user.id === BUILTIN_INSTLLATION_ADMIN_USER_ID) {
+            log.info(`Authorization is not permitted for admin user.`);
+            res.redirect(
+                this.getSorryUrl(`Authorization is not permitted for admin user. Please login with a user account.`),
+            );
             return;
         }
         const returnTo: string | undefined = req.query.returnTo?.toString();

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -132,6 +132,7 @@ import { ScmService } from "./scm/scm-service";
 import { ContextService } from "./workspace/context-service";
 import { RateLimitter } from "./rate-limitter";
 import { AnalyticsController } from "./analytics-controller";
+import { InstallationAdminCleanup } from "./jobs/installation-admin-cleanup";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -371,6 +372,7 @@ export const productionContainerModule = new ContainerModule(
         bind(SnapshotsJob).toSelf().inSingletonScope();
         bind(JobRunner).toSelf().inSingletonScope();
         bind(RelationshipUpdateJob).toSelf().inSingletonScope();
+        bind(InstallationAdminCleanup).toSelf().inSingletonScope();
 
         // Redis
         bind(Redis).toDynamicValue((ctx) => {

--- a/components/server/src/jobs/installation-admin-cleanup.ts
+++ b/components/server/src/jobs/installation-admin-cleanup.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, UserDB } from "@gitpod/gitpod-db/lib";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Job } from "./runner";
+
+@injectable()
+export class InstallationAdminCleanup implements Job {
+    @inject(UserDB) protected readonly userDb: UserDB;
+
+    public name = "installation-admin-cleanup";
+    public frequencyMs = 5 * 60 * 1000; // every 5 minutes
+
+    public async run(): Promise<void> {
+        try {
+            const installationAdmin = await this.userDb.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+            if (!installationAdmin) {
+                return;
+            }
+
+            let cleanupRequired = false;
+            for (const identity of installationAdmin.identities) {
+                cleanupRequired = true;
+                identity.deleted = true;
+                await this.userDb.deleteTokens(identity);
+            }
+            if (cleanupRequired) {
+                await this.userDb.storeUser(installationAdmin);
+                log.info("Cleaned up SCM connections of installation admin.");
+            }
+        } catch (err) {
+            log.error("Failed to clean up SCM connections of installation admin.", err);
+            throw err;
+        }
+    }
+}

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -20,6 +20,7 @@ import { RelationshipUpdateJob } from "../authorization/relationship-updater-job
 import { WorkspaceStartController } from "../workspace/workspace-start-controller";
 import { runWithRequestContext } from "../util/request-context";
 import { SYSTEM_USER } from "../authorization/authorizer";
+import { InstallationAdminCleanup } from "./installation-admin-cleanup";
 
 export const Job = Symbol("Job");
 
@@ -42,6 +43,7 @@ export class JobRunner {
         @inject(SnapshotsJob) private readonly snapshotsJob: SnapshotsJob,
         @inject(RelationshipUpdateJob) private readonly relationshipUpdateJob: RelationshipUpdateJob,
         @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
+        @inject(InstallationAdminCleanup) private readonly installationAdminCleanup: InstallationAdminCleanup,
     ) {}
 
     public start(): DisposableCollection {
@@ -56,6 +58,7 @@ export class JobRunner {
             this.snapshotsJob,
             this.relationshipUpdateJob,
             this.workspaceStartController,
+            this.installationAdminCleanup,
         ];
 
         for (const job of jobs) {


### PR DESCRIPTION
## Description
Installation admins should not be allowed to create SCM connections, as this leads to a lot of confusion and dead-end situations in Dedicated cells. This PR add a clean-up routine and block new SCM connections. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1684

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-admin-cleanup</li>
	<li><b>🔗 URL</b> - <a href="https://at-admin-cleanup.preview.gitpod-dev.com/workspaces" target="_blank">at-admin-cleanup.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-admin-cleanup-gha.24142</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-admin-cleanup%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
