### PR TITLE
[ws-manager-mk2] logging improvements

### DIFF
--- a/components/ws-manager-mk2/controllers/metrics.go
+++ b/components/ws-manager-mk2/controllers/metrics.go
@@ -11,15 +11,14 @@ import (
 	"time"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/activity"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/maintenance"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
-	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -154,58 +153,58 @@ func newControllerMetrics(r *WorkspaceReconciler) (*controllerMetrics, error) {
 	}, nil
 }
 
-func (m *controllerMetrics) recordWorkspaceStartupTime(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) recordWorkspaceStartupTime(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	hist, err := m.startupTimeHistVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
-		log.Error(err, "could not record workspace startup time", "type", tpe, "class", class)
+		log.WithError(err).WithField("type", tpe).WithField("class", class).Error("could not record workspace startup time")
 	}
 
 	duration := time.Since(ws.CreationTimestamp.Time)
 	hist.Observe(float64(duration.Seconds()))
 }
 
-func (m *controllerMetrics) recordWorkspacePendingTime(log *logr.Logger, ws *workspacev1.Workspace, pendingTs time.Time) {
+func (m *controllerMetrics) recordWorkspacePendingTime(ws *workspacev1.Workspace, pendingTs time.Time) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	hist, err := m.pendingTimeHistVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
-		log.Error(err, "could not record workspace pending time", "type", tpe, "class", class)
+		log.WithError(err).WithField("type", tpe).WithField("class", class).Error("could not record workspace pending time")
 	}
 
 	hist.Observe(time.Since(pendingTs).Seconds())
 }
 
-func (m *controllerMetrics) recordWorkspaceCreatingTime(log *logr.Logger, ws *workspacev1.Workspace, creatingTs time.Time) {
+func (m *controllerMetrics) recordWorkspaceCreatingTime(ws *workspacev1.Workspace, creatingTs time.Time) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	hist, err := m.creatingTimeHistVec.GetMetricWithLabelValues(tpe, class)
 	if err != nil {
-		log.Error(err, "could not record workspace creating time", "type", tpe, "class", class)
+		log.WithError(err).WithField("type", tpe).WithField("class", class).Error("could not record workspace creating time")
 	}
 
 	hist.Observe(time.Since(creatingTs).Seconds())
 }
 
-func (m *controllerMetrics) countWorkspaceStartFailures(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countWorkspaceStartFailures(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	m.totalStartsFailureCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countWorkspaceFailure(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countWorkspaceFailure(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	m.totalFailuresCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countWorkspaceStop(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countWorkspaceStop(ws *workspacev1.Workspace) {
 	var reason string
 	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)); c != nil {
 		reason = StopReasonFailed
@@ -231,28 +230,28 @@ func (m *controllerMetrics) countWorkspaceStop(log *logr.Logger, ws *workspacev1
 	m.totalStopsCounterVec.WithLabelValues(reason, tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countTotalBackups(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countTotalBackups(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	m.totalBackupCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countTotalBackupFailures(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countTotalBackupFailures(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	m.totalBackupFailureCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countTotalRestores(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countTotalRestores(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
 	m.totalRestoreCounterVec.WithLabelValues(tpe, class).Inc()
 }
 
-func (m *controllerMetrics) countTotalRestoreFailures(log *logr.Logger, ws *workspacev1.Workspace) {
+func (m *controllerMetrics) countTotalRestoreFailures(ws *workspacev1.Workspace) {
 	class := ws.Spec.Class
 	tpe := string(ws.Spec.Type)
 
@@ -308,7 +307,7 @@ func newMetricState(ws *workspacev1.Workspace) metricState {
 }
 
 // getWorkspace returns the last recorded metric state for that workspace.
-func (m *controllerMetrics) getWorkspace(log *logr.Logger, ws *workspacev1.Workspace) (bool, metricState) {
+func (m *controllerMetrics) getWorkspace(ws *workspacev1.Workspace) (bool, metricState) {
 	s, ok := m.cache.Get(ws.Name)
 	if !ok {
 		return false, metricState{}
@@ -538,7 +537,7 @@ func (n *nodeUtilizationVec) Collect(ch chan<- prometheus.Metric) {
 	var nodes corev1.NodeList
 	err := n.reconciler.List(ctx, &nodes)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "cannot list nodes for node utilization metric")
+		log.WithError(err).Error("cannot list nodes for node utilization metric")
 		return
 	}
 
@@ -567,7 +566,7 @@ func (n *nodeUtilizationVec) Collect(ch chan<- prometheus.Metric) {
 
 	var workspaces workspacev1.WorkspaceList
 	if err = n.reconciler.List(ctx, &workspaces, client.InNamespace(n.reconciler.Config.Namespace)); err != nil {
-		log.FromContext(ctx).Error(err, "cannot list workspaces for node utilization metric")
+		log.WithError(err).Error("cannot list workspaces for node utilization metric")
 		return
 	}
 
@@ -576,7 +575,7 @@ func (n *nodeUtilizationVec) Collect(ch chan<- prometheus.Metric) {
 		// This list is indexed and reads from memory, so it's not that expensive to do this for every workspace.
 		pods, err := n.reconciler.listWorkspacePods(ctx, &ws)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "cannot list workspace pods for node utilization metric", "workspace", ws.Name)
+			log.WithField("workspace", ws.Name).WithError(err).Error("cannot list workspace pods for node utilization metric")
 			continue
 		}
 
@@ -612,7 +611,7 @@ func (n *nodeUtilizationVec) Collect(ch chan<- prometheus.Metric) {
 			nodeType := nodeTypes[nodeName]
 			metric, err := prometheus.NewConstMetric(n.desc, prometheus.GaugeValue, value, nodeName, resource.String(), nodeType)
 			if err != nil {
-				log.FromContext(ctx).Error(err, "cannot create node utilization metric", "node", nodeName, "resource", resource.String(), "type", nodeType)
+				log.WithError(err).WithField("node", nodeName).WithField("resource", resource.String()).WithField("type", nodeType).Error("cannot create node utilization metric")
 				continue
 			}
 
@@ -648,23 +647,20 @@ func (wav *workspaceActivityVec) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (wav *workspaceActivityVec) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetesOperationTimeout)
-	defer cancel()
-
 	active, notActive, err := wav.getWorkspaceActivityCounts()
 	if err != nil {
-		log.FromContext(ctx).Error(err, fmt.Sprintf("cannot determine active/inactive counts - %s will be inaccurate", wav.name))
+		log.WithError(err).Error(fmt.Sprintf("cannot determine active/inactive counts - %s will be inaccurate", wav.name))
 		return
 	}
 
 	activeMetrics, err := prometheus.NewConstMetric(wav.desc, prometheus.GaugeValue, float64(active), "true")
 	if err != nil {
-		log.FromContext(ctx).Error(err, "cannot create wrokspace activity metric", "active", "true")
+		log.WithError(err).WithField("active", "true").Error("cannot create wrokspace activity metric")
 		return
 	}
 	notActiveMetrics, err := prometheus.NewConstMetric(wav.desc, prometheus.GaugeValue, float64(notActive), "false")
 	if err != nil {
-		log.FromContext(ctx).Error(err, "cannot create wrokspace activity metric", "active", "false")
+		log.WithError(err).WithField("active", "false").Error("cannot create wrokspace activity metric")
 		return
 	}
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -43,14 +43,13 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	span, ctx := tracing.FromContext(ctx, "updateWorkspaceStatus")
 	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	tracing.ApplyOWI(span, owi)
-	log := log.Extract(ctx)
 	defer tracing.FinishSpan(span, &err)
 
 	oldPhase := workspace.Status.Phase
 
 	defer func() {
 		if oldPhase != workspace.Status.Phase {
-			log.WithField("oldPhase", oldPhase).WithField("phase", workspace.Status.Phase).Info("workspace phase updated")
+			log.Extract(ctx).WithField("oldPhase", oldPhase).WithField("phase", workspace.Status.Phase).Info("workspace phase updated")
 		}
 	}()
 
@@ -127,7 +126,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 
 	if failure != "" && !workspace.IsConditionTrue(workspacev1.WorkspaceConditionFailed) {
 		// workspaces can fail only once - once there is a failed condition set, stick with it
-		log.WithField("reason", failure).Info("workspace failed")
+		log.Extract(ctx).WithField("reason", failure).Info("workspace failed")
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionFailed(failure))
 		r.Recorder.Event(workspace, corev1.EventTypeWarning, "Failed", failure)
 	}
@@ -237,7 +236,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	default:
-		log.WithField("podStatus", pod.Status).Info("cannot determine workspace phase")
+		log.Extract(ctx).WithField("podStatus", pod.Status).Info("cannot determine workspace phase")
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	}
@@ -249,7 +248,6 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 	span, ctx := tracing.FromContext(ctx, "checkNodeDisappeared")
 	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	tracing.ApplyOWI(span, owi)
-	log := log.Extract(ctx)
 	defer tracing.FinishSpan(span, &err)
 
 	if pod.Spec.NodeName == "" {
@@ -270,7 +268,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
-		log.WithField("node", pod.Spec.NodeName).Error("workspace node disappeared while disposal has not finished yet")
+		log.Extract(ctx).WithField("node", pod.Spec.NodeName).Error("workspace node disappeared while disposal has not finished yet")
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -49,7 +49,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 
 	defer func() {
 		if oldPhase != workspace.Status.Phase {
-			log.WithFields(owi).WithField("oldPhase", oldPhase).WithField("phase", workspace.Status.Phase).Info("workspace phase updated")
+			log.WithField("oldPhase", oldPhase).WithField("phase", workspace.Status.Phase).Info("workspace phase updated")
 		}
 	}()
 
@@ -126,7 +126,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 
 	if failure != "" && !workspace.IsConditionTrue(workspacev1.WorkspaceConditionFailed) {
 		// workspaces can fail only once - once there is a failed condition set, stick with it
-		log.WithFields(owi).WithField("reason", failure).Info("workspace failed")
+		log.WithField("reason", failure).Info("workspace failed")
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionFailed(failure))
 		r.Recorder.Event(workspace, corev1.EventTypeWarning, "Failed", failure)
 	}
@@ -236,7 +236,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	default:
-		log.WithFields(owi).WithField("podStatus", pod.Status).Info("cannot determine workspace phase")
+		log.WithField("podStatus", pod.Status).Info("cannot determine workspace phase")
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	}
@@ -268,7 +268,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
-		log.WithFields(owi).WithField("node", pod.Spec.NodeName).Error("workspace node disappeared while disposal has not finished yet")
+		log.WithField("node", pod.Spec.NodeName).Error("workspace node disappeared while disposal has not finished yet")
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -45,6 +45,14 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
+	oldPhase := workspace.Status.Phase
+
+	defer func() {
+		if oldPhase != workspace.Status.Phase {
+			log.WithFields(owi).WithField("oldPhase", oldPhase).WithField("phase", workspace.Status.Phase).Info("workspace phase updated")
+		}
+	}()
+
 	switch len(pods.Items) {
 	case 0:
 		if workspace.Status.Phase == "" {

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -43,6 +43,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	span, ctx := tracing.FromContext(ctx, "updateWorkspaceStatus")
 	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	tracing.ApplyOWI(span, owi)
+	log := log.Extract(ctx)
 	defer tracing.FinishSpan(span, &err)
 
 	oldPhase := workspace.Status.Phase
@@ -248,6 +249,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 	span, ctx := tracing.FromContext(ctx, "checkNodeDisappeared")
 	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	tracing.ApplyOWI(span, owi)
+	log := log.Extract(ctx)
 	defer tracing.FinishSpan(span, &err)
 
 	if pod.Spec.NodeName == "" {

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -236,7 +236,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	default:
-		log.WithFields(owi).Info("cannot determine workspace phase", "podStatus", pod.Status)
+		log.WithFields(owi).WithField("podStatus", pod.Status).Info("cannot determine workspace phase")
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 
 	}
@@ -268,7 +268,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
-		log.WithFields(owi).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
+		log.WithFields(owi).WithField("node", pod.Spec.NodeName).Error("workspace node disappeared while disposal has not finished yet")
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -119,7 +119,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	workspacePods, err := r.listWorkspacePods(ctx, &workspace)
 	if err != nil {
-		clog.WithFields(owi).Error(err, "unable to list workspace pods")
+		clog.WithFields(owi).WithError(err).Error("unable to list workspace pods")
 		return ctrl.Result{}, fmt.Errorf("failed to list workspace pods: %w", err)
 	}
 
@@ -184,13 +184,13 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 		case workspace.Status.PodStarts == 0:
 			sctx, err := newStartWorkspaceContext(ctx, r.Config, workspace)
 			if err != nil {
-				clog.WithFields(owi).Error(err, "unable to create startWorkspace context")
+				clog.WithFields(owi).WithError(err).Error("unable to create startWorkspace context")
 				return ctrl.Result{Requeue: true}, err
 			}
 
 			pod, err := r.createWorkspacePod(sctx)
 			if err != nil {
-				clog.WithFields(owi).Error(err, "unable to produce workspace pod")
+				clog.WithFields(owi).WithError(err).Error("unable to produce workspace pod")
 				return ctrl.Result{}, err
 			}
 
@@ -202,7 +202,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			if apierrors.IsAlreadyExists(err) {
 				// pod exists, we're good
 			} else if err != nil {
-				clog.WithFields(owi).WithField("pod", pod).Error(err, "unable to create Pod for Workspace")
+				clog.WithFields(owi).WithField("pod", pod).WithError(err).Error("unable to create Pod for Workspace")
 				return ctrl.Result{Requeue: true}, err
 			} else {
 				// TODO(cw): replicate the startup mechanism where pods can fail to be scheduled,

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -113,7 +113,8 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		workspace.Status.Conditions = []metav1.Condition{}
 	}
 
-	log.AddFields(ctx, log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name))
+	// avoid logging the workspace name (in this context, workspace.Name is actually the instanceId)
+	log.Log.Data = log.OWI(workspace.Spec.Ownership.Owner, "", workspace.Name)
 	log.WithField("phase", workspace.Status.Phase).Debug("reconciling workspace")
 
 	workspacePods, err := r.listWorkspacePods(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -30,6 +30,7 @@ import (
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/components/scrubber"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/constants"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/maintenance"
 	config "github.com/gitpod-io/gitpod/ws-manager/api/config"
@@ -136,7 +137,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		log.WithFields(owi).WithField("status", workspace.Status).WithField("podStatus", podStatus).Info("updating workspace status")
+		log.WithFields(owi).WithField("status", scrubber.Default.DeepCopyStruct(workspace.Status)).WithField("podStatus", &log.TrustedValueWrap{Value: podStatus}).Info("updating workspace status")
 	}
 
 	err = r.Status().Update(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -137,7 +137,12 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		log.WithFields(owi).WithField("status", scrubber.Default.DeepCopyStruct(workspace.Status)).WithField("podStatus", &log.TrustedValueWrap{Value: podStatus}).Info("updating workspace status")
+		log.WithFields(owi).
+			// allow the top level object, and rely on its annotations to redact at the field level
+			WithField("workspaceStatus", &log.TrustedValueWrap{Value: scrubber.Default.DeepCopyStruct(workspace.Status)}).
+			// we don't own the corev1.PodStatus type, so we trust the whole thing
+			WithField("podStatus", &log.TrustedValueWrap{Value: podStatus}).
+			Info("updating workspace status")
 	}
 
 	err = r.Status().Update(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
@@ -37,7 +36,7 @@ import (
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	"github.com/prometheus/client_golang/prometheus"
 
-	clog "github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
 const (
@@ -101,7 +100,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err = r.Get(ctx, req.NamespacedName, &workspace)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			clog.Error(err, "unable to fetch workspace")
+			log.Error(err, "unable to fetch workspace")
 		}
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
@@ -113,12 +112,12 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		workspace.Status.Conditions = []metav1.Condition{}
 	}
 
-	owi := clog.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
-	clog.WithFields(owi).WithField("phase", workspace.Status.Phase).Info("reconciling workspace")
+	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
+	log.WithFields(owi).WithField("phase", workspace.Status.Phase).Info("reconciling workspace")
 
 	workspacePods, err := r.listWorkspacePods(ctx, &workspace)
 	if err != nil {
-		clog.WithFields(owi).WithError(err).Error("unable to list workspace pods")
+		log.WithFields(owi).WithError(err).Error("unable to list workspace pods")
 		return ctrl.Result{}, fmt.Errorf("failed to list workspace pods: %w", err)
 	}
 
@@ -137,7 +136,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		clog.WithFields(owi).WithField("status", workspace.Status).WithField("podStatus", podStatus).Info("updating workspace status")
+		log.WithFields(owi).WithField("status", workspace.Status).WithField("podStatus", podStatus).Info("updating workspace status")
 	}
 
 	err = r.Status().Update(ctx, &workspace)
@@ -168,7 +167,7 @@ func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspa
 
 func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (result ctrl.Result, err error) {
 	span, ctx := tracing.FromContext(ctx, "actOnStatus")
-	owi := clog.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
+	owi := log.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
@@ -183,13 +182,13 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 		case workspace.Status.PodStarts == 0:
 			sctx, err := newStartWorkspaceContext(ctx, r.Config, workspace)
 			if err != nil {
-				clog.WithFields(owi).WithError(err).Error("unable to create startWorkspace context")
+				log.WithFields(owi).WithError(err).Error("unable to create startWorkspace context")
 				return ctrl.Result{Requeue: true}, err
 			}
 
 			pod, err := r.createWorkspacePod(sctx)
 			if err != nil {
-				clog.WithFields(owi).WithError(err).Error("unable to produce workspace pod")
+				log.WithFields(owi).WithError(err).Error("unable to produce workspace pod")
 				return ctrl.Result{}, err
 			}
 
@@ -201,7 +200,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			if apierrors.IsAlreadyExists(err) {
 				// pod exists, we're good
 			} else if err != nil {
-				clog.WithFields(owi).WithField("pod", pod).WithError(err).Error("unable to create Pod for Workspace")
+				log.WithFields(owi).WithField("pod", pod).WithError(err).Error("unable to create Pod for Workspace")
 				return ctrl.Result{Requeue: true}, err
 			} else {
 				// TODO(cw): replicate the startup mechanism where pods can fail to be scheduled,
@@ -214,7 +213,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 				patch := client.MergeFrom(workspace.DeepCopy())
 				workspace.Status.PodStarts++
 				if err := r.Status().Patch(ctx, workspace, patch); err != nil {
-					clog.WithFields(owi).WithError(err).Error("Failed to patch PodStarts in workspace status")
+					log.WithFields(owi).WithError(err).Error("Failed to patch PodStarts in workspace status")
 					return ctrl.Result{}, err
 				}
 
@@ -305,7 +304,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 	case workspace.Status.Phase == workspacev1.WorkspacePhaseRunning:
 		err := r.deleteWorkspaceSecrets(ctx, workspace)
 		if err != nil {
-			clog.WithFields(owi).WithError(err).Error("could not delete workspace secrets")
+			log.WithFields(owi).WithError(err).Error("could not delete workspace secrets")
 		}
 
 	// we've disposed already - try to remove the finalizer and call it a day
@@ -326,64 +325,62 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 }
 
 func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *workspacev1.Workspace) {
-	log := log.FromContext(ctx)
-
-	ok, lastState := r.metrics.getWorkspace(&log, workspace)
+	ok, lastState := r.metrics.getWorkspace(workspace)
 	if !ok {
 		return
 	}
 
 	if !lastState.recordedInitFailure && wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, workspacev1.ReasonInitializationFailure) {
-		r.metrics.countTotalRestoreFailures(&log, workspace)
+		r.metrics.countTotalRestoreFailures(workspace)
 		lastState.recordedInitFailure = true
 	}
 
 	if !lastState.recordedFailure && workspace.IsConditionTrue(workspacev1.WorkspaceConditionFailed) {
-		r.metrics.countWorkspaceFailure(&log, workspace)
+		r.metrics.countWorkspaceFailure(workspace)
 		lastState.recordedFailure = true
 	}
 
 	if lastState.pendingStartTime.IsZero() && workspace.Status.Phase == workspacev1.WorkspacePhasePending {
 		lastState.pendingStartTime = time.Now()
 	} else if !lastState.pendingStartTime.IsZero() && workspace.Status.Phase != workspacev1.WorkspacePhasePending {
-		r.metrics.recordWorkspacePendingTime(&log, workspace, lastState.pendingStartTime)
+		r.metrics.recordWorkspacePendingTime(workspace, lastState.pendingStartTime)
 		lastState.pendingStartTime = time.Time{}
 	}
 
 	if lastState.creatingStartTime.IsZero() && workspace.Status.Phase == workspacev1.WorkspacePhaseCreating {
 		lastState.creatingStartTime = time.Now()
 	} else if !lastState.creatingStartTime.IsZero() && workspace.Status.Phase != workspacev1.WorkspacePhaseCreating {
-		r.metrics.recordWorkspaceCreatingTime(&log, workspace, lastState.creatingStartTime)
+		r.metrics.recordWorkspaceCreatingTime(workspace, lastState.creatingStartTime)
 		lastState.creatingStartTime = time.Time{}
 	}
 
 	if !lastState.recordedContentReady && workspace.IsConditionTrue(workspacev1.WorkspaceConditionContentReady) {
-		r.metrics.countTotalRestores(&log, workspace)
+		r.metrics.countTotalRestores(workspace)
 		lastState.recordedContentReady = true
 	}
 
 	if !lastState.recordedBackupFailed && workspace.IsConditionTrue(workspacev1.WorkspaceConditionBackupFailure) {
-		r.metrics.countTotalBackups(&log, workspace)
-		r.metrics.countTotalBackupFailures(&log, workspace)
+		r.metrics.countTotalBackups(workspace)
+		r.metrics.countTotalBackupFailures(workspace)
 		lastState.recordedBackupFailed = true
 	}
 
 	if !lastState.recordedBackupCompleted && workspace.IsConditionTrue(workspacev1.WorkspaceConditionBackupComplete) {
-		r.metrics.countTotalBackups(&log, workspace)
+		r.metrics.countTotalBackups(workspace)
 		lastState.recordedBackupCompleted = true
 	}
 
 	if !lastState.recordedStartTime && workspace.Status.Phase == workspacev1.WorkspacePhaseRunning {
-		r.metrics.recordWorkspaceStartupTime(&log, workspace)
+		r.metrics.recordWorkspaceStartupTime(workspace)
 		lastState.recordedStartTime = true
 	}
 
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseStopped {
-		r.metrics.countWorkspaceStop(&log, workspace)
+		r.metrics.countWorkspaceStop(workspace)
 
 		if !lastState.recordedStartFailure && isStartFailure(workspace) {
 			// Workspace never became ready, count as a startup failure.
-			r.metrics.countWorkspaceStartFailures(&log, workspace)
+			r.metrics.countWorkspaceStartFailures(workspace)
 			// No need to record in metricState, as we're forgetting the workspace state next anyway.
 		}
 
@@ -438,7 +435,7 @@ func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev
 
 func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) (err error) {
 	span, ctx := tracing.FromContext(ctx, "deleteWorkspaceSecrets")
-	owi := clog.OWI(ws.Spec.Ownership.Owner, ws.Spec.Ownership.WorkspaceID, ws.Name)
+	owi := log.OWI(ws.Spec.Ownership.Owner, ws.Spec.Ownership.WorkspaceID, ws.Name)
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
@@ -448,13 +445,13 @@ func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *wo
 	err = r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "env"), r.Config.Namespace)
 	if err != nil {
 		errs = append(errs, err.Error())
-		clog.WithFields(owi).WithError(err).Error("could not delete environment secret")
+		log.WithFields(owi).WithError(err).Error("could not delete environment secret")
 	}
 
 	err = r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "tokens"), r.Config.SecretsNamespace)
 	if err != nil {
 		errs = append(errs, err.Error())
-		clog.WithFields(owi).WithError(err).Error("could not delete token secret")
+		log.WithFields(owi).WithError(err).Error("could not delete token secret")
 	}
 
 	if len(errs) != 0 {
@@ -479,13 +476,13 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 		}
 
 		if err != nil {
-			clog.WithField("secret", name).WithError(err).Error("cannot retrieve secret scheduled for deletion")
+			log.WithField("secret", name).WithError(err).Error("cannot retrieve secret scheduled for deletion")
 			return false, nil
 		}
 
 		err = r.Client.Delete(ctx, &secret)
 		if err != nil && !apierrors.IsNotFound(err) {
-			clog.WithError(err).WithField("secret", name).Error("cannot delete secret")
+			log.WithError(err).WithField("secret", name).Error("cannot delete secret")
 			return false, nil
 		}
 
@@ -553,7 +550,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				var wsList workspacev1.WorkspaceList
 				err := r.List(ctx, &wsList)
 				if err != nil {
-					clog.WithError(err).Error("cannot list workspaces")
+					log.WithError(err).Error("cannot list workspaces")
 					return
 				}
 				for _, ws := range wsList.Items {

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -83,20 +83,6 @@ type WorkspaceReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pod,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pod/status,verbs=get
 
-type TrustedControllersFields struct {
-	workspaceStatus workspacev1.WorkspaceStatus
-	podStatus       *corev1.PodStatus
-}
-
-func (TrustedControllersFields) IsTrustedValue() {}
-
-func convertTo(podStatus *corev1.PodStatus, workspaceStatus workspacev1.WorkspaceStatus) *TrustedControllersFields {
-	return &TrustedControllersFields{
-		podStatus:       podStatus,
-		workspaceStatus: workspaceStatus,
-	}
-}
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // Modify the Reconcile function to compare the state specified by
@@ -148,10 +134,9 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if len(workspacePods.Items) > 0 {
 		podStatus = &workspacePods.Items[0].Status
 	}
-	trusted := convertTo(podStatus, workspace.Status)
 
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		log.WithFields(owi).WithField("status", trusted.workspaceStatus).WithField("podStatus", trusted.podStatus).Info("updating workspace status")
+		log.WithFields(owi).WithField("status", workspace.Status).WithField("podStatus", podStatus).Info("updating workspace status")
 	}
 
 	err = r.Status().Update(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -37,6 +37,8 @@ import (
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+
+	clog "github.com/gitpod-io/gitpod/common-go/log"
 )
 
 const (
@@ -135,8 +137,9 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		podStatus = &workspacePods.Items[0].Status
 	}
 
+	owi := clog.OWI(workspace.Spec.Ownership.Owner, workspace.Spec.Ownership.WorkspaceID, workspace.Name)
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		log.Info("updating workspace status", "status", workspace.Status, "podStatus", podStatus)
+		log.Info("updating workspace status", "status", workspace.Status, "podStatus", podStatus, "owi", owi)
 	}
 
 	err = r.Status().Update(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -83,6 +83,20 @@ type WorkspaceReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pod,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pod/status,verbs=get
 
+type TrustedControllersFields struct {
+	workspaceStatus workspacev1.WorkspaceStatus
+	podStatus       *corev1.PodStatus
+}
+
+func (TrustedControllersFields) IsTrustedValue() {}
+
+func convertTo(podStatus *corev1.PodStatus, workspaceStatus workspacev1.WorkspaceStatus) *TrustedControllersFields {
+	return &TrustedControllersFields{
+		podStatus:       podStatus,
+		workspaceStatus: workspaceStatus,
+	}
+}
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // Modify the Reconcile function to compare the state specified by
@@ -134,9 +148,10 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if len(workspacePods.Items) > 0 {
 		podStatus = &workspacePods.Items[0].Status
 	}
+	trusted := convertTo(podStatus, workspace.Status)
 
 	if !equality.Semantic.DeepDerivative(oldStatus, workspace.Status) {
-		log.WithFields(owi).WithField("status", workspace.Status).WithField("podStatus", podStatus).Info("updating workspace status")
+		log.WithFields(owi).WithField("status", trusted.workspaceStatus).WithField("podStatus", trusted.podStatus).Info("updating workspace status")
 	}
 
 	err = r.Status().Update(ctx, &workspace)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. Add OWI info to logs where missing
2. On phase change, log the value before and after (to easily build a timeline for transitions)
3. Change status/metrics/workspace_controller.go files to use common-go/log
   * other controllers still use `"sigs.k8s.io/controller-runtime/pkg/log"`, we should remove for consistency in a follow-on PR

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-2016

## How to test
<!-- Provide steps to test this PR -->
Observe [preview env logs](https://cloudlogging.app.goo.gl/CHMDyAqnnSJpaV7eA).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-status-log</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-status-log.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-status-log.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-status-log-gha.24215</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-status-log%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
