### PR TITLE
[image-builder] Fix ignoring of user-passed authentication

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1060,7 +1060,6 @@ export class WorkspaceStarter {
         imgsrc: WorkspaceImageSource,
         user: User,
         additionalAuth: Map<string, string>,
-        ignoreBaseImageresolvedAndRebuildBase: boolean = false,
     ): Promise<{ src: BuildSource; auth: BuildRegistryAuth; disposable?: Disposable }> {
         const span = TraceContext.startSpan("prepareBuildRequest", ctx);
 
@@ -1176,7 +1175,6 @@ export class WorkspaceStarter {
                 workspace.imageSource!,
                 user,
                 additionalAuth,
-                ignoreBaseImageresolvedAndRebuildBase || forceRebuild,
             );
 
             const req = new BuildRequest();


### PR DESCRIPTION
## Description
With https://github.com/gitpod-io/gitpod/pull/19474 a bug was introduced that ignores two registry authentication special cases:
 1. installation defined registry auth ([code](https://github.com/gitpod-io/gitpod/pull/19474/files#diff-b1c591e18af598ccba93b570ce7c97dece0988c9109a6d3be82bbe0df1fbd619L1057-L1062))
    - this is an old self-hosted feature, and we don't seem to be using it anymore :heavy_check_mark:  
 2. user-defined registry auth (the `GITPOD_IMAGE_AUTH` variable)
    - this one is fixed with this PR :point_down:  

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-72

## How to test
 - start an image build referencing a base image in a private repository (via `GITPOD_IMAGE_AUTH`)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-72-fixab59193ca7</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-72-fixab59193ca7.preview.gitpod-dev.com/workspaces" target="_blank">gpl-72-fixab59193ca7.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-72-fix-image-auth-gha.25210</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-72-fixab59193ca7%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
