### PR TITLE
Deal with clipboard permission issues

### DIFF
--- a/components/dashboard/src/components/InputWithCopy.tsx
+++ b/components/dashboard/src/components/InputWithCopy.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FC, useCallback } from "react";
+import { FC, useCallback, useState } from "react";
 import Tooltip from "../components/Tooltip";
 import { ReactComponent as CopyIcon } from "../images/copy.svg";
 import { ReactComponent as CheckIcon } from "../images/check-currentColor.svg";
@@ -12,42 +12,58 @@ import { copyToClipboard } from "../utils";
 import { Button } from "@podkit/buttons/Button";
 import { TextInput } from "./forms/TextInputField";
 import { useTemporaryState } from "../hooks/use-temporary-value";
+import { cn } from "@podkit/lib/cn";
 
 type Props = { value: string; tip?: string; className?: string };
-
 export const InputWithCopy: FC<Props> = ({ value, tip = "Click to copy", className }) => {
     const [copied, setCopied] = useTemporaryState(false, 2000);
+    const [copyError, setCopyError] = useState<string | undefined>();
 
     const handleCopyToClipboard = useCallback(
         (e) => {
             e.preventDefault();
 
-            copyToClipboard(value);
-            setCopied(true);
+            copyToClipboard(value)
+                .then(() => {
+                    setCopied(true);
+                })
+                .catch((error) => {
+                    if (error instanceof DOMException) {
+                        setCopyError(
+                            "Gitpod is not allowed to copy to clipboard. Please copy the URL manually or adjust your browser permissions.",
+                        );
+                        return;
+                    }
+
+                    setCopyError("Failed to copy to clipboard. Please copy the URL manually.");
+                });
         },
         [setCopied, value],
     );
 
     return (
-        // max-w-lg is to mirror width of TextInput so Tooltip is positioned correctly
-        <div className={`w-full relative max-w-lg ${className ?? ""}`}>
-            <TextInput
-                value={value}
-                disabled
-                className="w-full pr-8 overscroll-none bg-pk-surface-tertiary text-pk-content-primary"
-            />
+        <>
+            {/* max-w-lg is to mirror width of TextInput so Tooltip is positioned correctly */}
+            <div className={cn(`w-full relative max-w-lg`, className)}>
+                <TextInput
+                    value={value}
+                    disabled
+                    className="w-full pr-8 overscroll-none bg-pk-surface-tertiary text-pk-content-primary"
+                />
 
-            <Tooltip content={tip} className="absolute top-0 right-0">
-                <Button
-                    variant="ghost"
-                    size={"icon"}
-                    onClick={handleCopyToClipboard}
-                    type="button"
-                    className="ring-inset"
-                >
-                    {copied ? <CheckIcon className="text-green-500 w-5 h-5" /> : <CopyIcon className="w-3.5 h-3.5" />}
-                </Button>
-            </Tooltip>
-        </div>
+                <Tooltip content={tip} className="absolute top-0 right-0">
+                    <Button
+                        variant="ghost"
+                        size={"icon"}
+                        onClick={handleCopyToClipboard}
+                        type="button"
+                        className="ring-inset"
+                    >
+                        {copied ? <CheckIcon className="text-green-500 w-5 h-5" /> : <CopyIcon className="size-3.5" />}
+                    </Button>
+                </Tooltip>
+            </div>
+            {copyError && <p className="text-pk-content-danger mt-1 max-w-lg">{copyError}</p>}
+        </>
     );
 };

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -77,7 +77,9 @@ export function inResource(pathname: string, resources: string[]): boolean {
     return resources.map((res) => trimmedResource.startsWith(trimResource(res))).some(Boolean);
 }
 
-export const copyToClipboard = navigator.clipboard.writeText.bind(navigator.clipboard);
+export const copyToClipboard = async (data: string) => {
+    await navigator.clipboard.writeText(data);
+};
 
 export function getURLHash() {
     return window.location.hash.replace(/^[#/]+/, "");

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -77,9 +77,7 @@ export function inResource(pathname: string, resources: string[]): boolean {
     return resources.map((res) => trimmedResource.startsWith(trimResource(res))).some(Boolean);
 }
 
-export function copyToClipboard(text: string) {
-    navigator.clipboard.writeText(text);
-}
+export const copyToClipboard = navigator.clipboard.writeText.bind(navigator.clipboard);
 
 export function getURLHash() {
     return window.location.hash.replace(/^[#/]+/, "");

--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -80,9 +80,9 @@ function SSHView(props: SSHProps) {
                         <span>The following shell command can be used to SSH into this workspace.</span>
                     ) : (
                         <span>
-                            The following shell command can be used to SSH into this workspace with a{" "}
+                            The following shell command can be used to SSH into this workspace with an{" "}
                             <Link to={settingsPathSSHKeys} className="gp-link">
-                                ssh key
+                                SSH key
                             </Link>
                             .
                         </span>

--- a/components/supervisor/frontend/src/shared/loading-frame.ts
+++ b/components/supervisor/frontend/src/shared/loading-frame.ts
@@ -16,6 +16,7 @@ export function load(): Promise<{
         frame.src = startUrl.toString();
         frame.style.visibility = "visible";
         frame.className = "gitpod-frame loading";
+        frame.allow = "clipboard-read;"
         document.body.prepend(frame);
 
         frame.onload = () => {

--- a/components/supervisor/frontend/src/shared/loading-frame.ts
+++ b/components/supervisor/frontend/src/shared/loading-frame.ts
@@ -16,7 +16,7 @@ export function load(): Promise<{
         frame.src = startUrl.toString();
         frame.style.visibility = "visible";
         frame.className = "gitpod-frame loading";
-        frame.allow = "clipboard-read;"
+        frame.allow = "clipboard-write"
         document.body.prepend(frame);
 
         frame.onload = () => {


### PR DESCRIPTION
## Description

Writing to the clipboard can throw. We deal with that now.

In addition to that, one needs to allow cross-origin iframes to write to the clipboard, which we did not do and so copying did not work.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-5 EXP-1737

## How to test

Use a Chromium based browser like Chrome, Arc, Brave.

1. Start a workspace with a non-vscode browser editor
2. On the start page, try to copy the SSH command

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-catch-c4866f0f606</li>
	<li><b>🔗 URL</b> - <a href="https://ft-catch-c4866f0f606.preview.gitpod-dev.com/workspaces" target="_blank">ft-catch-c4866f0f606.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-catch-clipboard-exceptions-gha.24858</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-catch-c4866f0f606%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
