### PR TITLE
[code] upgrade Browser VS Code to 1.89.1

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -20,6 +20,14 @@
         ],
         "versions": [
           {
+            "version": "1.89.1",
+            "image": "{{.Repository}}/ide/code:commit-06ae77a61f11e65a8f9cbb871eb69383caa6fbd4",
+            "imageLayers": [
+              "{{.CodeWebExtensionImage}}",
+              "{{.CodeHelperImage}}"
+            ]
+          },
+          {
             "version": "1.89.0",
             "image": "{{.Repository}}/ide/code:commit-8a412095311a2ee0460abca3a4461704c4533374",
             "imageLayers": [

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                  = "ide/code"
-	CodeIDEImageStableVersion     = "commit-8a412095311a2ee0460abca3a4461704c4533374" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion     = "commit-06ae77a61f11e65a8f9cbb871eb69383caa6fbd4" // stable version that will be updated manually on demand
 	Code1_85IDEImageStableVersion = "commit-cb1173f2a457633550a7fdc89af86d8d4da51876"
 	CodeHelperIDEImage            = "ide/code-codehelper"
 	CodeWebExtensionImage         = "ide/gitpod-code-web"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Upgrade Browser VS Code to 1.89.1

## How to test
<!-- Provide steps to test this PR -->
Tested on https://github.com/gitpod-io/gitpod/pull/19726. So we can check about page's commit sha with stable code

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-1891-vs</li>
	<li><b>🔗 URL</b> - <a href="https://hw-1891-vs.preview.gitpod-dev.com/workspaces" target="_blank">hw-1891-vs.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-1891-vs-gha.25123</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-1891-vs%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-large-vm

/hold
