### PR TITLE
[jb] Remove clion versions

### DIFF
--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -377,24 +377,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PluginLatestImage: jbPluginLatestImage,
 					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
 					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.4",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
 				},
 				xterm: {
 					OrderKey: "120",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove clion versions

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
