### PR TITLE
Lift the SCM identity restriction for org owned accounts

### DIFF
--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -587,7 +587,7 @@ export abstract class GenericAuthProvider implements AuthProvider {
 
                 // we need to check current provider authorizations first...
                 try {
-                    await this.userAuthentication.asserNoTwinAccount(
+                    await this.userAuthentication.assertNoTwinAccount(
                         currentGitpodUser,
                         this.host,
                         this.authProviderId,

--- a/components/server/src/user/user-authentication.ts
+++ b/components/server/src/user/user-authentication.ts
@@ -117,7 +117,17 @@ export class UserAuthentication {
         await this.userDb.storeUser(user);
     }
 
-    async asserNoTwinAccount(currentUser: User, authHost: string, authProviderId: string, candidate: Identity) {
+    async assertNoTwinAccount(currentUser: User, authHost: string, authProviderId: string, candidate: Identity) {
+        if (User.isOrganizationOwned(currentUser)) {
+            /**
+             * The restriction of SCM identities doesn't apply to organization owned accounts which were
+             * created through OIDC SSO because this identity is not used to create/find the account of a user.
+             *
+             * Hint: with this restriction lifted, the subsequent call to `#updateUserOnLogin` would always add/update
+             * the SCM identity for the given `currentUser` if it's owned by an organization.
+             */
+            return;
+        }
         if (currentUser.identities.some((i) => Identity.equals(i, candidate))) {
             return; // same user => OK
         }


### PR DESCRIPTION
The restriction of SCM identities doesn't apply to organization owned accounts which were created through OIDC SSO, because this identity is not used to create/find the account of a user.

Hint: with this restriction lifted, the subsequent call to `#updateUserOnLogin` would always add/update the SCM identity for the given `currentUser` if it's owned by an organization.



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
