### PR TITLE
WorkspaceStarter: fix + cleanup error handling

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -384,7 +384,12 @@ export class WorkspaceStarter {
                             workspace.context,
                         );
 
-                        await this.actuallyStartWorkspace(ctx, instance, workspace, user, envVars);
+                        const useNewStart = await isNewWorkspaceStartEnabled(user);
+                        if (useNewStart) {
+                            await this.actuallyStartWorkspace(ctx, instance, workspace, user, envVars);
+                        } else {
+                            await this.actuallyStartWorkspaceOld(ctx, instance, workspace, user, envVars);
+                        }
                     } catch (err) {
                         this.logAndTraceStartWorkspaceError(
                             ctx,
@@ -672,6 +677,163 @@ export class WorkspaceStarter {
                 }
                 await this.failInstanceStart({ span }, err, workspace, instance);
                 err = new StartInstanceError(failReason, err);
+            }
+
+            this.logAndTraceStartWorkspaceError({ span }, logCtx, err);
+        } finally {
+            if (ctxIsAborted()) {
+                ctx.span?.setTag("aborted", true);
+            }
+            span.finish();
+        }
+    }
+
+    private async actuallyStartWorkspaceOld(
+        ctx: TraceContext,
+        instance: WorkspaceInstance,
+        workspace: Workspace,
+        user: User,
+        envVars: ResolvedEnvVars,
+    ): Promise<void> {
+        const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
+        const region = instance.configuration.regionPreference;
+        span.setTag("region_preference", region);
+        const logCtx: LogContext = {
+            instanceId: instance.id,
+            userId: user.id,
+            organizationId: workspace.organizationId,
+            workspaceId: workspace.id,
+        };
+        const forceRebuild = !!workspace.context.forceImageBuild;
+        log.info(logCtx, "Attempting to start workspace", {
+            forceRebuild: forceRebuild,
+        });
+
+        try {
+            // choose a cluster and start the instance
+            let resp: StartWorkspaceResponse.AsObject | undefined = undefined;
+            let startRequest: StartWorkspaceRequest;
+            let retries = 0;
+            try {
+                if (instance.status.phase === "pending") {
+                    // due to the reconciliation loop we might have already started the workspace, especially in the "pending" phase
+                    const workspaceAlreadyExists = await this.existsWithWsManager(ctx, instance);
+                    if (workspaceAlreadyExists) {
+                        log.debug(
+                            { instanceId: instance.id, workspaceId: instance.workspaceId },
+                            "workspace already exists, not starting again",
+                            { phase: instance.status.phase },
+                        );
+                        return;
+                    }
+                }
+
+                // build workspace image
+                const additionalAuth = await this.getAdditionalImageAuth(envVars);
+                instance = await this.buildWorkspaceImage(
+                    { span },
+                    user,
+                    workspace,
+                    instance,
+                    additionalAuth,
+                    forceRebuild,
+                    forceRebuild,
+                    region,
+                );
+
+                // create spec
+                const spec = await this.createSpec({ span }, user, workspace, instance, envVars);
+
+                // create start workspace request
+                const metadata = await this.createMetadata(workspace);
+                startRequest = new StartWorkspaceRequest();
+                startRequest.setId(instance.id);
+                startRequest.setMetadata(metadata);
+                startRequest.setType(workspace.type === "prebuild" ? WorkspaceType.PREBUILD : WorkspaceType.REGULAR);
+                startRequest.setSpec(spec);
+                startRequest.setServicePrefix(workspace.id);
+
+                for (; retries < MAX_INSTANCE_START_RETRIES; retries++) {
+                    if (ctxIsAborted()) {
+                        return;
+                    }
+                    resp = await this.tryStartOnCluster({ span }, startRequest, user, workspace, instance, region);
+                    if (resp) {
+                        break;
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, INSTANCE_START_RETRY_INTERVAL_SECONDS * 1000));
+                }
+            } catch (err) {
+                if (isGrpcError(err) && err.code === grpc.status.ALREADY_EXISTS) {
+                    // This might happen because of timing: When we did the "workspaceAlreadyExists" check above, the DB state was not updated yet.
+                    // But when calling ws-manager to start the workspace, it was already present.
+                    //
+                    // By returning we skip the current cycle and wait for the next run of the workspace-start-controller.
+                    // This gives ws-manager(-bridge) some time to emit(/digest) updates.
+                    log.info(logCtx, "workspace already exists, waiting for ws-manager to push new state", err);
+                    return;
+                }
+
+                if (err instanceof StartInstanceError) {
+                    // we already took care of classification at a lower level, bubble it up!
+                    throw err;
+                }
+
+                let reason: FailedInstanceStartReason = "startOnClusterFailed";
+                if (isResourceExhaustedError(err)) {
+                    reason = "resourceExhausted";
+                }
+                if (isClusterMaintenanceError(err)) {
+                    reason = "workspaceClusterMaintenance";
+                    err = new Error(
+                        "We're in the middle of an update. We'll be back to normal soon. Please try again in a few minutes.",
+                    );
+                }
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                throw new StartInstanceError(reason, err);
+            }
+
+            if (!resp) {
+                const err = new Error("cannot start a workspace because no workspace clusters are available");
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                throw new StartInstanceError("clusterSelectionFailed", err);
+            }
+            increaseSuccessfulInstanceStartCounter(retries);
+
+            this.analytics.track({
+                userId: user.id,
+                event: "workspace_started",
+                properties: {
+                    workspaceId: workspace.id,
+                    instanceId: instance.id,
+                    projectId: workspace.projectId,
+                    contextURL: workspace.contextURL,
+                    type: workspace.type,
+                    class: instance.workspaceClass,
+                    ideConfig: instance.configuration?.ideConfig,
+                    usesPrebuild: startRequest.getSpec()?.getInitializer()?.hasPrebuild(),
+                },
+                timestamp: new Date(instance.creationTime),
+            });
+
+            if (workspace.type === "prebuild") {
+                // do not await
+                this.notifyOnPrebuildQueued(ctx, workspace.id).catch((err) => {
+                    log.error("failed to notify on prebuild queued", err);
+                });
+            }
+        } catch (err) {
+            if (isGrpcError(err) && (err.code === grpc.status.UNAVAILABLE || err.code === grpc.status.ALREADY_EXISTS)) {
+                // fall-through: we don't want to fail but retry/wait for future updates to resolve this
+                log.warn(logCtx, "cannot start workspace instance due to temporary error", err);
+            } else if (ScmStartError.isScmStartError(err)) {
+                // user does not have access to SCM
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                err = new StartInstanceError("scmAccessFailed", err);
+            } else if (!(err instanceof StartInstanceError)) {
+                // fallback in case we did not already handle this error
+                await this.failInstanceStart({ span }, err, workspace, instance);
+                err = new StartInstanceError("other", err); // don't throw because there's nobody catching it. We just want to log/trace it.
             }
 
             this.logAndTraceStartWorkspaceError({ span }, logCtx, err);
@@ -1953,8 +2115,8 @@ function resolveGitpodTasks(ws: Workspace, instance: WorkspaceInstance): TaskCon
     return tasks;
 }
 
-export async function isCheckPendingFirstEnabled(user: { id: string }): Promise<boolean> {
-    return getExperimentsClientForBackend().getValueAsync("workspace_start_check_pending_first", false, {
+export async function isNewWorkspaceStartEnabled(user: { id: string }): Promise<boolean> {
+    return getExperimentsClientForBackend().getValueAsync("workspace_start_new", false, {
         user: user,
     });
 }


### PR DESCRIPTION
## Description
This PR does three things:
 1. does away with the feature flag `workspace_start_check_pending_first`
 2. fixes a bug that failed to map `ScmStartError` to `StartInstanceError`
 3. merges the two cascading try...catch block into a single one

To be more safe while rolling this out, we also keep the old code around, and have the feature flag `workspace_start_old` to switch back to it should be notice anything odd.

:information_source: The PR is best reviewed a) commit-per-commit and b) with "split view"+"whitespace hidden":
![image](https://github.com/gitpod-io/gitpod/assets/32448529/32a5b127-354c-4b8e-9501-eaee90d7a5e1)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-178

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-178-scm-error</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-178-scm-error.preview.gitpod-dev.com/workspaces" target="_blank">gpl-178-scm-error.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-178-scm-error-gha.25431</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-178-scm-error%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
