### PR TITLE
[preview] deploy monitoring after gitpod is deployed

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -548,3 +548,7 @@ leeway run components:add-smith-token \
   -DPREVIEW_NAMESPACE="${PREVIEW_NAMESPACE}"
 
 log_success "Installation is happy: https://${DOMAIN}/workspaces"
+
+leeway run dev/preview:deploy-monitoring-satellite
+
+log_success "Installation is still happy: https://${DOMAIN}/workspaces"

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -34,4 +34,4 @@ ensure_gcloud_auth
 
 leeway run dev/preview:create-preview dev/preview:build
 previewctl install-context --timeout 10m
-leeway run dev/preview:deploy-gitpod dev/preview:deploy-monitoring-satellite
+leeway run dev/preview:deploy-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This helps avoid the scenario where the image-pull-secret is added to the monitoring-satellite namespace, and not our default namespace (which I am encountering on main, when doing `leeway run dev:preview` from a local branch).


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
`leeway run dev:preview` from a local branch, all pods should enter ready
and
Can start a workspace from the preview made by this PR's build 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-fix-preview</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-fix-preview.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-fix-preview.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-fix-preview-gha.24864</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-fix-preview%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
