### PR TITLE
Provide option to disable fuse device

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_fuse_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_fuse_v2.go
@@ -29,6 +29,10 @@ func (c *FuseDeviceEnablerV2) Name() string  { return "fuse-device-enabler-v2" }
 func (c *FuseDeviceEnablerV2) Type() Version { return Version2 }
 
 func (c *FuseDeviceEnablerV2) Apply(ctx context.Context, opts *PluginOptions) error {
+	if val, ok := opts.Annotations["gitpod.io/fuse-device"]; ok && val == "false" {
+		return nil
+	}
+
 	fullCgroupPath := filepath.Join(opts.BasePath, opts.CgroupPath)
 	log.WithField("cgroupPath", fullCgroupPath).Debug("configuring devices")
 


### PR DESCRIPTION
## Description
Modifying the eBPF program attached to the cgroup can interfere with other components that also want to modify the eBPF program. This provides a way to selectively disable the modification of the eBPF program. This is a temporary measure until we switch to device plugins.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-190

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
