### PR TITLE
[jb] bring more compatibility to cwm joinLink

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -362,6 +362,7 @@ type Projects struct {
 }
 type Response struct {
 	AppPid   int        `json:"appPid"`
+	JoinLink string     `json:"joinLink"`
 	Projects []Projects `json:"projects"`
 }
 type JoinLinkResponse struct {
@@ -433,10 +434,15 @@ func resolveJsonLink2(backendPort string) (*JoinLinkResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(jsonResp.Projects) != 1 {
-		return nil, xerrors.Errorf("project is not found")
+	if len(jsonResp.Projects) > 0 {
+		return &JoinLinkResponse{AppPid: jsonResp.AppPid, JoinLink: jsonResp.Projects[0].JoinLink}, nil
+
 	}
-	return &JoinLinkResponse{AppPid: jsonResp.AppPid, JoinLink: jsonResp.Projects[0].JoinLink}, nil
+	if len(jsonResp.JoinLink) > 0 {
+		return &JoinLinkResponse{AppPid: jsonResp.AppPid, JoinLink: jsonResp.JoinLink}, nil
+	}
+	log.Error("failed to resolve JetBrains JoinLink")
+	return nil, xerrors.Errorf("failed to resolve JoinLink")
 }
 
 func terminateIDE(backendPort string) error {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<img width="1591" alt="SCR-20240517-beey" src="https://github.com/gitpod-io/gitpod/assets/20944364/62db784c-1ebe-4c68-95e5-38357a0206f2">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- If preview env is deleted, you may need to recreate yourself `TF_VAR_with_large_vm=true leeway run dev:preview` and change `g1-standard` workspace class to have `30Gi` storage
- Open this PR with **Gitpod** and exec cmd below to use current launcher
```
cd /workspace/gitpod/components/ide/jetbrains/launcher
./hot-deploy.sh
```
- Open this repo with **preview env** + stable IntelliJ
- Exec commands below to get a dev env launched, it should be able to connect
```
cd /workspace/gitpod/components/ide/jetbrains/backend-plugin
./launch-dev-server.sh -s
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-impv</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-impv.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-impv.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-impv-gha.25269</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-impv%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
