### PR TITLE
[github action] change contents permission to write

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: write # This is required for actions/checkout and create release
   pull-requests: write
 on:
   pull_request:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[github action] change contents permission to write so that github action can create a release

failure case https://github.com/gitpod-io/gitpod/actions/runs/8852933272/job/24320257571

<img width="967" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/67d2cc0c-2f98-4a93-b8f5-4b62997ddc7e">


see [document](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#:~:text=Work%20with%20the%20contents%20of%20the%20repository.%20For%20example%2C%20contents%3A%20read%20permits%20an%20action%20to%20list%20the%20commits%2C%20and%20contents%3A%20write%20allows%20the%20action%20to%20create%20a%20release.%20For%20more%20information%2C%20see)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
