### PR TITLE
[server] Issue new token in case of new signing key

### DIFF
--- a/components/server/src/auth/jwt.spec.ts
+++ b/components/server/src/auth/jwt.spec.ts
@@ -49,7 +49,7 @@ class TestAuthJWT {
         const subject = "user-id";
         const encoded = await sut.sign(subject, {});
 
-        const decoded = await sut.verify(encoded);
+        const decoded = (await sut.verify(encoded)).payload;
 
         expect(decoded["sub"]).to.equal(subject);
         expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");
@@ -70,7 +70,7 @@ class TestAuthJWT {
         });
 
         // should use the second validating key and succesfully verify
-        const decoded = await sut.verify(encoded);
+        const decoded = (await sut.verify(encoded)).payload;
 
         expect(decoded["sub"]).to.equal(subject);
         expect(decoded["iss"]).to.equal("https://mp-server-d7650ec945.preview.gitpod-dev.com");

--- a/components/server/src/auth/jwt.ts
+++ b/components/server/src/auth/jwt.ts
@@ -32,7 +32,7 @@ export class AuthJWT {
         return sign(payload, this.config.auth.pki.signing.privateKey, opts);
     }
 
-    async verify(encoded: string): Promise<jsonwebtoken.JwtPayload> {
+    async verify(encoded: string): Promise<{ payload: jsonwebtoken.JwtPayload; keyId: string }> {
         const keypairs = [this.config.auth.pki.signing, ...this.config.auth.pki.validating];
         const publicKeysByID = keypairs.reduce<{ [id: string]: string }>((byID, keypair) => {
             byID[keypair.id] = keypair.publicKey;
@@ -57,7 +57,10 @@ export class AuthJWT {
             algorithms: [authJWTAlgorithm],
         });
 
-        return verified;
+        return {
+            payload: verified,
+            keyId: keyID,
+        };
     }
 }
 


### PR DESCRIPTION
## Description
This change makes sure we issue a new token regularly in case their is a new signing key. This makes sure that people using Gitpod can be transitioned to a new token smoothly, without them noticing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: EXP-1842

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
