### PR TITLE
[dashboard] Restructure Organization Settings

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -60,6 +60,7 @@ const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../tea
 const TeamUsageBasedBilling = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamUsageBasedBilling"));
 const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"));
 const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
+const TeamPolicies = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamPolicies"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/ProjectSettings"));
@@ -201,6 +202,7 @@ export const AppRoutes = () => {
                             <Route exact path="/members" component={Members} />
                             <Route exact path="/settings" component={TeamSettings} />
                             <Route exact path="/settings/git" component={TeamGitIntegrations} />
+                            <Route exact path="/settings/policy" component={TeamPolicies} />
                             {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
                             <Route exact path="/billing" component={TeamUsageBasedBilling} />
                             <Route exact path="/sso" component={SSO} />

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -62,6 +62,7 @@ const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"))
 const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
 const TeamPolicies = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamPolicies"));
 const TeamNetworking = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamNetworking"));
+const TeamAuthentication = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamAuthentication"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/ProjectSettings"));
@@ -205,6 +206,7 @@ export const AppRoutes = () => {
                             <Route exact path="/settings/git" component={TeamGitIntegrations} />
                             <Route exact path="/settings/policy" component={TeamPolicies} />
                             <Route exact path="/settings/networking" component={TeamNetworking} />
+                            <Route exact path="/settings/auth" component={TeamAuthentication} />
                             {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
                             <Route exact path="/billing" component={TeamUsageBasedBilling} />
                             <Route exact path="/sso" component={SSO} />

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -61,6 +61,7 @@ const TeamUsageBasedBilling = React.lazy(() => import(/* webpackPrefetch: true *
 const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"));
 const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
 const TeamPolicies = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamPolicies"));
+const TeamNetworking = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamNetworking"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/ProjectSettings"));
@@ -203,6 +204,7 @@ export const AppRoutes = () => {
                             <Route exact path="/settings" component={TeamSettings} />
                             <Route exact path="/settings/git" component={TeamGitIntegrations} />
                             <Route exact path="/settings/policy" component={TeamPolicies} />
+                            <Route exact path="/settings/networking" component={TeamNetworking} />
                             {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
                             <Route exact path="/billing" component={TeamUsageBasedBilling} />
                             <Route exact path="/sso" component={SSO} />

--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -73,7 +73,7 @@ export const SubmenuItem: FC<SubmenuItemProps> = ({ title, link, icon }) => {
     if (isCurrent) {
         classes += " bg-gray-300 text-gray-800 dark:bg-gray-800 dark:text-gray-50";
     } else {
-        classes += " hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-400";
+        classes += " hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-pk-content-secondary";
     }
 
     return (

--- a/components/dashboard/src/components/PillLabel.tsx
+++ b/components/dashboard/src/components/PillLabel.tsx
@@ -8,7 +8,7 @@ export type PillType = "info" | "warn" | "success" | "neutral";
 
 const PillClsMap: Record<PillType, string> = {
     info: "bg-blue-50 text-blue-500 dark:bg-blue-500 dark:text-blue-100",
-    warn: "bg-orange-100 text-orange-700 dark:bg-orange-600 dark:text-orange-100",
+    warn: "bg-kumquat-light text-pk-content-secondary",
     success: "bg-green-100 text-green-700 dark:bg-green-600 dark:text-green-100",
     neutral: "bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-100",
 };

--- a/components/dashboard/src/components/PillLabel.tsx
+++ b/components/dashboard/src/components/PillLabel.tsx
@@ -8,7 +8,7 @@ export type PillType = "info" | "warn" | "success" | "neutral";
 
 const PillClsMap: Record<PillType, string> = {
     info: "bg-blue-50 text-blue-500 dark:bg-blue-500 dark:text-blue-100",
-    warn: "bg-kumquat-light text-pk-content-secondary",
+    warn: "bg-kumquat-ripe text-gray-900",
     success: "bg-green-100 text-green-700 dark:bg-green-600 dark:text-green-100",
     neutral: "bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-100",
 };
@@ -27,6 +27,6 @@ const PillClsMap: Record<PillType, string> = {
  */
 export default function PillLabel(props: { children?: React.ReactNode; type?: PillType; className?: string }) {
     const type = props.type || "info";
-    const style = `px-2 py-1 text-sm uppercase rounded-xl ${PillClsMap[type]} ${props.className}`;
+    const style = `px-3 py-0.5 text-xs uppercase rounded-xl font-semibold ${PillClsMap[type]} ${props.className}`;
     return <span className={style}>{props.children}</span>;
 }

--- a/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
+++ b/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
@@ -11,6 +11,7 @@ import React from "react";
 export interface LinkButtonProps extends ButtonProps {
     asChild?: false;
     href: string;
+    isExternalUrl?: boolean;
 }
 
 /**
@@ -20,7 +21,13 @@ export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
     ({ asChild, children, href, ...props }, ref) => {
         return (
             <Button ref={ref} {...props} asChild>
-                <Link to={href}>{children}</Link>
+                {props.isExternalUrl ? (
+                    <a href={href} target="_blank" rel="noreferrer">
+                        {children}
+                    </a>
+                ) : (
+                    <Link to={href}>{children}</Link>
+                )}
             </Button>
         );
     },

--- a/components/dashboard/src/components/podkit/typography/Headings.tsx
+++ b/components/dashboard/src/components/podkit/typography/Headings.tsx
@@ -64,7 +64,7 @@ export const Heading3: FC<HeadingProps> = ({ id, tracking, className, children, 
  */
 export const Subheading: FC<HeadingProps> = ({ id, tracking, className, children }) => {
     return (
-        <p id={id} className={cn("text-base text-pk-content-tertiary", getTracking(tracking), className)}>
+        <p id={id} className={cn("text-base text-pk-content-secondary", getTracking(tracking), className)}>
             {children}
         </p>
     );

--- a/components/dashboard/src/components/typography/headings.tsx
+++ b/components/dashboard/src/components/typography/headings.tsx
@@ -55,10 +55,7 @@ export const Heading3: FC<HeadingProps> = ({ id, color, tracking, className, chi
 // Intended to be placed beneath a heading to provide more context
 export const Subheading: FC<HeadingProps> = ({ id, tracking, className, children }) => {
     return (
-        <p
-            id={id}
-            className={classNames("text-base text-gray-500 dark:text-gray-500", getTracking(tracking), className)}
-        >
+        <p id={id} className={classNames("text-base text-pk-content-secondary", getTracking(tracking), className)}>
             {children}
         </p>
     );

--- a/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
@@ -11,5 +11,5 @@ type Props = {
     className?: string;
 };
 export const ConfigurationSettingsField = ({ children, className }: Props) => {
-    return <div className={cn("border border-pk-border-strong rounded-xl p-6", className)}>{children}</div>;
+    return <div className={cn("border border-pk-border-base rounded-xl p-6", className)}>{children}</div>;
 };

--- a/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
+++ b/components/dashboard/src/repositories/detail/ConfigurationSettingsField.tsx
@@ -11,5 +11,5 @@ type Props = {
     className?: string;
 };
 export const ConfigurationSettingsField = ({ children, className }: Props) => {
-    return <div className={cn("border border-pk-border-base rounded-xl p-6", className)}>{children}</div>;
+    return <div className={cn("border border-pk-border-strong rounded-xl p-6", className)}>{children}</div>;
 };

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -91,7 +91,7 @@ function getOrgSettingsMenu(params: {
     if (isGitpodIo()) {
         result.push(
             {
-                title: "Neworking",
+                title: "Networking",
                 link: [`/settings/networking`],
             },
             {

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -15,6 +15,7 @@ import { useCurrentOrg } from "../data/organizations/orgs-query";
 import { useFeatureFlag } from "../data/featureflag-query";
 import { Organization } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
 import { useIsOwner } from "../data/organizations/members-query";
+import { isGitpodIo } from "../utils";
 
 export interface OrgSettingsPageProps {
     children: React.ReactNode;
@@ -82,7 +83,23 @@ function getOrgSettingsMenu(params: {
             title: "General",
             link: [`/settings`],
         },
+        {
+            title: "Policies",
+            link: [`/settings/policy`],
+        },
     ];
+    if (isGitpodIo()) {
+        result.push(
+            {
+                title: "Neworking",
+                link: [`/settings/networking`],
+            },
+            {
+                title: "Authentication",
+                link: [`/settings/auth`],
+            },
+        );
+    }
     if (isOwner && ssoEnabled) {
         result.push({
             title: "SSO",

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -85,7 +85,7 @@ const PrivateImageRegistryCard = () => {
                 href="https://www.gitpod.io/docs/enterprise/setup-gitpod/use-private-ecr-repos-for-workspace-images"
                 isExternalUrl={true}
             >
-                Dcoumentation
+                Documentation
             </LinkButton>
         </ConfigurationSettingsField>
     );
@@ -105,7 +105,7 @@ const PrivateSourceControlAccess = () => {
                 href="https://www.gitpod.io/docs/enterprise/setup-gitpod/scm-integration"
                 isExternalUrl={true}
             >
-                Dcoumentation
+                Documentation
             </LinkButton>
         </ConfigurationSettingsField>
     );

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -33,7 +33,10 @@ export default function TeamPoliciesPage() {
                                 <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
                             </PillLabel>
                         </Heading2>
-                        <Subheading className="mt-1">Manage your organization's authentication settings.</Subheading>
+                        <Subheading className="mt-1">
+                            Manage users through single sign-on and privately authenticate with source control and image
+                            registries.
+                        </Subheading>
                     </div>
 
                     <SSOCard />

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -16,7 +16,7 @@ import { Redirect } from "react-router";
 import PillLabel from "../components/PillLabel";
 
 export default function TeamPoliciesPage() {
-    useDocumentTitle("Organization Settings - Networking");
+    useDocumentTitle("Organization Settings - Authentication");
 
     if (!isGitpodIo) {
         return <Redirect to="/settings" />;
@@ -28,47 +28,37 @@ export default function TeamPoliciesPage() {
                 <div className="space-y-8">
                     <div>
                         <Heading2 className="flex items-center gap-4">
-                            Networking
+                            Authentication
                             <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
                                 <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
                             </PillLabel>
                         </Heading2>
-                        <Subheading className="mt-1">Manage your organization's networking settings.</Subheading>
+                        <Subheading className="mt-1">Manage your organization's authentication settings.</Subheading>
                     </div>
 
-                    <SelfHostedCalloutCard />
-                    <DeployedRegionCard />
-                    <VPNCard />
+                    <SSOCard />
+                    <PrivateImageRegistryCard />
+                    <PrivateSourceControlAccess />
                 </div>
             </OrgSettingsPage>
         </>
     );
 }
 
-const SelfHostedCalloutCard = () => {
+const SSOCard = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Self-host in your cloud account</Heading3>
-            <Subheading className="mt-1">
-                Deploy the Gitpod infrastructure into your own cloud account and connect to your private network
-            </Subheading>
+            <Heading3>Single sign-on (SSO)</Heading3>
+            <Subheading className="mt-1">More control over workspace access for your organization</Subheading>
 
-            <div className="mt-1 flex flex-col space-y-2">
+            <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Managed application feature releases and updates
+                    Includes support for Google, Okta, AWS Cognito and others
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Managed provisioning and scaling of workspaces
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed backup and restore processes
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed security updates and patches
+                    Instantly revoke access and off-board users from Gitpod
                 </div>
             </div>
 
@@ -83,29 +73,16 @@ const SelfHostedCalloutCard = () => {
     );
 };
 
-const DeployedRegionCard = () => {
+const PrivateImageRegistryCard = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Choose your deployed region</Heading3>
-            <Subheading className="mt-1">
-                Deploy Gitpod to any location, such as: United States, South America, Europe and Asia Pacific
-            </Subheading>
-
-            <div className="mt-8 flex flex-col space-y-2">
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Meet data residency compliance requirements
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Reduce your workspace latency
-                </div>
-            </div>
+            <Heading3>Private container image registry</Heading3>
+            <Subheading className="mt-1">Provide secure access to private image registries such as ECR</Subheading>
 
             <LinkButton
                 variant="secondary"
                 className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
-                href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
+                href="https://www.gitpod.io/docs/enterprise/setup-gitpod/use-private-ecr-repos-for-workspace-images"
                 isExternalUrl={true}
             >
                 Dcoumentation
@@ -114,18 +91,18 @@ const DeployedRegionCard = () => {
     );
 };
 
-const VPNCard = () => {
+const PrivateSourceControlAccess = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Virtual Private Network (VPN)</Heading3>
+            <Heading3>Private source control access</Heading3>
             <Subheading className="mt-1">
-                Ensure that only your developers can access your Gitpod instance through your VPN network
+                Connect to your private source control like GitHub, BitBucket and GitLab
             </Subheading>
 
             <LinkButton
                 variant="secondary"
                 className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
-                href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
+                href="https://www.gitpod.io/docs/enterprise/setup-gitpod/scm-integration"
                 isExternalUrl={true}
             >
                 Dcoumentation

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -54,11 +54,11 @@ const SSOCard = () => {
 
             <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Includes support for Google, Okta, AWS Cognito and others
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Instantly revoke access and off-board users from Gitpod
                 </div>
             </div>

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -29,9 +29,7 @@ export default function TeamPoliciesPage() {
                     <div>
                         <Heading2 className="flex items-center gap-4">
                             Authentication
-                            <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
-                                <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
-                            </PillLabel>
+                            <PillLabel type="warn">Enterprise</PillLabel>
                         </Heading2>
                         <Subheading className="mt-1">
                             Manage users through single sign-on and privately authenticate with source control and image
@@ -84,7 +82,7 @@ const PrivateImageRegistryCard = () => {
 
             <LinkButton
                 variant="secondary"
-                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                 href="https://www.gitpod.io/docs/enterprise/setup-gitpod/use-private-ecr-repos-for-workspace-images"
                 isExternalUrl={true}
             >
@@ -104,7 +102,7 @@ const PrivateSourceControlAccess = () => {
 
             <LinkButton
                 variant="secondary"
-                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                 href="https://www.gitpod.io/docs/enterprise/setup-gitpod/scm-integration"
                 isExternalUrl={true}
             >

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { isGitpodIo } from "../utils";
+import React from "react";
+import { Heading2, Heading3, Subheading } from "../components/typography/headings";
+import { OrgSettingsPage } from "./OrgSettingsPage";
+import { ConfigurationSettingsField } from "../repositories/detail/ConfigurationSettingsField";
+import { useDocumentTitle } from "../hooks/use-document-title";
+import { LinkButton } from "@podkit/buttons/LinkButton";
+import { CheckCircle2Icon } from "lucide-react";
+import { Redirect } from "react-router";
+import PillLabel from "../components/PillLabel";
+
+export default function TeamPoliciesPage() {
+    useDocumentTitle("Organization Settings - Networking");
+
+    if (!isGitpodIo) {
+        return <Redirect to="/settings" />;
+    }
+
+    return (
+        <>
+            <OrgSettingsPage>
+                <div className="space-y-8">
+                    <div>
+                        <Heading2 className="flex items-center gap-4">
+                            Networking
+                            <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
+                                <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
+                            </PillLabel>
+                        </Heading2>
+                        <Subheading className="mt-2">Manage your organization's networking settings.</Subheading>
+                    </div>
+
+                    <SelfHostedCalloutCard />
+                    <DeployedRegionCard />
+                    <VPNCard />
+                </div>
+            </OrgSettingsPage>
+        </>
+    );
+}
+
+const SelfHostedCalloutCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Self-host in your cloud account</Heading3>
+            <Subheading>
+                Deploy the Gitpod infrastructure into your own cloud account and connect to your private network
+            </Subheading>
+
+            <div className="mt-2 flex flex-col space-y-2">
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed application feature releases and updates
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed provisioning and scaling of workspaces
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed backup and restore processes
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed security updates and patches
+                </div>
+            </div>
+
+            <LinkButton
+                href="https://www.gitpod.io/contact/enterprise-self-serve"
+                isExternalUrl={true}
+                className="mt-8 rounded-xl"
+            >
+                Request Free Trial
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};
+
+const DeployedRegionCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Choose your deployed region</Heading3>
+            <Subheading>
+                Deploy Gitpod to any location, such as: United States, South America, Europe and Asia Pacific
+            </Subheading>
+
+            <div className="mt-8 flex flex-col space-y-2">
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Meet data residency compliance requirements
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Reduce your workspace latency
+                </div>
+            </div>
+
+            <LinkButton
+                variant="secondary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
+                isExternalUrl={true}
+            >
+                Dcoumentation
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};
+
+const VPNCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Virtual Private Network (VPN)</Heading3>
+            <Subheading>
+                Ensure that only your developers can access your Gitpod instance through your VPN network
+            </Subheading>
+
+            <LinkButton
+                variant="secondary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
+                isExternalUrl={true}
+            >
+                Dcoumentation
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -108,7 +108,7 @@ const DeployedRegionCard = () => {
                 href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
                 isExternalUrl={true}
             >
-                Dcoumentation
+                Documentation
             </LinkButton>
         </ConfigurationSettingsField>
     );
@@ -128,7 +128,7 @@ const VPNCard = () => {
                 href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
                 isExternalUrl={true}
             >
-                Dcoumentation
+                Documentation
             </LinkButton>
         </ConfigurationSettingsField>
     );

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -55,11 +55,11 @@ const SelfHostedCalloutCard = () => {
 
             <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Managed application feature release and backup process
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Managed security updates and patches
                 </div>
             </div>
@@ -85,11 +85,11 @@ const DeployedRegionCard = () => {
 
             <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Meet data residency compliance requirements
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
+                    <CheckCircle2Icon size={20} className="text-pk-content-primary" />
                     Reduce latency and bring your code closer to your data
                 </div>
             </div>

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -33,7 +33,9 @@ export default function TeamPoliciesPage() {
                                 <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
                             </PillLabel>
                         </Heading2>
-                        <Subheading className="mt-1">Manage your organization's networking settings.</Subheading>
+                        <Subheading className="mt-1">
+                            Self-host a single-tenant installation in your own cloud account.
+                        </Subheading>
                     </div>
 
                     <SelfHostedCalloutCard />
@@ -53,18 +55,10 @@ const SelfHostedCalloutCard = () => {
                 Deploy the Gitpod infrastructure into your own cloud account and connect to your private network
             </Subheading>
 
-            <div className="mt-1 flex flex-col space-y-2">
+            <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Managed application feature releases and updates
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed provisioning and scaling of workspaces
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed backup and restore processes
+                    Managed application feature release and backup process
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
@@ -98,7 +92,7 @@ const DeployedRegionCard = () => {
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Reduce your workspace latency
+                    Reduce latency and bring your code closer to your data
                 </div>
             </div>
 
@@ -119,7 +113,7 @@ const VPNCard = () => {
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
             <Heading3>Virtual Private Network (VPN)</Heading3>
             <Subheading className="mt-1">
-                Ensure that only your developers can access your Gitpod instance through your VPN network
+                Restrict access to your instance using your own private VPN network
             </Subheading>
 
             <LinkButton

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -29,9 +29,7 @@ export default function TeamPoliciesPage() {
                     <div>
                         <Heading2 className="flex items-center gap-4">
                             Networking
-                            <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
-                                <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
-                            </PillLabel>
+                            <PillLabel type="warn">Enterprise</PillLabel>
                         </Heading2>
                         <Subheading className="mt-1">
                             Self-host a single-tenant installation in your own cloud account.
@@ -98,7 +96,7 @@ const DeployedRegionCard = () => {
 
             <LinkButton
                 variant="secondary"
-                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                 href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
                 isExternalUrl={true}
             >
@@ -118,7 +116,7 @@ const VPNCard = () => {
 
             <LinkButton
                 variant="secondary"
-                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                 href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
                 isExternalUrl={true}
             >

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -66,7 +66,7 @@ export default function TeamPoliciesPage() {
     return (
         <>
             <OrgSettingsPage>
-                <div className="space-y-4">
+                <div className="space-y-8">
                     <div>
                         <Heading2>Policies</Heading2>
                         <Subheading>

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -295,7 +295,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
-                    Dcoumentation
+                    Documentation
                 </LinkButton>
                 <LinkButton
                     variant="secondary"

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -280,9 +280,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
             <Heading3 className="flex items-center gap-4">
                 Additional workspace classes
-                <PillLabel type="warn" className="!px-3 !py-0 !text-xs border">
-                    <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
-                </PillLabel>
+                <PillLabel type="warn">Enterprise</PillLabel>
             </Heading3>
             <Subheading>
                 Access to more powerful workspace classes with up to 30 cores 54GB of RAM and 100GB storage
@@ -291,7 +289,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
             <div className="mt-6 flex flex-row space-x-2">
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
@@ -299,7 +297,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 </LinkButton>
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-primary bg-pk-surface-primary"
                     href="https://www.gitpod.io/docs/enterprise"
                     isExternalUrl={true}
                 >

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { isGitpodIo } from "../utils";
+import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
+import React, { useCallback, useMemo, useState } from "react";
+import Alert from "../components/Alert";
+import { CheckboxInputField } from "../components/forms/CheckboxInputField";
+import { Heading2, Heading3, Subheading } from "../components/typography/headings";
+import { useIsOwner } from "../data/organizations/members-query";
+import { useOrgSettingsQuery } from "../data/organizations/org-settings-query";
+import { useCurrentOrg } from "../data/organizations/orgs-query";
+import { useUpdateOrgSettingsMutation } from "../data/organizations/update-org-settings-mutation";
+import { OrgSettingsPage } from "./OrgSettingsPage";
+import { Button } from "@podkit/buttons/Button";
+import { useAllowedWorkspaceClassesMemo } from "../data/workspaces/workspace-classes-query";
+import { ConfigurationSettingsField } from "../repositories/detail/ConfigurationSettingsField";
+import {
+    WorkspaceClassesModifyModal,
+    WorkspaceClassesModifyModalProps,
+    WorkspaceClassesOptions,
+} from "../components/WorkspaceClassesOptions";
+import { useMutation } from "@tanstack/react-query";
+import { useAllowedWorkspaceEditorsMemo } from "../data/ide-options/ide-options-query";
+import { IdeOptions, IdeOptionsModifyModal, IdeOptionsModifyModalProps } from "../components/IdeOptions";
+import { useFeatureFlag } from "../data/featureflag-query";
+import { useDocumentTitle } from "../hooks/use-document-title";
+import { LinkButton } from "@podkit/buttons/LinkButton";
+import PillLabel from "../components/PillLabel";
+
+export default function TeamPoliciesPage() {
+    useDocumentTitle("Organization Settings - Policies");
+    const org = useCurrentOrg().data;
+    const isOwner = useIsOwner();
+    const orgLevelEditorRestrictionEnabled = useFeatureFlag("org_level_editor_restriction_enabled");
+
+    const { data: settings, isLoading } = useOrgSettingsQuery();
+    const updateTeamSettings = useUpdateOrgSettingsMutation();
+
+    const handleUpdateTeamSettings = useCallback(
+        async (newSettings: Partial<OrganizationSettings>, options?: { throwMutateError?: boolean }) => {
+            if (!org?.id) {
+                throw new Error("no organization selected");
+            }
+            if (!isOwner) {
+                throw new Error("no organization settings change permission");
+            }
+            try {
+                await updateTeamSettings.mutateAsync({
+                    ...settings,
+                    ...newSettings,
+                });
+            } catch (error) {
+                if (options?.throwMutateError) {
+                    throw error;
+                }
+                console.error(error);
+            }
+        },
+        [updateTeamSettings, org?.id, isOwner, settings],
+    );
+
+    return (
+        <>
+            <OrgSettingsPage>
+                <div className="space-y-4">
+                    <div>
+                        <Heading2>Policies</Heading2>
+                        <Subheading>
+                            Restrict workspace classes, editors and sharing across your organization.
+                        </Subheading>
+                    </div>
+
+                    <ConfigurationSettingsField>
+                        <Heading3>Collaboration and sharing</Heading3>
+
+                        {updateTeamSettings.isError && (
+                            <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
+                                <span>Failed to update organization settings: </span>
+                                <span>{updateTeamSettings.error.message || "unknown error"}</span>
+                            </Alert>
+                        )}
+
+                        <CheckboxInputField
+                            label="Workspace Sharing"
+                            hint="Allow workspaces created within an Organization to share the workspace with any authenticated user."
+                            checked={!settings?.workspaceSharingDisabled}
+                            onChange={(checked) => handleUpdateTeamSettings({ workspaceSharingDisabled: !checked })}
+                            disabled={isLoading || !isOwner}
+                        />
+                    </ConfigurationSettingsField>
+
+                    <OrgWorkspaceClassesOptions
+                        isOwner={isOwner}
+                        settings={settings}
+                        handleUpdateTeamSettings={handleUpdateTeamSettings}
+                    />
+
+                    {isGitpodIo() && <WorkspaceClassesEnterpriseCallout />}
+
+                    {orgLevelEditorRestrictionEnabled && (
+                        <EditorOptions
+                            isOwner={isOwner}
+                            settings={settings}
+                            handleUpdateTeamSettings={handleUpdateTeamSettings}
+                        />
+                    )}
+                </div>
+            </OrgSettingsPage>
+        </>
+    );
+}
+
+interface OrgWorkspaceClassesOptionsProps {
+    isOwner: boolean;
+    settings?: OrganizationSettings;
+    handleUpdateTeamSettings: (
+        newSettings: Partial<OrganizationSettings>,
+        options?: { throwMutateError?: boolean },
+    ) => Promise<void>;
+}
+const OrgWorkspaceClassesOptions = ({
+    isOwner,
+    settings,
+    handleUpdateTeamSettings,
+}: OrgWorkspaceClassesOptionsProps) => {
+    const [showModal, setShowModal] = useState(false);
+    const { data: allowedClassesInOrganization, isLoading: isLoadingClsInOrg } = useAllowedWorkspaceClassesMemo(
+        undefined,
+        {
+            filterOutDisabled: true,
+            ignoreScope: ["configuration"],
+        },
+    );
+    const { data: allowedClassesInInstallation, isLoading: isLoadingClsInInstall } = useAllowedWorkspaceClassesMemo(
+        undefined,
+        {
+            filterOutDisabled: true,
+            ignoreScope: ["organization", "configuration"],
+        },
+    );
+
+    const restrictedWorkspaceClasses = useMemo(() => {
+        const allowedList = settings?.allowedWorkspaceClasses ?? [];
+        if (allowedList.length === 0) {
+            return [];
+        }
+        return allowedClassesInInstallation.filter((cls) => !allowedList.includes(cls.id)).map((cls) => cls.id);
+    }, [settings?.allowedWorkspaceClasses, allowedClassesInInstallation]);
+
+    const updateMutation: WorkspaceClassesModifyModalProps["updateMutation"] = useMutation({
+        mutationFn: async ({ restrictedWorkspaceClasses }) => {
+            let allowedWorkspaceClasses = allowedClassesInInstallation.map((e) => e.id);
+            if (restrictedWorkspaceClasses.length > 0) {
+                allowedWorkspaceClasses = allowedWorkspaceClasses.filter(
+                    (e) => !restrictedWorkspaceClasses.includes(e),
+                );
+            }
+            const allAllowed = allowedClassesInInstallation.every((e) => allowedWorkspaceClasses.includes(e.id));
+            if (allAllowed) {
+                // empty means allow all classes
+                allowedWorkspaceClasses = [];
+            }
+            await handleUpdateTeamSettings({ allowedWorkspaceClasses }, { throwMutateError: true });
+        },
+    });
+
+    return (
+        <ConfigurationSettingsField>
+            <Heading3>Available workspace classes</Heading3>
+            <Subheading>
+                Limit the available workspace classes in your organization. Requires{" "}
+                <span className="font-medium">Owner</span> permissions to change.
+            </Subheading>
+
+            <WorkspaceClassesOptions
+                isLoading={isLoadingClsInOrg}
+                className="mt-4"
+                classes={allowedClassesInOrganization}
+            />
+
+            {isOwner && (
+                <Button className="mt-6" onClick={() => setShowModal(true)}>
+                    Manage Classes
+                </Button>
+            )}
+
+            {showModal && (
+                <WorkspaceClassesModifyModal
+                    isLoading={isLoadingClsInInstall}
+                    showSetDefaultButton={false}
+                    showSwitchTitle={false}
+                    restrictedWorkspaceClasses={restrictedWorkspaceClasses}
+                    allowedClasses={allowedClassesInInstallation}
+                    updateMutation={updateMutation}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
+        </ConfigurationSettingsField>
+    );
+};
+
+interface EditorOptionsProps {
+    settings: OrganizationSettings | undefined;
+    isOwner: boolean;
+    handleUpdateTeamSettings: (
+        newSettings: Partial<OrganizationSettings>,
+        options?: { throwMutateError?: boolean },
+    ) => Promise<void>;
+}
+const EditorOptions = ({ isOwner, settings, handleUpdateTeamSettings }: EditorOptionsProps) => {
+    const [showModal, setShowModal] = useState(false);
+    const { data: installationOptions, isLoading: installationOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(
+        undefined,
+        {
+            filterOutDisabled: true,
+            ignoreScope: ["organization", "configuration"],
+        },
+    );
+    const { data: orgOptions, isLoading: orgOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(undefined, {
+        filterOutDisabled: true,
+        ignoreScope: ["configuration"],
+    });
+
+    const updateMutation: IdeOptionsModifyModalProps["updateMutation"] = useMutation({
+        mutationFn: async ({ restrictedEditors, pinnedEditorVersions }) => {
+            const updatedRestrictedEditors = [...restrictedEditors.keys()];
+            const updatedPinnedEditorVersions = Object.fromEntries(pinnedEditorVersions.entries());
+
+            await handleUpdateTeamSettings(
+                { restrictedEditorNames: updatedRestrictedEditors, pinnedEditorVersions: updatedPinnedEditorVersions },
+                { throwMutateError: true },
+            );
+        },
+    });
+
+    const restrictedEditors = new Set<string>(settings?.restrictedEditorNames || []);
+    const pinnedEditorVersions = new Map<string, string>(Object.entries(settings?.pinnedEditorVersions || {}));
+
+    return (
+        <ConfigurationSettingsField>
+            <Heading3>Available editors</Heading3>
+            <Subheading>
+                Limit the available editors in your organization. Requires <span className="font-medium">Owner</span>{" "}
+                permissions to change.
+            </Subheading>
+
+            <IdeOptions
+                isLoading={orgOptionsIsLoading}
+                className="mt-4"
+                ideOptions={orgOptions}
+                pinnedEditorVersions={pinnedEditorVersions}
+            />
+
+            {isOwner && (
+                <Button className="mt-6" onClick={() => setShowModal(true)}>
+                    Manage Editors
+                </Button>
+            )}
+
+            {showModal && (
+                <IdeOptionsModifyModal
+                    isLoading={installationOptionsIsLoading}
+                    ideOptions={installationOptions}
+                    restrictedEditors={restrictedEditors}
+                    pinnedEditorVersions={pinnedEditorVersions}
+                    updateMutation={updateMutation}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
+        </ConfigurationSettingsField>
+    );
+};
+
+const WorkspaceClassesEnterpriseCallout = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3 className="flex items-center gap-4">
+                Additional workspace classes
+                <PillLabel type="warn" className="!px-3 !py-0 !text-xs border">
+                    <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
+                </PillLabel>
+            </Heading3>
+            <Subheading>
+                Access to more powerful workspace classes with up to 30 cores 54GB of RAM and 100GB storage
+            </Subheading>
+
+            <div className="mt-6 flex flex-row space-x-2">
+                <LinkButton
+                    variant="secondary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
+                    isExternalUrl={true}
+                >
+                    Dcoumentation
+                </LinkButton>
+                <LinkButton
+                    variant="secondary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    href="https://www.gitpod.io/docs/enterprise"
+                    isExternalUrl={true}
+                >
+                    Learn more about Enterprise
+                </LinkButton>
+            </div>
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -291,7 +291,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
             <div className="mt-6 flex flex-row space-x-2">
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
@@ -299,7 +299,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 </LinkButton>
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
                     href="https://www.gitpod.io/docs/enterprise"
                     isExternalUrl={true}
                 >

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -291,7 +291,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
             <div className="mt-6 flex flex-row space-x-2">
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
@@ -299,7 +299,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 </LinkButton>
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
                     href="https://www.gitpod.io/docs/enterprise"
                     isExternalUrl={true}
                 >

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -10,7 +10,6 @@ import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { InputWithCopy } from "../components/InputWithCopy";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
-import { CheckboxInputField } from "../components/forms/CheckboxInputField";
 import { InputField } from "../components/forms/InputField";
 import { TextInputField } from "../components/forms/TextInputField";
 import { Heading2, Heading3, Subheading } from "../components/typography/headings";
@@ -28,20 +27,12 @@ import { OrgSettingsPage } from "./OrgSettingsPage";
 import { ErrorCode } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Button } from "@podkit/buttons/Button";
 import { useInstallationDefaultWorkspaceImageQuery } from "../data/installation/default-workspace-image-query";
-import { useAllowedWorkspaceClassesMemo } from "../data/workspaces/workspace-classes-query";
 import { ConfigurationSettingsField } from "../repositories/detail/ConfigurationSettingsField";
-import {
-    WorkspaceClassesModifyModal,
-    WorkspaceClassesModifyModalProps,
-    WorkspaceClassesOptions,
-} from "../components/WorkspaceClassesOptions";
-import { useMutation } from "@tanstack/react-query";
-import { useAllowedWorkspaceEditorsMemo } from "../data/ide-options/ide-options-query";
-import { IdeOptions, IdeOptionsModifyModal, IdeOptionsModifyModalProps } from "../components/IdeOptions";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@podkit/select/Select";
+import { useDocumentTitle } from "../hooks/use-document-title";
 
 export default function TeamSettingsPage() {
+    useDocumentTitle("Organization Settings - General");
     const user = useCurrentUser();
     const org = useCurrentOrg().data;
     const isOwner = useIsOwner();
@@ -51,7 +42,6 @@ export default function TeamSettingsPage() {
     const [teamName, setTeamName] = useState(org?.name || "");
     const [updated, setUpdated] = useState(false);
     const updateOrg = useUpdateOrgMutation();
-    const orgLevelEditorRestrictionEnabled = useFeatureFlag("org_level_editor_restriction_enabled");
 
     const close = () => setModal(false);
 
@@ -130,8 +120,10 @@ export default function TeamSettingsPage() {
             <OrgSettingsPage>
                 <div className="space-y-4">
                     <div>
-                        <Heading2>Organization Details</Heading2>
-                        <Subheading>Details of your organization within Gitpod.</Subheading>
+                        <Heading2>General</Heading2>
+                        <Subheading>
+                            Set the default role and workspace image, name or delete your organization.
+                        </Subheading>
                     </div>
                     <ConfigurationSettingsField>
                         {updateOrg.isError && (
@@ -197,25 +189,6 @@ export default function TeamSettingsPage() {
                     </ConfigurationSettingsField>
 
                     <ConfigurationSettingsField>
-                        <Heading3>Collaboration and sharing</Heading3>
-
-                        {updateTeamSettings.isError && (
-                            <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
-                                <span>Failed to update organization settings: </span>
-                                <span>{updateTeamSettings.error.message || "unknown error"}</span>
-                            </Alert>
-                        )}
-
-                        <CheckboxInputField
-                            label="Workspace Sharing"
-                            hint="Allow workspaces created within an Organization to share the workspace with any authenticated user."
-                            checked={!settings?.workspaceSharingDisabled}
-                            onChange={(checked) => handleUpdateTeamSettings({ workspaceSharingDisabled: !checked })}
-                            disabled={isLoading || !isOwner}
-                        />
-                    </ConfigurationSettingsField>
-
-                    <ConfigurationSettingsField>
                         <Heading3>Workspace images</Heading3>
                         <Subheading>Choose a default image for all workspaces in the organization.</Subheading>
 
@@ -232,20 +205,6 @@ export default function TeamSettingsPage() {
                             settings={settings}
                             installationDefaultWorkspaceImage={installationDefaultImage}
                             onClose={() => setShowImageEditModal(false)}
-                        />
-                    )}
-
-                    <OrgWorkspaceClassesOptions
-                        isOwner={isOwner}
-                        settings={settings}
-                        handleUpdateTeamSettings={handleUpdateTeamSettings}
-                    />
-
-                    {orgLevelEditorRestrictionEnabled && (
-                        <EditorOptions
-                            isOwner={isOwner}
-                            settings={settings}
-                            handleUpdateTeamSettings={handleUpdateTeamSettings}
                         />
                     )}
 
@@ -447,164 +406,3 @@ function OrgDefaultWorkspaceImageModal(props: OrgDefaultWorkspaceImageModalProps
         </Modal>
     );
 }
-
-interface OrgWorkspaceClassesOptionsProps {
-    isOwner: boolean;
-    settings?: OrganizationSettings;
-    handleUpdateTeamSettings: (
-        newSettings: Partial<OrganizationSettings>,
-        options?: { throwMutateError?: boolean },
-    ) => Promise<void>;
-}
-const OrgWorkspaceClassesOptions = ({
-    isOwner,
-    settings,
-    handleUpdateTeamSettings,
-}: OrgWorkspaceClassesOptionsProps) => {
-    const [showModal, setShowModal] = useState(false);
-    const { data: allowedClassesInOrganization, isLoading: isLoadingClsInOrg } = useAllowedWorkspaceClassesMemo(
-        undefined,
-        {
-            filterOutDisabled: true,
-            ignoreScope: ["configuration"],
-        },
-    );
-    const { data: allowedClassesInInstallation, isLoading: isLoadingClsInInstall } = useAllowedWorkspaceClassesMemo(
-        undefined,
-        {
-            filterOutDisabled: true,
-            ignoreScope: ["organization", "configuration"],
-        },
-    );
-
-    const restrictedWorkspaceClasses = useMemo(() => {
-        const allowedList = settings?.allowedWorkspaceClasses ?? [];
-        if (allowedList.length === 0) {
-            return [];
-        }
-        return allowedClassesInInstallation.filter((cls) => !allowedList.includes(cls.id)).map((cls) => cls.id);
-    }, [settings?.allowedWorkspaceClasses, allowedClassesInInstallation]);
-
-    const updateMutation: WorkspaceClassesModifyModalProps["updateMutation"] = useMutation({
-        mutationFn: async ({ restrictedWorkspaceClasses }) => {
-            let allowedWorkspaceClasses = allowedClassesInInstallation.map((e) => e.id);
-            if (restrictedWorkspaceClasses.length > 0) {
-                allowedWorkspaceClasses = allowedWorkspaceClasses.filter(
-                    (e) => !restrictedWorkspaceClasses.includes(e),
-                );
-            }
-            const allAllowed = allowedClassesInInstallation.every((e) => allowedWorkspaceClasses.includes(e.id));
-            if (allAllowed) {
-                // empty means allow all classes
-                allowedWorkspaceClasses = [];
-            }
-            await handleUpdateTeamSettings({ allowedWorkspaceClasses }, { throwMutateError: true });
-        },
-    });
-
-    return (
-        <ConfigurationSettingsField>
-            <Heading3>Available workspace classes</Heading3>
-            <Subheading>
-                Limit the available workspace classes in your organization. Requires{" "}
-                <span className="font-medium">Owner</span> permissions to change.
-            </Subheading>
-
-            <WorkspaceClassesOptions
-                isLoading={isLoadingClsInOrg}
-                className="mt-4"
-                classes={allowedClassesInOrganization}
-            />
-
-            {isOwner && (
-                <Button className="mt-6" onClick={() => setShowModal(true)}>
-                    Manage Classes
-                </Button>
-            )}
-
-            {showModal && (
-                <WorkspaceClassesModifyModal
-                    isLoading={isLoadingClsInInstall}
-                    showSetDefaultButton={false}
-                    showSwitchTitle={false}
-                    restrictedWorkspaceClasses={restrictedWorkspaceClasses}
-                    allowedClasses={allowedClassesInInstallation}
-                    updateMutation={updateMutation}
-                    onClose={() => setShowModal(false)}
-                />
-            )}
-        </ConfigurationSettingsField>
-    );
-};
-
-interface EditorOptionsProps {
-    settings: OrganizationSettings | undefined;
-    isOwner: boolean;
-    handleUpdateTeamSettings: (
-        newSettings: Partial<OrganizationSettings>,
-        options?: { throwMutateError?: boolean },
-    ) => Promise<void>;
-}
-const EditorOptions = ({ isOwner, settings, handleUpdateTeamSettings }: EditorOptionsProps) => {
-    const [showModal, setShowModal] = useState(false);
-    const { data: installationOptions, isLoading: installationOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(
-        undefined,
-        {
-            filterOutDisabled: true,
-            ignoreScope: ["organization", "configuration"],
-        },
-    );
-    const { data: orgOptions, isLoading: orgOptionsIsLoading } = useAllowedWorkspaceEditorsMemo(undefined, {
-        filterOutDisabled: true,
-        ignoreScope: ["configuration"],
-    });
-
-    const updateMutation: IdeOptionsModifyModalProps["updateMutation"] = useMutation({
-        mutationFn: async ({ restrictedEditors, pinnedEditorVersions }) => {
-            const updatedRestrictedEditors = [...restrictedEditors.keys()];
-            const updatedPinnedEditorVersions = Object.fromEntries(pinnedEditorVersions.entries());
-
-            await handleUpdateTeamSettings(
-                { restrictedEditorNames: updatedRestrictedEditors, pinnedEditorVersions: updatedPinnedEditorVersions },
-                { throwMutateError: true },
-            );
-        },
-    });
-
-    const restrictedEditors = new Set<string>(settings?.restrictedEditorNames || []);
-    const pinnedEditorVersions = new Map<string, string>(Object.entries(settings?.pinnedEditorVersions || {}));
-
-    return (
-        <ConfigurationSettingsField>
-            <Heading3>Available editors</Heading3>
-            <Subheading>
-                Limit the available editors in your organization. Requires <span className="font-medium">Owner</span>{" "}
-                permissions to change.
-            </Subheading>
-
-            <IdeOptions
-                isLoading={orgOptionsIsLoading}
-                className="mt-4"
-                ideOptions={orgOptions}
-                pinnedEditorVersions={pinnedEditorVersions}
-            />
-
-            {isOwner && (
-                <Button className="mt-6" onClick={() => setShowModal(true)}>
-                    Manage Editors
-                </Button>
-            )}
-
-            {showModal && (
-                <IdeOptionsModifyModal
-                    isLoading={installationOptionsIsLoading}
-                    ideOptions={installationOptions}
-                    restrictedEditors={restrictedEditors}
-                    pinnedEditorVersions={pinnedEditorVersions}
-                    updateMutation={updateMutation}
-                    onClose={() => setShowModal(false)}
-                />
-            )}
-        </ConfigurationSettingsField>
-    );
-};

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -118,7 +118,7 @@ export default function TeamSettingsPage() {
     return (
         <>
             <OrgSettingsPage>
-                <div className="space-y-4">
+                <div className="space-y-8">
                     <div>
                         <Heading2>General</Heading2>
                         <Subheading>

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -171,7 +171,7 @@ function ListAccessTokensView() {
                 <div>
                     <Heading2 className="flex gap-4 items-center">
                         Access Tokens
-                        <PillLabel type="warn" className="font-semibold self-center py-0.5 px-1.5">
+                        <PillLabel type="warn">
                             <a href="https://www.gitpod.io/docs/references/gitpod-releases">
                                 <span className="text-xs">BETA</span>
                             </a>

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -169,8 +169,8 @@ function ListAccessTokensView() {
         <>
             <div className="flex items-center sm:justify-between mb-4">
                 <div>
-                    <Heading2>
-                        Access Tokens{" "}
+                    <Heading2 className="flex gap-4 items-center">
+                        Access Tokens
                         <PillLabel type="warn" className="font-semibold self-center py-0.5 px-1.5">
                             <a href="https://www.gitpod.io/docs/references/gitpod-releases">
                                 <span className="text-xs">BETA</span>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces a division of the Organization's "General settings" into two distinct sections: "General" and "Policies." This change aims to provide more fine-grained control over organization settings. Additionally, new sections for "Networking" and "Authentication" have been introduced with specific visibility rules for PAYG (Pay-As-You-Go)

#### Changes

1. **General Settings Split:**
   - **General:**
     - **Content:** Set the default role and workspace image, name or delete your organization.
     - **Visibility:** Available on both Enterprise and PAYG.
     - **URL Structure:** `/settings`
   - **Policies:**
     - **Content:** Restrict workspace classes, editors, and sharing across your organization.
     - **Visibility:** Available on both Enterprise and PAYG.
     - **URL Structure:** `/settings/policy`

2. **New Sections:**
   - **Networking:**
     - **Visibility:** Only on PAYG.
     - **URL Structure:** `/settings/networking`
     - **Redirection:** Enterprise users will be redirected to `/settings` if they try to access this page.
   - **Authentication:**
     - **Visibility:** Only on PAYG.
     - **URL Structure:** `/settings/auth`
     - **Redirection:** Enterprise users will be redirected to `/settings` if they try to access this page.

3. **Existing Sections:**
   - **Billing:**
     - **Visibility:** Only on PAYG (unchanged).
   - **SSO:**
     - **Visibility:** Only on Enterprise (unchanged).
   - **Git Providers:**
     - **Visibility:** Only on Enterprise (unchanged).

#### Testing

- Copy texts in each settings section
- Verify that the "General" and "Policies" sections are visible and functional on both Enterprise and PAYG accounts.
- Ensure that the "Networking" and "Authentication" sections are only visible on PAYG accounts and that Enterprise users are redirected appropriately. -- _I'm unsure, how?_
- Confirm that the existing sections ("Billing," "SSO," and "Git Providers") retain their original visibility and functionality.
- Check URL navigation for all settings sections to ensure correct routing and redirection.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-605

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-ofef127027b</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-ofef127027b.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-ofef127027b.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-opm-605-add-references-to-enterprise-in-the-organizational-settings-gha.25544</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-ofef127027b%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
