### PR TITLE
Remove default metrics port from ws-proxy deployment

### DIFF
--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -128,9 +128,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Name:          HTTPSProxyPortName,
 				ContainerPort: HTTPSProxyPort,
 			}, {
-				Name:          baseserver.BuiltinMetricsPortName,
-				ContainerPort: baseserver.BuiltinMetricsPort,
-			}, {
 				Name:          SSHPortName,
 				ContainerPort: SSHServicePort,
 			}},


### PR DESCRIPTION
Removes the default metrics port from the ws-proxy deployment. This deployment also includes kube-rbac-proxy, which exposes the same port. The conflict is keeping us from scraping metrics for ws-proxy.