### PR TITLE
[supervisor] Fix race on terminal listener closing

### DIFF
--- a/components/supervisor/pkg/terminal/terminal.go
+++ b/components/supervisor/pkg/terminal/terminal.go
@@ -484,8 +484,8 @@ func (l *multiWriterListener) CloseWithError(err error) error {
 		if err != nil {
 			l.closeErr = err
 		}
-		close(l.closeChan)
 		l.closed = true
+		close(l.closeChan)
 
 		// actual cleanup happens in a go routine started by Listen()
 	})
@@ -561,17 +561,19 @@ func (mw *multiWriter) ListenWithOptions(options TermListenOptions) io.ReadClose
 	go func() {
 		// listener cleanup on close
 		<-closeChan
+
 		if res.closeErr != nil {
 			log.WithError(res.closeErr).Error("terminal listener droped out")
 			w.CloseWithError(res.closeErr)
 		} else {
 			w.Close()
 		}
-		close(cchan)
 
 		mw.mu.Lock()
+		defer mw.mu.Unlock()
+		close(cchan)
+
 		delete(mw.listener, res)
-		mw.mu.Unlock()
 	}()
 
 	mw.listener[res] = struct{}{}


### PR DESCRIPTION
## Description
Before closing the listeners channel, we need to make sure we don't write into it anymore. We do set a flag ("closed"), however neither that nor the actually channel closing is synced with the actual `Write` method's mutex.

This change just moves the lock acquiring up one line to make sure we close the channel only if there's nobody writing to it.
We don't wrap the more of the function, because we don't want to block all listeners if closing a single writer is slow

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-175

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
