### PR TITLE
[JetBrains] support new cwm response format

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -129,7 +129,7 @@
             "image": "{{.Repository}}/ide/intellij:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -137,7 +137,7 @@
             "image": "{{.Repository}}/ide/intellij:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -185,7 +185,7 @@
             "image": "{{.Repository}}/ide/goland:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -193,7 +193,7 @@
             "image": "{{.Repository}}/ide/goland:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -230,7 +230,7 @@
             "image": "{{.Repository}}/ide/pycharm:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -238,7 +238,7 @@
             "image": "{{.Repository}}/ide/pycharm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -274,7 +274,7 @@
             "image": "{{.Repository}}/ide/phpstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -282,7 +282,7 @@
             "image": "{{.Repository}}/ide/phpstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -318,7 +318,7 @@
             "image": "{{.Repository}}/ide/rubymine:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -326,7 +326,7 @@
             "image": "{{.Repository}}/ide/rubymine:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -362,7 +362,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -370,7 +370,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -378,7 +378,7 @@
             "image": "{{.Repository}}/ide/webstorm:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-dc860e22fa7c07401c6dce62360589ff36e36bba",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -414,7 +414,7 @@
             "image": "{{.Repository}}/ide/rider:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           },
           {
@@ -422,7 +422,7 @@
             "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]
@@ -458,7 +458,7 @@
             "image": "{{.Repository}}/ide/clion:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
               "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-92fccc81ef03c56615d0b14c49a7ac6ddd9216e6"
+              "{{.Repository}}/ide/jb-launcher:commit-304eda30826ad765c5a9e810a37af433016bb798"
             ]
           }
         ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

CodeWithMe response data's format is changed and it also affects old IDE versions 🫨

See also https://github.com/gitpod-io/gitpod/pull/19751

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-204

## How to test
<!-- Provide steps to test this PR -->

It should be able to start workspaces with IntelliJ 2023 (must test) and other changed versions

example repo: https://github.com/spring-projects/spring-petclinic

✅ 
<img width="541" alt="SCR-20240529-uqaw" src="https://github.com/gitpod-io/gitpod/assets/20944364/07f1ef25-cd8a-4a53-af95-01710ea7acfb">
<img width="1046" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/61013a77-771b-40eb-9e58-78506d7f57be">
<img width="1068" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/e6f76778-ff8e-4b71-8e4a-7cd1b2dea0e8">



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-iu2023</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-iu2023.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-iu2023.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-iu2023-gha.25632</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-iu2023%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
