### PR TITLE
Tolerate GPU taint

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -189,6 +189,13 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: pointer.Int64(30),
 					InitContainers:                initContainers,
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "gitpod.io/gpu",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+					},
 					Containers: []corev1.Container{{
 						Name:            Component,
 						Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.RegistryFacade.Version),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -204,6 +204,11 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Operator: "Exists",
 			Effect:   "NoExecute",
 		},
+		{
+			Key:      "gitpod.io/gpu",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
 	}
 
 	podSpec := corev1.PodSpec{


### PR DESCRIPTION
## Description
Ensures that ws-daemon and registry-facade can tolerate taints on GPU nodes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-201



#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
