### PR TITLE
Store ide configmap in a json file

### DIFF
--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -92,6 +92,26 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 			}
 		}
 		cfg.IdeOptions.Options[id] = option
+
+		if len(option.Versions) > 0 && option.ImageVersion != "" {
+			found := false
+			for _, version := range option.Versions {
+				if version.Version == option.ImageVersion {
+					found = true
+					break
+				}
+			}
+			if !found {
+				var versions []config.IDEVersion
+				versions = append(versions, config.IDEVersion{
+					Version:     option.ImageVersion,
+					Image:       option.Image,
+					ImageLayers: option.ImageLayers,
+				})
+				versions = append(versions, option.Versions...)
+				option.Versions = versions
+			}
+		}
 	}
 
 	return &cfg, nil

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -11,6 +11,7 @@ packages:
       - "pkg/components/**/*.key"
       - "pkg/components/**/*.pem"
       - "pkg/components/**/*.sql"
+      - "pkg/components/**/*.json"
       - "pkg/components/spicedb/data/*.yaml"
       - "scripts/*.sh"
       - "third_party/charts/*/Chart.yaml"

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -1,5 +1,5 @@
 {
-  "supervisorImage": "{{.Repository}}/supervisor:commit-d1fc093e2b0cf3a7db3a35d6e7dbc6d742c3f956",
+  "supervisorImage": "{{.Repository}}/supervisor:{{.WorkspaceVersions.Workspace.Supervisor.Version}}",
   "ideOptions": {
     "options": {
       "code": {
@@ -8,8 +8,8 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-7721fe825201d4d8d53975f81de0b063d94383cc",
-        "latestImage": "{{.ResolvedLatestCodeBrowserImage}}",
+        "image": "{{.Repository}}/ide/code:{{.CodeBrowserVersionStable}}",
+        "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.CodeWebExtensionImage}}",
           "{{.CodeHelperImage}}"
@@ -70,8 +70,8 @@
         "title": "VS Code",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
-        "image": "{{.Repository}}/ide/code-desktop:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592",
-        "latestImage": "{{.Repository}}/ide/code-desktop-insiders:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592"
+        "image": "{{.Repository}}/ide/code-desktop:{{.WorkspaceVersions.Workspace.DesktopIdeImages.CodeDesktopImage.Version}}",
+        "latestImage": "{{.Repository}}/ide/code-desktop-insiders:{{.WorkspaceVersions.Workspace.DesktopIdeImages.CodeDesktopImageInsiders.Version}}"
       },
       "intellij": {
         "orderKey": "040",
@@ -79,7 +79,7 @@
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/intellijIdeaLogo.svg",
         "label": "Ultimate",
-        "image": "{{.Repository}}/ide/intellij:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/intellij:{{.WorkspaceVersions.Workspace.DesktopIdeImages.IntelliJImage.Version}}",
         "latestImage": "{{.Repository}}/ide/intellij:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -127,7 +127,7 @@
         "title": "GoLand",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/golandLogo.svg",
-        "image": "{{.Repository}}/ide/goland:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/goland:{{.WorkspaceVersions.Workspace.DesktopIdeImages.GoLandImage.Version}}",
         "latestImage": "{{.Repository}}/ide/goland:latest",
         "pluginImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4",
         "pluginLatestImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4-latest",
@@ -164,7 +164,7 @@
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/pycharmLogo.svg",
         "label": "Professional",
-        "image": "{{.Repository}}/ide/pycharm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/pycharm:{{.WorkspaceVersions.Workspace.DesktopIdeImages.PyCharmImage.Version}}",
         "latestImage": "{{.Repository}}/ide/pycharm:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -200,7 +200,7 @@
         "title": "PhpStorm",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/phpstormLogo.svg",
-        "image": "{{.Repository}}/ide/phpstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/phpstorm:{{.WorkspaceVersions.Workspace.DesktopIdeImages.PhpStormImage.Version}}",
         "latestImage": "{{.Repository}}/ide/phpstorm:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -236,7 +236,7 @@
         "title": "RubyMine",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/rubymineLogo.svg",
-        "image": "{{.Repository}}/ide/rubymine:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/rubymine:{{.WorkspaceVersions.Workspace.DesktopIdeImages.RubyMineImage.Version}}",
         "latestImage": "{{.Repository}}/ide/rubymine:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -272,7 +272,7 @@
         "title": "WebStorm",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/webstormLogo.svg",
-        "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/webstorm:{{.WorkspaceVersions.Workspace.DesktopIdeImages.WebStormImage.Version}}",
         "latestImage": "{{.Repository}}/ide/webstorm:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -308,7 +308,7 @@
         "title": "Rider",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/riderLogo.svg",
-        "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/rider:{{.WorkspaceVersions.Workspace.DesktopIdeImages.RiderImage.Version}}",
         "latestImage": "{{.Repository}}/ide/rider:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
@@ -326,7 +326,7 @@
         "title": "CLion",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/clionLogo.svg",
-        "image": "{{.Repository}}/ide/clion:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "image": "{{.Repository}}/ide/clion:{{.WorkspaceVersions.Workspace.DesktopIdeImages.CLionImage.Version}}",
         "latestImage": "{{.Repository}}/ide/clion:latest",
         "pluginImage": "{{.JetBrainsPluginImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -1,0 +1,392 @@
+{
+  "supervisorImage": "{{.Repository}}/supervisor:commit-d1fc093e2b0cf3a7db3a35d6e7dbc6d742c3f956",
+  "ideOptions": {
+    "options": {
+      "code": {
+        "orderKey": "010",
+        "title": "VS Code",
+        "type": "browser",
+        "logo": "{{.IdeLogoBase}}/vscode.svg",
+        "label": "Browser",
+        "image": "{{.Repository}}/ide/code:commit-7721fe825201d4d8d53975f81de0b063d94383cc",
+        "latestImage": "{{.ResolvedLatestCodeBrowserImage}}",
+        "imageLayers": [
+          "{{.CodeWebExtensionImage}}",
+          "{{.CodeHelperImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.CodeWebExtensionImage}}",
+          "{{.CodeHelperImage}}"
+        ],
+        "versions": [
+          {
+            "version": "1.88.0",
+            "image": "{{.Repository}}/ide/code:commit-7721fe825201d4d8d53975f81de0b063d94383cc",
+            "imageLayers": [
+              "{{.CodeWebExtensionImage}}",
+              "{{.CodeHelperImage}}"
+            ]
+          },
+          {
+            "version": "1.87.1",
+            "image": "{{.Repository}}/ide/code:commit-aaa9aeb1a12870ab8c19ca8a928d76849bc24c84",
+            "imageLayers": [
+              "{{.CodeWebExtensionImage}}",
+              "{{.CodeHelperImage}}"
+            ]
+          },
+          {
+            "version": "1.87.0",
+            "image": "{{.Repository}}/ide/code:commit-82dc424633bdc7266b46302042dd98af201fa8f8",
+            "imageLayers": [
+              "{{.CodeWebExtensionImage}}",
+              "{{.CodeHelperImage}}"
+            ]
+          },
+          {
+            "version": "1.86.2",
+            "image": "{{.Repository}}/ide/code:commit-d86f6aa033943c9650d06339915e68063b0cf142",
+            "imageLayers": [
+              "{{.CodeWebExtensionImage}}",
+              "{{.CodeHelperImage}}"
+            ]
+          }
+        ]
+      },
+      "code-desktop": {
+        "orderKey": "020",
+        "title": "VS Code",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/vscode.svg",
+        "image": "{{.Repository}}/ide/code-desktop:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592",
+        "latestImage": "{{.Repository}}/ide/code-desktop-insiders:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592"
+      },
+      "code1_85": {
+        "orderKey": "011",
+        "title": "VS Code",
+        "type": "browser",
+        "logo": "{{.IdeLogoBase}}/vscode.svg",
+        "label": "Browser",
+        "image": "{{.Repository}}/ide/code:commit-cb1173f2a457633550a7fdc89af86d8d4da51876",
+        "imageLayers": [
+          "{{.CodeWebExtensionImage}}",
+          "{{.CodeHelperImage}}"
+        ]
+      },
+      "intellij": {
+        "orderKey": "040",
+        "title": "IntelliJ IDEA",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/intellijIdeaLogo.svg",
+        "label": "Ultimate",
+        "image": "{{.Repository}}/ide/intellij:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/intellij:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/intellij:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.6",
+            "image": "{{.Repository}}/ide/intellij:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "intellij-previous": {
+        "orderKey": "041",
+        "title": "IntelliJ IDEA",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/intellijIdeaLogo.svg",
+        "label": "Ultimate",
+        "image": "{{.Repository}}/ide/intellij:2022.3.3",
+        "imageLayers": [
+          "{{.JetBrainsPluginImagePrevious}}",
+          "{{.JetBrainsLauncherImagePrevious}}"
+        ]
+      },
+      "goland": {
+        "orderKey": "050",
+        "title": "GoLand",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/golandLogo.svg",
+        "image": "{{.Repository}}/ide/goland:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/goland:latest",
+        "pluginImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4",
+        "pluginLatestImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4-latest",
+        "imageLayers": [
+          "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4",
+          "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+        ],
+        "latestImageLayers": [
+          "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4-latest",
+          "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/goland:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.6",
+            "image": "{{.Repository}}/ide/goland:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "pycharm": {
+        "orderKey": "060",
+        "title": "PyCharm",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/pycharmLogo.svg",
+        "label": "Professional",
+        "image": "{{.Repository}}/ide/pycharm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/pycharm:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/pycharm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.5",
+            "image": "{{.Repository}}/ide/pycharm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "phpstorm": {
+        "orderKey": "070",
+        "title": "PhpStorm",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/phpstormLogo.svg",
+        "image": "{{.Repository}}/ide/phpstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/phpstorm:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/phpstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.6",
+            "image": "{{.Repository}}/ide/phpstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "rubymine": {
+        "orderKey": "080",
+        "title": "RubyMine",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/rubymineLogo.svg",
+        "image": "{{.Repository}}/ide/rubymine:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/rubymine:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/rubymine:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.6",
+            "image": "{{.Repository}}/ide/rubymine:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "webstorm": {
+        "orderKey": "090",
+        "title": "WebStorm",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/webstormLogo.svg",
+        "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/webstorm:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "versions": [
+          {
+            "version": "2024.1",
+            "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          },
+          {
+            "version": "2023.3.6",
+            "image": "{{.Repository}}/ide/webstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
+              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+            ]
+          }
+        ]
+      },
+      "rider": {
+        "orderKey": "100",
+        "title": "Rider",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/riderLogo.svg",
+        "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/rider:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ]
+      },
+      "clion": {
+        "orderKey": "110",
+        "title": "CLion",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/clionLogo.svg",
+        "image": "{{.Repository}}/ide/clion:commit-ef400309563b040b84d9588862805ce2f26d688a",
+        "latestImage": "{{.Repository}}/ide/clion:latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
+        "imageLayers": [
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ],
+        "latestImageLayers": [
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
+        ]
+      },
+      "xterm": {
+        "orderKey": "120",
+        "title": "Terminal",
+        "type": "browser",
+        "logo": "{{.IdeLogoBase}}/terminal.svg",
+        "label": "Insiders",
+        "image": "{{.Repository}}/ide/xterm-web:latest",
+        "latestImage": "{{.Repository}}/ide/xterm-web:latest",
+        "resolveImageDigest": true
+      }
+    },
+    "defaultIde": "code",
+    "defaultDesktopIde": "code-desktop",
+    "clients": {
+      "jetbrains-gateway": {
+        "defaultDesktopIDE": "intellij",
+        "desktopIDEs": [
+          "intellij",
+          "goland",
+          "pycharm",
+          "phpstorm",
+          "rubymine",
+          "webstorm",
+          "rider",
+          "clion"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below."
+        ]
+      },
+      "vscode": {
+        "defaultDesktopIDE": "code-desktop",
+        "desktopIDEs": [
+          "code-desktop"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below."
+        ]
+      },
+      "vscode-insiders": {
+        "defaultDesktopIDE": "code-desktop",
+        "desktopIDEs": [
+          "code-desktop"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below."
+        ]
+      }
+    }
+  }
+}

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -129,15 +129,15 @@
         "logo": "{{.IdeLogoBase}}/golandLogo.svg",
         "image": "{{.Repository}}/ide/goland:{{.WorkspaceVersions.Workspace.DesktopIdeImages.GoLandImage.Version}}",
         "latestImage": "{{.Repository}}/ide/goland:latest",
-        "pluginImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4",
-        "pluginLatestImage": "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4-latest",
+        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
         "imageLayers": [
-          "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4",
-          "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsLauncherImage}}"
         ],
         "latestImageLayers": [
-          "{{.Repository}}/ide/jb-backend-plugin:commit-51866638eaee0cf51bd11e46ef6e1cecf54d23c4-latest",
-          "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+          "{{.JetBrainsPluginLatestImage}}",
+          "{{.JetBrainsLauncherImage}}"
         ],
         "versions": [
           {

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -53,14 +53,6 @@
           }
         ]
       },
-      "code-desktop": {
-        "orderKey": "020",
-        "title": "VS Code",
-        "type": "desktop",
-        "logo": "{{.IdeLogoBase}}/vscode.svg",
-        "image": "{{.Repository}}/ide/code-desktop:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592",
-        "latestImage": "{{.Repository}}/ide/code-desktop-insiders:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592"
-      },
       "code1_85": {
         "orderKey": "011",
         "title": "VS Code",
@@ -72,6 +64,14 @@
           "{{.CodeWebExtensionImage}}",
           "{{.CodeHelperImage}}"
         ]
+      },
+      "code-desktop": {
+        "orderKey": "020",
+        "title": "VS Code",
+        "type": "desktop",
+        "logo": "{{.IdeLogoBase}}/vscode.svg",
+        "image": "{{.Repository}}/ide/code-desktop:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592",
+        "latestImage": "{{.Repository}}/ide/code-desktop-insiders:commit-9d4bc72a7ffeb47ff083aabb9747a7f67c459592"
       },
       "intellij": {
         "orderKey": "040",

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -5,10 +5,13 @@
 package ide_service
 
 import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
 	"fmt"
+	"html/template"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace/ide"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 
@@ -19,13 +22,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+//go:embed ide-configmap.json
+var ideConfigFile string
+
 func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	getIdeLogoPath := func(name string) string {
-		return fmt.Sprintf("https://ide.%s/image/ide-logo/%s.svg", ctx.Config.Domain, name)
-	}
-
-	codeDesktop := "code-desktop"
-
 	/*
 		Upgrading previous JB Version:
 
@@ -44,19 +44,6 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 		TODO: When should it happen? Once a year? Each time when a new major is released, move previous to next, i.e. tracking 1 year behind?
 	*/
-	intellijPrevious := "intellij-previous"
-	jbPluginPrevious := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f")
-	jbLauncherPrevious := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9")
-
-	intellij := "intellij"
-	goland := "goland"
-	pycharm := "pycharm"
-	phpstorm := "phpstorm"
-	rubymine := "rubymine"
-	webstorm := "webstorm"
-	rider := "rider"
-	clion := "clion"
-	xterm := "xterm"
 
 	resolveLatestImage := func(name string, tag string, bundledLatest versions.Versioned) string {
 		resolveLatest := true
@@ -69,330 +56,51 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return ctx.ImageName(ctx.Config.Repository, name, bundledLatest.Version)
 	}
 
-	codeHelperImage := ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, ctx.VersionManifest.Components.Workspace.CodeHelperImage.Version)
-	codeWebExtensionImage := ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, ide.CodeWebExtensionVersion)
-	jbPluginImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginImage.Version)
-	jbPluginLatestImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version)
-	jbLauncherImage := ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version)
-	idecfg := ide_config.IDEConfig{
-		SupervisorImage: ctx.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
-		IdeOptions: ide_config.IDEOptions{
-			Clients: map[string]ide_config.IDEClient{
-				"vscode": {
-					DefaultDesktopIDE: codeDesktop,
-					DesktopIDEs:       []string{codeDesktop},
-					InstallationSteps: []string{
-						"If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
-					},
-				},
-				"vscode-insiders": {
-					DefaultDesktopIDE: codeDesktop,
-					DesktopIDEs:       []string{codeDesktop},
-					InstallationSteps: []string{
-						"If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
-					},
-				},
-				"jetbrains-gateway": {
-					DefaultDesktopIDE: intellij,
-					DesktopIDEs:       []string{intellij, goland, pycharm, phpstorm, rubymine, webstorm, rider, clion},
-					InstallationSteps: []string{
-						"If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
-					},
-				},
-			},
-			Options: map[string]ide_config.IDEOption{
-				"code": {
-					OrderKey:          "010",
-					Title:             "VS Code",
-					Type:              ide_config.IDETypeBrowser,
-					Label:             "Browser",
-					Logo:              getIdeLogoPath("vscode"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.CodeIDEImageStableVersion),
-					ImageLayers:       []string{codeWebExtensionImage, codeHelperImage},
-					LatestImage:       resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
-					LatestImageLayers: []string{codeWebExtensionImage, codeHelperImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "1.88.0",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-7721fe825201d4d8d53975f81de0b063d94383cc"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, "commit-4e069a6195f3926ba8b84725bc806228f4cb94ec"),
-								ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, "commit-4f921cd94dfe046097167e177a6e781f3aa00d70"),
-							},
-						},
-						{
-							Version: "1.87.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-aaa9aeb1a12870ab8c19ca8a928d76849bc24c84"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, "commit-4e069a6195f3926ba8b84725bc806228f4cb94ec"),
-								ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, "commit-4f921cd94dfe046097167e177a6e781f3aa00d70"),
-							},
-						},
-						{
-							Version: "1.87.0",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-82dc424633bdc7266b46302042dd98af201fa8f8"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, "commit-4e069a6195f3926ba8b84725bc806228f4cb94ec"),
-								ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, "commit-4f921cd94dfe046097167e177a6e781f3aa00d70"),
-							},
-						},
-						{
-							Version: "1.86.2",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, "commit-d86f6aa033943c9650d06339915e68063b0cf142"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, "commit-4e069a6195f3926ba8b84725bc806228f4cb94ec"),
-								ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, "commit-4f921cd94dfe046097167e177a6e781f3aa00d70"),
-							},
-						},
-					},
-				},
-				"code1_85": {
-					OrderKey:    "011",
-					Title:       "VS Code",
-					Type:        ide_config.IDETypeBrowser,
-					Label:       "Browser",
-					Logo:        getIdeLogoPath("vscode"),
-					Image:       ctx.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.Code1_85IDEImageStableVersion),
-					ImageLayers: []string{codeWebExtensionImage, codeHelperImage},
-				},
-				codeDesktop: {
-					OrderKey:    "020",
-					Title:       "VS Code",
-					Type:        ide_config.IDETypeDesktop,
-					Logo:        getIdeLogoPath("vscode"),
-					Image:       ctx.ImageName(ctx.Config.Repository, ide.CodeDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImage.Version),
-					LatestImage: ctx.ImageName(ctx.Config.Repository, ide.CodeDesktopInsidersIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImageInsiders.Version),
-				},
-				intellij: {
-					OrderKey:          "040",
-					Title:             "IntelliJ IDEA",
-					Label:             "Ultimate",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("intellijIdeaLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.IntelliJImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.6",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				intellijPrevious: {
-					OrderKey:    "041",
-					Title:       "IntelliJ IDEA",
-					Label:       "Ultimate",
-					Type:        ide_config.IDETypeDesktop,
-					Logo:        getIdeLogoPath("intellijIdeaLogo"),
-					Image:       ctx.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, "2022.3.3"),
-					ImageLayers: []string{jbPluginPrevious, jbLauncherPrevious},
-				},
-				goland: {
-					OrderKey:          "050",
-					Title:             "GoLand",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("golandLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.6",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				pycharm: {
-					OrderKey:          "060",
-					Title:             "PyCharm",
-					Label:             "Professional",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("pycharmLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PyCharmImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.5",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				phpstorm: {
-					OrderKey:          "070",
-					Title:             "PhpStorm",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("phpstormLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PhpStormImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.6",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				rubymine: {
-					OrderKey:          "080",
-					Title:             "RubyMine",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("rubymineLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.RubyMineImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.6",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.RubyMineDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				webstorm: {
-					OrderKey:          "090",
-					Title:             "WebStorm",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("webstormLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.WebStormImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-					Versions: []ide_config.IDEVersion{
-						{
-							Version: "2024.1",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-ef400309563b040b84d9588862805ce2f26d688a"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-						{
-							Version: "2023.3.6",
-							Image:   ctx.ImageName(ctx.Config.Repository, ide.WebStormDesktopIdeImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-							ImageLayers: []string{
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-dc860e22fa7c07401c6dce62360589ff36e36bba"),
-								ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"),
-							},
-						},
-					},
-				},
-				rider: {
-					OrderKey:          "100",
-					Title:             "Rider",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("riderLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.RiderImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.RiderDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-				},
-				clion: {
-					OrderKey:          "110",
-					Title:             "CLion",
-					Type:              ide_config.IDETypeDesktop,
-					Logo:              getIdeLogoPath("clionLogo"),
-					Image:             ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CLionImage.Version),
-					LatestImage:       ctx.ImageName(ctx.Config.Repository, ide.CLionDesktopIdeImage, "latest"),
-					PluginImage:       jbPluginImage,
-					PluginLatestImage: jbPluginLatestImage,
-					ImageLayers:       []string{jbPluginImage, jbLauncherImage},
-					LatestImageLayers: []string{jbPluginLatestImage, jbLauncherImage},
-				},
-				xterm: {
-					OrderKey: "120",
-					Title:    "Terminal",
-					Type:     ide_config.IDETypeBrowser,
-					Logo:     getIdeLogoPath("terminal"),
-					Label:    "Insiders",
-					// todo(ft): implement proper versioning for xterm
-					Image:              ctx.ImageName(ctx.Config.Repository, ide.XtermIDEImage, "latest"),
-					LatestImage:        ctx.ImageName(ctx.Config.Repository, ide.XtermIDEImage, "latest"),
-					ResolveImageDigest: true,
-				},
-			},
-			DefaultIde:        "code",
-			DefaultDesktopIde: codeDesktop,
-		},
+	type ConfigTemplate struct {
+		Repository  string
+		IdeLogoBase string
+
+		ResolvedLatestCodeBrowserImage string
+		CodeHelperImage                string
+		CodeWebExtensionImage          string
+
+		JetBrainsPluginImage           string
+		JetBrainsPluginLatestImage     string
+		JetBrainsLauncherImage         string
+		JetBrainsPluginImagePrevious   string
+		JetBrainsLauncherImagePrevious string
+	}
+
+	configTmpl := ConfigTemplate{
+		Repository:  ctx.Config.Repository,
+		IdeLogoBase: fmt.Sprintf("https://ide.%s/image/ide-logo", ctx.Config.Domain),
+
+		ResolvedLatestCodeBrowserImage: resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
+		CodeHelperImage:                ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, ctx.VersionManifest.Components.Workspace.CodeHelperImage.Version),
+		CodeWebExtensionImage:          ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, ide.CodeWebExtensionVersion),
+
+		JetBrainsPluginImage:           ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginImage.Version),
+		JetBrainsPluginLatestImage:     ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version),
+		JetBrainsLauncherImage:         ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version),
+		JetBrainsPluginImagePrevious:   ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f"),
+		JetBrainsLauncherImagePrevious: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9"),
+	}
+
+	tmpl, err := template.New("configmap").Parse(ideConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ide-config config: %w", err)
+	}
+
+	result := &bytes.Buffer{}
+	err = tmpl.Execute(result, configTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute ide-config config: %w", err)
+	}
+
+	idecfg := ide_config.IDEConfig{}
+	err = json.Unmarshal(result.Bytes(), &idecfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ide-config config: %w", err)
 	}
 
 	if idecfg.IdeOptions.Options[idecfg.IdeOptions.DefaultIde].Type != ide_config.IDETypeBrowser {

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -41,7 +41,8 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Repository  string
 		IdeLogoBase string
 
-		ResolvedLatestCodeBrowserImage string
+		CodeBrowserVersionStable       string
+		ResolvedCodeBrowserImageLatest string
 		CodeHelperImage                string
 		CodeWebExtensionImage          string
 
@@ -50,13 +51,16 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		JetBrainsLauncherImage         string
 		JetBrainsPluginImagePrevious   string
 		JetBrainsLauncherImagePrevious string
+
+		WorkspaceVersions versions.Components
 	}
 
 	configTmpl := ConfigTemplate{
 		Repository:  ctx.Config.Repository,
 		IdeLogoBase: fmt.Sprintf("https://ide.%s/image/ide-logo", ctx.Config.Domain),
 
-		ResolvedLatestCodeBrowserImage: resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
+		CodeBrowserVersionStable:       ide.CodeIDEImageStableVersion,
+		ResolvedCodeBrowserImageLatest: resolveLatestImage(ide.CodeIDEImage, "nightly", ctx.VersionManifest.Components.Workspace.CodeImage),
 		CodeHelperImage:                ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, ctx.VersionManifest.Components.Workspace.CodeHelperImage.Version),
 		CodeWebExtensionImage:          ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, ide.CodeWebExtensionVersion),
 
@@ -65,6 +69,8 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		JetBrainsLauncherImage:         ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version),
 		JetBrainsPluginImagePrevious:   ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f"),
 		JetBrainsLauncherImagePrevious: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9"),
+
+		WorkspaceVersions: ctx.VersionManifest.Components,
 	}
 
 	tmpl, err := template.New("configmap").Parse(ideConfigFile)

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -26,25 +26,6 @@ import (
 var ideConfigFile string
 
 func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	/*
-		Upgrading previous JB Version:
-
-		1. Access the previous JB version at: https://github.com/gitpod-io/gitpod/tree/jb/previous
-		2. Upgrade Process:
-		   - Navigate to the update script:
-		     https://github.com/gitpod-io/gitpod/blob/jb/previous/components/ide/jetbrains/image/gha-update-image
-		   - Execute the script with the desired version as an argument. For example, to upgrade to versions below 231:
-		     node index.js 231
-		   - This action will update both the WORKSPACE.yaml and the backend plugin's target platform version.
-		3. Transfer the changes to gradle-latest.properties to avoid version incompatibilities with latest.
-		4. Resolve any incompatibility issues that arise with the plugin.
-		5. Commit and push your changes to GitHub. This will trigger the build job, generating new images.
-		6. Test the new images in preview environments with stable versions.
-		7. If everything works as expected, update the versions for the plugin and IDEs here where the previous plugin was used.
-
-		TODO: When should it happen? Once a year? Each time when a new major is released, move previous to next, i.e. tracking 1 year behind?
-	*/
-
 	resolveLatestImage := func(name string, tag string, bundledLatest versions.Versioned) string {
 		resolveLatest := true
 		if ctx.Config.Components != nil && ctx.Config.Components.IDE != nil && ctx.Config.Components.IDE.ResolveLatest != nil {


### PR DESCRIPTION
## Description

Introduces a JSON file, which will act as a single source of truth for the IDE configmap of `ide-service`. This change is made in order to enable its automatic change when new JetBrains IDEs are released (pending follow-up PR).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1805

## How to test

Test that all IDEs still launch properly.

You can also compare the configmap - it should be the same as it was before these changes.

```
kubectl get cm ide-config -o yaml > configmap.yaml
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-ide-condcfaf3a439</li>
	<li><b>🔗 URL</b> - <a href="https://ft-ide-condcfaf3a439.preview.gitpod-dev.com/workspaces" target="_blank">ft-ide-condcfaf3a439.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-ide-configmap-as-json-gha.24319</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-ide-condcfaf3a439%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
