### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -402,6 +402,14 @@
         ],
         "versions": [
           {
+            "version": "2024.1.2",
+            "image": "{{.Repository}}/ide/rider:commit-e6e412c809dfa004678166a82f1243cedd3e7167",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+            ]
+          },
+          {
             "version": "2024.1.1",
             "image": "{{.Repository}}/ide/rider:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_