### PR TITLE
[obs] alert on-call when ws-manager-bridge events received is too high

### DIFF
--- a/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
+++ b/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
@@ -20,3 +20,14 @@ spec:
         summary: WS Manager Bridge has excessive CPU usage.
         description: WS Manager Bridge is consumming too much CPU. Please investigate.
         dashboard_url: https://grafana.gitpod.io/d/AJKH-pJ4k/kubernetes-applications?var-cluster={{ $labels.cluster }}&var-job=ws-manager-bridge&var-pod=All
+    - alert: WsManagerBridgeHighEventsReceived
+      expr: sum(rate(gitpod_ws_manager_bridge_workspace_instance_update_completed_seconds_count{job="ws-manager-bridge"}[5m])) by (cluster) > 10
+      for: 10m
+      labels:
+        severity: error
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WsManagerBridgeHighEventsReceived.md
+        summary: WS Manager Bridge events received from ws-manager-mk2 is abnormally high
+        description: If it becomes too high, it'll prevent workspaces from starting. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/AJKH-pJ4k/kubernetes-applications?var-cluster={{ $labels.cluster }}&var-job=ws-manager-bridge&var-pod=All


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Alert on-call when `ws-manager-bridge` events received is too high. I'll open a PR next for the runbook.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
This would of been detected here:
![image](https://github.com/gitpod-io/gitpod/assets/1272076/3028c37a-e0ca-4338-abc2-f612d5e92893)

And helped us sooner detect:
https://www.gitpodstatus.com/incidents/45kq0brg7pfx

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
