### PR TITLE
[dashboard] Add Organization Authenitcation settings page

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -62,6 +62,7 @@ const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"))
 const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
 const TeamPolicies = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamPolicies"));
 const TeamNetworking = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamNetworking"));
+const TeamAuthentication = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamAuthentication"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/ProjectSettings"));
@@ -205,6 +206,7 @@ export const AppRoutes = () => {
                             <Route exact path="/settings/git" component={TeamGitIntegrations} />
                             <Route exact path="/settings/policy" component={TeamPolicies} />
                             <Route exact path="/settings/networking" component={TeamNetworking} />
+                            <Route exact path="/settings/auth" component={TeamAuthentication} />
                             {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
                             <Route exact path="/billing" component={TeamUsageBasedBilling} />
                             <Route exact path="/sso" component={SSO} />

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -16,7 +16,7 @@ import { Redirect } from "react-router";
 import PillLabel from "../components/PillLabel";
 
 export default function TeamPoliciesPage() {
-    useDocumentTitle("Organization Settings - Networking");
+    useDocumentTitle("Organization Settings - Authentication");
 
     if (!isGitpodIo) {
         return <Redirect to="/settings" />;
@@ -28,47 +28,37 @@ export default function TeamPoliciesPage() {
                 <div className="space-y-8">
                     <div>
                         <Heading2 className="flex items-center gap-4">
-                            Networking
+                            Authentication
                             <PillLabel type="warn" className="!px-3 !py-0.5 !text-xs border">
                                 <span className="text-sm font-semibold text-pk-content-secondary">Enterprise</span>
                             </PillLabel>
                         </Heading2>
-                        <Subheading className="mt-1">Manage your organization's networking settings.</Subheading>
+                        <Subheading className="mt-1">Manage your organization's authentication settings.</Subheading>
                     </div>
 
-                    <SelfHostedCalloutCard />
-                    <DeployedRegionCard />
-                    <VPNCard />
+                    <SSOCard />
+                    <PrivateImageRegistryCard />
+                    <PrivateSourceControlAccess />
                 </div>
             </OrgSettingsPage>
         </>
     );
 }
 
-const SelfHostedCalloutCard = () => {
+const SSOCard = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Self-host in your cloud account</Heading3>
-            <Subheading className="mt-1">
-                Deploy the Gitpod infrastructure into your own cloud account and connect to your private network
-            </Subheading>
+            <Heading3>Single sign-on (SSO)</Heading3>
+            <Subheading className="mt-1">More control over workspace access for your organization</Subheading>
 
-            <div className="mt-1 flex flex-col space-y-2">
+            <div className="mt-8 flex flex-col space-y-2">
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Managed application feature releases and updates
+                    Includes support for Google, Okta, AWS Cognito and others
                 </div>
                 <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
                     <CheckCircle2Icon size={20} />
-                    Managed provisioning and scaling of workspaces
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed backup and restore processes
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Managed security updates and patches
+                    Instantly revoke access and off-board users from Gitpod
                 </div>
             </div>
 
@@ -83,29 +73,16 @@ const SelfHostedCalloutCard = () => {
     );
 };
 
-const DeployedRegionCard = () => {
+const PrivateImageRegistryCard = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Choose your deployed region</Heading3>
-            <Subheading className="mt-1">
-                Deploy Gitpod to any location, such as: United States, South America, Europe and Asia Pacific
-            </Subheading>
-
-            <div className="mt-8 flex flex-col space-y-2">
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Meet data residency compliance requirements
-                </div>
-                <div className="flex flex-row gap-2 items-center text-pk-content-secondary">
-                    <CheckCircle2Icon size={20} />
-                    Reduce your workspace latency
-                </div>
-            </div>
+            <Heading3>Private container image registry</Heading3>
+            <Subheading className="mt-1">Provide secure access to private image registries such as ECR</Subheading>
 
             <LinkButton
                 variant="secondary"
                 className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
-                href="https://www.gitpod.io/docs/enterprise/overview#aws-support-and-regions"
+                href="https://www.gitpod.io/docs/enterprise/setup-gitpod/use-private-ecr-repos-for-workspace-images"
                 isExternalUrl={true}
             >
                 Dcoumentation
@@ -114,18 +91,18 @@ const DeployedRegionCard = () => {
     );
 };
 
-const VPNCard = () => {
+const PrivateSourceControlAccess = () => {
     return (
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
-            <Heading3>Virtual Private Network (VPN)</Heading3>
+            <Heading3>Private source control access</Heading3>
             <Subheading className="mt-1">
-                Ensure that only your developers can access your Gitpod instance through your VPN network
+                Connect to your private source control like GitHub, BitBucket and GitLab
             </Subheading>
 
             <LinkButton
                 variant="secondary"
                 className="mt-8 border border-pk-content-tertiary text-pk-content-tertiary"
-                href="https://www.gitpod.io/docs/enterprise/getting-started/networking#private-networking-configuration-highly-restrictive"
+                href="https://www.gitpod.io/docs/enterprise/setup-gitpod/scm-integration"
                 isExternalUrl={true}
             >
                 Dcoumentation

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -291,7 +291,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
             <div className="mt-6 flex flex-row space-x-2">
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
                     href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes#enterprise"
                     isExternalUrl={true}
                 >
@@ -299,7 +299,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 </LinkButton>
                 <LinkButton
                     variant="secondary"
-                    className="border border-pk-content-tertiary text-pk-content-tertiary rounded-xl"
+                    className="border border-pk-content-tertiary text-pk-content-tertiary"
                     href="https://www.gitpod.io/docs/enterprise"
                     isExternalUrl={true}
                 >


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Related to #19788

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-610

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
