### PR TITLE
Add openvscode-server release in code update GHA

### DIFF
--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -7,91 +7,91 @@ on:
         description: "The commit of gitpod-io/openvscode-server release branch like gp-code/release/1.89"
 
 jobs:
-    update:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install dependencies
-              run: |
-                cd ./components/ide/code/gha-update-image/
-                yarn
-                npm i -g bun
-            - name: Check for updates
-              id: updates
-              run: |
-                cd ./components/ide/code/gha-update-image/
-                bun run check-code-build.ts --branch ${{inputs.branch}}
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          cd ./components/ide/code/gha-update-image/
+          yarn
+          npm i -g bun
+      - name: Check for updates
+        id: updates
+        run: |
+          cd ./components/ide/code/gha-update-image/
+          bun run check-code-build.ts --branch ${{inputs.branch}}
 
-                if [ -f /tmp/__gh_output.txt ]
-                then
-                  cat /tmp/__gh_output.txt >> $GITHUB_OUTPUT
-                fi
+          if [ -f /tmp/__gh_output.txt ]
+          then
+            cat /tmp/__gh_output.txt >> $GITHUB_OUTPUT
+          fi
 
-            - name: Detect file changes
-              id: changes
-              run: |
-                if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-                  echo "dirty=true" >> $GITHUB_OUTPUT
-                else
-                  echo "dirty=false" >> $GITHUB_OUTPUT
-                fi
-            - name: Create Release Pull Request
-              if: steps.changes.outputs.dirty
-              uses: peter-evans/create-pull-request@v6
-              with:
-                title: '[VS Code Browser] Build stable code `${{steps.updates.outputs.codeVersion}}`'
-                body: |
-                  ## Description
+      - name: Detect file changes
+        id: changes
+        run: |
+          if [ $(git status --porcelain | wc -l) -gt 0 ]; then
+            echo "dirty=true" >> $GITHUB_OUTPUT
+          else
+            echo "dirty=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Release Pull Request
+        if: steps.changes.outputs.dirty
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[VS Code Browser] Build stable code `${{steps.updates.outputs.codeVersion}}`"
+          body: |
+            ## Description
 
-                  Build code version `${{steps.updates.outputs.codeVersion}}` (`${{steps.updates.outputs.codeCommit}}`)
+            Build code version `${{steps.updates.outputs.codeVersion}}` (`${{steps.updates.outputs.codeCommit}}`)
 
-                  ## How to test
+            ## How to test
 
-                  - Switch to VS Code Browser Insiders in settings.
-                  - Start a workspace.
-                  - Test the following:
-                    - [ ] terminals are preserved and resized properly between window reloads
-                    - [ ] WebViews are working
-                    - [ ] extension host process: check language smartness and debugging
-                    - [ ] extension management (installing/uninstalling)
-                    - [ ] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
-                    - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
-                      - [ ] extensions from `.gitpod.yml` are not installed as sync
-                      - [ ] extensions installed as sync are actually synced to all new workspaces
-                    - [ ] settings should not contain any mentions of MS telemetry
-                    - [ ] WebSockets and workers are properly proxied
-                      - [ ] diff editor should be operable
-                      - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
-                    - [ ] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
-                    - [ ] that a PR view is preloaded when opening a PR URL
-                    - [ ] test `gp open` and `gp preview`
-                    - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
-                    - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)
+            - Switch to VS Code Browser Insiders in settings.
+            - Start a workspace.
+            - Test the following:
+              - [ ] terminals are preserved and resized properly between window reloads
+              - [ ] WebViews are working
+              - [ ] extension host process: check language smartness and debugging
+              - [ ] extension management (installing/uninstalling)
+              - [ ] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
+              - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
+                - [ ] extensions from `.gitpod.yml` are not installed as sync
+                - [ ] extensions installed as sync are actually synced to all new workspaces
+              - [ ] settings should not contain any mentions of MS telemetry
+              - [ ] WebSockets and workers are properly proxied
+                - [ ] diff editor should be operable
+                - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
+              - [ ] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
+              - [ ] that a PR view is preloaded when opening a PR URL
+              - [ ] test `gp open` and `gp preview`
+              - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
+              - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)
 
-                  ### Preview status
-                  gitpod:summary
+            ### Preview status
+            gitpod:summary
 
-                  ## Werft options:
+            ## Werft options:
 
-                  - [x] /werft with-preview
-                  - [x] /werft analytics=segment
-                  - [x] /werft with-large-vm
-                commit-message: "[VS Code Browser] Build stable code `${{steps.updates.outputs.codeVersion}}`"
-                branch: "ide/code-stable"
-                labels: "team: IDE,editor: code (browser)"
-                token: ${{ secrets.ROBOQUAT_REPO_PAT }}
-                committer: Robo Quat <roboquat@gitpod.io>
-                author: Robo Quat <roboquat@gitpod.io>
-                team-reviewers: |
-                  team-experience
-            - name: Get previous job's status
-              id: lastrun
-              uses: filiptronicek/get-last-job-status@main
-            - name: Slack Notification
-              if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-              uses: rtCamp/action-slack-notify@v2
-              env:
-                  SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
-                  SLACK_COLOR: ${{ job.status }}
-                  SLACK_TITLE: "VS Code Browser Build"
-                  SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
+            - [x] /werft with-preview
+            - [x] /werft analytics=segment
+            - [x] /werft with-large-vm
+          commit-message: "[VS Code Browser] Build stable code `${{steps.updates.outputs.codeVersion}}`"
+          branch: "ide/code-stable"
+          labels: "team: IDE,editor: code (browser)"
+          token: ${{ secrets.ROBOQUAT_REPO_PAT }}
+          committer: Robo Quat <roboquat@gitpod.io>
+          author: Robo Quat <roboquat@gitpod.io>
+          team-reviewers: |
+            team-experience
+      - name: Get previous job's status
+        id: lastrun
+        uses: filiptronicek/get-last-job-status@main
+      - name: Slack Notification
+        if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: "VS Code Browser Build"
+          SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -1,7 +1,7 @@
 name: Code Nightly
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: read # This is required for actions/checkout
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -108,3 +108,31 @@ jobs:
                   SLACK_TITLE: "VS Code Browser release `${{ steps.updates.outputs.codeVersion }}`"
                   SLACK_MESSAGE: "PR is created ${{ steps.code-update-pr.pull-request-url }}"
                   SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
+    release-openvscode-server:
+        runs-on: ubuntu-latest
+        needs: [ update ]
+        if: ${{ needs.update.steps.changes.outputs.dirty && needs.update.steps.updates.outputs.codeVersion }}
+        steps:
+            - uses: gitpod-io/gh-app-auth@v0.1
+              id: auth
+              name: Auth GH App
+              with:
+                private-key: ${{ secrets.ACTIONS_APP_PKEY }}
+                app-id: 308947
+                installation-id: 35574470
+            - name: Trigger Open VS Code Server Release
+              uses: actions/github-script@v6
+              with:
+                github-token: ${{ steps.auth.outputs.token }}
+                script: |
+                  const releaseBranch = "release/" + "${{ needs.update.steps.updates.outputs.codeVersion }}".split(".").slice(0, 2).join(".")
+                  const result = await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: 'openvscode-releases',
+                    workflow_id: 'release.yml',
+                    ref: 'main',
+                    inputs: {
+                      "quality": "stable",
+                      "commit": releaseBranch,
+                    }
+                  })

--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -4,135 +4,135 @@ on:
   workflow_call:
 
 jobs:
-    update:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install dependencies
-              run: |
-                cd ./components/ide/code/gha-update-image/
-                yarn
-                npm i -g bun
-            - name: Check for updates
-              id: updates
-              run: |
-                cd ./components/ide/code/gha-update-image/
-                bun run index.ts
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          cd ./components/ide/code/gha-update-image/
+          yarn
+          npm i -g bun
+      - name: Check for updates
+        id: updates
+        run: |
+          cd ./components/ide/code/gha-update-image/
+          bun run index.ts
 
-                if [ -f /tmp/__gh_output.txt ]
-                then
-                  cat /tmp/__gh_output.txt >> $GITHUB_OUTPUT
-                fi
+          if [ -f /tmp/__gh_output.txt ]
+          then
+            cat /tmp/__gh_output.txt >> $GITHUB_OUTPUT
+          fi
 
-            - name: Detect file changes
-              id: changes
-              run: |
-                if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-                  echo "dirty=true" >> $GITHUB_OUTPUT
-                else
-                  echo "dirty=false" >> $GITHUB_OUTPUT
-                fi
-            - name: Create Release Pull Request
-              if: ${{steps.changes.outputs.dirty && steps.updates.outputs.codeVersion}}
-              id: code-update-pr
-              uses: peter-evans/create-pull-request@v6
-              with:
-                title: "[VS Code Browser] Update stable code to `${{steps.updates.outputs.codeVersion}}`"
-                body: |
-                  ## Description
-                  Update code to `${{steps.updates.outputs.codeVersion}}`
+      - name: Detect file changes
+        id: changes
+        run: |
+          if [ $(git status --porcelain | wc -l) -gt 0 ]; then
+            echo "dirty=true" >> $GITHUB_OUTPUT
+          else
+            echo "dirty=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Release Pull Request
+        if: ${{steps.changes.outputs.dirty && steps.updates.outputs.codeVersion}}
+        id: code-update-pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[VS Code Browser] Update stable code to `${{steps.updates.outputs.codeVersion}}`"
+          body: |
+            ## Description
+            Update code to `${{steps.updates.outputs.codeVersion}}`
 
-                  ## How to test
+            ## How to test
 
-                  Should be tested already in build PR, double check:
+            Should be tested already in build PR, double check:
 
-                  - [ ] New version is pinnable
-                  - [ ] Stable version is updated and it can start workspace with it
+            - [ ] New version is pinnable
+            - [ ] Stable version is updated and it can start workspace with it
 
-                  ### Preview status
-                  gitpod:summary
+            ### Preview status
+            gitpod:summary
 
-                  ## Werft options:
+            ## Werft options:
 
-                  - [x] /werft with-preview
-                  - [x] /werft analytics=segment
-                commit-message: "[VS Code Browser] Update stable code to `${{steps.updates.outputs.codeVersion}}`"
-                branch: "ide/code-stable"
-                labels: "team: IDE,editor: code (browser)"
-                token: ${{ secrets.ROBOQUAT_REPO_PAT }}
-                committer: Robo Quat <roboquat@gitpod.io>
-                author: Robo Quat <roboquat@gitpod.io>
-                team-reviewers: |
-                  team-experience
+            - [x] /werft with-preview
+            - [x] /werft analytics=segment
+          commit-message: "[VS Code Browser] Update stable code to `${{steps.updates.outputs.codeVersion}}`"
+          branch: "ide/code-stable"
+          labels: "team: IDE,editor: code (browser)"
+          token: ${{ secrets.ROBOQUAT_REPO_PAT }}
+          committer: Robo Quat <roboquat@gitpod.io>
+          author: Robo Quat <roboquat@gitpod.io>
+          team-reviewers: |
+            team-experience
 
-            - name: Create Images Update Pull Request
-              if: ${{steps.changes.outputs.dirty && !steps.updates.outputs.codeVersion}}
-              uses: peter-evans/create-pull-request@v6
-              with:
-                  title: "[code] update code image layers"
-                  body: |
-                      ## Description
-                      This PR updates the VS Code Browser image layers to the most recent intaller version.
+      - name: Create Images Update Pull Request
+        if: ${{steps.changes.outputs.dirty && !steps.updates.outputs.codeVersion}}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[code] update code image layers"
+          body: |
+            ## Description
+            This PR updates the VS Code Browser image layers to the most recent intaller version.
 
-                      ## How to test
+            ## How to test
 
-                      Test if changes are working.
+            Test if changes are working.
 
-                      i.e.
-                      - `code-helper` it can start browser code with extensions installed
-                      - `gitpod-web-extension` extension functionalities are works well
-                      - `code` is not expected it to be changed
+            i.e.
+            - `code-helper` it can start browser code with extensions installed
+            - `gitpod-web-extension` extension functionalities are works well
+            - `code` is not expected it to be changed
 
-                      ### Preview status
-                      gitpod:summary
+            ### Preview status
+            gitpod:summary
 
-                      ## Werft options:
+            ## Werft options:
 
-                      - [x] /werft with-preview
-                      - [x] /werft analytics=segment
+            - [x] /werft with-preview
+            - [x] /werft analytics=segment
 
-                  commit-message: "[code] update code image layers"
-                  branch: "ide/code-stable"
-                  labels: "team: IDE,editor: code (browser)"
-                  token: ${{ secrets.ROBOQUAT_REPO_PAT }}
-                  committer: Robo Quat <roboquat@gitpod.io>
-                  author: Robo Quat <roboquat@gitpod.io>
-                  team-reviewers: |
-                    team-experience
-            - name: Slack notification (code)
-              if: ${{ steps.code-update-pr.pull-request-url }}
-              uses: rtCamp/action-slack-notify@v2
-              env:
-                  SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
-                  SLACK_COLOR: ${{ job.status }}
-                  SLACK_TITLE: "VS Code Browser release `${{ steps.updates.outputs.codeVersion }}`"
-                  SLACK_MESSAGE: "PR is created ${{ steps.code-update-pr.pull-request-url }}"
-                  SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
-    release-openvscode-server:
-        runs-on: ubuntu-latest
-        needs: [ update ]
-        if: ${{ needs.update.steps.changes.outputs.dirty && needs.update.steps.updates.outputs.codeVersion }}
-        steps:
-            - uses: gitpod-io/gh-app-auth@v0.1
-              id: auth
-              name: Auth GH App
-              with:
-                private-key: ${{ secrets.ACTIONS_APP_PKEY }}
-                app-id: 308947
-                installation-id: 35574470
-            - name: Trigger Open VS Code Server Release
-              uses: actions/github-script@v6
-              with:
-                github-token: ${{ steps.auth.outputs.token }}
-                script: |
-                  const releaseBranch = "release/" + "${{ needs.update.steps.updates.outputs.codeVersion }}".split(".").slice(0, 2).join(".")
-                  const result = await github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: 'openvscode-releases',
-                    workflow_id: 'release.yml',
-                    ref: 'main',
-                    inputs: {
-                      "quality": "stable",
-                      "commit": releaseBranch,
-                    }
-                  })
+          commit-message: "[code] update code image layers"
+          branch: "ide/code-stable"
+          labels: "team: IDE,editor: code (browser)"
+          token: ${{ secrets.ROBOQUAT_REPO_PAT }}
+          committer: Robo Quat <roboquat@gitpod.io>
+          author: Robo Quat <roboquat@gitpod.io>
+          team-reviewers: |
+            team-experience
+      - name: Slack notification (code)
+        if: ${{ steps.code-update-pr.pull-request-url }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: "VS Code Browser release `${{ steps.updates.outputs.codeVersion }}`"
+          SLACK_MESSAGE: "PR is created ${{ steps.code-update-pr.pull-request-url }}"
+          SLACK_FOOTER: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow logs>"
+  release-openvscode-server:
+    runs-on: ubuntu-latest
+    needs: [update]
+    if: ${{ needs.update.steps.changes.outputs.dirty && needs.update.steps.updates.outputs.codeVersion }}
+    steps:
+      - uses: gitpod-io/gh-app-auth@v0.1
+        id: auth
+        name: Auth GH App
+        with:
+          private-key: ${{ secrets.ACTIONS_APP_PKEY }}
+          app-id: 308947
+          installation-id: 35574470
+      - name: Trigger Open VS Code Server Release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.auth.outputs.token }}
+          script: |
+            const releaseBranch = "release/" + "${{ needs.update.steps.updates.outputs.codeVersion }}".split(".").slice(0, 2).join(".")
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'openvscode-releases',
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: {
+                "quality": "stable",
+                "commit": releaseBranch,
+              }
+            })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
