### PR TITLE
[registry-facade] switch to use hostPort

### DIFF
--- a/dev/preview/workflow/preview/post-process.sh
+++ b/dev/preview/workflow/preview/post-process.sh
@@ -56,8 +56,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
    NAME=$(yq r k8s.yaml -d "$documentIndex" metadata.name)
    KIND=$(yq r k8s.yaml -d "$documentIndex" kind)
    if [[ "$SIZE" -ne "0" ]] && [[ "$NAME" == "registry-facade" ]] && [[ "$KIND" == "DaemonSet" ]] ; then
-      echo "setting $NAME to $REG_DAEMON_PORT"
-      yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.containers.[0].ports.[0].hostPort "$REG_DAEMON_PORT"
       echo "setting $NAME probe period to 120s"
       yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.containers.[0].livenessProbe.periodSeconds 120
       yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.containers.[0].livenessProbe.initialDelaySeconds 15

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -203,6 +203,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Ports: []corev1.ContainerPort{{
 							Name:          ContainerPortName,
 							ContainerPort: ServicePort,
+							HostPort:      ServicePort,
 						}},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               pointer.Bool(false),

--- a/install/installer/pkg/components/registry-facade/objects.go
+++ b/install/installer/pkg/components/registry-facade/objects.go
@@ -24,13 +24,7 @@ var Objects = common.CompositeRenderFunc(
 			ServicePort:   ServicePort,
 		},
 	}, func(svc *corev1.Service) {
-		svc.Spec.Type = corev1.ServiceTypeNodePort
-		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
-
-		clusterInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-		svc.Spec.InternalTrafficPolicy = &clusterInternalTrafficPolicy
-
-		svc.Spec.Ports[0].NodePort = common.RegistryFacadeServicePort
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
 	}),
 	common.DefaultServiceAccount(Component),
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[registry-facade] switch to use hostPort

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-30

## How to test
<!-- Provide steps to test this PR -->

Tested mutil workspace node
<img width="1714" alt="SCR-20240513-opno" src="https://github.com/gitpod-io/gitpod/assets/8299500/24d087f1-b9fb-4c57-800c-c63ded205cd3">

Tested start from zero node

<img width="1717" alt="SCR-20240513-orty" src="https://github.com/gitpod-io/gitpod/assets/8299500/126584b6-5f04-44a8-b95b-42cb1f70c2cc">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-hostnetwork</li>
	<li><b>🔗 URL</b> - <a href="https://pd-hostnetwork.preview.gitpod-dev.com/workspaces" target="_blank">pd-hostnetwork.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-hostnetwork-gha.25194</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-hostnetwork%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
