### PR TITLE
No user onboarding on preview envs

### DIFF
--- a/components/dashboard/src/onboarding/use-show-user-onboarding.ts
+++ b/components/dashboard/src/onboarding/use-show-user-onboarding.ts
@@ -8,7 +8,8 @@ import { useCurrentUser } from "../user-context";
 import { useQueryParams } from "../hooks/use-query-params";
 import { FORCE_ONBOARDING_PARAM, FORCE_ONBOARDING_PARAM_VALUE } from "./UserOnboarding";
 import { isOrganizationOwned } from "@gitpod/public-api-common/lib/user-utils";
-import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
+import type { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
+import { isPreviewEnvironment } from "../utils";
 
 export const useShowUserOnboarding = () => {
     const user = useCurrentUser();
@@ -19,10 +20,11 @@ export const useShowUserOnboarding = () => {
     }
 
     // Show new signup flow if:
-    // * User is onboarding (no ide selected yet, not org user, hasn't onboarded before)
+    // * User is onboarding (no ide selected yet, not org user, hasn't onboarded before) and we aren't in a preview environment
     // * OR query param `onboarding=force` is set
     const showUserOnboarding =
-        isOnboardingUser(user) || search.get(FORCE_ONBOARDING_PARAM) === FORCE_ONBOARDING_PARAM_VALUE;
+        (isOnboardingUser(user) && !isPreviewEnvironment()) ||
+        search.get(FORCE_ONBOARDING_PARAM) === FORCE_ONBOARDING_PARAM_VALUE;
 
     return showUserOnboarding;
 };

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -54,8 +54,13 @@ export function isGitpodIo() {
     return (
         window.location.hostname === "gitpod.io" ||
         window.location.hostname === "gitpod-staging.com" ||
-        window.location.hostname.endsWith("gitpod-dev.com") ||
-        window.location.hostname.endsWith("gitpod-io-dev.com")
+        isPreviewEnvironment()
+    );
+}
+
+export function isPreviewEnvironment() {
+    return (
+        window.location.hostname.endsWith("gitpod-dev.com") || window.location.hostname.endsWith("gitpod-io-dev.com")
     );
 }
 


### PR DESCRIPTION
## Description

It is sometimes very annoying to have to onboard your user any time your preview environments spins up, which can happen multiple times per PR.

This PR simply disables automatic user onboarding, while still leaving it available by adding `?onboarding=force` to the URL.

## How to test

Go to https://ft-no-prev6c69baa1d4.preview.gitpod-dev.com/workspaces and ensure you don't get an onboarding process shown to you.

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
