### PR TITLE
[bitbucket.org] fix normalizeScopes

### DIFF
--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -100,14 +100,18 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
 
     protected normalizeScopes(scopes: string[]) {
         const set = new Set(scopes);
-        if (set.has("issue:write")) {
-            set.add("repository:write");
+        if (set.has(BitbucketOAuthScopes.REPOSITORY_WRITE)) {
+            set.add(BitbucketOAuthScopes.REPOSITORY_READ);
         }
-        if (set.has("repository:write")) {
-            set.add("repository");
+        if (set.has(BitbucketOAuthScopes.PULL_REQUEST_READ)) {
+            // https://developer.atlassian.com/cloud/bitbucket/bitbucket-cloud-rest-api-scopes/#pullrequest
+            set.add(BitbucketOAuthScopes.REPOSITORY_READ);
         }
-        if (set.has("pullrequest:write")) {
-            set.add("pullrequest");
+        if (set.has(BitbucketOAuthScopes.PULL_REQUEST_WRITE)) {
+            // https://developer.atlassian.com/cloud/bitbucket/bitbucket-cloud-rest-api-scopes/#pullrequest-write
+            set.add(BitbucketOAuthScopes.REPOSITORY_WRITE);
+            set.add(BitbucketOAuthScopes.REPOSITORY_READ);
+            set.add(BitbucketOAuthScopes.PULL_REQUEST_READ);
         }
         for (const item of set.values()) {
             if (!BitbucketOAuthScopes.Requirements.DEFAULT.includes(item)) {


### PR DESCRIPTION
Aligned with official docs on BB scopes:
https://developer.atlassian.com/cloud/bitbucket/bitbucket-cloud-rest-api-scopes/

For the reviewer, please proofread the related section in the linked docs and pay attention to the implied scopes. 

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - at-bb-imply-scopes</li>
	<li><b>🔗 URL</b> - <a href="https://at-bb-imply-scopes.preview.gitpod-dev.com/workspaces" target="_blank">at-bb-imply-scopes.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - at-bb-imply-scopes-gha.24330</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-at-bb-imply-scopes%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
