### PR TITLE
Update JetBrains launcher image

### DIFF
--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -14,6 +14,7 @@ for (let ide in json.ideOptions.options) {
         json.ideOptions.options[ide].latestImage = replaceImage(json.ideOptions.options[ide].latestImage);
         json.ideOptions.options[ide].versions = json.ideOptions.options[ide].versions?.map((version) => {
             version.image = replaceImage(version.image);
+            version.imageLayers = version.imageLayers.map(replaceImage);
             return version;
         });
     }

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -121,7 +121,7 @@
             "image": "{{.Repository}}/ide/intellij:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -129,7 +129,7 @@
             "image": "{{.Repository}}/ide/intellij:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -137,7 +137,7 @@
             "image": "{{.Repository}}/ide/intellij:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -177,7 +177,7 @@
             "image": "{{.Repository}}/ide/goland:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -185,7 +185,7 @@
             "image": "{{.Repository}}/ide/goland:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -193,7 +193,7 @@
             "image": "{{.Repository}}/ide/goland:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -222,7 +222,7 @@
             "image": "{{.Repository}}/ide/pycharm:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -230,7 +230,7 @@
             "image": "{{.Repository}}/ide/pycharm:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -238,7 +238,7 @@
             "image": "{{.Repository}}/ide/pycharm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -266,7 +266,7 @@
             "image": "{{.Repository}}/ide/phpstorm:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -274,7 +274,7 @@
             "image": "{{.Repository}}/ide/phpstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -282,7 +282,7 @@
             "image": "{{.Repository}}/ide/phpstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -310,7 +310,7 @@
             "image": "{{.Repository}}/ide/rubymine:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -318,7 +318,7 @@
             "image": "{{.Repository}}/ide/rubymine:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -326,7 +326,7 @@
             "image": "{{.Repository}}/ide/rubymine:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -354,7 +354,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -362,7 +362,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -370,7 +370,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -378,7 +378,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -406,7 +406,7 @@
             "image": "{{.Repository}}/ide/rider:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -414,7 +414,7 @@
             "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]
@@ -442,7 +442,7 @@
             "image": "{{.Repository}}/ide/clion:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-2e8e2d9d60156010db07711335f362299242c6a7"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           },
           {
@@ -450,7 +450,7 @@
             "image": "{{.Repository}}/ide/clion:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-614cc59b70f3ebfe26b3a31a32088da54af1c9db"
+              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
             ]
           }
         ]

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -68,7 +68,7 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		JetBrainsPluginLatestImage:     ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version),
 		JetBrainsLauncherImage:         ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version),
 		JetBrainsPluginImagePrevious:   ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-e7eb44545510a8293c5c6aa814a0ad4e81852e5f"),
-		JetBrainsLauncherImagePrevious: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-b6bd8411cbb5682eb18ef60a3b9fa8cdbb2b64d9"),
+		JetBrainsLauncherImagePrevious: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, "commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"),
 
 		WorkspaceVersions: ctx.VersionManifest.Components,
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Part 2 of https://github.com/gitpod-io/gitpod/pull/19710

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-19, ENT-35

## How to test
<!-- Provide steps to test this PR -->
Smoke test IDEs, they should all works
Feature flags:
- `jb_wait_backend_plugin_readiness` - control whether launcher will check backend-plugin or not
- `supervisor_ide_not_ready_shutdown_duration` - control the duration of supervisor to shutdown itself when IDEs are not ready

|Case|FF|VSCode Desktop | IntelliJ | pinned IntelliJ (2023.3.6) | previous IntelliJ | Rider (buggy) |
|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| ✅ FF init values | `false`, `undefined` | <img width="639" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/dd54b4ad-0257-49b2-a5d4-4dda1fbb87e9">|<img width="1157" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/2f3055d8-0976-43bb-8ddb-c7edd85c4337">|<img width="1146" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/c1d21553-4b3b-4d54-b83f-28d8a698c676">|<img width="1143" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/bf99b63a-96f6-4dee-a518-55fb959d0ab8">|<img width="631" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/e9402c4a-efd1-49e4-a868-34076660b35c">Have no license to activate|
| ✅ wait backend-plugin| `true`, `2m` | <img width="516" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/7ee2ec93-c6af-49ca-8e3a-f2933a3330d9">|<img width="1188" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/b037a294-b686-478c-98ff-ec08af0220a0">|<img width="558" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/0715a9e0-a8d8-492c-ac45-a97fb31e95b6"> <img width="689" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/b335bc5b-3e95-4a77-9b9b-d499c1d826f4">| <img width="520" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/ab24987d-4319-4e88-842f-fc601f7c7329"><img width="657" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/7e6ce506-0eb3-435a-8f1a-554801b68568">|<img width="412" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/32e6b44c-1b8c-421b-9780-0840f14fcfae"><img width="587" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/81b1a01f-a369-42a9-8f99-a8a4738aebab">|

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-launcher</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-launcher.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-launcher.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-launcher-gha.25188</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-launcher%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] with-monitoring
</details>

/hold
