### PR TITLE
[jb] add 2023.3 versions back

### DIFF
--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -365,24 +365,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.4",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
 				},
 				clion: {
 					OrderKey:          "110",

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -175,6 +175,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.6",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				intellijPrevious: {
 					OrderKey:    "041",
@@ -196,6 +214,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.6",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				pycharm: {
 					OrderKey:          "060",
@@ -209,6 +245,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.5",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				phpstorm: {
 					OrderKey:          "070",
@@ -221,6 +275,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.6",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				rubymine: {
 					OrderKey:          "080",
@@ -233,6 +305,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.6",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				webstorm: {
 					OrderKey:          "090",
@@ -245,6 +335,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.6",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				rider: {
 					OrderKey:          "100",
@@ -257,6 +365,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.4",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				clion: {
 					OrderKey:          "110",
@@ -269,6 +395,24 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
+					Versions: []ide_config.IDEVersion{
+						{
+							Version: "2024.1",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+						{
+							Version: "2023.3.4",
+							Image:   ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+							ImageLayers: []string{
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
+								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
+							},
+						},
+					},
 				},
 				xterm: {
 					OrderKey: "120",


### PR DESCRIPTION
## Description

Progress of testing and validating progress: 

- [x] IntelliJ
- [x] GoLand
- [x] PyCharm
- [x] PhpStorm
- [x] RubyMine
- [x] WebStorm
- [ ] Rider
	- fails with https://www.jetbrains.com/rider/nextversion/
- [x] CLion

Preview env: https://ak-revert-2024-jb.preview.gitpod-dev.com/workspaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
