### PR TITLE
[loadgen] fix the org associated with template repos

### DIFF
--- a/dev/loadgen/configs/prod-benchmark.yaml
+++ b/dev/loadgen/configs/prod-benchmark.yaml
@@ -73,7 +73,7 @@ repos:
     # tasks
     - name: "GITPOD_TASKS"
       value: "[{\"name\":\"Setup\",\"init\":\"sudo install-packages stress-ng fio && gp sync-done setup\"},{\"name\":\"start cpu stress\",\"init\":\"gp sync-await setup\",\"command\":\"stress-ng --cpu ${CPU_COUNT:-3} --backoff ${CPU_BACKOFF:-10000000} --timeout ${CPU_TIMEOUT:-600s}\"},{\"name\":\"start io stress\",\"init\":\"gp sync-await setup\",\"command\":\"fio --name io-stress --eta-newline=5s --filename=/workspace/gitpod.temp --rw=${DISK_IO_MODE} --size=${DISK_IO_FILE_SIZE:-2g} --io_size=${DISK_IO_TOTAL:-50g} --blocksize=${DISK_IO_BLOCKSIZE} --ioengine=libaio --fsync=${DISK_IO_FSYNC} --iodepth=${DISK_IO_DEPTH} --direct=1 --numjobs=${DISK_IO_JOBS} --runtime=${DISK_IO_TIMEOUT:-600}\"},{\"name\":\"start memory stress\",\"init\":\"gp sync-await setup\",\"command\":\"stress-ng --vm 1 --vm-keep --vm-bytes ${MEMORY_BYTES:-6G} --timeout ${MEMORY_TIMEOUT:-600s}\"},{\"name\":\"create backup file\",\"init\":\"gp sync-await setup\",\"command\":\"dd if=/dev/zero of=/workspace/benchmark-backup bs=1000M count=${BACKUP_SIZE:-2}\"},{\"name\":\"start network stress\",\"init\":\"gp sync-await setup\",\"command\":\"stress-ng --class network --all ${NETWORK_WORKERS:-4}\"}]"
-  - cloneURL: https://github.com/gitpod-io/template-typescript-node
+  - cloneURL: https://github.com/gitpod-samples/template-typescript-node
     cloneTarget: master
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
@@ -81,7 +81,7 @@ repos:
     environment:
     - name: "GITPOD_TASKS"
       value: "[{\"name\":\"Open port 1\",\"command\":\"gp ports visibility 6879:private\"},{\"name\":\"Open port 2\",\"command\":\"gp ports visibility 7869:private\"}]"
-  - cloneURL: https://github.com/gitpod-io/template-typescript-react
+  - cloneURL: https://github.com/gitpod-samples/template-typescript-react
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
@@ -89,7 +89,7 @@ repos:
     environment:
     - name: "GITPOD_TASKS"
       value: "[{\"name\":\"Open port 1\",\"command\":\"gp ports visibility 6879:private\"},{\"name\":\"Open port 2\",\"command\":\"gp ports visibility 7869:private\"}]"
-  - cloneURL: https://github.com/gitpod-io/template-python-django
+  - cloneURL: https://github.com/gitpod-samples/template-python-django
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It moved from gitpod-io to gitpod-samples.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-13

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
