### PR TITLE
[bridge] Fix logging/bridge.stop

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -109,6 +109,7 @@ export class WorkspaceManagerBridge implements Disposable {
             controllerIntervalSeconds,
             this.config.controllerMaxDisconnectSeconds,
         );
+        this.disposables.push(this.workspaceInstanceController);
 
         const tim = setInterval(() => {
             this.updateWorkspaceClasses(cluster, clientProvider);

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -153,6 +153,7 @@ export class WorkspaceManagerBridge implements Disposable {
         this.disposables.push(subscriber);
 
         const onReconnect = (ctx: TraceContext, s: WorkspaceStatus[]) => {
+            log.info("ws-manager subscriber reconnected", logPayload);
             s.forEach((sx) => this.queueMessagesByInstanceId(ctx, sx));
         };
         const onStatusUpdate = (ctx: TraceContext, s: WorkspaceStatus) => {

--- a/components/ws-manager-bridge/src/workspace-instance-controller.ts
+++ b/components/ws-manager-bridge/src/workspace-instance-controller.ts
@@ -6,7 +6,7 @@
 
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { GetWorkspacesRequest } from "@gitpod/ws-manager/lib";
-import { DisposableCollection, RunningWorkspaceInfo, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { Disposable, DisposableCollection, RunningWorkspaceInfo, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from "inversify";
 import { Configuration } from "./config";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -23,7 +23,7 @@ import { durationLongerThanSeconds } from "@gitpod/gitpod-protocol/lib/util/time
 
 export const WorkspaceInstanceController = Symbol("WorkspaceInstanceController");
 
-export interface WorkspaceInstanceController {
+export interface WorkspaceInstanceController extends Disposable {
     start(
         workspaceClusterName: string,
         clientProvider: ClientProvider,
@@ -47,7 +47,7 @@ export interface WorkspaceInstanceController {
  * !!! It's statful, so make sure it's bound in transient mode !!!
  */
 @injectable()
-export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceController {
+export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceController, Disposable {
     constructor(
         @inject(Configuration) private readonly config: Configuration,
         @inject(Metrics) private readonly prometheusExporter: Metrics,
@@ -305,5 +305,9 @@ export class WorkspaceInstanceControllerImpl implements WorkspaceInstanceControl
         } finally {
             span.finish();
         }
+    }
+
+    public dispose() {
+        this.disposables.dispose();
     }
 }

--- a/components/ws-manager-bridge/src/wsman-subscriber.ts
+++ b/components/ws-manager-bridge/src/wsman-subscriber.ts
@@ -47,6 +47,7 @@ export class WsmanSubscriber implements Disposable {
                     // start subscription
                     const req = new SubscribeRequest();
                     this.sub = await client.subscribe({}, req);
+                    log.info("wsman subscription established", payload);
 
                     this.sub.on("data", (incoming: SubscribeResponse) => {
                         const status = incoming.getStatus();
@@ -77,6 +78,7 @@ export class WsmanSubscriber implements Disposable {
                         }
                     });
                     this.sub.on("end", function () {
+                        log.info("wsman subscription ended", payload);
                         resolve();
                     });
                     this.sub.on("error", function (e) {


### PR DESCRIPTION
## Description
Fixes logging, + a missign `dispoables.push`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-187

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-187-bridge-log</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-187-bridge-log.preview.gitpod-dev.com/workspaces" target="_blank">gpl-187-bridge-log.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-187-bridge-log-gha.25479</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-187-bridge-log%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
