### PR TITLE
Opportunistic token refresh (for BitBucket Server)

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-token-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-token-entry.ts
@@ -31,6 +31,12 @@ export class DBTokenEntry implements TokenEntry {
     })
     expiryDate?: string;
 
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    reservedUntilDate?: string;
+
     @Column()
     refreshable?: boolean;
 

--- a/components/gitpod-db/src/typeorm/migration/1715096375962-TokenReservedUntil.ts
+++ b/components/gitpod-db/src/typeorm/migration/1715096375962-TokenReservedUntil.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const table = "d_b_token_entry";
+const newColumn = "reservedUntilDate";
+
+export class TokenReservedUntil1715096375962 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, table, newColumn))) {
+            await queryRunner.query(
+                `ALTER TABLE ${table} ADD COLUMN \`${newColumn}\` varchar(255) NOT NULL DEFAULT ''`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, table, newColumn)) {
+            await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN \`${newColumn}\``);
+        }
+    }
+}

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -97,7 +97,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository, Trans
      * @param identity
      * @throws an error when there is more than one token
      */
-    findTokenForIdentity(identity: Identity): Promise<Token | undefined>;
+    findTokenEntryForIdentity(identity: Identity): Promise<TokenEntry | undefined>;
 
     /**
      *

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -618,6 +618,7 @@ export interface Token {
     scopes: string[];
     updateDate?: string;
     expiryDate?: string;
+    reservedUntilDate?: string;
     idToken?: string;
     refreshToken?: string;
     username?: string;
@@ -628,6 +629,7 @@ export interface TokenEntry {
     authId: string;
     token: Token;
     expiryDate?: string;
+    reservedUntilDate?: string;
     refreshable?: boolean;
 }
 
@@ -1416,7 +1418,7 @@ export interface OAuth2Config {
 }
 
 export namespace AuthProviderEntry {
-    export type Type = "GitHub" | "GitLab" | string;
+    export type Type = "GitHub" | "GitLab" | "Bitbucket" | "BitbucketServer" | string;
     export type Status = "pending" | "verified";
     export type NewEntry = Pick<AuthProviderEntry, "ownerId" | "host" | "type"> & {
         clientId?: string;

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -5,7 +5,7 @@
  */
 
 import express from "express";
-import { AuthProviderInfo, User, AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { AuthProviderInfo, User, AuthProviderEntry, Token } from "@gitpod/gitpod-protocol";
 
 import { UserEnvVarValue } from "@gitpod/gitpod-protocol";
 
@@ -89,7 +89,8 @@ export interface AuthProvider {
         state: string,
         scopes?: string[],
     ): void;
-    refreshToken?(user: User): Promise<void>;
+    refreshToken?(user: User, requestedLifetimeDate: Date): Promise<Token>;
+    requiresOpportunisticRefresh?(): boolean;
 }
 
 export interface AuthFlow {

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -385,7 +385,7 @@ export function reportAuthorizerSubjectId(match: AuthorizerSubjectIdMatch) {
 export const scmTokenRefreshRequestsTotal = new prometheusClient.Counter({
     name: "gitpod_scm_token_refresh_requests_total",
     help: "Counter for the number of token refresh requests we issue against SCM systems",
-    labelNames: ["host", "result"],
+    labelNames: ["host", "result", "opportunisticRefresh"],
 });
 export type ScmTokenRefreshResult =
     | "success"
@@ -395,8 +395,13 @@ export type ScmTokenRefreshResult =
     | "no_token"
     | "not_refreshable"
     | "success_after_timeout";
-export function reportScmTokenRefreshRequest(host: string, result: ScmTokenRefreshResult) {
-    scmTokenRefreshRequestsTotal.labels(host, result).inc();
+export type OpportunisticRefresh = "true" | "false" | "reserved";
+export function reportScmTokenRefreshRequest(
+    host: string,
+    opportunisticRefresh: OpportunisticRefresh,
+    result: ScmTokenRefreshResult,
+) {
+    scmTokenRefreshRequestsTotal.labels(host, result, opportunisticRefresh).inc();
 }
 
 export const scmTokenRefreshLatencyHistogram = new prometheusClient.Histogram({

--- a/components/server/src/user/token-provider.ts
+++ b/components/server/src/user/token-provider.ts
@@ -12,7 +12,7 @@ export interface TokenProvider {
      * Returns a valid authentication token for the given host and user
      * @param user
      * @param host
-     * @param expiryThreshold the time in minutes which a token has to be valid for to be considered as valid
+     * @param requestedLifetimeMins the time in minutes which a token has to be valid for to be considered as valid
      */
-    getTokenForHost(user: User | string, host: string, expiryThreshold?: number): Promise<Token | undefined>;
+    getTokenForHost(user: User | string, host: string, requestedLifetimeMins?: number): Promise<Token | undefined>;
 }

--- a/components/server/src/user/token-service.spec.db.ts
+++ b/components/server/src/user/token-service.spec.db.ts
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import "mocha";
+import { Container } from "inversify";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, TypeORM, UserDB } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import { OrganizationService } from "../orgs/organization-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
+import { UserService } from "./user-service";
+import { Organization, Token, User } from "@gitpod/gitpod-protocol";
+import { TokenService } from "./token-service";
+import { TokenProvider } from "./token-provider";
+import { HostContextProvider } from "../auth/host-context-provider";
+import { AuthProvider } from "../auth/auth-provider";
+import { HostContext } from "../auth/host-context";
+
+const expect = chai.expect;
+
+describe("TokenService", async () => {
+    const githubAuthProviderId = "Public-GitHub";
+    const githubAuthProviderHost = "github.com";
+    const githubUserAuthId = "github-authid";
+    const bbsAuthProviderId = "bitbucket-example-org";
+    const bbsAuthProviderHost = "bitbucket.example.org";
+    const bbsUserAuthId = "bbs-authid";
+
+    let container: Container;
+    let tokenService: TokenService;
+    let userService: UserService;
+    let userDB: UserDB;
+    let orgService: OrganizationService;
+    let org: Organization;
+    let owner: User;
+    let user: User;
+
+    let token: Token;
+
+    const date0h = new Date("2020-01-01T00:00:00.000Z");
+    const date1h30m = new Date("2020-01-01T01:30:00.000Z");
+    const date1h = new Date("2020-01-01T01:00:00.000Z");
+    const date2h = new Date("2020-01-01T02:00:00.000Z");
+    const date3h = new Date("2020-01-01T03:00:00.000Z");
+    // const date4h = new Date("2020-01-01T04:00:00.000Z");
+
+    let mockedDate: Date;
+    let globalDateCtor: DateConstructor;
+    class MockDate extends Date {
+        constructor(value: number | string | Date | undefined) {
+            if (!value) {
+                super(mockedDate);
+            } else {
+                super(value);
+            }
+        }
+
+        now() {
+            return mockedDate.getTime();
+        }
+    }
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        Experiments.configureTestingClient({
+            centralizedPermissions: true,
+            opportunistic_token_refresh: true,
+        });
+
+        // re-overwrite the stuff mocked out in createTestContainer
+        container.rebind(TokenProvider).toService(TokenService);
+        container.rebind(HostContextProvider).toConstantValue({
+            get: (host: string) => {
+                switch (host) {
+                    case githubAuthProviderHost: {
+                        return <HostContext>{
+                            authProvider: <AuthProvider>{
+                                authProviderId: githubAuthProviderId,
+                                info: {
+                                    authProviderId: githubAuthProviderId,
+                                    authProviderType: "GitHub",
+                                    host: githubAuthProviderHost,
+                                },
+                                refreshToken: async (user: User, requestedLifetimeDate: Date) => {
+                                    return refreshedToken(requestedLifetimeDate);
+                                },
+                            },
+                            services: {
+                                repositoryService: {
+                                    installAutomatedPrebuilds: async (user: any, cloneUrl: string) => {},
+                                },
+                                repositoryProvider: {
+                                    hasReadAccess: async (user: any, owner: string, repo: string) => {
+                                        return true;
+                                    },
+                                },
+                            },
+                        };
+                    }
+                    case bbsAuthProviderHost: {
+                        return <HostContext>{
+                            authProvider: <AuthProvider>{
+                                authProviderId: bbsAuthProviderId,
+                                info: {
+                                    authProviderId: bbsAuthProviderId,
+                                    authProviderType: "BitbucketServer",
+                                    host: bbsAuthProviderHost,
+                                },
+                                refreshToken: async (user: User, requestedLifetimeDate: Date) => {
+                                    return refreshedToken(requestedLifetimeDate);
+                                },
+                                requiresOpportunisticRefresh: () => {
+                                    return true;
+                                },
+                            },
+                            services: {
+                                repositoryService: {
+                                    installAutomatedPrebuilds: async (user: any, cloneUrl: string) => {},
+                                },
+                                repositoryProvider: {
+                                    hasReadAccess: async (user: any, owner: string, repo: string) => {
+                                        return true;
+                                    },
+                                },
+                            },
+                        };
+                    }
+                }
+            },
+        });
+
+        tokenService = container.get<TokenService>(TokenService);
+        userDB = container.get<UserDB>(UserDB);
+        userService = container.get<UserService>(UserService);
+        orgService = container.get<OrganizationService>(OrganizationService);
+        org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
+        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
+        // first not builtin user join an org will be an owner
+        owner = await userService.createUser({
+            organizationId: org.id,
+            identity: {
+                authId: "foo",
+                authName: "bar",
+                authProviderId: "github",
+                primaryEmail: "yolo@yolo.com",
+            },
+        });
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(owner.id, invite.id));
+
+        user = await userService.createUser({
+            organizationId: org.id,
+            identity: {
+                authId: githubUserAuthId,
+                authName: "github-authname",
+                authProviderId: githubAuthProviderId,
+                primaryEmail: "yolo@yolo.com",
+            },
+        });
+        user.identities.push({
+            authId: bbsUserAuthId,
+            authName: "bbs-authname",
+            authProviderId: bbsAuthProviderId,
+            primaryEmail: "yolo@yolo.com",
+        });
+        await userDB.storeUser(user);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(user.id, invite.id));
+
+        // test data
+        token = <Token>{
+            scopes: ["repo"],
+            value: "token",
+            updateDate: date0h.toISOString(),
+            expiryDate: date2h.toISOString(),
+            reservedUntilDate: undefined,
+            refreshToken: "refresh-token",
+            username: "username",
+        };
+        await userDB.storeSingleToken({ authId: githubUserAuthId, authProviderId: githubAuthProviderId }, token);
+        await userDB.storeSingleToken({ authId: bbsUserAuthId, authProviderId: bbsAuthProviderId }, token);
+
+        globalDateCtor = global.Date;
+        global.Date = MockDate as any as DateConstructor;
+        setTime(date0h);
+    });
+
+    function refreshedToken(requestedLifetimeDate: Date): Token {
+        const now = new Date();
+        const expiryDate = new Date(now);
+        expiryDate.setTime(now.getTime() + 2 * 60 * 60 * 1000);
+        return {
+            scopes: ["repo"],
+            value: "refreshed-token",
+            updateDate: now.toISOString(),
+            expiryDate: expiryDate.toISOString(),
+            reservedUntilDate: requestedLifetimeDate.toISOString(),
+            refreshToken: "refreshed-refresh-token",
+            username: "refreshed-username",
+        };
+    }
+
+    afterEach(async () => {
+        const typeorm = container.get(TypeORM);
+        await resetDB(typeorm);
+        // Deactivate all services
+        await container.unbindAllAsync();
+        global.Date = globalDateCtor;
+    });
+
+    function setTime(date: Date) {
+        mockedDate = date;
+    }
+
+    it("getTokenForHost - still valid", async () => {
+        setTime(date1h);
+
+        const actual = await tokenService.getTokenForHost(user, githubAuthProviderHost);
+        const expectation = <Token>{
+            scopes: ["repo"],
+            value: "token",
+            updateDate: "2020-01-01T00:00:00.000Z",
+            expiryDate: "2020-01-01T02:00:00.000Z",
+            reservedUntilDate: "2020-01-01T01:05:00.000Z",
+            refreshToken: "refresh-token",
+            username: "username",
+        };
+        expect(actual).to.deep.equal(expectation);
+    });
+
+    it("getTokenForHost - needs refresh", async () => {
+        setTime(date3h);
+
+        const actual = await tokenService.getTokenForHost(user, githubAuthProviderHost);
+        const expectation = <Token>{
+            scopes: ["repo"],
+            value: "refreshed-token",
+            updateDate: "2020-01-01T03:00:00.000Z",
+            expiryDate: "2020-01-01T05:00:00.000Z",
+            reservedUntilDate: "2020-01-01T03:05:00.000Z",
+            refreshToken: "refreshed-refresh-token",
+            username: "refreshed-username",
+        };
+        expect(actual).to.deep.equal(expectation);
+    });
+
+    it("getTokenForHost - still valid, with opportunistic refresh", async () => {
+        setTime(date1h);
+
+        // Bitbucket Server requires opportunistic refresh
+        const actual = await tokenService.getTokenForHost(user, bbsAuthProviderHost);
+        const expectation = <Token>{
+            scopes: ["repo"],
+            value: "refreshed-token",
+            updateDate: "2020-01-01T01:00:00.000Z",
+            expiryDate: "2020-01-01T03:00:00.000Z",
+            reservedUntilDate: "2020-01-01T01:05:00.000Z",
+            refreshToken: "refreshed-refresh-token",
+            username: "refreshed-username",
+        };
+        expect(actual).to.deep.equal(expectation);
+    });
+
+    it("getTokenForHost - still valid and reserved, no opportunistic refresh", async () => {
+        setTime(date1h);
+        const te = await userDB.findTokenEntryForIdentity({
+            authId: bbsUserAuthId,
+            authName: "llala",
+            authProviderId: bbsAuthProviderId,
+        });
+        // Token is reserved for 30 minutes
+        await userDB.updateTokenEntry({ uid: te!.uid, reservedUntilDate: date1h30m.toISOString() });
+
+        // Bitbucket Server requires opportunistic refresh
+        const actual = await tokenService.getTokenForHost(user, bbsAuthProviderHost);
+        const expectation = <Token>{
+            scopes: ["repo"],
+            value: "token",
+            updateDate: "2020-01-01T00:00:00.000Z",
+            expiryDate: "2020-01-01T02:00:00.000Z",
+            reservedUntilDate: "2020-01-01T01:30:00.000Z",
+            refreshToken: "refresh-token",
+            username: "username",
+        };
+        expect(actual).to.deep.equal(expectation);
+    });
+
+    it("getTokenForHost - still valid and reserved, no opportunistic refresh, but extended reservation", async () => {
+        setTime(date1h);
+        const te = await userDB.findTokenEntryForIdentity({
+            authId: bbsUserAuthId,
+            authName: "llala",
+            authProviderId: bbsAuthProviderId,
+        });
+        // Token is reserved for 3 minutes
+        await userDB.updateTokenEntry({ uid: te!.uid, reservedUntilDate: "2020-01-01T01:03:00.000Z" });
+
+        // Bitbucket Server requires opportunistic refresh
+        const actual = await tokenService.getTokenForHost(user, bbsAuthProviderHost);
+        const expectation = <Token>{
+            scopes: ["repo"],
+            value: "token",
+            updateDate: "2020-01-01T00:00:00.000Z",
+            expiryDate: "2020-01-01T02:00:00.000Z",
+            reservedUntilDate: "2020-01-01T01:05:00.000Z", // reservation extended to 5 minutes
+            refreshToken: "refresh-token",
+            username: "username",
+        };
+        expect(actual).to.deep.equal(expectation);
+    });
+});

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1854,7 +1854,7 @@ export class WorkspaceStarter {
             targetMode = CloneTargetMode.REMOTE_HEAD;
         }
 
-        const tokenValidityPeriodMins = (await getScmAccessTokenLifetime(user)) || SCM_TOKEN_LIFETIME_MINS;
+        const tokenValidityPeriodMins = await getScmAccessTokenLifetimeMins(user);
         const gitToken = await this.tokenProvider.getTokenForHost(user, host, tokenValidityPeriodMins);
         if (!gitToken) {
             throw new Error(`No token for host: ${host}`);
@@ -1981,14 +1981,16 @@ export async function isWorkspaceClassDiscoveryEnabled(user: { id: string }): Pr
     });
 }
 
-export async function getScmAccessTokenLifetime(user: { id: string }): Promise<number | undefined> {
-    return getExperimentsClientForBackend().getValueAsync<number | undefined>(
+export async function getScmAccessTokenLifetimeMins(user: { id: string }): Promise<number> {
+    const customValue = await getExperimentsClientForBackend().getValueAsync<number | undefined>(
         "workspace_start_scm_access_token_lifetime",
         undefined,
         {
             user: user,
         },
     );
+
+    return customValue || SCM_TOKEN_LIFETIME_MINS;
 }
 
 export class ScmStartError extends Error {


### PR DESCRIPTION
## Description
This aims to introduce a new feature for token refreshes with SCMs dubbed "opportunistic refresh". If the feature flag is enabled, AND the SCM requires it (for now only BitBucket Server!), we ask for a fresh token whenever we "safely" can.

This "safely" is determined by us storing a new `reservedUntilDate` with each SCM token, with is set/updated whenever we re-use a token. This way, whenever we do a lookup on a SCM token, we know whether we can safely refresh it or not.

**Operational controls**:
 - introduces the `workspace_start_scm_access_token_lifetime` feature flag which controls the requested lifetime of a SCM token
   - the default for SCM tokens is 5mins
   - the default for SCM tokens on workspace start is 10mins
   - we can override the later with this feature flag
 - introduces the `opportunistic_token_refresh` feature flag which controls whether "opportunistic refresh" is enabled at all
 - updates the `gitpod_scm_token_refresh_requests_total` metric with a new label `opportunisticRefresh` (`"true" | "false" | "reserved"`)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-4

## How to test
 - check the unit tests [here](https://github.com/gitpod-io/gitpod/pull/19715/files#diff-68da8a99b384ed20bcbaf557f87a2c9c0827fe138d7c158c7f4ec91c7ce51ccdR218-R313)
 - manual testing:
   - observe `kubectl logs server-5d5cdb8db5-tj9bl -f | grep "Token refreshed"` and noticed how values change
   - [join my org](https://gpl-bbs-toc9354957bc.preview.gitpod-dev.com/orgs/join?inviteId=80bd1d8e-cbc7-420a-94af-2f011b91becc), and open a repo from our BitBucket instance

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
