### PR TITLE
chore: fix some comments and typos

### DIFF
--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -214,7 +214,7 @@ type WorkspaceInstanceForUsage struct {
 }
 
 // WorkspaceRuntimeSeconds computes how long this WorkspaceInstance has been running.
-// If the instance is still running (no stopping time set), maxStopTime is used to to compute the duration - this is an upper bound on stop
+// If the instance is still running (no stopping time set), maxStopTime is used to compute the duration - this is an upper bound on stop
 func (i *WorkspaceInstanceForUsage) WorkspaceRuntimeSeconds(stopTimeIfInstanceIsStillRunning time.Time) int64 {
 	start := i.StartedTime.Time()
 	stop := stopTimeIfInstanceIsStillRunning

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -872,7 +872,7 @@ supervisorLoop:
 
 func launchIDE(cfg *Config, ideConfig *IDEConfig, cmd *exec.Cmd, ideStopped chan struct{}, ideReady *ideReadyState, s *ideStatus, ide IDEKind) {
 	go func() {
-		// prepareIDELaunch sets Pdeathsig, which on on Linux, will kill the
+		// prepareIDELaunch sets Pdeathsig, which on Linux, will kill the
 		// child process when the thread dies, not when the process dies.
 		// runtime.LockOSThread ensures that as long as this function is
 		// executing that OS thread will still be around.

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -152,7 +152,7 @@ func (wso *DefaultWorkspaceOperations) InitWorkspace(ctx context.Context, option
 		// Also, we cannot do this in wsinit because we're dropping all the privileges that would be
 		// required for this operation.
 		//
-		// With FWB this bit becomes unneccesary.
+		// With FWB this bit becomes unnecessary.
 		UID: (wsinit.GitpodUID + 100000 - 1),
 		GID: (wsinit.GitpodGID + 100000 - 1),
 		IdMappings: []archive.IDMapping{

--- a/components/ws-daemon/pkg/cpulimit/bandwidth.go
+++ b/components/ws-daemon/pkg/cpulimit/bandwidth.go
@@ -32,7 +32,7 @@ func BandwidthFromQuantity(v resource.Quantity) Bandwidth {
 	return Bandwidth(v.MilliValue())
 }
 
-// BandwithFromUsage computes the bandwidth neccesary to realise actual CPU time
+// BandwithFromUsage computes the bandwidth necessary to realise actual CPU time
 // consumption represented by two point samples.
 func BandwithFromUsage(t0, t1 CPUTime, dt time.Duration) (Bandwidth, error) {
 	if dt == 0 {

--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -179,7 +179,7 @@ type WorkspaceTimeoutConfiguration struct {
 
 // InitProbeConfiguration configures the behaviour of the workspace ready probe
 type InitProbeConfiguration struct {
-	// Disabled disables the workspace init probe - this is only neccesary during tests and in noDomain environments.
+	// Disabled disables the workspace init probe - this is only necessary during tests and in noDomain environments.
 	Disabled bool `json:"disabled,omitempty"`
 
 	// Timeout is the HTTP GET timeout during each probe attempt. Defaults to 5 seconds.

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -34,7 +34,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
     @optional()
     protected readonly clientCallMetrics: IClientCallMetrics;
 
-    // gRPC connections maintain their connectivity themselves, i.e. they reconnect when neccesary.
+    // gRPC connections maintain their connectivity themselves, i.e. they reconnect when necessary.
     // They can also be used concurrently, even across services.
     // Thus it makes sense to cache them rather than create a new connection for each request.
     protected readonly connectionCache = new Map<string, WorkspaceManagerClient>();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

fix some comments and typos

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
