### PR TITLE
[idp] improve idp

### DIFF
--- a/components/gitpod-cli/cmd/idp-gcloud-token.go
+++ b/components/gitpod-cli/cmd/idp-gcloud-token.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
@@ -22,7 +22,7 @@ var idpGCloudTokenOpts struct {
 
 var idpGCloudTokenCmd = &cobra.Command{
 	Use:   "gcloud-token",
-	Short: "Requests an gcloud format ID token for this workspace",
+	Short: "Requests a gcloud format ID token for this workspace",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 		if len(idpGCloudTokenOpts.Audience) == 0 {

--- a/components/gitpod-cli/cmd/idp-gcloud-token.go
+++ b/components/gitpod-cli/cmd/idp-gcloud-token.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/spf13/cobra"
+)
+
+var idpGCloudTokenOpts struct {
+	Audience []string
+}
+
+var idpGCloudTokenCmd = &cobra.Command{
+	Use:   "gcloud-token",
+	Short: "Requests an gcloud format ID token for this workspace",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		if len(idpGCloudTokenOpts.Audience) == 0 {
+			return fmt.Errorf("missing --audience or GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE env var")
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+
+		defer func() {
+			if err != nil {
+				out, _ := json.Marshal(map[string]any{
+					"version": 1,
+					"success": false,
+					"code":    "401",
+					"message": err.Error(),
+				})
+				fmt.Print(string(out))
+			}
+		}()
+
+		tkn, err := idpToken(ctx, idpGCloudTokenOpts.Audience)
+		if err != nil {
+			return err
+		}
+
+		token, _, err := jwt.NewParser().ParseUnverified(tkn, jwt.MapClaims{})
+		if err != nil {
+			return err
+		}
+
+		expirationDate, err := token.Claims.GetExpirationTime()
+		if err != nil {
+			return err
+		}
+		out, err := json.Marshal(map[string]any{
+			"version":         1,
+			"success":         true,
+			"token_type":      "urn:ietf:params:oauth:token-type:id_token",
+			"id_token":        tkn,
+			"expiration_time": expirationDate.Unix(),
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(out))
+		if output := os.Getenv("GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE"); output != "" {
+			err := os.MkdirAll(path.Dir(output), 0600)
+			if err != nil {
+				// omit error
+				return nil
+			}
+			// omit error
+			_ = os.WriteFile(output, out, 0600)
+		}
+		return nil
+	},
+}
+
+func init() {
+	idpCmd.AddCommand(idpGCloudTokenCmd)
+	audience := []string{}
+	if aud := os.Getenv("GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE"); aud != "" {
+		audience = append(audience, aud)
+	}
+	idpGCloudTokenCmd.Flags().StringArrayVar(&idpGCloudTokenOpts.Audience, "audience", audience, "audience of the ID token")
+}

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/gitpod-io/gitpod/components/scrubber v0.0.0-00010101000000-000000000000 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect

--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -42,6 +42,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=

--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -96,6 +96,9 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo.AppendClaims("context", workspace.Workspace.ContextURL)
 	userInfo.AppendClaims("workspace_id", workspaceID)
 
+	if workspace.Workspace.Context != nil && workspace.Workspace.Context.Repository != nil && workspace.Workspace.Context.Repository.CloneURL != "" {
+		userInfo.AppendClaims("repository", workspace.Workspace.Context.Repository.CloneURL)
+	}
 	if email != "" {
 		userInfo.SetEmail(email, user.OrganizationId != "")
 		userInfo.AppendClaims("email", email)

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -60,6 +60,11 @@ func TestGetIDToken(t *testing.T) {
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{
 							ContextURL: "https://github.com/gitpod-io/gitpod",
+							Context: &protocol.WorkspaceContext{
+								Repository: &protocol.Repository{
+									CloneURL: "https://github.com/gitpod-io/gitpod.git",
+								},
+							},
 						},
 					},
 					nil,
@@ -103,6 +108,11 @@ func TestGetIDToken(t *testing.T) {
 					&protocol.WorkspaceInfo{
 						Workspace: &protocol.Workspace{
 							ContextURL: "https://github.com/gitpod-io/gitpod",
+							Context: &protocol.WorkspaceContext{
+								Repository: &protocol.Repository{
+									CloneURL: "https://github.com/gitpod-io/gitpod.git",
+								},
+							},
 						},
 					},
 					nil,

--- a/components/public-api-server/pkg/identityprovider/cache.go
+++ b/components/public-api-server/pkg/identityprovider/cache.go
@@ -97,6 +97,7 @@ func (imc *InMemoryCache) PublicKeys(ctx context.Context) ([]byte, error) {
 			Key:       key.Key,
 			KeyID:     key.ID,
 			Algorithm: string(jose.RS256),
+			Use:       "sig",
 		})
 	}
 
@@ -197,6 +198,7 @@ func serializePublicKeyAsJSONWebKey(keyID string, key *rsa.PublicKey) ([]byte, e
 		Key:       key,
 		KeyID:     keyID,
 		Algorithm: string(jose.RS256),
+		Use:       "sig",
 	}
 	return json.Marshal(publicKey)
 }

--- a/components/public-api-server/pkg/identityprovider/cache_test.go
+++ b/components/public-api-server/pkg/identityprovider/cache_test.go
@@ -49,6 +49,7 @@ func TestRedisCachePublicKeys(t *testing.T) {
 			Key:       &key.PublicKey,
 			Algorithm: string(jose.RS256),
 			KeyID:     testKeyID(key),
+			Use:       "sig",
 		})
 	}
 	sortKeys(&jwks)
@@ -93,10 +94,10 @@ func TestRedisCachePublicKeys(t *testing.T) {
 		{
 			Name: "no key in memory",
 			StateMod: func(c *redis.Client) error {
-				return c.Set(context.Background(), redisIDPKeyPrefix+"foo", `{"kty":"RSA","kid":"fpp","alg":"RS256","n":"VGVsbCBDaHJpcyB5b3UgZm91bmQgdGhpcyAtIGRyaW5rJ3Mgb24gbWU","e":"AQAB"}`, 0).Err()
+				return c.Set(context.Background(), redisIDPKeyPrefix+"foo", `{"use":"sig","kty":"RSA","kid":"fpp","alg":"RS256","n":"VGVsbCBDaHJpcyB5b3UgZm91bmQgdGhpcyAtIGRyaW5rJ3Mgb24gbWU","e":"AQAB"}`, 0).Err()
 			},
 			Expectation: Expectation{
-				Response: []byte(`{"keys":[{"kty":"RSA","kid":"fpp","alg":"RS256","n":"VGVsbCBDaHJpcyB5b3UgZm91bmQgdGhpcyAtIGRyaW5rJ3Mgb24gbWU","e":"AQAB"}]}`),
+				Response: []byte(`{"keys":[{"use":"sig","kty":"RSA","kid":"fpp","alg":"RS256","n":"VGVsbCBDaHJpcyB5b3UgZm91bmQgdGhpcyAtIGRyaW5rJ3Mgb24gbWU","e":"AQAB"}]}`),
 			},
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR bring bunch of idp improve
1. add repository claim, this is because context is not stable, and difficult to use as an assert
2. add the missing `use` field for key cache [ref](https://datatracker.ietf.org/doc/html/rfc7517#section-4.2) Although it is optional, adding it would be better as some SPs require verification.
3. simplify logic for `idp token --decode` command
4. add gcloud-format token support [test below]


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

<img width="646" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/b9be28ea-3512-49b4-94dc-ce7e38a3d6e2">

<img width="926" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/3f766bcf-a451-47d8-a13c-022dab2f56e4">

<img width="1138" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/e6b115a7-c4b1-48b4-a241-8ff274bb2a04">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-idp-improve</li>
	<li><b>🔗 URL</b> - <a href="https://pd-idp-improve.preview.gitpod-dev.com/workspaces" target="_blank">pd-idp-improve.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-idp-improve-gha.24470</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-idp-improve%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
