### PR TITLE
IntelliJ 2022.3.3 deprecation warning

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -12,6 +12,7 @@ import { MiddleDot } from "./typography/MiddleDot";
 import { DisableScope } from "../data/workspaces/workspace-classes-query";
 import { Link } from "react-router-dom";
 import { repositoriesRoutes } from "../repositories/repositories.routes";
+import { isGitpodIo } from "../utils";
 
 interface SelectIDEComponentProps {
     selectedIdeOption?: string;
@@ -20,6 +21,7 @@ interface SelectIDEComponentProps {
     useLatest?: boolean;
     onSelectionChange: (ide: string, latest: boolean) => void;
     setError?: (error?: React.ReactNode) => void;
+    setWarning?: (warning?: React.ReactNode) => void;
     disabled?: boolean;
     loading?: boolean;
     ignoreRestrictionScopes: DisableScope[] | undefined;
@@ -34,6 +36,7 @@ export default function SelectIDEComponent({
     disabled = false,
     loading = false,
     setError,
+    setWarning,
     onSelectionChange,
     ignoreRestrictionScopes,
     availableOptions,
@@ -131,6 +134,24 @@ export default function SelectIDEComponent({
             setError?.(undefined);
         }
     }, [ide, availableOptions, setError, loading, disabled, ideOptionsLoading, helpMessage]);
+
+    useEffect(() => {
+        const shouldShowDeprecationNotice = isGitpodIo() && ["intellij-previous"].includes(ide);
+        if (shouldShowDeprecationNotice) {
+            setWarning?.(
+                <>
+                    <span className="font-semibold">IntelliJ IDEA 2022.3.3 is deprecated</span>. <br />
+                    Please use version 2024.1 or pin a different one in the{" "}
+                    <Link className="gp-link" to={"/settings"}>
+                        Organization settings
+                    </Link>
+                    .
+                </>,
+            );
+        } else {
+            setWarning?.(undefined);
+        }
+    }, [setError, setWarning, ide]);
 
     return (
         <Combobox

--- a/components/dashboard/src/onboarding/StepPersonalize.tsx
+++ b/components/dashboard/src/onboarding/StepPersonalize.tsx
@@ -4,12 +4,13 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback, useState } from "react";
+import { FC, ReactNode, useCallback, useState } from "react";
 import SelectIDEComponent from "../components/SelectIDEComponent";
 import { ThemeSelector } from "../components/ThemeSelector";
 import { Heading2, Subheading } from "../components/typography/headings";
 import { OnboardingStep } from "./OnboardingStep";
 import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
+import Alert from "../components/Alert";
 
 type Props = {
     user: User;
@@ -18,6 +19,7 @@ type Props = {
 export const StepPersonalize: FC<Props> = ({ user, onComplete }) => {
     const [ide, setIDE] = useState(user?.editorSettings?.name || "code");
     const [useLatest, setUseLatest] = useState(user?.editorSettings?.version === "latest");
+    const [ideWarning, setIdeWarning] = useState<ReactNode | undefined>(undefined);
 
     // This step doesn't save the ide selection yet (happens at the end), just passes them along
     const handleSubmitted = useCallback(() => {
@@ -35,11 +37,18 @@ export const StepPersonalize: FC<Props> = ({ user, onComplete }) => {
         >
             <Heading2>Choose an editor</Heading2>
             <Subheading className="mb-2">You can change this later in your user preferences.</Subheading>
+            {ideWarning && (
+                // We set a max width so that the layout does not shift when the warning is displayed.
+                <Alert type="warning" className="my-2 max-w-[28.5rem]">
+                    <span className="text-sm">{ideWarning}</span>
+                </Alert>
+            )}
             <SelectIDEComponent
                 onSelectionChange={(ide, latest) => {
                     setIDE(ide);
                     setUseLatest(latest);
                 }}
+                setWarning={setIdeWarning}
                 ignoreRestrictionScopes={["configuration", "organization"]}
                 selectedIdeOption={ide}
                 useLatest={useLatest}

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useCallback, useContext, useState } from "react";
+import { ReactNode, useCallback, useContext, useState } from "react";
 import { UserContext } from "../user-context";
 import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import SelectIDEComponent from "../components/SelectIDEComponent";
@@ -24,6 +24,7 @@ export default function SelectIDE(props: SelectIDEProps) {
 
     const [defaultIde, setDefaultIde] = useState<string>(user?.editorSettings?.name || "code");
     const [useLatestVersion, setUseLatestVersion] = useState<boolean>(user?.editorSettings?.version === "latest");
+    const [ideWarning, setIdeWarning] = useState<ReactNode | undefined>(undefined);
 
     const isOrgOwnedUser = user && isOrganizationOwned(user);
 
@@ -81,9 +82,12 @@ export default function SelectIDE(props: SelectIDEProps) {
                     onSelectionChange={actuallySetDefaultIde}
                     selectedIdeOption={defaultIde}
                     useLatest={useLatestVersion}
+                    setWarning={setIdeWarning}
                     ignoreRestrictionScopes={isOrgOwnedUser ? ["configuration"] : ["configuration", "organization"]}
                 />
             </div>
+
+            {ideWarning && <p className="text-left w-full text-gray-400 dark:text-gray-500 my-2">{ideWarning}</p>}
 
             {shouldShowJetbrainsNotice && (
                 <p className="text-left w-full text-gray-400 dark:text-gray-500">

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -8,7 +8,7 @@ import { SuggestedRepository } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
-import { FC, FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { FC, FunctionComponent, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from "react";
 import { useHistory, useLocation } from "react-router";
 import Alert from "../components/Alert";
 import { AuthorizeGit, useNeedsGitAuthorization } from "../components/AuthorizeGit";
@@ -100,8 +100,9 @@ export function CreateWorkspacePage() {
     const defaultWorkspaceClass = props.workspaceClass ?? computedDefaultClass;
     const { data: orgSettings } = useOrgSettingsQuery();
     const [selectedWsClass, setSelectedWsClass, selectedWsClassIsDirty] = useDirtyState(defaultWorkspaceClass);
-    const [errorWsClass, setErrorWsClass] = useState<React.ReactNode | undefined>(undefined);
-    const [errorIde, setErrorIde] = useState<React.ReactNode | undefined>(undefined);
+    const [errorWsClass, setErrorWsClass] = useState<ReactNode | undefined>(undefined);
+    const [errorIde, setErrorIde] = useState<ReactNode | undefined>(undefined);
+    const [warningIde, setWarningIde] = useState<ReactNode | undefined>(undefined);
     const [contextURL, setContextURL] = useState<string | undefined>(
         StartWorkspaceOptions.parseContextUrl(location.hash),
     );
@@ -481,6 +482,11 @@ export function CreateWorkspacePage() {
                                 }}
                             />
                         ) : null}
+                        {warningIde && (
+                            <Alert type="warning">
+                                <span className="text-sm">{warningIde}</span>
+                            </Alert>
+                        )}
 
                         <InputField>
                             <RepositoryFinder
@@ -499,6 +505,7 @@ export function CreateWorkspacePage() {
                                     defaultIdeSource === selectedProjectID ? availableEditorOptions : undefined
                                 }
                                 setError={setErrorIde}
+                                setWarning={setWarningIde}
                                 selectedIdeOption={selectedIde}
                                 selectedConfigurationId={selectedProjectID}
                                 pinnedEditorVersions={
@@ -752,7 +759,7 @@ export function LimitReachedParallelWorkspacesModal() {
     );
 }
 
-export function LimitReachedModal(p: { children: React.ReactNode }) {
+export function LimitReachedModal(p: { children: ReactNode }) {
     const user = useCurrentUser();
     return (
         // TODO: Use title and buttons props


### PR DESCRIPTION
## Description

We are removing IntelliJ IDEA 2022.3.3 on May 31st. This PR contributes a banner shown as an early warning to users who use it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

https://ft-jb-2022980f5035b2.preview.gitpod-dev.com/user/preferences

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
