### PR TITLE
[JetBrains] Update Platform Version from JetBrains Gateway Plugin (EAP)

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -1,10 +1,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=241.14494
+pluginSinceBuild=241.15989
 pluginUntilBuild=241.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.1
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=241.14494-EAP-CANDIDATE-SNAPSHOT
+platformVersion=241.15989-EAP-CANDIDATE-SNAPSHOT
 


### PR DESCRIPTION
## Description
This PR updates the Platform Version from JetBrains Gateway Plugin (EAP) to the latest version.

## How to test

Merge if tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. Ensure you have the Gateway installed from [JetBrains Toolbox App](https://www.jetbrains.com/toolbox-app/) and have it up-to-date.
  - You should use Gateway version corresponding to plugin qualifier, i.e. for stable plugin test with released, for latest test with EAP.
  - It could be that a new Gateway is not published for the given SDK yet then wait for it to be published. You can check the build version in the About dialog.
2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
  - You can also uninstall current Gitpod plugin, configure dev channel using https://plugins.jetbrains.com/plugins/list?channel=dev&pluginId=18438-gitpod-gateway and restart GW to test that the proper version is detected and installed.
3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
</details>

## Release Notes
```release-note
NONE
```

## Werft options:
- [x] /werft publish-to-jb-marketplace
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=true

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._