### PR TITLE
[PAYG-dashboard] Enterprise callout in Invite members modal for all PAYG users

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -24,6 +24,7 @@ import { useListOrganizationMembers, useOrganizationMembersInvalidator } from ".
 import { useInvitationId, useInviteInvalidator } from "../data/organizations/invite-query";
 import { Delayed } from "@podkit/loading/Delayed";
 import { Button } from "@podkit/buttons/Button";
+import { isGitpodIo } from "../utils";
 
 function getHumanReadable(role: OrganizationRole): string {
     return OrganizationRole[role].toLowerCase();
@@ -266,6 +267,19 @@ export default function MembersPage() {
                         >
                             <InputWithCopy value={inviteUrl} tip="Copy Invite URL" />
                         </InputField>
+                        {isGitpodIo() && (
+                            <div className="text-pk-content-tertiary mt-3">
+                                <span className="text-sm font-bold">Need SSO? </span>
+                                <a
+                                    className="text-sm gp-link"
+                                    href="https://www.gitpod.io/docs/enterprise"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    Try Gitpod Enterprise
+                                </a>
+                            </div>
+                        )}
                     </ModalBody>
                     <ModalFooter>
                         {!!inviteId && (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request adds an Enterprise callout in the Invite members modal for all PAYG users. 

| Before | After |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/55068936/a7c6f851-38c7-4aa4-8c06-c30cf3b9a143) | ![image](https://github.com/gitpod-io/gitpod/assets/55068936/623c4bca-ee79-4d35-ac6c-a0dd467143fa) | 


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal conversation](https://gitpod.slack.com/archives/C074K0JASMQ/p1716910331259239?thread_ts=1716780362.152069&cid=C074K0JASMQ)

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment
- Go to members section of your org.
- click on `Invite members` and see :eyes:

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
