### PR TITLE
[dashboard] only send close heartbeat when web IDEs are closed

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -170,6 +170,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
     private user: User | undefined;
     private ideCredentials!: string;
     private workspace!: Workspace;
+    private isDesktopIDE: boolean = false;
 
     private latestInfo?: IDEFrontendDashboardService.Info;
 
@@ -192,6 +193,9 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             }
             if (IDEFrontendDashboardService.isSetStateEventData(event.data)) {
                 this.onDidChangeEmitter.fire(event.data.state);
+                if (event.data.state.desktopIDE) {
+                    this.isDesktopIDE = true;
+                }
             }
             if (IDEFrontendDashboardService.isOpenDesktopIDE(event.data)) {
                 this.openDesktopIDE(event.data.url);
@@ -202,6 +206,10 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
                 return;
             }
             if (this.ownerId !== this.user?.id) {
+                return;
+            }
+            // we only send the close heartbeat if we are in a web IDE
+            if (this.isDesktopIDE) {
                 return;
             }
             // send last heartbeat (wasClosed: true)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We currently send a close heartbeat when a user closes the standard workspace tab that sits there when opening a workspace with a desktop IDE. This changes the timeout to 5 min which in cse of IntelliJ is often not long enough as it only treats cursor activity as activity.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-7/fix-timeout-problem

## How to test
<!-- Provide steps to test this PR -->
 - start a workspace with intellij
 - close the browser tab
 - wait for more than 5 min and verify that the workspace is not stopped (after 30min it should!)
 - close the intellij, wait 5min and verify that now the workspace timed out.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-heartbe6e1b517fd4</li>
	<li><b>🔗 URL</b> - <a href="https://se-heartbe6e1b517fd4.preview.gitpod-dev.com/workspaces" target="_blank">se-heartbe6e1b517fd4.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-heartbeat-improvement-gha.25361</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-heartbe6e1b517fd4%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
