### PR TITLE
Fix checking 401 error for GitHub

### DIFF
--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -88,7 +88,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             }
             return await this.handleDefaultContext({ span }, user, host, owner, repoName);
         } catch (error) {
-            if (error && error.code === 401) {
+            if (error && (error.code === 401 || error.message === "Unauthorized")) {
                 const token = await this.tokenHelper.getCurrentToken(user);
 
                 throw UnauthorizedError.create({


### PR DESCRIPTION
## Description

We have nice checking for a broken connection to our GitHub OAuth app, but the condition that needed to be met was not, because the error we threw did not have a `.code` property. This PR ensures a nicer UX which enables the user to reconnect the GitHub App if necessary.

| Before | After |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/29888641/8bf81f51-d8bb-4bec-b740-563b554d5df5) | <img width="651" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/fb984f50-c0e5-4d6a-9a20-06fb8d589f12"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Small part of the solution for EXP-1803

## How to test

1. Log in to the preview env
2. On github.com, revoke access to the harvester OAuth app
3. Try to create a workspace with a GitHub URL. You should be reprompted to authenticate.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-unautho614af3e9e8</li>
	<li><b>🔗 URL</b> - <a href="https://ft-unautho614af3e9e8.preview.gitpod-dev.com/workspaces" target="_blank">ft-unautho614af3e9e8.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-unauthorized-fixes-gha.24300</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-unautho614af3e9e8%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
