### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -14,7 +14,7 @@ defaultArgs:
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.1.tar.gz"
-  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.tar.gz"
+  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.1.tar.gz"
   rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.1.tar.gz"
   webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.1.1.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.1.tar.gz"

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -286,6 +286,14 @@
         ],
         "versions": [
           {
+            "version": "2024.1.1",
+            "image": "{{.Repository}}/ide/webstorm:commit-41fdcc803fbfc5cd62ab441f1480a61e7ae8c9b4",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-41fdcc803fbfc5cd62ab441f1480a61e7ae8c9b4",
+              "{{.Repository}}/ide/jb-launcher:commit-421e85624ac62a9b8d62b939dc8f81311d0e08ce"
+            ]
+          },
+          {
             "version": "2024.1",
             "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
@@ -321,6 +329,14 @@
           "{{.JetBrainsLauncherImage}}"
         ],
         "versions": [
+          {
+            "version": "2024.1.1",
+            "image": "{{.Repository}}/ide/rider:commit-41fdcc803fbfc5cd62ab441f1480a61e7ae8c9b4",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-41fdcc803fbfc5cd62ab441f1480a61e7ae8c9b4",
+              "{{.Repository}}/ide/jb-launcher:commit-421e85624ac62a9b8d62b939dc8f81311d0e08ce"
+            ]
+          },
           {
             "version": "2024.1",
             "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_