### PR TITLE
[.github] integration test comments

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -89,10 +89,16 @@ jobs:
                   echo "version=${{ inputs.version }}"
               } >> $GITHUB_OUTPUT
           else
-              # Find the most recent successful build on main. Look back up to 10 builds.
+              # Search the last 10 builds regardless of status (success and failed)
               RUNID=$(gh run list --repo gitpod-io/gitpod --branch main --workflow build.yml --limit 10 --json createdAt,conclusion,databaseId --jq 'map(select(.conclusion == "success")) | sort_by(.createdAt) | .[-1] | .databaseId')
               if [ "$RUNID" == "" ]; then
                 echo no successful build found on main branch in the last 10 commits, see https://github.com/gitpod-io/gitpod/actions/workflows/build.yml for details | tee -a $GITHUB_STEP_SUMMARY
+                # if we got here, it means in the last 10 builds on main, there wasn't a success, and then we'll keep getting this message
+                # to fix, manually trigger the tests with the latest main-gha asset till we get a success
+                # you might have to fix or disable flakey tests to do this
+                #
+                # for posterity, this will show when the last success actually was, but it shouldn't be used to get RUNID
+                # gh run list --repo gitpod-io/gitpod --branch main --workflow build.yml --limit 10 --json createdAt,conclusion,databaseId --status success --jq 'sort_by(.createdAt) | .[-1]'
                 exit 1
               fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To help support in the event of future, sustained failed runs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-13

## How to test
<!-- Provide steps to test this PR -->
n/a

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
