### PR TITLE
[dashboard] more robust ws class selection

### DIFF
--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -77,12 +77,7 @@ export default function SelectWorkspaceClassComponent({
             );
             return;
         }
-        // if the selected workspace class is not supported, we set an error and ask the user to pick one
-        if (selectedWorkspaceClass && !workspaceClasses?.find((c) => c.id === selectedWorkspaceClass)) {
-            setError?.(`The workspace class '${selectedWorkspaceClass}' is not supported.`);
-        } else {
-            setError?.(undefined);
-        }
+        setError?.(undefined);
     }, [
         loading,
         workspaceClassesLoading,
@@ -106,8 +101,20 @@ export default function SelectWorkspaceClassComponent({
         if (!workspaceClasses) {
             return undefined;
         }
-        const defaultClassId = workspaceClasses.find((ws) => ws.isDefault)?.id;
-        return workspaceClasses.find((ws) => ws.id === (selectedWorkspaceClass || defaultClassId));
+        // first we try to find the selected class, then the computed default, then the global default and finally the first one
+        const selectedWsClass = workspaceClasses.find((ws) => ws.id === selectedWorkspaceClass);
+        if (selectedWsClass) {
+            return selectedWsClass;
+        }
+        const computedDefaultClass = workspaceClasses.find((ws) => ws.isComputedDefaultClass);
+        if (computedDefaultClass) {
+            return computedDefaultClass;
+        }
+        const defaultClass = workspaceClasses.find((ws) => ws.isDefault);
+        if (defaultClass) {
+            return defaultClass;
+        }
+        return workspaceClasses[0];
     }, [selectedWorkspaceClass, workspaceClasses]);
     return (
         <Combobox


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make sure we always pick a workspace class.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- start a workspace with the standard class
- stop it
- disable the standard workspace class at the repo level
- try starting a new workspace

- before: you'll get the error
- now: small is selected

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-fix-ws-2a7a005022</li>
        <li><b>🔗 URL</b> - <a href="https://se-fix-ws-2a7a005022.preview.gitpod-dev.com/workspaces" target="_blank">se-fix-ws-2a7a005022.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-fix-ws-2a7a005022%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
