### PR TITLE
[image-builder-mk3] Improve logging and tracing for build

### DIFF
--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -21,9 +21,11 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/common-go/watch"
 	"github.com/gitpod-io/gitpod/image-builder/api"
 )
@@ -277,7 +279,11 @@ type Resolver struct {
 }
 
 // ResolveRequestAuth computes the allowed authentication for a build based on its request
-func (r Resolver) ResolveRequestAuth(auth *api.BuildRegistryAuth) (authFor AllowedAuthFor) {
+func (r Resolver) ResolveRequestAuth(ctx context.Context, auth *api.BuildRegistryAuth) (authFor AllowedAuthFor) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "ResolveRequestAuth")
+	var err error
+	defer tracing.FinishSpan(span, &err)
+
 	// by default we allow nothing
 	authFor = AllowedAuthForNone()
 	if auth == nil {

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -236,7 +236,7 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 		if req.Auth != nil && req.Auth.GetSelective() != nil {
 			// allow access to baseImage repository so we can look it up later
 			req.Auth.GetSelective().AllowBaserep = true
-			reqauth = o.AuthResolver.ResolveRequestAuth(req.Auth)
+			reqauth = o.AuthResolver.ResolveRequestAuth(ctx, req.Auth)
 		}
 
 		wsrefstr, err := o.getWorkspaceImageRef(ctx, req.BaseImageNameResolved)

--- a/components/image-builder-mk3/pkg/resolve/resolve.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve.go
@@ -152,6 +152,10 @@ type DockerRefResolverOption func(o *opts)
 
 // WithAuthentication sets a base64 encoded authentication for accessing a Docker registry
 func WithAuthentication(auth *auth.Authentication) DockerRefResolverOption {
+	if auth == nil {
+		log.Debug("WithAuthentication - auth was nil")
+	}
+
 	return func(o *opts) {
 		o.Auth = auth
 	}

--- a/dev/gpctl/cmd/imagebuilds-list.go
+++ b/dev/gpctl/cmd/imagebuilds-list.go
@@ -27,6 +27,7 @@ var imagebuildsListCmd = &cobra.Command{
 			log.WithError(err).Fatal("cannot connect")
 		}
 		defer conn.Close()
+		log.Info("connected")
 
 		// build did start, print log until done
 		resp, err := client.ListBuilds(ctx, &builder.ListBuildsRequest{})

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -64,6 +64,9 @@
             "path": "components/ws-manager-api"
         },
         {
+            "path": "components/ws-manager-bridge"
+        },
+        {
             "path": "components/ws-manager-mk2"
         },
         {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Improve logging and tracing for build
* Add ws-manager-bridge to VS Code workspace
* Be able to trigger image builds with gpctl again

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-72
Related to #19745 

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-i2fedbade13</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-i2fedbade13.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-i2fedbade13.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-imagebuild-unauth-gha.25151</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-i2fedbade13%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
