### PR TITLE
Do not show Editor type for JB

### DIFF
--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -62,7 +62,7 @@ export const IdeOptions = (props: IdeOptionsProps) => {
                                 {type && (
                                     <>
                                         <MiddleDot />
-                                        <span className="text-pk-content-primary  capitalize">{type}</span>
+                                        <span className="text-pk-content-primary capitalize">{type}</span>
                                     </>
                                 )}
                             </span>

--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -18,6 +18,7 @@ import { LoadingState } from "@podkit/loading/LoadingState";
 import { useIDEVersionsQuery } from "../data/ide-options/ide-options-query";
 import { useFeatureFlag } from "../data/featureflag-query";
 import { AllowedWorkspaceEditor } from "../data/ide-options/ide-options-query";
+import { isJetbrains } from "./SelectIDEComponent";
 
 interface IdeOptionsProps {
     ideOptions: AllowedWorkspaceEditor[] | undefined;
@@ -234,6 +235,9 @@ const IdeOptionSwitch = ({
             ))}
         </select>
     );
+
+    // For JetBrains, we don't show the type because it is always Desktop and hence redundant
+    const type = !isJetbrains(ideOption.id) && ideOption.type;
     const description = (
         <div className={cn("inline-flex items-center", contentColor)}>
             {(ideOption.imageVersion || pinnedIdeVersion || versionSelector) && (
@@ -243,8 +247,12 @@ const IdeOptionSwitch = ({
                     {versionSelector || <span>{pinnedIdeVersion || ideOption.imageVersion}</span>}
                 </>
             )}
-            <MiddleDot />
-            <span className="capitalize">{ideOption.type}</span>
+            {type && (
+                <>
+                    <MiddleDot />
+                    <span className="capitalize">{type}</span>
+                </>
+            )}
         </div>
     );
 

--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -35,30 +35,40 @@ export const IdeOptions = (props: IdeOptionsProps) => {
     if ((!props.ideOptions || props.ideOptions.length === 0) && props.emptyState) {
         return <>{props.emptyState}</>;
     }
+
     return (
         <div className={cn("space-y-2", props.className)}>
             {props.ideOptions &&
-                props.ideOptions.map((ide) => (
-                    <div key={ide.id} className="flex gap-2 items-center">
-                        <img className="w-5 h-5 self-center" src={ide.logo} alt="" />
-                        <span>
-                            <span className="font-medium text-pk-content-primary">{ide.title}</span>
-                            {ide.imageVersion && (
-                                <>
-                                    <MiddleDot />
-                                    {props.pinnedEditorVersions.get(ide.id) && (
-                                        <PinIcon size={16} className="inline align-text-bottom" />
-                                    )}
-                                    <span className="text-pk-content-primary">
-                                        {props.pinnedEditorVersions.get(ide.id) || ide.imageVersion}
-                                    </span>
-                                </>
-                            )}
-                            <MiddleDot />
-                            <span className="text-pk-content-primary capitalize">{ide.type}</span>
-                        </span>
-                    </div>
-                ))}
+                props.ideOptions.map((ide) => {
+                    const type = !isJetbrains(ide.id) && ide.type;
+
+                    return (
+                        <div key={ide.id} className="flex gap-2 items-center">
+                            <img className="w-5 h-5 self-center" src={ide.logo} alt="" />
+                            <span>
+                                <span className="font-medium text-pk-content-primary">{ide.title}</span>
+                                {ide.imageVersion && (
+                                    <>
+                                        <MiddleDot />
+                                        {props.pinnedEditorVersions.get(ide.id) && (
+                                            <PinIcon size={16} className="inline align-text-bottom" />
+                                        )}
+                                        <span className="text-pk-content-primary">
+                                            {props.pinnedEditorVersions.get(ide.id) || ide.imageVersion}
+                                        </span>
+                                    </>
+                                )}
+
+                                {type && (
+                                    <>
+                                        <MiddleDot />
+                                        <span className="text-pk-content-primary  capitalize">{type}</span>
+                                    </>
+                                )}
+                            </span>
+                        </div>
+                    );
+                })}
         </div>
     );
 };

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -82,7 +82,7 @@ export const Modal: FC<Props> = ({
                 tabIndex={0}
             >
                 {/* Modal outer-container for positioning */}
-                <div className="pointer-events-none relative h-[calc(100%-1rem)] w-auto min-[576px]:mx-auto min-[576px]:mt-7 min-[576px]:h-[calc(100%-3.5rem)] min-[576px]:max-w-[550px]">
+                <div className="pointer-events-none relative h-[calc(100%-1rem)] w-auto min-[576px]:mx-auto min-[576px]:mt-7 min-[576px]:h-[calc(100%-3.5rem)] min-[576px]:max-w-[500px]">
                     <FocusOn
                         autoFocus={autoFocus}
                         onClickOutside={handleClickOutside}

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -213,13 +213,18 @@ const IdeOptionElementSelected: FC<IdeOptionElementProps> = ({
     );
 };
 
+export const isJetbrains = (editor: string) => {
+    //todo(ft): find a better way to group IDEs by vendor
+    return !["code", "code-desktop", "xterm"].includes(editor); // a really hacky way to get just JetBrains IDEs
+};
+
 function IdeOptionElementInDropDown(p: IdeOptionElementProps): JSX.Element {
     const { option, useLatest } = p;
     if (!option) {
         return <></>;
     }
     const version = useLatest ? option.latestImageVersion : p.pinnedIdeVersion ?? option.imageVersion;
-    const label = capitalize(option.type);
+    const label = !isJetbrains(option.id) && capitalize(option.type);
 
     return (
         <div className="flex" title={option.title}>

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useContext, useState } from "react";
 import { UserContext } from "../user-context";
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
-import SelectIDEComponent from "../components/SelectIDEComponent";
+import SelectIDEComponent, { isJetbrains } from "../components/SelectIDEComponent";
 import PillLabel from "../components/PillLabel";
 import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutation";
 import { converter } from "../service/public-api";
@@ -71,8 +71,7 @@ export default function SelectIDE(props: SelectIDEProps) {
         [actualUpdateUserIDEInfo, defaultIde],
     );
 
-    //todo(ft): find a better way to group IDEs by vendor
-    const shouldShowJetbrainsNotice = !["code", "code-desktop", "xterm"].includes(defaultIde); // a really hacky way to get just JetBrains IDEs
+    const shouldShowJetbrainsNotice = isJetbrains(defaultIde);
 
     return (
         <>


### PR DESCRIPTION
## Description

This change aims to give us more real estate in the available editors modal in the organization settings by not showing `Desktop` as the type for every JetBrains IDE, which are all desktop and do not offer a browser-based alternative.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
https://gitpod.slack.com/archives/C05H5UQBW6Q/p1713082398905009?thread_ts=1712779784.619919&cid=C05H5UQBW6Q

## How to test
<!-- Provide steps to test this PR -->

Go to the org settings and try to configure available editors. There should be enough room in the UI even for version pinning of IntelliJ IDEA.

https://ft-jb-hide-label.preview.gitpod-dev.com/workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
