### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,12 +13,12 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8915adfdb17c4dc52c327ca81c50c547e80d3a99
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.1.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.1.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.2.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.2.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.1.1.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.1.tar.gz"
-  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.1.1.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.1.2.tar.gz"
+  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.1.2.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.1.3.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.2.tar.gz"
   clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.1.1.tar.gz"
   jbBackendVersion: "latest"

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -118,10 +118,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/intellij:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
+            "image": "{{.Repository}}/ide/intellij:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -174,10 +174,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/goland:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
+            "image": "{{.Repository}}/ide/goland:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -219,10 +219,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/pycharm:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
+            "image": "{{.Repository}}/ide/pycharm:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -263,10 +263,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/phpstorm:commit-9382d33ee521e6a72d763f906b24dd53893103df",
+            "image": "{{.Repository}}/ide/phpstorm:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -307,10 +307,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/rubymine:commit-9382d33ee521e6a72d763f906b24dd53893103df",
+            "image": "{{.Repository}}/ide/rubymine:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -351,10 +351,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/webstorm:commit-2c2d3cc34e65af282c0af29f66ce255a90a69069",
+            "image": "{{.Repository}}/ide/webstorm:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -403,10 +403,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rider:commit-e6e412c809dfa004678166a82f1243cedd3e7167",
+            "image": "{{.Repository}}/ide/rider:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -447,10 +447,10 @@
         "versions": [
           {
             "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/clion:commit-9382d33ee521e6a72d763f906b24dd53893103df",
+            "image": "{{.Repository}}/ide/clion:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6",
-              "{{.Repository}}/ide/jb-launcher:commit-120b50c982216c7b4ca9fe37d039b3f6644b4571"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-984fbea43973a87f68f906b9f45f6aeac1469921",
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_