### PR TITLE
Update usage scheduler according to FF

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -38,11 +38,12 @@ const featureFlags = {
     // Logging tracing for added for investigate hanging issue
     dashboard_logging_tracing: false,
     showBrowserExtensionPromotion: false,
+    usage_update_scheduler_duration: "15m",
 };
 
 type FeatureFlags = typeof featureFlags;
 
-export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] | boolean => {
+export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] => {
     const user = useCurrentUser();
     const org = useCurrentOrg().data;
     const project = useCurrentProject().project;
@@ -66,7 +67,7 @@ export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): Fe
     return query.data !== undefined ? query.data : featureFlags[featureFlag];
 };
 
-export const useDedicatedFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] | boolean => {
+export const useDedicatedFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] => {
     const queryKey = ["dedicatedFeatureFlag", featureFlag];
 
     const query = useQuery(queryKey, async () => {

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -43,7 +43,7 @@ const featureFlags = {
 
 type FeatureFlags = typeof featureFlags;
 
-export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] => {
+export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] | boolean => {
     const user = useCurrentUser();
     const org = useCurrentOrg().data;
     const project = useCurrentProject().project;
@@ -67,7 +67,7 @@ export const useFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): Fe
     return query.data !== undefined ? query.data : featureFlags[featureFlag];
 };
 
-export const useDedicatedFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] => {
+export const useDedicatedFeatureFlag = <K extends keyof FeatureFlags>(featureFlag: K): FeatureFlags[K] | boolean => {
     const queryKey = ["dedicatedFeatureFlag", featureFlag];
 
     const query = useQuery(queryKey, async () => {

--- a/components/dashboard/src/data/usage/usage-query.ts
+++ b/components/dashboard/src/data/usage/usage-query.ts
@@ -15,8 +15,8 @@ export function useListUsage(request: ListUsageRequest) {
             return getGitpodService().server.listUsage(request);
         },
         {
-            cacheTime: 1000 * 60 * 10, // 10 minutes
-            staleTime: 1000 * 60 * 10, // 10 minutes
+            cacheTime: 1000 * 60 * 1, // 1 minutes
+            staleTime: 1000 * 60 * 1, // 1 minutes
             retry: false,
         },
     );

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -105,8 +105,8 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
         }
         const unit = duration.slice(-1);
         const unitStr = durationUnitMap[unit];
-        console.error("failed to parse duration", duration);
         if (!unitStr) {
+            console.error("failed to parse duration", duration);
             return "15 minutes";
         }
         const value = parseInt(duration.slice(0, -1), 10);

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -100,6 +100,9 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
 
     const readableSchedulerDuration = useMemo(() => {
         const duration = schedulerDuration.toLowerCase();
+        if (duration === "undefined") {
+            return "15 minutes";
+        }
         const unit = duration.slice(-1);
         const unitStr = durationUnitMap[unit];
         console.error("failed to parse duration", duration);

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -24,12 +24,20 @@ import classNames from "classnames";
 import { UsageDateFilters } from "./UsageDateFilters";
 import { DownloadUsage } from "./download/DownloadUsage";
 import { useQueryParams } from "../hooks/use-query-params";
+import { useFeatureFlag } from "../data/featureflag-query";
 
 const DATE_PARAM_FORMAT = "YYYY-MM-DD";
 
 interface UsageViewProps {
     attributionId: AttributionId;
 }
+
+const durationUnitMap: Record<string, string | undefined> = {
+    s: "seconds",
+    m: "minutes",
+    h: "hours",
+};
+
 export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
     const location = useLocation();
     const history = useHistory();
@@ -88,9 +96,23 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
 
     const usageEntries = usagePage.data?.usageEntriesList || [];
 
+    const schedulerDuration = useFeatureFlag("usage_update_scheduler_duration");
+
+    const readableSchedulerDuration = useMemo(() => {
+        const duration = schedulerDuration.toLowerCase();
+        const unit = duration.slice(-1);
+        const unitStr = durationUnitMap[unit];
+        console.error("failed to parse duration", duration);
+        if (!unitStr) {
+            return "15 minutes";
+        }
+        const value = parseInt(duration.slice(0, -1), 10);
+        return `${value} ${unitStr}`;
+    }, [schedulerDuration]);
+
     return (
         <>
-            <Header title="Usage" subtitle="Organization usage, updated every 15 minutes." />
+            <Header title="Usage" subtitle={"Organization usage, updated every " + readableSchedulerDuration + "."} />
             <div className="app-container pt-5">
                 <div
                     className={classNames(

--- a/components/dashboard/src/usage/UsageView.tsx
+++ b/components/dashboard/src/usage/UsageView.tsx
@@ -99,7 +99,7 @@ export const UsageView: FC<UsageViewProps> = ({ attributionId }) => {
     const schedulerDuration = useFeatureFlag("usage_update_scheduler_duration");
 
     const readableSchedulerDuration = useMemo(() => {
-        const duration = schedulerDuration.toLowerCase();
+        const duration = schedulerDuration.toString().toLowerCase();
         if (duration === "undefined") {
             return "15 minutes";
         }

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -29,7 +29,9 @@ require (
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/configcat/go-sdk/v7 v7.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gitpod-io/gitpod/components/scrubber v0.0.0-00010101000000-000000000000 // indirect

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -12,6 +12,8 @@ github.com/alicebob/miniredis/v2 v2.30.2 h1:lc1UAUT9ZA7h4srlfBmBt2aorm5Yftk9nBjx
 github.com/alicebob/miniredis/v2 v2.30.2/go.mod h1:b25qWj4fCEsBeAAR2mlb0ufImGC6uH3VlUfb/HS5zKg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
 github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
@@ -28,6 +30,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
+github.com/configcat/go-sdk/v7 v7.6.0 h1:CthQJ7DMz4bvUrpc8aek6VouJjisCvZCfuTG2gyNzL4=
+github.com/configcat/go-sdk/v7 v7.6.0/go.mod h1:2245V6Igy1Xz6GXvcYuK5z996Ct0VyzyuI470XS6aTw=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -44,6 +48,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/frankban/quicktest v1.11.2 h1:mjwHjStlXWibxOohM7HYieIViKyh56mmt3+6viyhDDI=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -98,6 +104,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -180,6 +187,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -215,6 +215,9 @@ func startScheduler(ctx context.Context, cfg Config, redsyncPool *redsync.Redsyn
 				newLedgerSchedule := exps.GetStringValue(ctx, "usage_update_scheduler_duration", cfg.LedgerSchedule, experiments.Attributes{
 					GitpodHost: cfg.GitpodHost,
 				})
+				if newLedgerSchedule == "" {
+					newLedgerSchedule = cfg.LedgerSchedule
+				}
 				if ledgerSchedule == newLedgerSchedule {
 					continue
 				}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -215,7 +215,7 @@ func startScheduler(ctx context.Context, cfg Config, redsyncPool *redsync.Redsyn
 				newLedgerSchedule := exps.GetStringValue(ctx, "usage_update_scheduler_duration", cfg.LedgerSchedule, experiments.Attributes{
 					GitpodHost: cfg.GitpodHost,
 				})
-				if newLedgerSchedule == "" {
+				if newLedgerSchedule == "undefined" {
 					newLedgerSchedule = cfg.LedgerSchedule
 				}
 				if ledgerSchedule == newLedgerSchedule {

--- a/components/usage/pkg/server/server_test.go
+++ b/components/usage/pkg/server/server_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gitpod-io/gitpod/common-go/experiments"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
+	"github.com/go-redis/redis"
+	"github.com/go-redsync/redsync/v4"
+	"github.com/go-redsync/redsync/v4/redis/goredis"
+	"google.golang.org/grpc"
+)
+
+// TEST_SCHEDULER=true go test -timeout 60s -run ^Test_startScheduler$ github.com/gitpod-io/gitpod/usage/pkg/server
+func Test_startScheduler(t *testing.T) {
+	if os.Getenv("TEST_SCHEDULER") != "true" {
+		t.Skipf("Skipping test because TEST_SCHEDULER is not set to true")
+	}
+
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+
+	pool := goredis.NewPool(client)
+	rs := redsync.New(pool)
+
+	type args struct {
+		name               string
+		expHandler         func(exps *mockExps)
+		expectUsageTimes   []int
+		expectBillTImes    []int
+		cfgTimeStringUsage string
+		cfgTimeStringBill  string
+		ctxTimeout         time.Duration
+		tickerDuration     time.Duration
+	}
+
+	tests := []args{
+		{
+			name: "happy path no bill reset",
+			expHandler: func(exps *mockExps) {
+				exps.StringValue = "undefined"
+			},
+			expectUsageTimes: []int{1, 2, 3},
+			expectBillTImes:  []int{0, 0, 0},
+			// exec 3 times
+			cfgTimeStringUsage: "3s",
+			ctxTimeout:         10 * time.Second,
+			tickerDuration:     3*time.Second + 100*time.Millisecond,
+		},
+		{
+			name: "happy path with default values",
+			expHandler: func(exps *mockExps) {
+				exps.StringValue = "undefined"
+			},
+			expectUsageTimes: []int{1, 2, 3},
+			expectBillTImes:  []int{0, 1, 2},
+			// exec 3 times
+			cfgTimeStringUsage: "3s",
+			cfgTimeStringBill:  "4s",
+			ctxTimeout:         10 * time.Second,
+			tickerDuration:     3*time.Second + 100*time.Millisecond,
+		},
+		{
+			name: "happy path with different values FF",
+			expHandler: func(exps *mockExps) {
+				<-time.After(time.Second * 2)
+				exps.StringValue = "1s"
+			},
+			expectUsageTimes: []int{1, 2, 4, 6, 8, 10},
+			expectBillTImes:  []int{0, 0, 0, 1, 1, 2},
+			// exec 6 times
+			cfgTimeStringUsage: "2s",
+			cfgTimeStringBill:  "4s",
+			ctxTimeout:         13 * time.Second,
+			tickerDuration:     2*time.Second + 100*time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := Config{
+				LedgerSchedule:     tt.cfgTimeStringUsage,
+				ResetUsageSchedule: tt.cfgTimeStringBill,
+			}
+			exps := mockExps{StringValue: "undefined"}
+			usage := mockUsageService{}
+			billing := mockBillService{}
+			mockClients := func() (v1.UsageServiceClient, v1.BillingServiceClient, error) {
+				return &usage, &billing, nil
+			}
+			go tt.expHandler(&exps)
+			ctx, cancel := context.WithTimeout(context.Background(), tt.ctxTimeout)
+			defer cancel()
+			startScheduler(ctx, &exps, mockConfig, rs, mockClients)
+			ticker := time.NewTicker(tt.tickerDuration)
+			defer ticker.Stop()
+			gotUsage := []int{}
+			gotBill := []int{}
+			for ctx.Err() == nil {
+				select {
+				case <-ticker.C:
+					log.Infof(">> usage %d", usage.ReconcileUsageTimes)
+					log.Infof(">> bill %d", usage.ResetUsageTimes)
+					gotUsage = append(gotUsage, usage.ReconcileUsageTimes)
+					gotBill = append(gotBill, usage.ResetUsageTimes)
+				case <-ctx.Done():
+					break
+				}
+			}
+			if len(gotUsage) != len(tt.expectUsageTimes) {
+				t.Errorf("%s expected ReconcileUsageTimes %v, got %v", tt.name, tt.expectUsageTimes, gotUsage)
+				return
+			}
+			if len(gotBill) != len(tt.expectBillTImes) {
+				t.Errorf("%s expected ResetUsageTimes %v, got %v", tt.name, tt.expectBillTImes, gotBill)
+				return
+			}
+			for i, v := range tt.expectUsageTimes {
+				if gotUsage[i] != v {
+					t.Errorf("%s expected ReconcileUsageTimes %v, got %v", tt.name, tt.expectUsageTimes, gotUsage)
+					break
+				}
+			}
+			for i, v := range tt.expectBillTImes {
+				if gotBill[i] != v {
+					t.Errorf("%s expected ResetUsageTimes %v, got %v", tt.name, tt.expectBillTImes, gotBill)
+					break
+				}
+			}
+			log.Infof("test %s completed", tt.name)
+		})
+	}
+
+}
+
+type mockUsageService struct {
+	ReconcileUsageTimes    int
+	ReconcileUsageTimesArr []int
+	ResetUsageTimes        int
+}
+
+var _ v1.UsageServiceClient = (*mockUsageService)(nil)
+
+func (m *mockUsageService) AddUsageCreditNote(ctx context.Context, in *v1.AddUsageCreditNoteRequest, opts ...grpc.CallOption) (*v1.AddUsageCreditNoteResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockUsageService) GetBalance(ctx context.Context, in *v1.GetBalanceRequest, opts ...grpc.CallOption) (*v1.GetBalanceResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockUsageService) GetCostCenter(ctx context.Context, in *v1.GetCostCenterRequest, opts ...grpc.CallOption) (*v1.GetCostCenterResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockUsageService) ListUsage(ctx context.Context, in *v1.ListUsageRequest, opts ...grpc.CallOption) (*v1.ListUsageResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockUsageService) ReconcileUsage(ctx context.Context, in *v1.ReconcileUsageRequest, opts ...grpc.CallOption) (*v1.ReconcileUsageResponse, error) {
+	log.Info("usage.ReconcileUsage")
+	m.ReconcileUsageTimes++
+	return &v1.ReconcileUsageResponse{}, nil
+}
+
+func (m *mockUsageService) ResetUsage(ctx context.Context, in *v1.ResetUsageRequest, opts ...grpc.CallOption) (*v1.ResetUsageResponse, error) {
+	log.Info("usage.ResetUsage")
+	m.ResetUsageTimes++
+	return &v1.ResetUsageResponse{}, nil
+}
+
+func (m *mockUsageService) SetCostCenter(ctx context.Context, in *v1.SetCostCenterRequest, opts ...grpc.CallOption) (*v1.SetCostCenterResponse, error) {
+	panic("unimplemented")
+}
+
+type mockBillService struct {
+	ReconcileInvoicesTimes int
+}
+
+var _ v1.BillingServiceClient = (*mockBillService)(nil)
+
+func (m *mockBillService) CancelSubscription(ctx context.Context, in *v1.CancelSubscriptionRequest, opts ...grpc.CallOption) (*v1.CancelSubscriptionResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) CreateHoldPaymentIntent(ctx context.Context, in *v1.CreateHoldPaymentIntentRequest, opts ...grpc.CallOption) (*v1.CreateHoldPaymentIntentResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) CreateStripeCustomer(ctx context.Context, in *v1.CreateStripeCustomerRequest, opts ...grpc.CallOption) (*v1.CreateStripeCustomerResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) CreateStripeSubscription(ctx context.Context, in *v1.CreateStripeSubscriptionRequest, opts ...grpc.CallOption) (*v1.CreateStripeSubscriptionResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInvoiceRequest, opts ...grpc.CallOption) (*v1.FinalizeInvoiceResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) GetPriceInformation(ctx context.Context, in *v1.GetPriceInformationRequest, opts ...grpc.CallOption) (*v1.GetPriceInformationResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) GetStripeCustomer(ctx context.Context, in *v1.GetStripeCustomerRequest, opts ...grpc.CallOption) (*v1.GetStripeCustomerResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) OnChargeDispute(ctx context.Context, in *v1.OnChargeDisputeRequest, opts ...grpc.CallOption) (*v1.OnChargeDisputeResponse, error) {
+	panic("unimplemented")
+}
+
+func (m *mockBillService) ReconcileInvoices(ctx context.Context, in *v1.ReconcileInvoicesRequest, opts ...grpc.CallOption) (*v1.ReconcileInvoicesResponse, error) {
+	log.Info("bill.ReconcileInvoices")
+	m.ReconcileInvoicesTimes++
+	return &v1.ReconcileInvoicesResponse{}, nil
+}
+
+func (m *mockBillService) UpdateCustomerSubscriptionsTaxState(ctx context.Context, in *v1.UpdateCustomerSubscriptionsTaxStateRequest, opts ...grpc.CallOption) (*v1.UpdateCustomerSubscriptionsTaxStateResponse, error) {
+	panic("unimplemented")
+}
+
+type mockExps struct {
+	StringValue string
+}
+
+var _ experiments.Client = (*mockExps)(nil)
+
+func (m *mockExps) GetBoolValue(ctx context.Context, experimentName string, defaultValue bool, attributes experiments.Attributes) bool {
+	return defaultValue
+}
+
+func (m *mockExps) GetFloatValue(ctx context.Context, experimentName string, defaultValue float64, attributes experiments.Attributes) float64 {
+	return defaultValue
+}
+
+func (m *mockExps) GetIntValue(ctx context.Context, experimentName string, defaultValue int, attributes experiments.Attributes) int {
+	return defaultValue
+}
+
+func (m *mockExps) GetStringValue(ctx context.Context, experimentName string, defaultValue string, attributes experiments.Attributes) string {
+	return m.StringValue
+}

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -42,6 +42,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Address: common.ClusterAddress(redis.Component, ctx.Namespace, redis.Port),
 		},
 		ServerAddress: common.ClusterAddress(common.ServerComponent, ctx.Namespace, common.ServerGRPCAPIPort),
+		GitpodHost:    "https://" + ctx.Config.Domain,
 	}
 
 	expWebAppConfig := common.ExperimentalWebappConfig(ctx)

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -51,7 +51,8 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
              "address": "0.0.0.0:9001"
            }
          }
-       }
+       },
+	   "gitpodHost": "https://test.domain.everything.awesome.is"
      }`,
 		cfgmap.Data[configJSONFilename],
 	)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add FF `usage_update_scheduler_duration` to control repeat duration of usage data update

- Default is `15m`, see [ops](https://github.com/gitpod-io/ops/blob/0266f434887dbb517256f3c85c1824cfd2f9597d/deploy/production/meta-us02/app/installer-config.yaml#L190)
- Feature Flag [[non-production](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=337069)]

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1768

## How to test
<!-- Provide steps to test this PR -->
- Create workspace, stop workspace
- Usage page should show workspace was stopped after you stop it after 1 minute (based on [FF](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=337069) setting)
- Update FF should affect scheduler, after 4 minutes (max: proxy polling 3m + usage polling 1m). You can check usage logs via `kubectl logs -f usage-<tab tab> -c usage | code -`

You could try run script below in DevTool > Terminal to fetch usage data automatically. Don't forget to update your organization ID in `data`
```
const data = {"jsonrpc":"2.0","id":2,"method":"listUsage","params":{"attributionId":"team:d1d0637b-d605-443a-81ef-4631ea08fd92","from":1711900800000,"to":1724060799999,"order":0,"pagination":{"perPage":50,"page":1}}}
const listUsage = () => window._gp.gitpodService.server.listUsage(data.params).then(d => console.log(d))
listUsage()
setInterval(listUsage, 60 * 1000)
```

**Unit tests**

Unit tests should pass, see server_test.go, there's a command to exec tests. But tests is flaky because of timing, jobs may exec during each ticker we grab the value. We only need to make sure it can pass one time.

<img width="1332" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/ea74f73b-016e-46f9-95b0-c0c0b500d729">

<details>

<summary> ✅  Dashboard test result for 2m </summary>

<img width="1026" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/574ad8b9-d628-4e7b-bf6e-0f1d108146d9">



</details>




## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-exp-1768</li>
	<li><b>🔗 URL</b> - <a href="https://hw-exp-1768.preview.gitpod-dev.com/workspaces" target="_blank">hw-exp-1768.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-EXP-1768-gha.24563</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-exp-1768%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
