### PR TITLE
[ws-manager-mk2] logging improvements

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -498,7 +498,7 @@ func (w *Workspace) IsConditionTrue(condition WorkspaceCondition) bool {
 // OWI produces the owner, workspace, instance log metadata from the information
 // of this workspace.
 func (w *Workspace) OWI() logrus.Fields {
-	return log.OWI(w.Spec.Ownership.Owner, w.Spec.Ownership.WorkspaceID, w.Name)
+	return log.OWI(w.Spec.Ownership.Owner, "", w.Name)
 }
 
 func init() {

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -498,7 +498,7 @@ func (w *Workspace) IsConditionTrue(condition WorkspaceCondition) bool {
 // OWI produces the owner, workspace, instance log metadata from the information
 // of this workspace.
 func (w *Workspace) OWI() logrus.Fields {
-	return log.OWI(w.Spec.Ownership.Owner, "", w.Name)
+	return log.OWI(w.Spec.Ownership.Owner, w.Spec.Ownership.WorkspaceID, w.Name)
 }
 
 func init() {

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -42,7 +42,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	span, ctx := tracing.FromContext(ctx, "updateWorkspaceStatus")
 	defer tracing.FinishSpan(span, &err)
 	owi := workspace.OWI()
-	log := log.FromContext(ctx).WithValues(owi)
+	log := log.FromContext(ctx).WithValues("owi", owi)
 
 	oldPhase := workspace.Status.Phase
 	defer func() {
@@ -265,7 +265,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
 		owi := workspace.OWI()
-		log.FromContext(ctx).WithValues(owi).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
+		log.FromContext(ctx).WithValues("owi", owi).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	config "github.com/gitpod-io/gitpod/ws-manager/api/config"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/go-logr/logr"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,6 +43,7 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	span, ctx := tracing.FromContext(ctx, "updateWorkspaceStatus")
 	defer tracing.FinishSpan(span, &err)
 	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
+	ctx = logr.NewContext(ctx, log)
 
 	oldPhase := workspace.Status.Phase
 	defer func() {
@@ -263,7 +265,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
-		log.FromContext(ctx).WithValues("owi", workspace.OWI()).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
+		log.FromContext(ctx).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -41,8 +41,7 @@ const (
 func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace, pods *corev1.PodList, cfg *config.Configuration) (err error) {
 	span, ctx := tracing.FromContext(ctx, "updateWorkspaceStatus")
 	defer tracing.FinishSpan(span, &err)
-	owi := workspace.OWI()
-	log := log.FromContext(ctx).WithValues("owi", owi)
+	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
 
 	oldPhase := workspace.Status.Phase
 	defer func() {
@@ -264,8 +263,7 @@ func (r *WorkspaceReconciler) checkNodeDisappeared(ctx context.Context, workspac
 
 	if !isDisposalFinished(workspace) {
 		// Node disappeared before a backup could be taken, mark it with a backup failure.
-		owi := workspace.OWI()
-		log.FromContext(ctx).WithValues("owi", owi).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
+		log.FromContext(ctx).WithValues("owi", workspace.OWI()).Error(nil, "workspace node disappeared while disposal has not finished yet", "node", pod.Spec.NodeName)
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionBackupFailure("workspace node disappeared before backup was taken"))
 	}
 

--- a/components/ws-manager-mk2/controllers/timeout_controller.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/maintenance"
 	config "github.com/gitpod-io/gitpod/ws-manager/api/config"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/go-logr/logr"
 )
 
 func NewTimeoutReconciler(c client.Client, recorder record.EventRecorder, cfg config.Configuration, maintenance maintenance.Maintenance) (*TimeoutReconciler, error) {
@@ -81,6 +82,7 @@ func (r *TimeoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log = log.WithValues("owi", workspace.OWI())
+	ctx = logr.NewContext(ctx, log)
 
 	if workspace.IsConditionTrue(workspacev1.WorkspaceConditionTimeout) {
 		// Workspace has already been marked as timed out.

--- a/components/ws-manager-mk2/controllers/timeout_controller.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller.go
@@ -80,6 +80,7 @@ func (r *TimeoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		// backoff.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log = log.WithValues("owi", workspace.OWI())
 
 	if workspace.IsConditionTrue(workspacev1.WorkspaceConditionTimeout) {
 		// Workspace has already been marked as timed out.

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -113,6 +113,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		workspace.Status.Conditions = []metav1.Condition{}
 	}
 
+	log = log.WithValues("owi", workspace.OWI())
 	log.V(2).Info("reconciling workspace", "workspace", req.NamespacedName, "phase", workspace.Status.Phase)
 
 	workspacePods, err := r.listWorkspacePods(ctx, &workspace)

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -168,7 +168,7 @@ func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspa
 func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (result ctrl.Result, err error) {
 	span, ctx := tracing.FromContext(ctx, "actOnStatus")
 	defer tracing.FinishSpan(span, &err)
-	log := log.FromContext(ctx).WithValues(workspace.OWI())
+	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
 
 	if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped && !r.metrics.containsWorkspace(workspace) {
 		// If the workspace hasn't stopped yet, and we don't know about this workspace yet, remember it.
@@ -324,7 +324,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 }
 
 func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *workspacev1.Workspace) {
-	log := log.FromContext(ctx).WithValues(workspace.OWI())
+	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
 
 	ok, lastState := r.metrics.getWorkspace(&log, workspace)
 	if !ok {
@@ -437,7 +437,7 @@ func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev
 func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) (err error) {
 	span, ctx := tracing.FromContext(ctx, "deleteWorkspaceSecrets")
 	defer tracing.FinishSpan(span, &err)
-	log := log.FromContext(ctx).WithValues(ws.OWI())
+	log := log.FromContext(ctx).WithValues("owi", ws.OWI())
 
 	// if a secret cannot be deleted we do not return early because we want to attempt
 	// the deletion of the remaining secrets

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -114,6 +114,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log = log.WithValues("owi", workspace.OWI())
+	ctx = logr.NewContext(ctx, log)
 	log.V(2).Info("reconciling workspace", "workspace", req.NamespacedName, "phase", workspace.Status.Phase)
 
 	workspacePods, err := r.listWorkspacePods(ctx, &workspace)
@@ -169,7 +170,7 @@ func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspa
 func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (result ctrl.Result, err error) {
 	span, ctx := tracing.FromContext(ctx, "actOnStatus")
 	defer tracing.FinishSpan(span, &err)
-	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
+	log := log.FromContext(ctx)
 
 	if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped && !r.metrics.containsWorkspace(workspace) {
 		// If the workspace hasn't stopped yet, and we don't know about this workspace yet, remember it.
@@ -325,7 +326,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 }
 
 func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *workspacev1.Workspace) {
-	log := log.FromContext(ctx).WithValues("owi", workspace.OWI())
+	log := log.FromContext(ctx)
 
 	ok, lastState := r.metrics.getWorkspace(&log, workspace)
 	if !ok {

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -168,7 +168,7 @@ func (r *WorkspaceReconciler) listWorkspacePods(ctx context.Context, ws *workspa
 func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *workspacev1.Workspace, workspacePods *corev1.PodList) (result ctrl.Result, err error) {
 	span, ctx := tracing.FromContext(ctx, "actOnStatus")
 	defer tracing.FinishSpan(span, &err)
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithValues(workspace.OWI())
 
 	if workspace.Status.Phase != workspacev1.WorkspacePhaseStopped && !r.metrics.containsWorkspace(workspace) {
 		// If the workspace hasn't stopped yet, and we don't know about this workspace yet, remember it.
@@ -324,7 +324,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 }
 
 func (r *WorkspaceReconciler) updateMetrics(ctx context.Context, workspace *workspacev1.Workspace) {
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithValues(workspace.OWI())
 
 	ok, lastState := r.metrics.getWorkspace(&log, workspace)
 	if !ok {
@@ -437,7 +437,7 @@ func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev
 func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) (err error) {
 	span, ctx := tracing.FromContext(ctx, "deleteWorkspaceSecrets")
 	defer tracing.FinishSpan(span, &err)
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithValues(ws.OWI())
 
 	// if a secret cannot be deleted we do not return early because we want to attempt
 	// the deletion of the remaining secrets


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Record phase transitions, rather record phase each time we reconcile
* Add OWI to log instances
* Avoid logging workspace name in workspace_types.go, as it contains org and repo info.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENG-2016

## How to test
<!-- Provide steps to test this PR -->
Start a workspace and observe the logs. Also, results stored [here](https://github.com/gitpod-io/gitpod/pull/19635#issuecomment-2064659417).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-s8bc1d869e7</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-s8bc1d869e7.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-s8bc1d869e7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-status-log-2-gha.24387</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-s8bc1d869e7%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
