### PR TITLE
[dashboard] Add owner check to `/billing` page

### DIFF
--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -8,6 +8,8 @@ import { OrgSettingsPage } from "./OrgSettingsPage";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useIsOwner } from "../data/organizations/members-query";
+import { Redirect } from "react-router";
 
 export default function TeamUsageBasedBillingPage() {
     return (
@@ -19,6 +21,11 @@ export default function TeamUsageBasedBillingPage() {
 
 function TeamUsageBasedBilling() {
     const orgBillingMode = useOrgBillingMode();
+    const isOwner = useIsOwner();
+
+    if (!isOwner) {
+        return <Redirect to="/settings" />;
+    }
 
     if (!BillingMode.showUsageBasedBilling(orgBillingMode.data)) {
         return <></>;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request adds an owner check to the `/billing` page. If the user is not the owner of the organization, they will be redirected to the `/settings` page. This ensures that only the owner can access the billing page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal conv.](https://gitpod.slack.com/archives/C071G5TTS49/p1716949094559919)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
