### PR TITLE
[ws-proxy] Filter cookies on all routes that send traffic to the workspace (except supervisor)

### DIFF
--- a/components/ws-proxy/pkg/proxy/auth_test.go
+++ b/components/ws-proxy/pkg/proxy/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -232,7 +233,7 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 			rr := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", domain), nil)
 			if test.OwnerCookie != "" {
-				setOwnerTokenCookie(req, instanceID, test.OwnerCookie)
+				setOwnerTokenCookie(req, domain, instanceID, test.OwnerCookie)
 			}
 			vars := map[string]string{
 				common.WorkspaceIDIdentifier: test.WorkspaceID,
@@ -252,6 +253,13 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 	}
 }
 
-func setOwnerTokenCookie(r *http.Request, instanceID, token string) {
-	r.AddCookie(&http.Cookie{Name: "_test_domain_com_ws_" + instanceID + "_owner_", Value: token})
+func setOwnerTokenCookie(r *http.Request, domain, instanceID, token string) {
+	c := ownerTokenCookie(domain, instanceID, token)
+	r.AddCookie(c)
+}
+
+func ownerTokenCookie(domain, instanceID, token string) *http.Cookie {
+	domainPart := strings.ReplaceAll(domain, ".", "_")
+	domainPart = strings.ReplaceAll(domainPart, "-", "_")
+	return &http.Cookie{Name: "_" + domainPart + "_ws_" + instanceID + "_owner_", Value: token}
 }


### PR DESCRIPTION
## Description
Instead of only filtering auth cookies from port routes, filter it from all routes that are are:
 - pointing at the workspace pod
 - not directly meant for supervisor

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-70

## How to test
 - see that you can start a workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-70-fil05f72cb4be</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-70-fil05f72cb4be.preview.gitpod-dev.com/workspaces" target="_blank">gpl-70-fil05f72cb4be.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-70-filter-cookies-gha.25435</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-70-fil05f72cb4be%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
