### PR TITLE
[bridge] Remember last status update, and skip if they are identical

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -731,7 +731,7 @@ export interface Workspace {
 
 export type WorkspaceSoftDeletion = "user" | "gc";
 
-export type WorkspaceType = "regular" | "prebuild";
+export type WorkspaceType = "regular" | "prebuild" | "imagebuild";
 
 export namespace Workspace {
     export function getPullRequestNumber(ws: Workspace): number | undefined {

--- a/components/ws-manager-bridge/src/bridge.spec.ts
+++ b/components/ws-manager-bridge/src/bridge.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import { WorkspaceConditions, WorkspaceStatus } from "@gitpod/ws-manager/lib";
+import { hasRelevantDiff } from "./bridge";
+
+const expect = chai.expect;
+
+function createTestStatus(statusVersion: number, failed: string): WorkspaceStatus {
+    const conditions = new WorkspaceConditions();
+    conditions.setFailed(failed);
+    const status = new WorkspaceStatus();
+    status.setStatusVersion(statusVersion);
+    status.setConditions(conditions);
+    return status;
+}
+
+@suite
+class TestBridge {
+    @test public testWorkspaceStatus_hasRelevantDiff() {
+        const a = createTestStatus(123, "why on why");
+        const actual1 = hasRelevantDiff(a, a);
+        expect(actual1, "identical: no diff").to.be.false;
+
+        const b = createTestStatus(124, "why on why");
+        const actual2 = hasRelevantDiff(a, b);
+        expect(actual2, "should be same despite different statusVersion").to.equal(false);
+
+        const c = createTestStatus(125, "because!");
+        const actual3 = hasRelevantDiff(a, c);
+        expect(actual3, "different failed condition").to.equal(true);
+    }
+}
+module.exports = new TestBridge(); // Only to circumvent no usage warning :-/

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -48,6 +48,17 @@ function toBool(b: WorkspaceConditionBool | undefined): boolean | undefined {
 
 export type WorkspaceClusterInfo = Pick<WorkspaceCluster, "name" | "url">;
 
+type UpdateQueue = {
+    instanceId: string;
+    lastStatus?: WorkspaceStatus;
+    queue: Queue;
+};
+namespace UpdateQueue {
+    export function create(instanceId: string): UpdateQueue {
+        return { instanceId, queue: new Queue() };
+    }
+}
+
 @injectable()
 export class WorkspaceManagerBridge implements Disposable {
     constructor(
@@ -62,7 +73,7 @@ export class WorkspaceManagerBridge implements Disposable {
     ) {}
 
     protected readonly disposables = new DisposableCollection();
-    protected readonly queues = new Map<string, Queue>();
+    protected readonly queues = new Map<string, UpdateQueue>();
 
     protected cluster: WorkspaceClusterInfo;
 
@@ -138,46 +149,43 @@ export class WorkspaceManagerBridge implements Disposable {
         this.disposables.push(subscriber);
 
         const onReconnect = (ctx: TraceContext, s: WorkspaceStatus[]) => {
-            s.forEach((sx) =>
-                this.serializeMessagesByInstanceId<WorkspaceStatus>(
-                    ctx,
-                    sx,
-                    (m) => m.getId(),
-                    (ctx, msg) => this.handleStatusUpdate(ctx, msg),
-                ),
-            );
+            s.forEach((sx) => this.queueMessagesByInstanceId(ctx, sx));
         };
         const onStatusUpdate = (ctx: TraceContext, s: WorkspaceStatus) => {
-            this.serializeMessagesByInstanceId<WorkspaceStatus>(
-                ctx,
-                s,
-                (msg) => msg.getId(),
-                (ctx, s) => this.handleStatusUpdate(ctx, s),
-            );
+            this.queueMessagesByInstanceId(ctx, s);
         };
         await subscriber.subscribe({ onReconnect, onStatusUpdate }, logPayload);
     }
 
-    protected serializeMessagesByInstanceId<M>(
-        ctx: TraceContext,
-        msg: M,
-        getInstanceId: (msg: M) => string,
-        handler: (ctx: TraceContext, msg: M) => Promise<void>,
-    ) {
-        const instanceId = getInstanceId(msg);
+    protected queueMessagesByInstanceId(ctx: TraceContext, status: WorkspaceStatus) {
+        const instanceId = status.getId();
         if (!instanceId) {
-            log.warn("Received invalid message, could not read instanceId!", { msg });
+            log.warn("Received invalid message, could not read instanceId!", { msg: status });
             return;
         }
 
         // We can't just handle the status update directly, but have to "serialize" it to ensure the updates stay in order.
         // If we did not do this, the async nature of our code would allow for one message to overtake the other.
-        const q = this.queues.get(instanceId) || new Queue();
-        q.enqueue(() => handler(ctx, msg)).catch((e) => log.error({ instanceId }, e));
-        this.queues.set(instanceId, q);
+        const updateQueue = this.queues.get(instanceId) || UpdateQueue.create(instanceId);
+        this.queues.set(instanceId, updateQueue);
+
+        updateQueue.queue.enqueue(async () => {
+            try {
+                await this.handleStatusUpdate(ctx, status, updateQueue.lastStatus);
+                updateQueue.lastStatus = status;
+            } catch (err) {
+                log.error({ instanceId }, err);
+                // if an error ocurrs, we want to be save, and better make sure we don't accidentally skip the next update
+                updateQueue.lastStatus = undefined;
+            }
+        });
     }
 
-    protected async handleStatusUpdate(ctx: TraceContext, rawStatus: WorkspaceStatus) {
+    protected async handleStatusUpdate(
+        ctx: TraceContext,
+        rawStatus: WorkspaceStatus,
+        lastStatusUpdate: WorkspaceStatus | undefined,
+    ) {
         const start = performance.now();
         const status = rawStatus.toObject();
         log.info("Handling WorkspaceStatus update", filterStatus(status));
@@ -193,23 +201,36 @@ export class WorkspaceManagerBridge implements Disposable {
             userId: status.metadata!.owner!,
         };
 
+        let updateError: any | undefined;
+        let skipUpdate = false;
         try {
             this.metrics.reportWorkspaceInstanceUpdateStarted(this.cluster.name, status.spec.type);
+
+            // If the last status update is identical to the current one, we can skip the update.
+            skipUpdate = !!lastStatusUpdate && !hasRelevantDiff(rawStatus, lastStatusUpdate);
+            if (skipUpdate) {
+                log.info(logCtx, "Skipped WorkspaceInstance status update");
+                return;
+            }
+
             await this.statusUpdate(ctx, rawStatus);
+
+            log.info(logCtx, "Successfully completed WorkspaceInstance status update");
         } catch (e) {
+            updateError = e;
+
+            log.error(logCtx, "Failed to complete WorkspaceInstance status update", e);
+            throw e;
+        } finally {
             const durationMs = performance.now() - start;
             this.metrics.reportWorkspaceInstanceUpdateCompleted(
                 durationMs / 1000,
                 this.cluster.name,
                 status.spec.type,
-                e,
+                skipUpdate,
+                updateError,
             );
-            log.error(logCtx, "Failed to complete WorkspaceInstance status update", e);
-            throw e;
         }
-        const durationMs = performance.now() - start;
-        this.metrics.reportWorkspaceInstanceUpdateCompleted(durationMs / 1000, this.cluster.name, status.spec.type);
-        log.info(logCtx, "Successfully completed WorkspaceInstance status update");
     }
 
     private async statusUpdate(ctx: TraceContext, rawStatus: WorkspaceStatus) {
@@ -437,3 +458,16 @@ export const filterStatus = (status: WorkspaceStatus.AsObject): Partial<Workspac
         runtime: status.runtime,
     };
 };
+
+export function hasRelevantDiff(_a: WorkspaceStatus, _b: WorkspaceStatus): boolean {
+    const a = _a.cloneMessage();
+    const b = _b.cloneMessage();
+
+    // Ignore these fields
+    a.setStatusVersion(0);
+    b.setStatusVersion(0);
+
+    const as = a.serializeBinary();
+    const bs = b.serializeBinary();
+    return !(as.length === bs.length && as.every((v, i) => v === bs[i]));
+}

--- a/components/ws-manager-bridge/src/metrics.ts
+++ b/components/ws-manager-bridge/src/metrics.ts
@@ -155,9 +155,10 @@ export class Metrics {
         durationSeconds: number,
         workspaceCluster: string,
         type: WorkspaceType,
+        skippedUpdate: boolean,
         error?: Error,
     ): void {
-        const outcome = error ? "error" : "success";
+        const outcome = skippedUpdate ? "skipped" : error ? "error" : "success";
         this.workspaceInstanceUpdateCompletedSeconds
             .labels(workspaceCluster, WorkspaceType[type], outcome)
             .observe(durationSeconds);

--- a/components/ws-manager-bridge/src/metrics.ts
+++ b/components/ws-manager-bridge/src/metrics.ts
@@ -8,7 +8,7 @@ import * as prom from "prom-client";
 import { injectable } from "inversify";
 import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { WorkspaceClusterWoTLS } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
-import { WorkspaceType } from "@gitpod/ws-manager/lib/core_pb";
+import { WorkspaceType } from "@gitpod/gitpod-protocol";
 
 @injectable()
 export class Metrics {
@@ -148,7 +148,7 @@ export class Metrics {
     }
 
     reportWorkspaceInstanceUpdateStarted(workspaceCluster: string, type: WorkspaceType): void {
-        this.workspaceInstanceUpdateStartedTotal.labels(workspaceCluster, WorkspaceType[type]).inc();
+        this.workspaceInstanceUpdateStartedTotal.labels(workspaceCluster, type).inc();
     }
 
     reportWorkspaceInstanceUpdateCompleted(
@@ -159,9 +159,7 @@ export class Metrics {
         error?: Error,
     ): void {
         const outcome = skippedUpdate ? "skipped" : error ? "error" : "success";
-        this.workspaceInstanceUpdateCompletedSeconds
-            .labels(workspaceCluster, WorkspaceType[type], outcome)
-            .observe(durationSeconds);
+        this.workspaceInstanceUpdateCompletedSeconds.labels(workspaceCluster, type, outcome).observe(durationSeconds);
     }
 
     increasePrebuildsCompletedCounter(state: string) {


### PR DESCRIPTION
## Description
Only handles updates if there was a (relevant) change to the last one for that instanceId:

On a simple workspace start/stop cycle this means 11 of 22 events got "skipped".
```
gitpod /workspace/gitpod (gpl/49-bridge-updates) $ curl localhost:9500/metrics | grep update_completed
[...]
gitpod_ws_manager_bridge_workspace_instance_update_completed_seconds_count{workspace_cluster="dev",workspace_instance_type="regular",outcome="success"} 11
[...]
gitpod_ws_manager_bridge_workspace_instance_update_completed_seconds_count{workspace_cluster="dev",workspace_instance_type="regular",outcome="skipped"} 11
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-49

## How to test
 - [start a workspace](https://gpl-49-bri18e6cd4176.preview.gitpod-dev.com/#github.com/gitpod-io/gitpod) in the preview environment, try to modify it (ports) and stop it again

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-49-bri18e6cd4176</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-49-bri18e6cd4176.preview.gitpod-dev.com/workspaces" target="_blank">gpl-49-bri18e6cd4176.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-49-bridge-updates-gha.24932</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-49-bri18e6cd4176%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
