### PR TITLE
Build - make backend-plugin readiness a condition of JetBrains IDEs readiness

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
@@ -50,6 +50,9 @@ class GitpodCLIService : RestService() {
         /**
          * prod: curl http://localhost:63342/api/gitpod/cli?op=metrics
          * dev:  curl http://localhost:63343/api/gitpod/cli?op=metrics
+         *
+         * We will use this endpoint in JetBrains launcher to check if backend-plugin is ready.
+         * Please make sure this operation:metrics to respond 200
          */
         if (operation == "metrics") {
             val out = BufferExposingByteArrayOutputStream()

--- a/components/ide/jetbrains/launcher/go.mod
+++ b/components/ide/jetbrains/launcher/go.mod
@@ -10,8 +10,10 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/configcat/go-sdk/v7 v7.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gitpod-io/gitpod/components/scrubber v0.0.0-00010101000000-000000000000 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/components/ide/jetbrains/launcher/go.sum
+++ b/components/ide/jetbrains/launcher/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -9,6 +11,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/configcat/go-sdk/v7 v7.6.0 h1:CthQJ7DMz4bvUrpc8aek6VouJjisCvZCfuTG2gyNzL4=
+github.com/configcat/go-sdk/v7 v7.6.0/go.mod h1:2245V6Igy1Xz6GXvcYuK5z996Ct0VyzyuI470XS6aTw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -17,6 +21,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/frankban/quicktest v1.11.2 h1:mjwHjStlXWibxOohM7HYieIViKyh56mmt3+6viyhDDI=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -35,6 +41,7 @@ github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgj
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -54,8 +61,11 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -299,7 +299,7 @@ func serve(launchCtx *LaunchContext) {
 
 // isBackendPluginReady checks if the backend plugin is ready via backend plugin CLI GitpodCLIService.kt
 func isBackendPluginReady(backendPort string) error {
-	log.WithField("backendPort", backendPort).Info("wait backend plugin to be ready")
+	log.WithField("backendPort", backendPort).Debug("wait backend plugin to be ready")
 	// Use op=metrics so that we don't need to rebuild old backend-plugin
 	url, err := url.Parse("http://localhost:" + backendPort + "/api/gitpod/cli?op=metrics")
 	if err != nil {

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1087,6 +1087,9 @@ func getProductConfig(config *gitpod.GitpodConfig, alias string) *gitpod.Jetbrai
 
 func linkRemotePlugin(launchCtx *LaunchContext) error {
 	remotePluginsFolder := launchCtx.configDir + "/plugins"
+	if launchCtx.info.Version == "2022.3.3" {
+		remotePluginsFolder = launchCtx.backendDir + "/plugins"
+	}
 	remotePluginDir := remotePluginsFolder + "/gitpod-remote"
 	_, err := os.Stat(remotePluginDir)
 	if err == nil || !errors.Is(err, os.ErrNotExist) {

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	var exps experiments.Client
 	var gitpodHostname string
-	if gitpodUrl, err := url.Parse(wsInfo.GitpodHost); err != nil {
+	if gitpodUrl, err := url.Parse(wsInfo.GitpodHost); err == nil {
 		gitpodHost := gitpodUrl.Hostname()
 		gitpodHostname = gitpodHost
 		exps = experiments.NewClient(experiments.WithGitpodProxy(gitpodHost))

--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -83,7 +83,11 @@ var initCmd = &cobra.Command{
 			if err != nil && !(strings.Contains(err.Error(), "signal: ") || strings.Contains(err.Error(), "no child processes")) {
 				if eerr, ok := err.(*exec.ExitError); ok && eerr.ExitCode() != 0 {
 					logs := extractFailureFromRun()
-					log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
+					if eerr.ExitCode() == 2 {
+						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error")
+					} else {
+						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
+					}
 				}
 				log.WithError(err).Error("supervisor run error")
 				return

--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/process"
+	"github.com/gitpod-io/gitpod/supervisor/pkg/shared"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
 	"github.com/prometheus/procfs"
 	reaper "github.com/ramr/go-reaper"
@@ -83,8 +84,8 @@ var initCmd = &cobra.Command{
 			if err != nil && !(strings.Contains(err.Error(), "signal: ") || strings.Contains(err.Error(), "no child processes")) {
 				if eerr, ok := err.(*exec.ExitError); ok && eerr.ExitCode() != 0 {
 					logs := extractFailureFromRun()
-					if eerr.ExitCode() == 2 {
-						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error")
+					if shared.IsExpectedShutdown(eerr.ExitCode()) {
+						log.Fatal(logs)
 					} else {
 						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
 					}

--- a/components/supervisor/hot-deploy.sh
+++ b/components/supervisor/hot-deploy.sh
@@ -19,7 +19,7 @@ echo "Image Version: $version"
 bldfn="/tmp/build-$version.tar.gz"
 
 docker ps &> /dev/null || (echo "You need a working Docker daemon. Maybe set DOCKER_HOST?"; exit 1)
-leeway build -Dversion="$version" -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build .:docker --save "$bldfn"
+leeway build -Dversion="$version" -DimageRepoBase=eu.gcr.io/gitpod-dev-artifact/build .:docker --save "$bldfn"
 dev_image="$(tar xfO "$bldfn" ./imgnames.txt | head -n1)"
 echo "Dev Image: $dev_image"
 

--- a/components/supervisor/pkg/metrics/metrics.go
+++ b/components/supervisor/pkg/metrics/metrics.go
@@ -7,6 +7,7 @@ package metrics
 import (
 	"fmt"
 
+	"github.com/gitpod-io/gitpod/supervisor/pkg/shared"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -22,7 +23,7 @@ func NewMetrics() *SupervisorMetrics {
 		IDEReadyDurationTotal: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "supervisor_ide_ready_duration_total",
 			Help:    "the IDE startup time",
-			Buckets: []float64{0.1, 0.5, 1, 1.5, 2, 2.5, 5, 10},
+			Buckets: []float64{0.1, 0.5, 1, 1.5, 2, 2.5, 5, shared.IDEReadyDurationTotalMaxBucketSecond},
 		}, []string{"kind"}),
 		InitializerHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "supervisor_initializer_bytes_second",

--- a/components/supervisor/pkg/shared/constant.go
+++ b/components/supervisor/pkg/shared/constant.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package shared
+
+const (
+	IDEReadyDurationTotalMaxBucketSecond = 10
+	ExitCodeReasonIDEReadinessTimedOut   = 2
+)
+
+func IsExpectedShutdown(exitCode int) bool {
+	return exitCode == ExitCodeReasonIDEReadinessTimedOut
+}

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -53,9 +53,14 @@ type DesktopIDEStatus struct {
 }
 
 type ideReadyState struct {
-	ready bool
-	info  *DesktopIDEStatus
-	cond  *sync.Cond
+	ready     bool
+	ideConfig *IDEConfig
+	info      *DesktopIDEStatus
+	cond      *sync.Cond
+}
+
+func newIDEReadyState(ideConfig *IDEConfig) *ideReadyState {
+	return &ideReadyState{cond: sync.NewCond(&sync.Mutex{}), ideConfig: ideConfig}
 }
 
 // Wait returns a channel that emits when IDE is ready.

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -122,8 +122,7 @@ func WithRunGP(enable bool) RunOption {
 
 // The sum of those timeBudget* times has to fit within the terminationGracePeriod of the workspace pod.
 const (
-	timeBudgetIDEShutdown   = 15 * time.Second
-	ideReadyTimeoutDuration = 5 * time.Minute
+	timeBudgetIDEShutdown = 15 * time.Second
 )
 
 const (
@@ -422,6 +421,7 @@ func Run(options ...RunOption) {
 		}
 		allReady, waitFor := waitForIde(ctx, ideReady, desktopIdeReady, duration)
 		if !allReady {
+			log.WithField("waitFor", waitFor).WithField("duration", duration.String()).Error("shutdown as IDEs are not ready")
 			msg := []byte(fmt.Sprintf("%s timed out to start after %.0f minutes", waitFor, duration.Minutes()))
 			err := os.WriteFile("/dev/termination-log", msg, 0o644)
 			if err != nil {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -415,7 +415,7 @@ func Run(options ...RunOption) {
 	)
 	go func() {
 		<-cstate.ContentReady()
-		shouldWait, duration := waitSupervisorIDENotReadyShutdownDurationValue(ctx, exps, host)
+		shouldWait, duration := waitForIDENotReadyShutdownDuration(ctx, exps, host)
 		if !shouldWait {
 			return
 		}
@@ -526,7 +526,7 @@ func Run(options ...RunOption) {
 	wg.Wait()
 }
 
-func waitSupervisorIDENotReadyShutdownDurationValue(ctx context.Context, exps experiments.Client, gitpodHost string) (bool, time.Duration) {
+func waitForIDENotReadyShutdownDuration(ctx context.Context, exps experiments.Client, gitpodHost string) (bool, time.Duration) {
 	if exps == nil {
 		return false, time.Hour
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] Part 1/2 merge this PR to 
     - Bring functionality and compatibility to jb-launcer
     - Proper handle ide readiness timeout in supervisor
- [ ] Part 2/2 upgrade all backend-launcher to latest build after this PR merged into main

We have three launcher in ide-configmap.json

- `jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7` -> latest -> compatible
- `jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db` -> `f5127b661152e8040d0806a757862148e0c027c8` -> compatible
- `b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9` -> `b704c9c97e76e2a6cf42dcea14fdddfb4f313dcc`

Only the third one need to add compatible code
```
func linkRemotePlugin(launchCtx *LaunchContext) error {
	launchCtx.backendDir + "/plugins/gitpod-remote"

// to

func linkRemotePlugin(launchCtx *LaunchContext) error {
	launchCtx.configDir + "/plugins/gitpod-remote"
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates ENT-19, ENT-35

## How to test
<!-- Provide steps to test this PR -->
[Archive.zip](https://github.com/gitpod-io/gitpod/files/15246565/Archive.zip)

zip file above includes two `.yaml` files which could be used below

**It can connect and backend works well**

- Force update cm/ide-config to use latest launcher and reload ide-service
- Start IDEs (like IntelliJ) with stable, pined stable, intellij-previous, they should all works well

|stable `2024.1.1` | pinned stable `2023.3.6` | intellij-previous `2022.3.3` |
|:-:|:-:|:-:|
|<img width="934" alt="SCR-20240508-pgut" src="https://github.com/gitpod-io/gitpod/assets/20944364/57ae5304-1e7d-4c2f-91f5-a7e2f184dfba">|<img width="1037" alt="SCR-20240508-pfuq" src="https://github.com/gitpod-io/gitpod/assets/20944364/fd5f86fc-05ec-47f2-a028-3a96818c2dc1">|<img width="1219" alt="SCR-20240508-phma" src="https://github.com/gitpod-io/gitpod/assets/20944364/f23794d4-54b1-498b-97b6-b8c1ab2930a3">|


**IDE readiness should never ready with buggy backend plugin**
- Force update cm ide-config to use buggy config and reload ide-service
- Start IntelliJ with pinned stable `2023.3.6`. It should not be `Running` phase

| pinned stable `2023.3.6` | after 5 minutes|
|:-:|:-:|
|<img width="2127" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/71e18a02-4125-4f27-9fe6-2265cd75d561">|<img width="1029" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/d3bc5a8b-c572-4de8-9f52-271b1d987512">|

Metric status
<img width="2268" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/cd254a20-1c5e-4068-87ca-ae5af443b41c">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-backend-readiness</li>
	<li><b>🔗 URL</b> - <a href="https://hw-backend-readiness.preview.gitpod-dev.com/workspaces" target="_blank">hw-backend-readiness.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-backend-readiness-gha.25020</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-backend-readiness%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
