### PR TITLE
Update ws-manager-bridge to node 20 reduce logs

### DIFF
--- a/components/ws-manager-bridge/leeway.Dockerfile
+++ b/components/ws-manager-bridge/leeway.Dockerfile
@@ -2,13 +2,13 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:18.17.1-slim as builder
+FROM node:20-slim as builder
 COPY components-ws-manager-bridge--app /installer/
 
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM cgr.dev/chainguard/node:18.17.1@sha256:af073516c203b6bd0b55a77a806a0950b486f2e9ea7387a32b0f41ea72f20886
+FROM cgr.dev/chainguard/node:20@sha256:f30d39c6980f0a50119f2aa269498307a80c2654928d8e23bb25431b9cbbdc4f
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 COPY --from=builder --chown=node:node /app /app/

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -180,7 +180,7 @@ export class WorkspaceManagerBridge implements Disposable {
     protected async handleStatusUpdate(ctx: TraceContext, rawStatus: WorkspaceStatus) {
         const start = performance.now();
         const status = rawStatus.toObject();
-        log.info("Handling WorkspaceStatus update", filterStatus(status));
+        log.debug("Handling WorkspaceStatus update", filterStatus(status));
 
         if (!status.spec || !status.metadata || !status.conditions) {
             log.warn("Received invalid status update", status);
@@ -209,7 +209,7 @@ export class WorkspaceManagerBridge implements Disposable {
         }
         const durationMs = performance.now() - start;
         this.metrics.reportWorkspaceInstanceUpdateCompleted(durationMs / 1000, this.cluster.name, status.spec.type);
-        log.info(logCtx, "Successfully completed WorkspaceInstance status update");
+        log.debug(logCtx, "Successfully completed WorkspaceInstance status update");
     }
 
     private async statusUpdate(ctx: TraceContext, rawStatus: WorkspaceStatus) {

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -34,7 +34,7 @@ export class PrebuildUpdater {
         const workspaceId = status.metadata!.metaId!;
         const logCtx: LogContext = { instanceId, workspaceId, userId };
 
-        log.info(logCtx, "Handling prebuild workspace update.", filterStatus(status));
+        log.debug(logCtx, "Handling prebuild workspace update.", filterStatus(status));
 
         const span = TraceContext.startSpan("updatePrebuiltWorkspace", ctx);
         try {
@@ -46,14 +46,14 @@ export class PrebuildUpdater {
             }
             span.setTag("updatePrebuiltWorkspace.prebuildId", prebuild.id);
             span.setTag("updatePrebuiltWorkspace.workspaceInstance.statusVersion", status.statusVersion);
-            log.info(logCtx, "Found prebuild record in database.", prebuild);
+            log.debug(logCtx, "Found prebuild record in database.", prebuild);
 
             // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
             if (prebuild.statusVersion > 0 && prebuild.statusVersion >= status.statusVersion) {
                 // We've gotten an event which is younger than one we've already processed. We shouldn't process the stale one.
                 span.setTag("updatePrebuiltWorkspace.staleEvent", true);
                 this.prometheusExporter.recordStalePrebuildEvent();
-                log.info(logCtx, "Stale prebuild event received, skipping.");
+                log.warn(logCtx, "Stale prebuild event received, skipping.");
                 return;
             }
             prebuild.statusVersion = status.statusVersion;


### PR DESCRIPTION
## Description

Logs are 100% redacted. We have metrics, and leaving warning and error messages provides better readability.

[log sample](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-05-01T20:14:40.213Z;duration=PT30M;query=ws-manager-bridge%0Atimestamp%3D%222024-05-01T20:14:40.170Z%22%0AinsertId%3D%22i3w05b437gl7d6d4%22?project=gitpod-191109)


#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - aledbf-wsm</li>
	<li><b>🔗 URL</b> - <a href="https://aledbf-wsm.preview.gitpod-dev.com/workspaces" target="_blank">aledbf-wsm.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - aledbf-wsm-gha.24909</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-aledbf-wsm%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>
