### PR TITLE
Remove token refresh feature flags

### DIFF
--- a/components/server/src/user/token-service.spec.db.ts
+++ b/components/server/src/user/token-service.spec.db.ts
@@ -69,7 +69,6 @@ describe("TokenService", async () => {
         container = createTestContainer();
         Experiments.configureTestingClient({
             centralizedPermissions: true,
-            opportunistic_token_refresh: true,
         });
 
         // re-overwrite the stuff mocked out in createTestContainer

--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -18,7 +18,6 @@ import {
     reportScmTokenRefreshRequest,
     scmTokenRefreshLatencyHistogram,
 } from "../prometheus-metrics";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 
 @injectable()
 export class TokenService implements TokenProvider {
@@ -94,9 +93,7 @@ export class TokenService implements TokenProvider {
                     const { authProvider } = this.hostContextProvider.get(host)!;
                     if (isValidUntil(token, requestedLifetimeDate)) {
                         const doOpportunisticRefresh =
-                            (await isOpportunisticTokenRefreshEnabled(userId)) &&
-                            !!authProvider.requiresOpportunisticRefresh &&
-                            authProvider.requiresOpportunisticRefresh();
+                            !!authProvider.requiresOpportunisticRefresh && authProvider.requiresOpportunisticRefresh();
                         if (!doOpportunisticRefresh) {
                             // No opportunistic refresh? Update reserveation and we are done.
                             await updateReservation(tokenEntry.uid, token, requestedLifetimeDate);
@@ -201,14 +198,6 @@ export class TokenService implements TokenProvider {
         }
         return hostContext.authProvider.authProviderId;
     }
-}
-
-export async function isOpportunisticTokenRefreshEnabled(userId: string): Promise<boolean> {
-    return getExperimentsClientForBackend().getValueAsync("opportunistic_token_refresh", false, {
-        user: {
-            id: userId,
-        },
-    });
 }
 
 function nowPlusMins(mins: number): Date {


### PR DESCRIPTION
## Description
Drops the workspace_start_scm_access_token_lifetime and opportunistic_token_refresh feature flags

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-84
Fixes ENT-85

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
