### PR TITLE
Control whether to wait jb backend-plugin via supervisor

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -96,7 +96,8 @@ func main() {
 		return
 	}
 
-	waitBackendPlugin := os.Getenv("GITPOD_WAIT_IDE_BACKEND") == "true"
+	// supervisor refer see https://github.com/gitpod-io/gitpod/blob/main/components/supervisor/pkg/supervisor/supervisor.go#L961
+	shouldWaitBackendPlugin := os.Getenv("GITPOD_WAIT_IDE_BACKEND") == "true"
 	debugEnabled := os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true"
 	log.Init(ServiceName, Version, true, debugEnabled)
 	log.Info(ServiceName + ": " + Version)
@@ -170,7 +171,7 @@ func main() {
 		info:                    info,
 		backendVersion:          backendVersion,
 		wsInfo:                  wsInfo,
-		shouldWaitBackendPlugin: waitBackendPlugin,
+		shouldWaitBackendPlugin: shouldWaitBackendPlugin,
 	}
 
 	if launchCtx.warmup {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -403,6 +403,8 @@ func Run(options ...RunOption) {
 
 	shouldShutdown, shutdownDuration := getIDENotReadyShutdownDuration(ctx, exps, host)
 	// with value true, supervisor will pass env GITPOD_WAIT_IDE_BACKEND=true when starting IDEs
+	// works with IDEs:
+	// - JB backend-plugin https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/launcher/main.go#L80
 	shouldWaitBackend := shouldShutdown
 	var ideWG sync.WaitGroup
 	ideWG.Add(1)
@@ -953,7 +955,9 @@ func launchIDE(cfg *Config, ideConfig *IDEConfig, cmd *exec.Cmd, ideStopped chan
 		defer runtime.UnlockOSThread()
 
 		log.Info("start launchIDE")
-		if shouldWaitBackend {
+		if shouldWaitBackend && ide == DesktopIDE {
+			// works with IDEs:
+			// - JB backend-plugin https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/launcher/main.go#L80
 			cmd.Env = append(cmd.Env, "GITPOD_WAIT_IDE_BACKEND=true")
 		}
 		err := cmd.Start()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
> not sure how ready avg can be less than plugin install avg , maybe FF values is incorrect sometimes

## How to test
<!-- Provide steps to test this PR -->
- It can start JetBrains IDEs (Rider failed
- It can start VS Code Desktop

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
