### PR TITLE
[action] skip update image if it's failed to resolve

### DIFF
--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -50,10 +50,14 @@ jobs:
                     continue
                   fi
                   echo "Processing ${images2[i]} in file $file"
-                  updated_digest=$(crane digest "${images2[i]}")
-                  if [ "$updated_digest" != "${digests2[i]}" ] && [ -n "$updated_digest" ]; then
-                    echo "Digest ${digests2[i]} for image ${images2[i]} is different, new digest is $updated_digest, updating..."
-                    sed -i -e "s/${digests2[i]}/$updated_digest/g" "$file"
+                  updated_digest=$(crane digest "${images2[i]}" || true)
+                  if [ -n "$updated_digest" ]; then
+                      if [ "$updated_digest" != "${digests2[i]}" ]; then
+                          echo "Digest ${digests2[i]} for image ${images2[i]} is different, new digest is $updated_digest, updating..."
+                          sed -i -e "s/${digests2[i]}/$updated_digest/g" "$file"
+                      fi
+                  else
+                      echo "Failed to get digest for image ${images2[i]}, skipping..."
                   fi
                 done
             fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[action] skip update image if it's failed to resolve

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
see action https://github.com/gitpod-io/gitpod/actions/runs/9258611007 and automatic PR https://github.com/gitpod-io/gitpod/pull/19785

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
