### PR TITLE
Add metrics for ide start and stop

### DIFF
--- a/components/supervisor/pkg/metrics/metrics.go
+++ b/components/supervisor/pkg/metrics/metrics.go
@@ -12,6 +12,8 @@ import (
 
 type SupervisorMetrics struct {
 	IDEReadyDurationTotal *prometheus.HistogramVec
+	IDEStartTotal         *prometheus.CounterVec
+	IDEStopTotal          *prometheus.CounterVec
 	InitializerHistogram  *prometheus.HistogramVec
 	SSHTunnelOpenedTotal  *prometheus.CounterVec
 	SSHTunnelClosedTotal  *prometheus.CounterVec
@@ -24,6 +26,14 @@ func NewMetrics() *SupervisorMetrics {
 			Help:    "the IDE startup time",
 			Buckets: []float64{0.1, 0.5, 1, 1.5, 2, 2.5, 5, 10},
 		}, []string{"kind"}),
+		IDEStartTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "supervisor_ide_start_total",
+			Help: "Total number of IDE start count",
+		}, []string{"kind"}),
+		IDEStopTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "supervisor_ide_stop_total",
+			Help: "Total number of IDE stop count",
+		}, []string{"kind", "reason"}),
 		InitializerHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "supervisor_initializer_bytes_second",
 			Help:    "initializer speed in bytes per second",
@@ -43,6 +53,8 @@ func NewMetrics() *SupervisorMetrics {
 func (m *SupervisorMetrics) Register(registry *prometheus.Registry) error {
 	metrics := []prometheus.Collector{
 		m.IDEReadyDurationTotal,
+		m.IDEStartTotal,
+		m.IDEFailedTotal,
 		m.InitializerHistogram,
 		m.SSHTunnelOpenedTotal,
 		m.SSHTunnelClosedTotal,

--- a/components/supervisor/pkg/metrics/metrics.go
+++ b/components/supervisor/pkg/metrics/metrics.go
@@ -54,7 +54,7 @@ func (m *SupervisorMetrics) Register(registry *prometheus.Registry) error {
 	metrics := []prometheus.Collector{
 		m.IDEReadyDurationTotal,
 		m.IDEStartTotal,
-		m.IDEFailedTotal,
+		m.IDEStopTotal,
 		m.InitializerHistogram,
 		m.SSHTunnelOpenedTotal,
 		m.SSHTunnelClosedTotal,

--- a/components/supervisor/pkg/metrics/reporter.go
+++ b/components/supervisor/pkg/metrics/reporter.go
@@ -40,6 +40,8 @@ func NewGrpcMetricsReporter(gitpodHost string) *GrpcMetricsReporter {
 			"grpc_server_started_total":           true,
 			"grpc_server_handling_seconds":        true,
 			"supervisor_ide_ready_duration_total": true,
+			"supervisor_ide_start_total":          true,
+			"supervisor_ide_stop_total":           true,
 			"supervisor_initializer_bytes_second": true,
 			"supervisor_client_handled_total":     true,
 			"supervisor_client_handling_seconds":  true,

--- a/components/supervisor/pkg/metrics/reporter.go
+++ b/components/supervisor/pkg/metrics/reporter.go
@@ -71,6 +71,10 @@ func (r *GrpcMetricsReporter) Report(ctx context.Context) {
 	}
 }
 
+func (r *GrpcMetricsReporter) ReportImmediaterly() {
+	r.gather()
+}
+
 func (r *GrpcMetricsReporter) gather() {
 	families, err := r.Registry.Gather()
 	if err != nil {

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -342,6 +342,30 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels: []config.LabelAllowList{},
 		},
 		{
+			Name: "supervisor_ide_start_total",
+			Help: "Total number of IDE start count",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "kind",
+					AllowValues: []string{"web", "desktop"},
+				},
+			},
+		},
+		{
+			Name: "supervisor_ide_stop_total",
+			Help: "Total number of IDE stop count",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "kind",
+					AllowValues: []string{"web", "desktop"},
+				},
+				{
+					Name:        "reason",
+					AllowValues: []string{"*"},
+				},
+			},
+		},
+		{
 			Name: "supervisor_ssh_tunnel_closed_total",
 			Help: "Total number of SSH tunnels closed by the supervisor",
 			Labels: []config.LabelAllowList{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Start workspaces and make IDE exit with different reasons
- Check monitoring data by `./dev/preview/portforward-monitoring-satellite.sh`
- Query with supervisor_ide_start_total and supervisor_ide_stop_total

**Way to stop IDEs**
- Force kill PID
- Hot deploy launcher to make it start failed to mock cmd failed
- Hot deploy launcher to make it crush after seconds to mock crach
- Make mem increasing so that system could kill IDE

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ide-slo</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ide-slo.preview.gitpod-dev.com/workspaces" target="_blank">hw-ide-slo.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ide-slo-gha.24560</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ide-slo%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
