### PR TITLE
Switch to new instance when instanceId updated

### DIFF
--- a/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
+++ b/components/dashboard/src/data/workspaces/listen-to-workspace-ws-messages.ts
@@ -10,11 +10,7 @@ import { useEffect } from "react";
 import { getListWorkspacesQueryKey, ListWorkspacesQueryResult } from "./list-workspaces-query";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { stream, workspaceClient } from "../../service/public-api";
-import {
-    WatchWorkspaceStatusRequest,
-    WatchWorkspaceStatusResponse,
-    Workspace,
-} from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { WatchWorkspaceStatusResponse, Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 
 export const useListenToWorkspacesWSMessages = () => {
     const queryClient = useQueryClient();
@@ -54,7 +50,7 @@ export const useListenToWorkspacesWSMessages = () => {
 export type WatchWorkspaceStatusCallback = (response: WatchWorkspaceStatusResponse) => Promise<void> | void;
 
 export function watchWorkspaceStatus(workspaceId: string | undefined, cb: WatchWorkspaceStatusCallback): Disposable {
-    return stream<WatchWorkspaceStatusRequest>(
+    return stream<WatchWorkspaceStatusResponse>(
         (options) => workspaceClient.watchWorkspaceStatus({ workspaceId }, options),
         cb,
     );

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -330,20 +330,15 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         // Only exception is when we do the switch from the "old" to the "new" one.
         const startedInstanceId = this.state?.startedInstanceId;
         if (startedInstanceId !== workspace.status.instanceId) {
-            // do we want to switch to "new" instance we just received an update for?
-            const switchToNewInstance =
-                this.state.workspace?.status?.phase?.name === WorkspacePhase_Phase.STOPPED &&
-                workspace.status?.phase?.name !== WorkspacePhase_Phase.STOPPED;
-            if (!switchToNewInstance) {
-                return;
-            }
+            // do we want to switch to "new" instance we just received an update for? Yes
             this.setState({
                 startedInstanceId: workspace.status.instanceId,
                 workspace,
             });
-
-            // now we're listening to a new instance, which might have been started with other IDEoptions
-            this.fetchIDEOptions();
+            if (startedInstanceId) {
+                // now we're listening to a new instance, which might have been started with other IDEoptions
+                this.fetchIDEOptions();
+            }
         }
 
         await this.ensureWorkspaceAuth(workspace.status.instanceId, false); // Don't block the workspace auth retrieval, as it's guaranteed to get a seconds chance later on!

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -330,6 +330,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         // Only exception is when we do the switch from the "old" to the "new" one.
         const startedInstanceId = this.state?.startedInstanceId;
         if (startedInstanceId !== workspace.status.instanceId) {
+            const latestInfo = await workspaceClient.getWorkspace({ workspaceId: workspace.id });
+            const latestInstanceId = latestInfo.workspace?.status?.instanceId;
+            if (workspace.status.instanceId !== latestInstanceId) {
+                return;
+            }
             // do we want to switch to "new" instance we just received an update for? Yes
             this.setState({
                 startedInstanceId: workspace.status.instanceId,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

if instanceId changed while last received phase is not STOPPED (like network problem or something else), we will ignore status updates

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-52

## How to test
<!-- Provide steps to test this PR -->
Not sure

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-try-stop</li>
	<li><b>🔗 URL</b> - <a href="https://hw-try-stop.preview.gitpod-dev.com/workspaces" target="_blank">hw-try-stop.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-try-stop-gha.25249</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-try-stop%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
