### PR TITLE
[PAYG-dashboard] Add Gitpod Enterprise callout on login page for PAYG users

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -23,6 +23,7 @@ import { cn } from "@podkit/lib/cn";
 import { userClient } from "./service/public-api";
 import { ProductLogo } from "./components/ProductLogo";
 import { useIsDataOps } from "./data/featureflag-query";
+import { isGitpodIo } from "./utils";
 
 export function markLoggedIn() {
     document.cookie = GitpodCookie.generateCookie(window.location.hostname);
@@ -169,6 +170,14 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                                                 </span>
                                             </LoginButton>
                                         ))
+                                    )}
+                                    {isGitpodIo() && (
+                                        <div className="text-pk-content-tertiary my-4">
+                                            <span className="text-lg font-bold">Need SSO? </span>
+                                            <a className="text-lg gp-link" href="https://www.gitpod.io/enterprise">
+                                                Try Gitpod Enterprise
+                                            </a>
+                                        </div>
                                     )}
                                     <SSOLoginForm
                                         onSuccess={authorizeSuccessful}

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -174,7 +174,12 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                                     {isGitpodIo() && (
                                         <div className="text-pk-content-tertiary py-3">
                                             <span className="text-sm font-bold">Need SSO? </span>
-                                            <a className="text-sm gp-link" href="https://www.gitpod.io/enterprise">
+                                            <a
+                                                className="text-sm gp-link"
+                                                href="https://www.gitpod.io/docs/enterprise"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                            >
                                                 Try Gitpod Enterprise
                                             </a>
                                         </div>

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -172,9 +172,9 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                                         ))
                                     )}
                                     {isGitpodIo() && (
-                                        <div className="text-pk-content-tertiary my-4">
-                                            <span className="text-lg font-bold">Need SSO? </span>
-                                            <a className="text-lg gp-link" href="https://www.gitpod.io/enterprise">
+                                        <div className="text-pk-content-tertiary py-3">
+                                            <span className="text-sm font-bold">Need SSO? </span>
+                                            <a className="text-sm gp-link" href="https://www.gitpod.io/enterprise">
                                                 Try Gitpod Enterprise
                                             </a>
                                         </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds Gitpod Enterprise callout on `/login` page for PAYG users


![image](https://github.com/gitpod-io/gitpod/assets/55068936/c8c01e6d-69ec-4ba0-ae52-9b7098ca148a)

When opened via Context URL (e.g., GitHub repository)

![image](https://github.com/gitpod-io/gitpod/assets/55068936/faa0cb42-6f71-4c63-b48c-6fb201560dff)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-601

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment
- and see the changes on login page :)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-of465c1c6ad</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-of465c1c6ad.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-of465c1c6ad.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-opm-601-add-reference-for-enterprise-link-to-login-page-gha.25427</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-of465c1c6ad%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
