### PR TITLE
[ws-manager-mk2] allow the k8s client a higher limit

### DIFF
--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 
 	"github.com/bombsimon/logrusr/v4"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -140,6 +141,17 @@ func main() {
 		LeaderElection:                true,
 		LeaderElectionID:              "ws-manager-mk2-leader.gitpod.io",
 		LeaderElectionReleaseOnCancel: true,
+		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+			config.QPS = 100
+			config.Burst = 150
+
+			c, err := client.New(config, options)
+			if err != nil {
+				return nil, err
+			}
+
+			return c, nil
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This helps unblock consumers, such as gRPC and controller reconcilation.

The side effects are:
* the longest running reconcilation for mk2 is no longer 2s, it floats between 250-600ms.
* mk2  workqueue latency is consistent, and the duration doesn't become excessive anymore.
* mk2 work queue depth is high now, but, flattens as start workspace requests cease, and drops as workspaces stop (MarkActive volume)
* increased memory utilization for the API server (it doubles)

Thanks for pairing on this, @aledbf ! I never would have that the k8s client was rate limited!!

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-13, ENG-1940

## How to test
<!-- Provide steps to test this PR -->
Loadgen for many workspaces (10x what we usually do)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
