### PR TITLE
[dashboard] Don't lowercase context URLs

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -53,7 +53,6 @@ export function deduplicateAndFilterRepositories(
     onlyConfigurations = false,
     suggestedRepos: SuggestedRepository[],
 ): SuggestedRepository[] {
-    const normalizedSearchString = searchString.trim().toLowerCase();
     const collected = new Set<string>();
     const results: SuggestedRepository[] = [];
     const reposWithConfiguration = new Set<string>();
@@ -73,7 +72,7 @@ export function deduplicateAndFilterRepositories(
         }
 
         // filter out entries that don't match the search string
-        if (!`${repo.url}${repo.configurationName || ""}`.toLowerCase().includes(normalizedSearchString)) {
+        if (!`${repo.url}${repo.configurationName || ""}`.toLowerCase().includes(searchString.trim().toLowerCase())) {
             continue;
         }
         // filter out duplicates
@@ -87,11 +86,11 @@ export function deduplicateAndFilterRepositories(
 
     if (results.length === 0) {
         try {
-            // If the normalizedSearchString is a URL, and it's not present in the proposed results, "artificially" add it here.
-            new URL(normalizedSearchString);
+            // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
+            new URL(searchString);
             results.push(
                 new SuggestedRepository({
-                    url: normalizedSearchString,
+                    url: searchString,
                 }),
             );
         } catch {}


### PR DESCRIPTION
## Description
old:
![image](https://github.com/gitpod-io/gitpod/assets/32448529/5b2a2f70-233b-4bbd-b17a-ad8298a05036)



new:
![image](https://github.com/gitpod-io/gitpod/assets/32448529/6f9ea69f-1235-4f7c-8670-724c0be3273e)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-165
Fixes ENT-200

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-165-brda2d70b400</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-165-brda2d70b400.preview.gitpod-dev.com/workspaces" target="_blank">gpl-165-brda2d70b400.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-165-branch-capitalization-gha.25578</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-165-brda2d70b400%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
