### PR TITLE
Account for passed env vars with quickstart

### DIFF
--- a/components/dashboard/src/components/QuickStart.tsx
+++ b/components/dashboard/src/components/QuickStart.tsx
@@ -42,7 +42,9 @@ const QuickStart: FC = () => {
             const hashValue = hash.slice(1);
             let contextUrl: URL;
             try {
-                contextUrl = new URL(hashValue);
+                // We have to account for the case where environment variables are provided through the hash, so we search it for the URL.
+                const toParse = hashValue.match(/^https?:/) ? hashValue : hashValue.slice(hashValue.indexOf("/") + 1);
+                contextUrl = new URL(toParse);
             } catch {
                 setError("Invalid context URL");
                 return;


### PR DESCRIPTION
## Description

This PR aims to fix the situation where you try to pass [one-off environment variables](https://www.gitpod.io/docs/configure/repositories/environment-variables#providing-one-time-environment-variables-via-the-context-url) to a workspace.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1767

## How to test

Visit `/quickstart/#var=value,var2=value2/https://github.com/gitpod-io/new`, both env vars should be injected into the opened repo.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-normali0d3d458493</li>
	<li><b>🔗 URL</b> - <a href="https://ft-normali0d3d458493.preview.gitpod-dev.com/workspaces" target="_blank">ft-normali0d3d458493.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-normalize-hash-for-quickstart-gha.24178</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-normali0d3d458493%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
