### PR TITLE
[server] eagerly fetch config files in parallel

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
@@ -137,7 +137,7 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
     ): Promise<NavigatorContext> {
         const span = TraceContext.startSpan("BitbucketServerContextParser.handleNavigatorContext", ctx);
         try {
-            const repo = await this.api.getRepository(user, {
+            const repoPromise = this.api.getRepository(user, {
                 repoKind,
                 owner,
                 repositorySlug: repoName,
@@ -147,6 +147,7 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
                 owner,
                 repositorySlug: repoName,
             });
+            const repo = await repoPromise;
             const repository = this.toRepository(host, repo, repoKind, defaultBranch);
             span.log({ "request.finished": "" });
 

--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -26,11 +26,38 @@ export class ConfigInferrer {
     ];
 
     async getConfig(ctx: Context): Promise<WorkspaceConfig> {
-        for (const contrib of this.contributions) {
-            try {
-                await contrib(ctx);
-            } catch (e) {
-                console.log(e);
+        // initialize cache
+        await Promise.allSettled(
+            [
+                "package.json",
+                "yarn.lock",
+                "pnpm-lock.yaml",
+                "build.gradle",
+                "build.gradle.kts",
+                "gradlew",
+                "pom.xml",
+                "mvnw",
+                "Makefile",
+                "makefile",
+                "CMakeLists.txt",
+                "requirements.txt",
+                "setup.py",
+                "main.py",
+                "app.py",
+                "runserver.py",
+                "go.mod",
+                "Cargo.toml",
+                "packages.config",
+                "Gemfile",
+                "bin/setup",
+                "bin/startup",
+                "bin/rails",
+            ].map((file) => ctx.read(file)),
+        );
+        const result = await Promise.allSettled(this.contributions.map((contrib) => contrib(ctx)));
+        for (const p of result) {
+            if (p.status === "rejected") {
+                console.error(p.reason);
             }
         }
         return ctx.config;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The config inferrer currently checks the repo for config files sequentially.
With this change the files are fetched once in parallel in the beginning, cutting down to the longest request instead of the sum of all requests.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://linear.app/gitpod/issue/ENT-171/new-workspaces-dialog-is-blocked-for-5-sec-for-dynatrace

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-log-bbs-access</li>
	<li><b>🔗 URL</b> - <a href="https://se-log-bbs-access.preview.gitpod-dev.com/workspaces" target="_blank">se-log-bbs-access.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-log-bbs-access-gha.25478</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-log-bbs-access%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
