### PR TITLE
[ws-daemon] Change readiness behavior to wait for registry-facade

### DIFF
--- a/components/ws-daemon/pkg/container/config.go
+++ b/components/ws-daemon/pkg/container/config.go
@@ -35,6 +35,8 @@ type Config struct {
 
 	// Containerd contains the containerd CRI config if runtime == RuntimeContainerd
 	Containerd *ContainerdConfig `json:"containerd,omitempty"`
+
+	RegistryFacadeHost string `json:"registryFacadeHost,omitempty"`
 }
 
 // RuntimeType lists the supported container runtimes
@@ -63,7 +65,7 @@ func FromConfig(cfg *Config) (rt Runtime, err error) {
 		if cfg.Containerd == nil {
 			return nil, xerrors.Errorf("runtime is set to containerd, but not containerd config is provided")
 		}
-		return NewContainerd(cfg.Containerd, cfg.Mapping)
+		return NewContainerd(cfg.Containerd, cfg.Mapping, cfg.RegistryFacadeHost)
 	default:
 		return nil, xerrors.Errorf("unknown runtime type: %s", cfg.Runtime)
 	}

--- a/components/ws-daemon/pkg/container/containerd.go
+++ b/components/ws-daemon/pkg/container/containerd.go
@@ -504,7 +504,7 @@ func (s *Containerd) IsContainerdReady(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	return false, nil
+	return true, nil
 }
 
 var kubepodsQoSRegexp = regexp.MustCompile(`([^/]+)-([^/]+)-pod`)

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	OOMScores           cgroup.OOMScoreAdjConfig  `json:"oomScores"`
 	DiskSpaceGuard      diskguard.Config          `json:"disk"`
 	WorkspaceController WorkspaceControllerConfig `json:"workspaceController"`
+
+	RegistryFacadeHost string `json:"registryFacadeHost,omitempty"`
 }
 
 type WorkspaceControllerConfig struct {

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -113,6 +113,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	wsdcfg := wsdconfig.Config{
 		Daemon: daemon.Config{
+			RegistryFacadeHost: fmt.Sprintf("reg.%s:%d", ctx.Config.Domain, common.RegistryFacadeServicePort),
 			Runtime: daemon.RuntimeConfig{
 				KubernetesNamespace: ctx.Namespace,
 				SecretsNamespace:    common.WorkspaceSecretsNamespace,


### PR DESCRIPTION
## Description

Ensure predictable order of component start: containerd -> registry-facade -> ws-daemon

## How to test
- check node-labeler logs, we should always see registry-facade label being set before ws-daemon

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-ws-6700e0f0d2</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-ws-6700e0f0d2.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-ws-6700e0f0d2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-ws-daemon-check-gha.24608</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-ws-6700e0f0d2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-core-dev" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
