### PR TITLE
Fix one frame starting on workspace stopping page

### DIFF
--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
@@ -63,10 +63,21 @@ export function watchWorkspaceStatus(workspaceId: string | undefined, cb: WatchW
 const cachedCallbackInfoMap = new Map<string, { complete: WatchWorkspaceStatusCallback; priority: number }[]>();
 const cachedDisposables = new Map<string, Disposable>();
 
-// watchWorkspaceStatusInOrder watches the workspace status locally in order of priority.
+export enum WatchWorkspaceStatusPriority {
+    StartWorkspacePage = 100,
+    SupervisorService = 50,
+}
+
+/**
+ * Registers multiple callbacks to receive the same workspace status update in order of priority.
+ *
+ * @param workspaceId The workspace ID to watch. If undefined, all workspaces are watched.
+ * @param priority The priority of the callback. Higher priority callbacks are executed and waited first.
+ * @param callback The callback to execute when a workspace status update is received. Only executed after previous callbacks.
+ */
 export function watchWorkspaceStatusInOrder(
     workspaceId: string | undefined,
-    priority: number,
+    priority: WatchWorkspaceStatusPriority,
     callback: WatchWorkspaceStatusCallback,
 ): Disposable {
     const wsID = workspaceId || "ALL_WORKSPACES";

--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
@@ -71,7 +71,7 @@ export function watchWorkspaceStatusInOrder(
 ): Disposable {
     const wsID = workspaceId || "ALL_WORKSPACES";
     const newInfo = { complete: callback, priority };
-    const callbacks = cachedCallbackInfoMap.get(wsID) || [];
+    const callbacks = cachedCallbackInfoMap.get(wsID) ?? [];
     callbacks.push(newInfo);
     callbacks.sort((a, b) => b.priority - a.priority);
 

--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages2.test.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages2.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Disposable } from "@gitpod/gitpod-protocol";
+import { WatchWorkspaceStatusCallback, watchWorkspaceStatus } from "./listen-to-workspace-ws-messages";
+import { WatchWorkspaceStatusPriority, watchWorkspaceStatusInOrder } from "./listen-to-workspace-ws-messages2";
+import {
+    WatchWorkspaceStatusResponse,
+    WorkspacePhase_Phase,
+    WorkspaceStatus,
+} from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+
+jest.mock("./listen-to-workspace-ws-messages", () => ({
+    watchWorkspaceStatus: jest.fn(),
+}));
+
+describe("watchWorkspaceStatusInOrder", () => {
+    const mockWatchWorkspaceStatus = watchWorkspaceStatus as jest.MockedFunction<typeof watchWorkspaceStatus>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should clean up resources after all disposables is called", () => {
+        const mockDispose = jest.fn();
+        const mockDisposable: Disposable = { dispose: mockDispose };
+        mockWatchWorkspaceStatus.mockImplementation(
+            (wsId: string | undefined, cb: WatchWorkspaceStatusCallback) => mockDisposable,
+        );
+
+        const callback = jest.fn();
+        const result = watchWorkspaceStatusInOrder("ws3", WatchWorkspaceStatusPriority.StartWorkspacePage, callback);
+        const result2 = watchWorkspaceStatusInOrder("ws3", WatchWorkspaceStatusPriority.StartWorkspacePage, callback);
+        result.dispose();
+        expect(mockDispose).not.toHaveBeenCalled();
+        result2.dispose();
+        expect(mockDispose).toHaveBeenCalled();
+    });
+
+    it("should clean up resources when dispose is called", () => {
+        const mockDispose = jest.fn();
+        const mockDisposable: Disposable = { dispose: mockDispose };
+        mockWatchWorkspaceStatus.mockImplementation(
+            (wsId: string | undefined, cb: WatchWorkspaceStatusCallback) => mockDisposable,
+        );
+
+        const callback = jest.fn();
+        const result = watchWorkspaceStatusInOrder("ws3", WatchWorkspaceStatusPriority.StartWorkspacePage, callback);
+        result.dispose();
+        expect(mockDispose).toHaveBeenCalledTimes(1);
+        const result2 = watchWorkspaceStatusInOrder("ws3", WatchWorkspaceStatusPriority.StartWorkspacePage, callback);
+        result2.dispose();
+        expect(mockDispose).toHaveBeenCalledTimes(2);
+    });
+
+    it("should receive events in events ordering", async () => {
+        const phases: WorkspacePhase_Phase[] = [
+            WorkspacePhase_Phase.CREATING,
+            WorkspacePhase_Phase.RUNNING,
+            WorkspacePhase_Phase.RUNNING,
+            WorkspacePhase_Phase.STOPPING,
+            WorkspacePhase_Phase.STOPPED,
+            WorkspacePhase_Phase.RUNNING,
+        ];
+
+        mockWatchWorkspaceStatus.mockImplementation((wsId: string | undefined, cb: WatchWorkspaceStatusCallback) => {
+            setTimeout(() => {
+                for (const phase of phases) {
+                    cb(
+                        new WatchWorkspaceStatusResponse({
+                            status: new WorkspaceStatus({ phase: { name: phase } }),
+                        }),
+                    );
+                }
+            }, 20);
+            return {
+                dispose: jest.fn(),
+            };
+        });
+
+        const startPagePhases: WorkspacePhase_Phase[] = [];
+        const supervisorPhases: WorkspacePhase_Phase[] = [];
+        watchWorkspaceStatusInOrder("ws4", WatchWorkspaceStatusPriority.StartWorkspacePage, async (resp) => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            startPagePhases.push(resp.status?.phase?.name ?? WorkspacePhase_Phase.UNSPECIFIED);
+        });
+        watchWorkspaceStatusInOrder("ws4", WatchWorkspaceStatusPriority.SupervisorService, (resp) => {
+            supervisorPhases.push(resp.status?.phase?.name ?? WorkspacePhase_Phase.UNSPECIFIED);
+        });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        expect(startPagePhases).toEqual(phases);
+        expect(supervisorPhases).toEqual(phases);
+    });
+
+    it("should receive events in ordering of priority", async () => {
+        const phases: WorkspacePhase_Phase[] = [
+            WorkspacePhase_Phase.CREATING,
+            WorkspacePhase_Phase.RUNNING,
+            WorkspacePhase_Phase.RUNNING,
+            WorkspacePhase_Phase.STOPPING,
+            WorkspacePhase_Phase.STOPPED,
+            WorkspacePhase_Phase.RUNNING,
+        ];
+
+        mockWatchWorkspaceStatus.mockImplementation((wsId: string | undefined, cb: WatchWorkspaceStatusCallback) => {
+            setTimeout(() => {
+                for (const phase of phases) {
+                    cb(
+                        new WatchWorkspaceStatusResponse({
+                            status: new WorkspaceStatus({ phase: { name: phase } }),
+                        }),
+                    );
+                }
+            }, 20);
+            return {
+                dispose: jest.fn(),
+            };
+        });
+
+        const receivePhases: WorkspacePhase_Phase[] = [];
+        const allReceivedPhases: WorkspacePhase_Phase[] = [];
+        watchWorkspaceStatusInOrder("ws5", WatchWorkspaceStatusPriority.StartWorkspacePage, async (resp) => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            receivePhases.push(resp.status?.phase?.name ?? WorkspacePhase_Phase.UNSPECIFIED);
+        });
+        watchWorkspaceStatusInOrder("ws5", WatchWorkspaceStatusPriority.SupervisorService, (resp) => {
+            expect(receivePhases[0]).toEqual(resp.status?.phase?.name);
+            receivePhases.shift();
+            allReceivedPhases.push(resp.status?.phase?.name ?? WorkspacePhase_Phase.UNSPECIFIED);
+        });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        expect(receivePhases).toEqual([]);
+        expect(allReceivedPhases).toEqual(phases);
+    });
+});

--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages2.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages2.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Disposable } from "@gitpod/gitpod-protocol";
+import { WatchWorkspaceStatusCallback, watchWorkspaceStatus } from "./listen-to-workspace-ws-messages";
+
+const cachedCallbackInfoMap = new Map<string, { complete: WatchWorkspaceStatusCallback; priority: number }[]>();
+const cachedDisposables = new Map<string, Disposable>();
+
+export enum WatchWorkspaceStatusPriority {
+    StartWorkspacePage = 100,
+    SupervisorService = 50,
+}
+
+/**
+ * Registers multiple callbacks to receive the same workspace status update in order of priority.
+ *
+ * @param workspaceId The workspace ID to watch. If undefined, all workspaces are watched.
+ * @param priority The priority of the callback. Higher priority callbacks are executed and waited first.
+ * @param callback The callback to execute when a workspace status update is received. Only executed after previous callbacks.
+ */
+export function watchWorkspaceStatusInOrder(
+    workspaceId: string | undefined,
+    priority: WatchWorkspaceStatusPriority,
+    callback: WatchWorkspaceStatusCallback,
+): Disposable {
+    const wsID = workspaceId || "ALL_WORKSPACES";
+    const newInfo = { complete: callback, priority };
+    const callbacks = cachedCallbackInfoMap.get(wsID) ?? [];
+    callbacks.push(newInfo);
+    callbacks.sort((a, b) => b.priority - a.priority);
+
+    if (!cachedDisposables.has(wsID)) {
+        const disposable = watchWorkspaceStatus(wsID, async (response) => {
+            const list = cachedCallbackInfoMap.get(wsID);
+            if (!list) {
+                return;
+            }
+            for (const info of list) {
+                await info.complete(response);
+            }
+        });
+        cachedDisposables.set(wsID, disposable);
+    }
+    cachedCallbackInfoMap.set(wsID, callbacks);
+    return Disposable.create(() => {
+        const currentCallbacks = cachedCallbackInfoMap.get(wsID)?.filter((info) => info !== newInfo) ?? [];
+        cachedCallbackInfoMap.set(wsID, currentCallbacks);
+        // Dispose the watcher if no more callbacks are registered
+        if (currentCallbacks.length === 0) {
+            cachedDisposables.get(wsID)?.dispose();
+            cachedDisposables.delete(wsID);
+            cachedCallbackInfoMap.delete(wsID);
+        }
+    });
+}

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -26,7 +26,7 @@ import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
 import {
     WatchWorkspaceStatusPriority,
     watchWorkspaceStatusInOrder,
-} from "../data/workspaces/listen-to-workspace-ws-messages";
+} from "../data/workspaces/listen-to-workspace-ws-messages2";
 import { Workspace, WorkspaceSpec_WorkspaceType, WorkspaceStatus } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { sendTrackEvent } from "../Analytics";
 

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -24,12 +24,7 @@ import { instrumentWebSocket } from "./metrics";
 import { LotsOfRepliesResponse } from "@gitpod/public-api/lib/gitpod/experimental/v1/dummy_pb";
 import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
 import { watchWorkspaceStatusInOrder } from "../data/workspaces/listen-to-workspace-ws-messages";
-import {
-    Workspace,
-    WorkspacePhase_Phase,
-    WorkspaceSpec_WorkspaceType,
-    WorkspaceStatus,
-} from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { Workspace, WorkspaceSpec_WorkspaceType, WorkspaceStatus } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { sendTrackEvent } from "../Analytics";
 
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
@@ -248,27 +243,10 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             this.sendInfoUpdate(this.latestInfo);
         };
         reconcile();
-        const processStatus = (status: WorkspaceStatus) => {
-            if (this.latestInfo?.statusPhase === "running" && status.phase?.name === WorkspacePhase_Phase.STOPPING) {
-                return new Promise<void>((resolve) => {
-                    // Fix one frame starting on workspace stopping page - race between supervisor-frontend render and stopping page render
-                    // But this will not lead a bad UX to users, hope 300ms is enough for StartWorkspace.tsx to render
-                    setTimeout(() => {
-                        reconcile(status);
-                        resolve();
-                    }, 300);
-                });
-            }
-            reconcile(status);
-            return Promise.resolve();
-        };
-
-        let queue = Promise.resolve();
         watchWorkspaceStatusInOrder(this.workspaceID, 0, (response) => {
-            if (!response.status) {
-                return;
+            if (response.status) {
+                reconcile(response.status);
             }
-            queue = queue.then(() => processStatus(response.status!));
         });
     }
 

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -23,7 +23,10 @@ import { getExperimentsClient } from "../experiments/client";
 import { instrumentWebSocket } from "./metrics";
 import { LotsOfRepliesResponse } from "@gitpod/public-api/lib/gitpod/experimental/v1/dummy_pb";
 import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
-import { watchWorkspaceStatusInOrder } from "../data/workspaces/listen-to-workspace-ws-messages";
+import {
+    WatchWorkspaceStatusPriority,
+    watchWorkspaceStatusInOrder,
+} from "../data/workspaces/listen-to-workspace-ws-messages";
 import { Workspace, WorkspaceSpec_WorkspaceType, WorkspaceStatus } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { sendTrackEvent } from "../Analytics";
 
@@ -243,7 +246,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             this.sendInfoUpdate(this.latestInfo);
         };
         reconcile();
-        watchWorkspaceStatusInOrder(this.workspaceID, 0, (response) => {
+        watchWorkspaceStatusInOrder(this.workspaceID, WatchWorkspaceStatusPriority.SupervisorService, (response) => {
             if (response.status) {
                 reconcile(response.status);
             }

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -23,7 +23,7 @@ import { getExperimentsClient } from "../experiments/client";
 import { instrumentWebSocket } from "./metrics";
 import { LotsOfRepliesResponse } from "@gitpod/public-api/lib/gitpod/experimental/v1/dummy_pb";
 import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
-import { watchWorkspaceStatus } from "../data/workspaces/listen-to-workspace-ws-messages";
+import { watchWorkspaceStatusInOrder } from "../data/workspaces/listen-to-workspace-ws-messages";
 import { Workspace, WorkspaceSpec_WorkspaceType, WorkspaceStatus } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { sendTrackEvent } from "../Analytics";
 
@@ -243,7 +243,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             this.sendInfoUpdate(this.latestInfo);
         };
         reconcile();
-        watchWorkspaceStatus(this.workspaceID, (response) => {
+        watchWorkspaceStatusInOrder(this.workspaceID, 0, (response) => {
             if (response.status) {
                 reconcile(response.status);
             }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -130,16 +130,18 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         try {
-            const watchDispose = watchWorkspaceStatusInOrder(this.props.workspaceId, 99, (resp) => {
+            const watchDispose = watchWorkspaceStatusInOrder(this.props.workspaceId, 99, async (resp) => {
                 if (resp.workspaceId !== this.props.workspaceId || !resp.status) {
                     return;
                 }
-                this.onWorkspaceUpdate(
+                await this.onWorkspaceUpdate(
                     new Workspace({
                         ...this.state.workspace,
                         status: resp.status,
                     }),
                 );
+                // wait for next frame
+                await new Promise((resolve) => setTimeout(resolve, 0));
             });
             this.toDispose.push(watchDispose);
             this.toDispose.push(

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -20,7 +20,10 @@ import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
 import Alert from "../components/Alert";
 import { workspaceClient } from "../service/public-api";
-import { watchWorkspaceStatusInOrder } from "../data/workspaces/listen-to-workspace-ws-messages";
+import {
+    WatchWorkspaceStatusPriority,
+    watchWorkspaceStatusInOrder,
+} from "../data/workspaces/listen-to-workspace-ws-messages";
 import { Button } from "@podkit/buttons/Button";
 import {
     GetWorkspaceRequest,
@@ -130,19 +133,23 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         try {
-            const watchDispose = watchWorkspaceStatusInOrder(this.props.workspaceId, 99, async (resp) => {
-                if (resp.workspaceId !== this.props.workspaceId || !resp.status) {
-                    return;
-                }
-                await this.onWorkspaceUpdate(
-                    new Workspace({
-                        ...this.state.workspace,
-                        status: resp.status,
-                    }),
-                );
-                // wait for next frame
-                await new Promise((resolve) => setTimeout(resolve, 0));
-            });
+            const watchDispose = watchWorkspaceStatusInOrder(
+                this.props.workspaceId,
+                WatchWorkspaceStatusPriority.StartWorkspacePage,
+                async (resp) => {
+                    if (resp.workspaceId !== this.props.workspaceId || !resp.status) {
+                        return;
+                    }
+                    await this.onWorkspaceUpdate(
+                        new Workspace({
+                            ...this.state.workspace,
+                            status: resp.status,
+                        }),
+                    );
+                    // wait for next frame
+                    await new Promise((resolve) => setTimeout(resolve, 0));
+                },
+            );
             this.toDispose.push(watchDispose);
             this.toDispose.push(
                 getGitpodService().registerClient({

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -130,8 +130,8 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         try {
-            const watchDispose = watchWorkspaceStatusInOrder(this.state.workspace?.id, 99, (resp) => {
-                if (resp.workspaceId !== this.state.workspace?.id || !resp.status) {
+            const watchDispose = watchWorkspaceStatusInOrder(this.props.workspaceId, 99, (resp) => {
+                if (resp.workspaceId !== this.props.workspaceId || !resp.status) {
                     return;
                 }
                 this.onWorkspaceUpdate(

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -20,7 +20,7 @@ import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
 import Alert from "../components/Alert";
 import { workspaceClient } from "../service/public-api";
-import { watchWorkspaceStatus } from "../data/workspaces/listen-to-workspace-ws-messages";
+import { watchWorkspaceStatusInOrder } from "../data/workspaces/listen-to-workspace-ws-messages";
 import { Button } from "@podkit/buttons/Button";
 import {
     GetWorkspaceRequest,
@@ -130,7 +130,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         try {
-            const watchDispose = watchWorkspaceStatus(this.state.workspace?.id, (resp) => {
+            const watchDispose = watchWorkspaceStatusInOrder(this.state.workspace?.id, 99, (resp) => {
                 if (resp.workspaceId !== this.state.workspace?.id || !resp.status) {
                     return;
                 }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -23,7 +23,7 @@ import { workspaceClient } from "../service/public-api";
 import {
     WatchWorkspaceStatusPriority,
     watchWorkspaceStatusInOrder,
-} from "../data/workspaces/listen-to-workspace-ws-messages";
+} from "../data/workspaces/listen-to-workspace-ws-messages2";
 import { Button } from "@podkit/buttons/Button";
 import {
     GetWorkspaceRequest,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove race conditions

- **Network** Use the same watch streaming request on `service.tsx` and `StartWorkspace.tsx` page
-  **Render** Add complete (similar with  expresss.next) to make sure `StartWorkspace` is rendered before `Service.tsx` render (setTimeout 0 to wait React render next frame)

See also [[internal chat](https://gitpod.slack.com/archives/C05H5UQBW6Q/p1712927029262389?thread_ts=1712926365.740049&cid=C05H5UQBW6Q)]

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1621

## How to test
<!-- Provide steps to test this PR -->
- Record your screen
- Stop workspace via `gp stop`
- There should have no `starting` screen shows

<img width="860" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/e72a0aba-cc5a-4445-8afa-57025ca33d3f">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-status-ordering</li>
	<li><b>🔗 URL</b> - <a href="https://hw-status-ordering.preview.gitpod-dev.com/workspaces" target="_blank">hw-status-ordering.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-status-ordering-gha.24204</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-status-ordering%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
