### PR TITLE
Hide editor versions for user prefs

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -228,7 +228,7 @@ const IdeOptionElementSelected = ({
                             <span className="font-normal">{version}</span>{" "}
                         </>
                     )}
-                    {useLatest && (
+                    {useLatest && !hideVersion && (
                         <div className="ml-1 rounded-xl bg-pk-content-tertiary/10 px-2 py-1 inline text-sm font-normal">
                             Latest
                         </div>
@@ -282,7 +282,7 @@ function IdeOptionElementInDropDown({ option, useLatest, pinnedIdeVersion, hideV
                         <span className="capitalize">{label}</span>
                     </>
                 )}
-                {useLatest && <div className="ml-2 rounded-xl bg-gray-200 px-2">Latest</div>}
+                {useLatest && !hideVersion && <div className="ml-2 rounded-xl bg-gray-200 px-2">Latest</div>}
             </div>
         </div>
     );

--- a/components/dashboard/src/onboarding/StepPersonalize.tsx
+++ b/components/dashboard/src/onboarding/StepPersonalize.tsx
@@ -52,6 +52,7 @@ export const StepPersonalize: FC<Props> = ({ user, onComplete }) => {
                 ignoreRestrictionScopes={["configuration", "organization"]}
                 selectedIdeOption={ide}
                 useLatest={useLatest}
+                hideVersions
             />
 
             <ThemeSelector className="mt-4" />

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -90,6 +90,7 @@ export default function SelectIDE(props: SelectIDEProps) {
                     useLatest={useLatestVersion}
                     setWarning={setIdeWarning}
                     ignoreRestrictionScopes={isOrgOwnedUser ? ["configuration"] : ["configuration", "organization"]}
+                    hideVersions
                 />
             </div>
 

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -112,7 +112,7 @@
       },
       "intellij-previous": {
         "orderKey": "041",
-        "title": "IntelliJ IDEA",
+        "title": "IntelliJ IDEA 2022.3.3",
         "type": "desktop",
         "logo": "{{.IdeLogoBase}}/intellijIdeaLogo.svg",
         "label": "Ultimate",


### PR DESCRIPTION
## Description

IDE versions were previously shown in user preferences, but workspaces are not based on user preferences - the versions used are fetched from the organization's config. Because of this, we are changing these UIs to hide the version, and only show it in the create workspace page, where the version which will actually be used is shown.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1801

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-user-pr1e95611825</li>
	<li><b>🔗 URL</b> - <a href="https://ft-user-pr1e95611825.preview.gitpod-dev.com/workspaces" target="_blank">ft-user-pr1e95611825.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-user-prefs-no-editor-versions-gha.24424</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-user-pr1e95611825%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
