### PR TITLE
[test] fix integration tests

### DIFF
--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -182,13 +182,14 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    return false;
+                    log.warn({ userId }, "EntitlementService warn: no billing mode");
+                    return true;
                 case "usage-based":
                     return this.ubp.limitNetworkConnections(userId, organizationId);
             }
         } catch (err) {
             log.warn({ userId }, "EntitlementService error: limitNetworkConnections", err);
-            return false;
+            return true;
         }
     }
 

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -182,13 +182,13 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    return true;
+                    return false;
                 case "usage-based":
                     return this.ubp.limitNetworkConnections(userId, organizationId);
             }
         } catch (err) {
             log.warn({ userId }, "EntitlementService error: limitNetworkConnections", err);
-            return true;
+            return false;
         }
     }
 

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -182,7 +182,6 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    log.warn({ userId }, "EntitlementService warn: no billing mode");
                     return true;
                 case "usage-based":
                     return this.ubp.limitNetworkConnections(userId, organizationId);

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -182,7 +182,7 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    return true;
+                    return false;
                 case "usage-based":
                     return this.ubp.limitNetworkConnections(userId, organizationId);
             }

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -182,7 +182,7 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingMode(userId, organizationId);
             switch (billingMode.mode) {
                 case "none":
-                    return false;
+                    return true;
                 case "usage-based":
                     return this.ubp.limitNetworkConnections(userId, organizationId);
             }

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -23,7 +23,7 @@ variable "dev_kube_context" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202402021944"
+  default     = "gitpod-k3s-202404302137"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -23,7 +23,7 @@ variable "vm_type" {
 variable "vm_image" {
   type        = string
   description = "The VM image"
-  default     = "gitpod-k3s-202402021944"
+  default     = "gitpod-k3s-202404302137"
 }
 
 variable "cert_issuer" {

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -289,6 +289,7 @@ then
       --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
       --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
       apply -n ${PREVIEW_NAMESPACE} -f -
+  yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.server.StripeSecret "stripe-api-keys"
 fi
 
 #

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -209,7 +209,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 			for _, test := range tests {
 				test := test
 				t.Run(test.Name, func(t *testing.T) {
-					// t.Parallel()
+					t.Parallel()
 
 					ctx, cancel := context.WithTimeout(testCtx, time.Duration(10*len(tests))*time.Minute)
 					defer cancel()

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -272,7 +272,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 					// launch the workspace from prebuild
 					// TODO: change to use server API to launch the workspace, so we could run the integration test as the user code flow
 					//       which is client -> server -> ws-manager rather than client -> ws-manager directly
-					ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
+					ws, stopWsFunc, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
 						req.Spec.FeatureFlags = test.FF
 						req.Spec.Initializer = &csapi.WorkspaceInitializer{
 							Spec: &csapi.WorkspaceInitializer_Prebuild{
@@ -301,7 +301,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 
 					t.Cleanup(func() {
 						// stop workspace in defer function to prevent we forget to stop the workspace
-						if err := stopWorkspace(t, cfg, stopWs); err != nil {
+						if err := stopWorkspace(t, cfg, stopWsFunc); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 					})
@@ -343,14 +343,14 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 					sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					defer sapi.Done(t)
 
-					// stop workspace without wait
-					_, err = stopWs(false, sapi)
+					// stop workspace and wait, we're about to restart it
+					_, err = stopWsFunc(true, sapi)
 					if err != nil {
 						t.Fatal(err)
 					}
 
 					// reopen the workspace and make sure the file foobar.txt exists
-					ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(t, ctx, sapi, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
+					ws1, stopWs1Func, err := integration.LaunchWorkspaceDirectly(t, ctx, sapi, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
 						req.ServicePrefix = ws.Req.ServicePrefix
 						req.Metadata.MetaId = ws.Req.Metadata.MetaId
 						req.Metadata.Owner = ws.Req.Metadata.Owner
@@ -372,7 +372,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 
 					t.Cleanup(func() {
 						// stop workspace in defer function to prevent we forget to stop the workspace
-						if err := stopWorkspace(t, cfg, stopWs1); err != nil {
+						if err := stopWorkspace(t, cfg, stopWs1Func); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 					})

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -209,7 +209,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 			for _, test := range tests {
 				test := test
 				t.Run(test.Name, func(t *testing.T) {
-					t.Parallel()
+					// t.Parallel()
 
 					ctx, cancel := context.WithTimeout(testCtx, time.Duration(10*len(tests))*time.Minute)
 					defer cancel()

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -593,7 +593,7 @@ func checkPrebuildLogExist(t *testing.T, cfg *envconf.Config, rsa *integration.R
 		Command: "bash",
 		Args: []string{
 			"-c",
-			fmt.Sprintf("grep %s *", prebuildLog),
+			fmt.Sprintf("grep -r %s *", prebuildLog),
 		},
 	}, &grepResp)
 	if err == nil && grepResp.ExitCode == 0 && strings.Trim(grepResp.Stdout, " \t\n") != "" {
@@ -603,7 +603,7 @@ func checkPrebuildLogExist(t *testing.T, cfg *envconf.Config, rsa *integration.R
 		return
 	}
 
-	t.Logf("cannot found the prebuild message %s in %s, err:%v, exitCode:%d, stdout:%s", prebuildLog, prebuildLogPath, err, grepResp.ExitCode, grepResp.Stdout)
+	t.Logf("cannot found the prebuild message %s in %s, err:%v, exitCode:%d, stdout:%s, stderr:%s", prebuildLog, prebuildLogPath, err, grepResp.ExitCode, grepResp.Stdout, grepResp.Stderr)
 
 	// somehow, the prebuild log message '🍊 This task ran as a workspace prebuild' does not exists
 	// we fall back to check the init task message within the /workspace/.gitpod/prebuild-log-* or not

--- a/test/tests/workspace/process_priority_test.go
+++ b/test/tests/workspace/process_priority_test.go
@@ -68,7 +68,7 @@ func TestProcessPriority(t *testing.T) {
 			defer rsa.Close()
 
 			t.Logf("waiting for the next ws-daemon tick, before running ps")
-			time.Sleep(11 * time.Second)
+			time.Sleep(15 * time.Second)
 
 			var res agent.ExecResponse
 			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{

--- a/test/tests/workspace/process_priority_test.go
+++ b/test/tests/workspace/process_priority_test.go
@@ -67,7 +67,9 @@ func TestProcessPriority(t *testing.T) {
 			}
 			defer rsa.Close()
 
-			t.Logf("running ps")
+			t.Logf("waiting for the next ws-daemon tick, before running ps")
+			time.Sleep(11 * time.Second)
+
 			var res agent.ExecResponse
 			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 				Dir:     "/workspace",
@@ -93,9 +95,11 @@ func TestProcessPriority(t *testing.T) {
 func checkProcessPriorities(t *testing.T, output string) {
 	t.Helper()
 
+	t.Log("output", output)
 	processes := strings.Split(output, "\n")
 	for _, p := range processes {
 		parts := strings.Fields(p)
+		t.Log("parts:", parts)
 		if len(parts) >= 2 {
 			checkProcessPriority(t, parts[0], parts[1])
 		}
@@ -109,6 +113,8 @@ func checkProcessPriority(t *testing.T, priority, process string) {
 	if err != nil {
 		return
 	}
+
+	t.Logf("checkProcessPriority, process {%s}, priority {%s} ", process, priority)
 
 	expectedPrio, err := determinePriority(process)
 	if err != nil {

--- a/test/tests/workspace/process_priority_test.go
+++ b/test/tests/workspace/process_priority_test.go
@@ -95,11 +95,9 @@ func TestProcessPriority(t *testing.T) {
 func checkProcessPriorities(t *testing.T, output string) {
 	t.Helper()
 
-	t.Log("output", output)
 	processes := strings.Split(output, "\n")
 	for _, p := range processes {
 		parts := strings.Fields(p)
-		t.Log("parts:", parts)
 		if len(parts) >= 2 {
 			checkProcessPriority(t, parts[0], parts[1])
 		}
@@ -113,8 +111,6 @@ func checkProcessPriority(t *testing.T, priority, process string) {
 	if err != nil {
 		return
 	}
-
-	t.Logf("checkProcessPriority, process {%s}, priority {%s} ", process, priority)
 
 	expectedPrio, err := determinePriority(process)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A few tests have been consistently failing.

1. **TestNetworkLimiting** was failing because the user we use for testing in previews does not use UBP, and the default is not to network limit for those users. I've changed `server`, so that we always limit network connections regardless of billing mode, and to also limit if there was an error inspecting the billing mode.
2. **TestProcessPriority** was failing because it was running the assertion too early. We need to give `ws-daemon` time to apply process priority before asserting priority has been adjusted.
3. **TestOpenWorkspaceFromPrebuild** had a couple problems. First, `grep` needs to be set to explicitly recurse through folders (it was failing on the logs folder). Second, the test wasn't waiting for a workspace to stop, prior to attempting to restart the workspace.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to ENT-13

## How to test
<!-- Provide steps to test this PR -->
The tests are green [now](https://github.com/gitpod-io/gitpod/actions/runs/8945272181/job/24574160445?pr=19692). After this lands on main, we'll need to trigger a manual run with the updated main-gha asset. Why? We only test the last successful build of main-gha when testing, and the tests passing are considered part of the success.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-g683e0a0e27</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-g683e0a0e27.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-g683e0a0e27.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-gen111-tests-gha.24891</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-g683e0a0e27%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
