### PR TITLE
[dashboard] tell users to verify by signing up

### DIFF
--- a/components/dashboard/src/start/VerifyModal.tsx
+++ b/components/dashboard/src/start/VerifyModal.tsx
@@ -16,6 +16,7 @@ import { useFeatureFlag } from "../data/featureflag-query";
 import { verificationClient } from "../service/public-api";
 import { InputField } from "../components/forms/InputField";
 import { TextInputField } from "../components/forms/TextInputField";
+import { Link } from "react-router-dom";
 
 interface VerifyModalState {
     phoneNumber?: string;
@@ -70,7 +71,13 @@ export function VerifyModal() {
                 onSubmit={sendCode}
                 title="User Validation Required"
                 buttons={
-                    <div>
+                    <div className="space-x-4">
+                        <Link to="/billing">
+                            {/* secondary button */}
+                            <Button type="button" variant="secondary">
+                                Subscribe to paid plan
+                            </Button>
+                        </Link>
                         <Button type="submit" disabled={!state.phoneNumberValid || state.sending}>
                             {phoneVerificationByCall ? "Send Code via Voice call" : "Send Code via SMS"}
                         </Button>
@@ -79,11 +86,15 @@ export function VerifyModal() {
                 visible={true}
             >
                 <Alert type="warning" className="mt-2">
-                    To use Gitpod you'll need to validate your account with your phone number. This is required to
-                    discourage and reduce abuse on Gitpod infrastructure.
+                    To use Gitpod for free you'll need to validate your account with your phone number. This is required
+                    to discourage and reduce abuse on Gitpod infrastructure.
+                </Alert>
+                <Alert type="info" className="mt-4">
+                    Alternatively, you can verify by subscribing to our paid plan.
                 </Alert>
                 <div className="text-gray-600 dark:text-gray-400 mt-2">
-                    Enter a mobile phone number you would like to use to verify your account. If you encounter issues, please retry later or use a different number.
+                    Enter a mobile phone number you would like to use to verify your account. If you encounter issues,
+                    please retry later or use a different number.
                 </div>
                 {state.message ? (
                     <Alert type={state.message.type} className="mt-4 py-3">
@@ -172,7 +183,13 @@ export function VerifyModal() {
                 onSubmit={verifyToken}
                 title="User Validation Required"
                 buttons={
-                    <div>
+                    <div className="space-x-4">
+                        <Link to="/billing">
+                            {/* secondary button */}
+                            <Button type="button" variant="secondary">
+                                Subscribe to paid plan
+                            </Button>
+                        </Link>
                         <Button type="submit" disabled={!isTokenFilled()}>
                             Validate Account
                         </Button>
@@ -181,8 +198,8 @@ export function VerifyModal() {
                 visible={true}
             >
                 <Alert type="warning" className="mt-2">
-                    To use Gitpod you'll need to validate your account with your phone number. This is required to
-                    discourage and reduce abuse on Gitpod infrastructure.
+                    To use Gitpod for free you'll need to validate your account with your phone number. This is required
+                    to discourage and reduce abuse on Gitpod infrastructure.
                 </Alert>
                 <div className="pt-4">
                     <LinkButton onClick={reset}>&larr; Use a different phone number</LinkButton>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We so far don't tell users that they could put in a credit card in order to verify.

<img width="528" alt="Screenshot 2024-05-29 at 10 45 20" src="https://github.com/gitpod-io/gitpod/assets/372735/2e536597-705d-415e-8ddf-00aa0efa162f">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
