### PR TITLE
Add adminVerifyUser command to gpctl

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -421,6 +421,23 @@ func (gp *APIoverJSONRPC) AdminBlockUser(ctx context.Context, message *AdminBloc
 	return
 }
 
+// AdminVerifyUser calls adminVerifyUser on the server
+func (gp *APIoverJSONRPC) AdminVerifyUser(ctx context.Context, userId string) (err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	var _params []interface{}
+	_params = append(_params, userId)
+
+	var _result interface{}
+	err = gp.C.Call(ctx, "adminVerifyUser", _params, &_result)
+	if err != nil {
+		return err
+	}
+	return
+}
+
 // GetLoggedInUser calls getLoggedInUser on the server
 func (gp *APIoverJSONRPC) GetLoggedInUser(ctx context.Context) (res *User, err error) {
 	if gp == nil {

--- a/dev/gpctl/cmd/users-verify.go
+++ b/dev/gpctl/cmd/users-verify.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// usersBlockCmd represents the describe command
+var usersVerifyCmd = &cobra.Command{
+	Use:   "verify <userID> ... <userID>",
+	Short: "verifies a user",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		verifyUser(ctx, args)
+	},
+}
+
+func init() {
+	usersCmd.AddCommand(usersVerifyCmd)
+}

--- a/dev/gpctl/cmd/users.go
+++ b/dev/gpctl/cmd/users.go
@@ -81,3 +81,23 @@ func blockUser(ctx context.Context, args []string, block bool) {
 	}
 	log.Fatal("no args")
 }
+
+func verifyUser(ctx context.Context, args []string) {
+	client, err := newLegacyAPIConn()
+	if err != nil {
+		log.WithError(err).Fatal("cannot connect")
+	}
+	defer client.Close()
+
+	for _, uid := range args {
+		err = client.AdminVerifyUser(ctx, uid)
+		if err != nil {
+			log.WithField("uid", uid).Errorf("AdminVerifyUser failed with: %v", err)
+			return
+		} else {
+			log.WithField("uid", uid).Info("AdminVerifyUser")
+			return
+		}
+	}
+	log.Fatal("no args")
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is helpful when I need to verify multiple users from support tickets.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open the admin link for the user here: https://gitpodsupport.zendesk.com/agent/tickets/2613
- Copy their userid from URL
- Run `cd dev/gpctl && go run . users verify <their-userid> --token <your-token>`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
