### PR TITLE
[server, ws-proxy] Test cookie filter against real name generator

### DIFF
--- a/components/server/go/BUILD.yaml
+++ b/components/server/go/BUILD.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: lib
+    type: go
+    srcs:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+    config:
+      packaging: library

--- a/components/server/go/go.mod
+++ b/components/server/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/gitpod-io/gitpod/server
+
+go 1.22.2

--- a/components/server/go/go.mod
+++ b/components/server/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/gitpod-io/gitpod/server
+module github.com/gitpod-io/gitpod/server/go
 
 go 1.22.2

--- a/components/server/go/pkg/lib/cookie.go
+++ b/components/server/go/pkg/lib/cookie.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package lib
+
+import "regexp"
+
+func CookieNameFromDomain(domain string) string {
+	// replace all non-word characters with underscores
+	derived := regexp.MustCompile(`[\W_]+`).ReplaceAllString(domain, "_")
+	return "_" + derived + "_jwt2_"
+}

--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -14,6 +14,7 @@ packages:
       - components/registry-facade-api/go:lib
       - components/supervisor-api/go:lib
       - components/ws-manager-api/go:lib
+      - components/server/go:lib
     env:
       - CGO_ENABLED=0
       - GOOS=linux
@@ -52,6 +53,7 @@ packages:
       - components/registry-facade-api/go:lib
       - components/supervisor-api/go:lib
       - components/ws-manager-api/go:lib
+      - components/server/go:lib
     env:
       - CGO_ENABLED=0
       - GOOS=linux

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/gitpod-protocol v0.0.0-00010101000000-000000000000
-	github.com/gitpod-io/gitpod/server v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/server/go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/golang-crypto v0.0.0-20231122075959-de838e9cb174
@@ -119,7 +119,7 @@ replace github.com/gitpod-io/gitpod/supervisor/api => ../supervisor-api/go // le
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../ws-manager-api/go // leeway
 
-replace github.com/gitpod-io/gitpod/server => ../server/go // leeway
+replace github.com/gitpod-io/gitpod/server/go => ../server/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.29.3 // leeway indirect from components/common-go:lib
 

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -1,11 +1,12 @@
 module github.com/gitpod-io/gitpod/ws-proxy
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/gitpod-protocol v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/server v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/golang-crypto v0.0.0-20231122075959-de838e9cb174
@@ -117,6 +118,8 @@ replace github.com/gitpod-io/gitpod/registry-facade/api => ../registry-facade-ap
 replace github.com/gitpod-io/gitpod/supervisor/api => ../supervisor-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../ws-manager-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/server => ../server/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.29.3 // leeway indirect from components/common-go:lib
 

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/util"
-	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
+	server_lib "github.com/gitpod-io/gitpod/server/go/pkg/lib"
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/sshproxy"

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/util"
+	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/sshproxy"
@@ -978,13 +979,14 @@ func TestNoSSHGatewayRouter(t *testing.T) {
 
 func TestRemoveSensitiveCookies(t *testing.T) {
 	var (
-		domain            = "test-domain.com"
-		sessionCookie     = &http.Cookie{Domain: domain, Name: "_test_domain_com_", Value: "fobar"}
-		sessionCookieJwt2 = &http.Cookie{Domain: domain, Name: "_test_domain_com_jwt2_", Value: "fobar"}
-		portAuthCookie    = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_port_auth_", Value: "some-token"}
-		ownerCookie       = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_owner_", Value: "some-other-token"}
-		miscCookie        = &http.Cookie{Domain: domain, Name: "some-other-cookie", Value: "I like cookies"}
-		invalidCookieName = &http.Cookie{Domain: domain, Name: "foobar[0]", Value: "violates RFC6266"}
+		domain                  = "test-domain.com"
+		sessionCookie           = &http.Cookie{Domain: domain, Name: "_test_domain_com_", Value: "fobar"}
+		sessionCookieJwt2       = &http.Cookie{Domain: domain, Name: "_test_domain_com_jwt2_", Value: "fobar"}
+		realGitpodSessionCookie = &http.Cookie{Domain: domain, Name: server_lib.CookieNameFromDomain(domain), Value: "fobar"}
+		portAuthCookie          = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_port_auth_", Value: "some-token"}
+		ownerCookie             = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_owner_", Value: "some-other-token"}
+		miscCookie              = &http.Cookie{Domain: domain, Name: "some-other-cookie", Value: "I like cookies"}
+		invalidCookieName       = &http.Cookie{Domain: domain, Name: "foobar[0]", Value: "violates RFC6266"}
 	)
 
 	tests := []struct {
@@ -992,13 +994,14 @@ func TestRemoveSensitiveCookies(t *testing.T) {
 		Input    []*http.Cookie
 		Expected []*http.Cookie
 	}{
-		{"no cookies", []*http.Cookie{}, []*http.Cookie{}},
-		{"session cookie", []*http.Cookie{sessionCookie, miscCookie}, []*http.Cookie{miscCookie}},
-		{"session cookie ending on _jwt2_", []*http.Cookie{sessionCookieJwt2, miscCookie}, []*http.Cookie{miscCookie}},
-		{"portAuth cookie", []*http.Cookie{portAuthCookie, miscCookie}, []*http.Cookie{miscCookie}},
-		{"owner cookie", []*http.Cookie{ownerCookie, miscCookie}, []*http.Cookie{miscCookie}},
-		{"misc cookie", []*http.Cookie{miscCookie}, []*http.Cookie{miscCookie}},
-		{"invalid cookie name", []*http.Cookie{invalidCookieName}, []*http.Cookie{invalidCookieName}},
+		{Name: "no cookies", Input: []*http.Cookie{}, Expected: []*http.Cookie{}},
+		{Name: "session cookie", Input: []*http.Cookie{sessionCookie, miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "session cookie ending on _jwt2_", Input: []*http.Cookie{sessionCookieJwt2, miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "real Gitpod session cookie", Input: []*http.Cookie{realGitpodSessionCookie, miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "portAuth cookie", Input: []*http.Cookie{portAuthCookie, miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "owner cookie", Input: []*http.Cookie{ownerCookie, miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "misc cookie", Input: []*http.Cookie{miscCookie}, Expected: []*http.Cookie{miscCookie}},
+		{Name: "invalid cookie name", Input: []*http.Cookie{invalidCookieName}, Expected: []*http.Cookie{invalidCookieName}},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -1020,9 +1023,9 @@ func TestSensitiveCookieHandler(t *testing.T) {
 		Input    string
 		Expected string
 	}{
-		{"no cookies", "", ""},
-		{"valid cookie", miscCookie.String(), `some-other-cookie="I like cookies";Domain=test-domain.com`},
-		{"invalid cookie", `foobar[0]="violates RFC6266"`, `foobar[0]="violates RFC6266"`},
+		{Name: "no cookies", Input: "", Expected: ""},
+		{Name: "valid cookie", Input: miscCookie.String(), Expected: `some-other-cookie="I like cookies";Domain=test-domain.com`},
+		{Name: "invalid cookie", Input: `foobar[0]="violates RFC6266"`, Expected: `foobar[0]="violates RFC6266"`},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -41,6 +41,7 @@ packages:
       - components/node-labeler:lib
       - dev/addlicense:app
       - components/spicedb:lib
+      - components/server/go:lib
     env:
       - CGO_ENABLED=0
     argdeps:

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -1,6 +1,6 @@
 module github.com/gitpod-io/gitpod/installer
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -19,6 +19,7 @@ require (
 	github.com/gitpod-io/gitpod/image-builder/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/openvsx-proxy v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/server v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/usage v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon/api v0.0.0-00010101000000-000000000000
@@ -361,6 +362,8 @@ replace github.com/gitpod-io/gitpod/ws-manager/api => ../../components/ws-manage
 replace github.com/gitpod-io/gitpod/ws-proxy => ../../components/ws-proxy // leeway
 
 replace github.com/gitpod-io/gitpod/node-labeler => ../../components/node-labeler // leeway
+
+replace github.com/gitpod-io/gitpod/server => ../../components/server/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.29.3 // leeway indirect from components/common-go:lib
 

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gitpod-io/gitpod/image-builder/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/openvsx-proxy v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
-	github.com/gitpod-io/gitpod/server v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/server/go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/usage v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon/api v0.0.0-00010101000000-000000000000
@@ -363,7 +363,7 @@ replace github.com/gitpod-io/gitpod/ws-proxy => ../../components/ws-proxy // lee
 
 replace github.com/gitpod-io/gitpod/node-labeler => ../../components/node-labeler // leeway
 
-replace github.com/gitpod-io/gitpod/server => ../../components/server/go // leeway
+replace github.com/gitpod-io/gitpod/server/go => ../../components/server/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.29.3 // leeway indirect from components/common-go:lib
 

--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -6,10 +6,10 @@ package auth
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -45,7 +45,7 @@ func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount
 			Issuer:          fmt.Sprintf("https://%s", ctx.Config.Domain),
 			Cookie: CookieConfig{
 				// Caution: changing these have security implications for the application. Make sure you understand what you're doing.
-				Name:     cookieNameFromDomain(ctx.Config.Domain),
+				Name:     server_lib.CookieNameFromDomain(ctx.Config.Domain),
 				MaxAge:   lifetime,
 				SameSite: "lax",
 				Secure:   true,
@@ -53,10 +53,4 @@ func GetConfig(ctx *common.RenderContext) ([]corev1.Volume, []corev1.VolumeMount
 			},
 		},
 	}
-}
-
-func cookieNameFromDomain(domain string) string {
-	// replace all non-word characters with underscores
-	derived := regexp.MustCompile(`[\W_]+`).ReplaceAllString(domain, "_")
-	return "_" + derived + "_jwt2_"
 }

--- a/install/installer/pkg/components/auth/config.go
+++ b/install/installer/pkg/components/auth/config.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
+	server_lib "github.com/gitpod-io/gitpod/server/go/pkg/lib"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/install/installer/pkg/components/auth/config_test.go
+++ b/install/installer/pkg/components/auth/config_test.go
@@ -7,7 +7,7 @@ package auth
 import (
 	"testing"
 
-	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
+	server_lib "github.com/gitpod-io/gitpod/server/go/pkg/lib"
 )
 
 func TestCookieNameFromDomain(t *testing.T) {

--- a/install/installer/pkg/components/auth/config_test.go
+++ b/install/installer/pkg/components/auth/config_test.go
@@ -4,7 +4,11 @@
 
 package auth
 
-import "testing"
+import (
+	"testing"
+
+	server_lib "github.com/gitpod-io/gitpod/server/pkg/lib"
+)
 
 func TestCookieNameFromDomain(t *testing.T) {
 	tests := []struct {
@@ -56,7 +60,7 @@ func TestCookieNameFromDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := cookieNameFromDomain(tt.domain)
+			actual := server_lib.CookieNameFromDomain(tt.domain)
 			if actual != tt.expectedOutcome {
 				t.Errorf("expected %q, got %q", tt.expectedOutcome, actual)
 			}


### PR DESCRIPTION
## Description
Follow up after an incident we had recently.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-67

## How to test
 - see that the build is :green_circle: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-67-cookie-test</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-67-cookie-test.preview.gitpod-dev.com/workspaces" target="_blank">gpl-67-cookie-test.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-67-cookie-test-gha.25448</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-67-cookie-test%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
