### PR TITLE
improve dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -323,4 +323,5 @@ ENV PRE_COMMIT_HOME=/workspace/.pre-commit
 
 # Setting the environment variable here so that it will be accessible to all tasks and
 # terminal sessions in Gitpod workspaces.
-ENV PREVIEW_ENV_DEV_SA_KEY_PATH=
+ENV PREVIEW_ENV_DEV_SA_KEY_PATH=/root/.config/gcloud/sa.json
+ENV GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,11 @@
         "dockerfile": "./Dockerfile"
     },
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/gitpod,type=bind",
-    "workspaceFolder": "/workspace/gitpod",
-    "updateContentCommand": "dev/install-dependencies.sh",
+    "workspaceFolder": "/workspace/gitpod/",
+    "postCreateCommand": "dev/install-dependencies.sh",
+    "mounts": [
+        "source=/usr/local/gitpod/config/,target=/usr/local/gitpod/config/,type=bind"
+    ],
     "remoteEnv": {
         "GIT_EDITOR": "code --wait",
         "KUBE_EDITOR": "code --wait"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       #- id: check-yaml
       #  args: [--allow-multiple-documents]
       - id: check-json
+        exclude: ^.devcontainer/devcontainer.json$
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-symlinks
@@ -80,5 +81,10 @@ repos:
         language: system
         pass_filenames: false
         files: ^components/dashboard/
+  - repo: https://gitlab.com/bmares/check-json5
+    rev: v1.0.0
+    hooks:
+    - id: check-json5
+      files: ^.devcontainer/devcontainer.json$
 
 exclude: ^install/installer/.*/.*\.golden$

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -26,7 +26,36 @@ packages:
       image:
         - ${imageRepoBase}/dev-utils:${version}
         - ${imageRepoBase}/dev-utils:commit-${__git_commit}
+  - name: "install"
+    type: "generic"
+    deps:
+      - dev/gpctl:app
+      - dev/kubecdl:app
+      - dev/gp-gcloud:app
+    config:
+      commands:
+        - [ "sh", "-c", "sudo mv dev-gpctl--app/gpctl /usr/local/bin/gpctl" ]
+        - [ "sh", "-c", "sudo mv dev-kubecdl--app/kubecdl /usr/local/bin/kubecdl" ]
+        - [ "sh", "-c", "sudo mv dev-gp-gcloud--app/gp-gcloud /usr/local/bin/gp-gcloud" ]
+
 scripts:
   - name: preview
     description: Build Gitpod, create a preview environment, and deploy to it
     script: ./preview/workflow/preview/preview.sh
+  - name: prepare
+    description: Prepare the repository for development
+    script: |
+      leeway run dev:prepare-go dev:prepare-ts
+  - name: prepare-go
+    description: Prepare go packages
+    script: |
+      ./components/gitpod-protocol/go/scripts/generate-config.sh
+      leeway exec --filter-type go -v -- go mod verify
+  - name: prepare-ts
+    description: Prepare typescript packages
+    script: |
+      yarn --network-timeout 100000 && yarn build
+  - name: install-dev-utils
+    description: Install dev-utils
+    script: |
+      leeway build dev:install --dont-test --cache=remote-pull

--- a/dev/install-dependencies.sh
+++ b/dev/install-dependencies.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+git config --global alias.lg "log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+leeway run dev/preview:configure-workspace
+leeway run dev:install-dev-utils
 leeway run dev/preview/previewctl:install
 pre-commit install --install-hooks

--- a/dev/next-oidc/oidc.js
+++ b/dev/next-oidc/oidc.js
@@ -1,0 +1,78 @@
+const fs = require("fs");
+const http2 = require("http2");
+
+const getIDToken = async () => {
+    return new Promise((resolve, reject) => {
+        try {
+            const configPath = "/usr/local/gitpod/config/initial-spec.json";
+            const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+
+            const controlPlaneApiEndpoint = config.controlPlaneApiEndpoint;
+            const workspaceToken = config.workspaceToken;
+
+            const url = new URL(controlPlaneApiEndpoint);
+            const client = http2.connect(url.origin);
+
+            const req = client.request({
+                ":method": "POST",
+                "content-type": "application/json",
+                authorization: `Bearer ${workspaceToken}`,
+                ":path": `${url.pathname}/gitpod.v1.IdentityService/GetIDToken`,
+            });
+
+            let responseData = "";
+
+            req.on("data", (chunk) => {
+                responseData += chunk;
+            });
+
+            req.on("end", () => {
+                try {
+                    const result = JSON.parse(responseData);
+                    const token = result.token;
+                    resolve(token);
+                } catch (error) {
+                    reject(new Error("Error parsing response: " + error.message));
+                } finally {
+                    client.close();
+                }
+            });
+
+            req.on("error", (error) => {
+                reject(new Error(error.message));
+                client.close();
+            });
+
+            req.end(
+                JSON.stringify({
+                    audience: ["accounts.google.com"],
+                }),
+            );
+        } catch (e) {
+            reject(new Error(e.message));
+        }
+    });
+};
+
+(async () => {
+    try {
+        const token = await getIDToken();
+        console.log(
+            JSON.stringify({
+                version: 1,
+                success: true,
+                token_type: "urn:ietf:params:oauth:token-type:id_token",
+                id_token: token,
+            }),
+        );
+    } catch (error) {
+        console.log(
+            JSON.stringify({
+                version: 1,
+                success: false,
+                code: "401",
+                message: error.message,
+            }),
+        );
+    }
+})();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds OIDC support for dev container, and introduces some leeway scripts 

```shell
# for one time setup workspace, it will build typescript package and verify go modules
leeway run dev:prepare

# for install internal dev utils such as gpctl,kubecdl,gp-gcloud
leeway run dev:install-dev-utils

# for build and install typescript deps
leeway run dev:prepare-ts

```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open this PR in ec2 / dogfood check everything still work

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
