### PR TITLE
[dashboard] Add Organization Networking settings page

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -61,6 +61,7 @@ const TeamUsageBasedBilling = React.lazy(() => import(/* webpackPrefetch: true *
 const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"));
 const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
 const TeamPolicies = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamPolicies"));
+const TeamNetworking = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamNetworking"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/ProjectSettings"));
@@ -203,6 +204,7 @@ export const AppRoutes = () => {
                             <Route exact path="/settings" component={TeamSettings} />
                             <Route exact path="/settings/git" component={TeamGitIntegrations} />
                             <Route exact path="/settings/policy" component={TeamPolicies} />
+                            <Route exact path="/settings/networking" component={TeamNetworking} />
                             {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
                             <Route exact path="/billing" component={TeamUsageBasedBilling} />
                             <Route exact path="/sso" component={SSO} />

--- a/components/dashboard/src/teams/TeamNetworking.tsx
+++ b/components/dashboard/src/teams/TeamNetworking.tsx
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { isGitpodIo } from "../utils";
+import React from "react";
+import { Heading2, Heading3, Subheading } from "../components/typography/headings";
+import { OrgSettingsPage } from "./OrgSettingsPage";
+import { ConfigurationSettingsField } from "../repositories/detail/ConfigurationSettingsField";
+import { useDocumentTitle } from "../hooks/use-document-title";
+import { LinkButton } from "@podkit/buttons/LinkButton";
+import { CheckCircle2Icon } from "lucide-react";
+import { Redirect } from "react-router";
+import PillLabel from "../components/PillLabel";
+
+export default function TeamPoliciesPage() {
+    useDocumentTitle("Organization Settings - Networking");
+
+    if (!isGitpodIo) {
+        return <Redirect to="/settings" />;
+    }
+
+    return (
+        <>
+            <OrgSettingsPage>
+                <div className="space-y-8">
+                    <div>
+                        <Heading2 className="flex items-center gap-4">
+                            Networking
+                            <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
+                                <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
+                            </PillLabel>
+                        </Heading2>
+                        <Subheading className="mt-2">Manage your organization's networking settings.</Subheading>
+                    </div>
+
+                    <SelfHostedCalloutCard />
+                    <DeployedRegionCard />
+                    <VPNCard />
+                </div>
+            </OrgSettingsPage>
+        </>
+    );
+}
+
+const SelfHostedCalloutCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Self-host in your cloud account</Heading3>
+            <Subheading>
+                Deploy the Gitpod infrastructure into your own cloud account and connect to your private network
+            </Subheading>
+
+            <div className="mt-2 flex flex-col space-y-2">
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed application feature releases and updates
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed provisioning and scaling of workspaces
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed backup and restore processes
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Managed security updates and patches
+                </div>
+            </div>
+
+            <LinkButton
+                href="https://www.gitpod.io/contact/enterprise-self-serve"
+                isExternalUrl={true}
+                className="mt-8 rounded-xl"
+            >
+                Request Free Trial
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};
+
+const DeployedRegionCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Choose your deployed region</Heading3>
+            <Subheading>
+                Deploy Gitpod to any location, such as: United States, South America, Europe and Asia Pacific
+            </Subheading>
+
+            <div className="mt-8 flex flex-col space-y-2">
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Meet data residency compliance requirements
+                </div>
+                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
+                    <CheckCircle2Icon size={20} />
+                    Reduce your workspace latency
+                </div>
+            </div>
+
+            <LinkButton
+                variant="secondary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
+                isExternalUrl={true}
+            >
+                Dcoumentation
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};
+
+const VPNCard = () => {
+    return (
+        <ConfigurationSettingsField className="bg-pk-surface-secondary">
+            <Heading3>Virtual Private Network (VPN)</Heading3>
+            <Subheading>
+                Ensure that only your developers can access your Gitpod instance through your VPN network
+            </Subheading>
+
+            <LinkButton
+                variant="secondary"
+                className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
+                isExternalUrl={true}
+            >
+                Dcoumentation
+            </LinkButton>
+        </ConfigurationSettingsField>
+    );
+};

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -291,7 +291,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
             <div className="mt-6 flex flex-row space-x-2">
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
@@ -299,7 +299,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 </LinkButton>
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
                     href="https://www.gitpod.io/docs/enterprise"
                     isExternalUrl={true}
                 >


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Related to https://github.com/gitpod-io/gitpod/pull/19788

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-609

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
