### PR TITLE
[server] delete project env vars

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -75,12 +75,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_project_env_var",
-            primaryKeys: ["id", "projectId"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_project_info",
             primaryKeys: ["projectId"],
             deletionColumn: "deleted",

--- a/components/gitpod-db/src/typeorm/migration/1715064681193-DeleteDanglingProjectEnvVars.ts
+++ b/components/gitpod-db/src/typeorm/migration/1715064681193-DeleteDanglingProjectEnvVars.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DeleteDanglingProjectEnvVars1715064681193 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "DELETE FROM d_b_project_env_var WHERE projectId IN (SELECT id FROM d_b_project WHERE markedDeleted=true)",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -223,12 +223,7 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
 
     public async deleteProjectEnvironmentVariable(variableId: string): Promise<void> {
         const envVarRepo = await this.getProjectEnvVarRepo();
-        const envVarWithValue = await envVarRepo.findOne({ id: variableId, deleted: false });
-        if (!envVarWithValue) {
-            throw new Error("A environment variable with this name could not be found for this project");
-        }
-        envVarWithValue.deleted = true;
-        await envVarRepo.update({ id: envVarWithValue.id, projectId: envVarWithValue.projectId }, envVarWithValue);
+        await envVarRepo.delete({ id: variableId });
     }
 
     public async getProjectEnvironmentVariableValues(envVars: ProjectEnvVar[]): Promise<ProjectEnvVarWithValue[]> {

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -320,6 +320,12 @@ export class ProjectsService {
                 orgId = project.teamId;
                 await db.markDeleted(projectId);
 
+                // delete env vars
+                const envVars = await db.getProjectEnvironmentVariables(projectId);
+                for (const envVar of envVars) {
+                    await db.deleteProjectEnvironmentVariable(envVar.id);
+                }
+
                 await this.auth.removeProjectFromOrg(userId, orgId, projectId);
             });
             this.analytics.track({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Deletes project env vars together with the project.
Remove sthe two phase deletion of project env vars.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-58/project-deletion-does-not-delete-project-env-vars-to-remain-in

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
