### PR TITLE
Enhance token long and experiment with longer token validity expectation

### DIFF
--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -47,15 +47,15 @@ export class TokenService implements TokenProvider {
             }
 
             const aboutToExpireTime = new Date();
-            aboutToExpireTime.setTime(aboutToExpireTime.getTime() + expiryThreshold * 60 * 1000);
+            aboutToExpireTime.setTime(aboutToExpireTime.getTime() + expiryThreshold * 1_000 * 60);
             if (t.expiryDate >= aboutToExpireTime.toISOString()) {
                 return true;
             }
 
             // This is to help us understand whether extending the default expiration tolerance actually helped or not and can be removed after verifying the changes.
             const defaultAboutToExpireTime = new Date();
-            aboutToExpireTime.setTime(
-                defaultAboutToExpireTime.getTime() + TokenService.DEFAULT_EXPIRY_THRESHOLD * 60 * 1000,
+            defaultAboutToExpireTime.setTime(
+                defaultAboutToExpireTime.getTime() + TokenService.DEFAULT_EXPIRY_THRESHOLD * 1_000 * 60,
             );
             if (
                 expiryThreshold !== TokenService.DEFAULT_EXPIRY_THRESHOLD &&
@@ -64,6 +64,7 @@ export class TokenService implements TokenProvider {
                 log.debug({ userId }, `Token refreshed with an extended threshold not covered by the default one`, {
                     host,
                     expiryThreshold,
+                    tokenExpiresAt: t.expiryDate,
                 });
             }
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1728,7 +1728,7 @@ export class WorkspaceStarter {
                 result.setGit(initializer);
             }
         } else {
-            throw new Error("cannot create initializer for unkown context type");
+            throw new Error("cannot create initializer for unknown context type");
         }
         if (AdditionalContentContext.is(context)) {
             const additionalInit = new FileDownloadInitializer();
@@ -1839,7 +1839,8 @@ export class WorkspaceStarter {
             targetMode = CloneTargetMode.REMOTE_HEAD;
         }
 
-        const gitToken = await this.tokenProvider.getTokenForHost(user, host, 30);
+        const tokenValidityThreshold = (await isLongAccessTokenValidityThresholdEnabled(user)) ? 50 : 30;
+        const gitToken = await this.tokenProvider.getTokenForHost(user, host, tokenValidityThreshold);
         if (!gitToken) {
             throw new Error(`No token for host: ${host}`);
         }
@@ -1955,6 +1956,12 @@ function resolveGitpodTasks(ws: Workspace, instance: WorkspaceInstance): TaskCon
 
 export async function isWorkspaceClassDiscoveryEnabled(user: { id: string }): Promise<boolean> {
     return getExperimentsClientForBackend().getValueAsync("workspace_class_discovery_enabled", false, {
+        user: user,
+    });
+}
+
+export async function isLongAccessTokenValidityThresholdEnabled(user: { id: string }): Promise<boolean> {
+    return getExperimentsClientForBackend().getValueAsync("workspace_start_extended_token_validity_threshold", false, {
         user: user,
     });
 }


### PR DESCRIPTION
## Description

We are experimenting with forcing the access tokens used by workspace starter to be valid at least for 50 more minutes. This is because some bitbucket installations seem to be misbehaving and giving us a hard time when cloning repos after image builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes 

## How to test

I tested this by debugging the server (`/components/dashboard/debug.sh`) and seeing what the expiration value requested by the `getTokenForHost` is. 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-token-validity</li>
	<li><b>🔗 URL</b> - <a href="https://ft-token-validity.preview.gitpod-dev.com/workspaces" target="_blank">ft-token-validity.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-token-validity-gha.24545</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-token-validity%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
