### PR TITLE
chore: fix function names in comment

### DIFF
--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -196,7 +196,7 @@ func (ws InfringingWorkspace) VID() string {
 	return fmt.Sprintf("%s/%s", ws.Pod, strings.Join(vt, ":"))
 }
 
-// DescibeInfringements returns a string representation of all infringements of this workspace
+// DescribeInfringements returns a string representation of all infringements of this workspace
 func (ws InfringingWorkspace) DescribeInfringements(charCount int) string {
 	res := make([]string, len(ws.Infringements))
 	for i, v := range ws.Infringements {

--- a/components/ee/agent-smith/pkg/classifier/sinature.go
+++ b/components/ee/agent-smith/pkg/classifier/sinature.go
@@ -300,7 +300,7 @@ func (s *Signature) matchAny(in *SignatureReadCache) (bool, error) {
 	return false, nil
 }
 
-// matchesString checks if the signature matches a string (respects and caches regexp)
+// matches checks if the signature matches a string (respects and caches regexp)
 func (s *Signature) matches(v []byte) (bool, error) {
 	if s.Regexp {
 		if s.compiledRegexp == nil {

--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -218,7 +218,7 @@ func (l *shutdownLoggerImpl) TerminateSync(ctx context.Context, pid int) {
 	}
 }
 
-// extractFailureFromLogs attempts to extract the last error message from `supervisor run` command
+// extractFailureFromRun attempts to extract the last error message from `supervisor run` command
 func extractFailureFromRun() string {
 	logs, err := os.ReadFile("/dev/termination-log")
 	if err != nil {

--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -31,7 +31,7 @@ func (basePath CgroupV1CFSController) Usage() (usage CPUTime, err error) {
 	return CPUTime(cputime), nil
 }
 
-// SetQuota sets a new CFS quota on the cgroup
+// SetLimit sets a new CFS limit on the cgroup
 func (basePath CgroupV1CFSController) SetLimit(limit Bandwidth) (changed bool, err error) {
 	period, err := basePath.readCfsPeriod()
 	if err != nil {

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -494,7 +494,7 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 	return err
 }
 
-// errorLogConflict logs the error if it's a conflict, instead of returning it as a reconciler error.
+// errorResultLogConflict logs the error if it's a conflict, instead of returning it as a reconciler error.
 // This is to reduce noise in our error logging, as conflicts are to be expected.
 // For conflicts, instead a result with `Requeue: true` is returned, which has the same requeuing
 // behaviour as returning an error.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

 fix function names in comment 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
