### PR TITLE
[server] Fix mistaken re-classification of workspace start errors

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -623,6 +623,11 @@ export class WorkspaceStarter {
                     return;
                 }
 
+                if (err instanceof StartInstanceError) {
+                    // we already took care of classification at a lower level, bubble it up!
+                    throw err;
+                }
+
                 let reason: FailedInstanceStartReason = "startOnClusterFailed";
                 if (isResourceExhaustedError(err)) {
                     reason = "resourceExhausted";


### PR DESCRIPTION
## Description
imageBuildFailedUser got reported as startOnClusterFailed: 
![image](https://github.com/gitpod-io/gitpod/assets/32448529/cbd34596-5b71-45c1-9656-eed5b5e20e24)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow up for https://github.com/gitpod-io/gitpod/pull/19705

## How to test


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
