### PR TITLE
[dashboard] Fix queries useOrgSettings/useConfiguration

### DIFF
--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -70,7 +70,7 @@ export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefin
     const organizationId = useCurrentOrg().data?.id;
     const { data: orgSettings, isLoading: isLoadingOrgSettings } = useOrgSettingsQuery();
     const { data: installationOptions, isLoading: isLoadingInstallationCls } = useIDEOptions();
-    const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId ?? "");
+    const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId);
     let isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
     if (!organizationId) {
         // If there's no orgID set (i.e. User onboarding page), isLoadingOrgSettings will always be true

--- a/components/dashboard/src/data/ide-options/ide-options-query.ts
+++ b/components/dashboard/src/data/ide-options/ide-options-query.ts
@@ -11,7 +11,6 @@ import { DisableScope, Scope } from "../workspaces/workspace-classes-query";
 import { useOrgSettingsQuery } from "../organizations/org-settings-query";
 import { OrganizationSettings } from "@gitpod/public-api/lib/gitpod/v1/organization_pb";
 import { useMemo } from "react";
-import { useCurrentOrg } from "../organizations/orgs-query";
 import { useConfiguration } from "../configurations/configuration-queries";
 import { useDeepCompareMemoize } from "use-deep-compare-effect";
 
@@ -67,16 +66,10 @@ interface FilterOptions {
     ignoreScope?: DisableScope[];
 }
 export const useAllowedWorkspaceEditorsMemo = (configurationId: string | undefined, options?: FilterOptions) => {
-    const organizationId = useCurrentOrg().data?.id;
     const { data: orgSettings, isLoading: isLoadingOrgSettings } = useOrgSettingsQuery();
     const { data: installationOptions, isLoading: isLoadingInstallationCls } = useIDEOptions();
     const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId);
-    let isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
-    if (!organizationId) {
-        // If there's no orgID set (i.e. User onboarding page), isLoadingOrgSettings will always be true
-        // So we will filter it out
-        isLoading = isLoadingInstallationCls || isLoadingConfiguration;
-    }
+    const isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
     const depItems = [
         installationOptions,
         options?.ignoreScope,

--- a/components/dashboard/src/data/organizations/org-settings-query.ts
+++ b/components/dashboard/src/data/organizations/org-settings-query.ts
@@ -20,18 +20,18 @@ export function useOrgSettingsQueryInvalidator() {
 
 export function useOrgSettingsQuery() {
     const organizationId = useCurrentOrg().data?.id;
-    return useQuery<OrganizationSettings, Error>(
+    return useQuery<OrganizationSettings | null, Error, OrganizationSettings | undefined>(
         getQueryKey(organizationId),
         async () => {
             if (!organizationId) {
-                throw new Error("No org selected.");
+                return null;
             }
 
             const settings = await organizationClient.getOrganizationSettings({ organizationId });
             return settings.settings || new OrganizationSettings();
         },
         {
-            enabled: !!organizationId,
+            select: (data) => data || undefined,
         },
     );
 }

--- a/components/dashboard/src/data/workspaces/workspace-classes-query.ts
+++ b/components/dashboard/src/data/workspaces/workspace-classes-query.ts
@@ -120,7 +120,7 @@ export const useAllowedWorkspaceClassesMemo = (
     const { data: orgSettings, isLoading: isLoadingOrgSettings } = useOrgSettingsQuery();
     const { data: installationClasses, isLoading: isLoadingInstallationCls } = useWorkspaceClasses();
     // empty configurationId will return undefined
-    const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId ?? "");
+    const { data: configuration, isLoading: isLoadingConfiguration } = useConfiguration(configurationId);
 
     const isLoading = isLoadingOrgSettings || isLoadingInstallationCls || isLoadingConfiguration;
 

--- a/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
+++ b/components/dashboard/src/prebuilds/list/RunPrebuildModal.tsx
@@ -43,7 +43,7 @@ export const RunPrebuildModal: FC<Props> = ({ defaultRepositoryId: defaultConfig
         data: prebuildId,
     } = useTriggerPrebuildQuery(configurationId, branchName);
 
-    const { data: configuration } = useConfiguration(configurationId ?? "");
+    const { data: configuration } = useConfiguration(configurationId);
 
     const handleSubmit = useCallback(() => {
         if (!configurationId) {


### PR DESCRIPTION
## Description
This PR fixes two related bugs in two react queries:
 - react query can't store `undefined` in the cache, hence the errors we saw before (bug 1)
 - we can't work around that with errors as they bubble up the chain and pollute logs :red_circle: 
 - we can't work around that with `enabled: !!organizationId`, as that will lead to the query be stuck on `isLoading: true` indefinitely (bug 2)
 - solution:
   - internally store `null`
   - map that to `undefined` using the `select` option


Proof that `useOrgSettingsQuery` still works in the `organizationId: undefined` (sign up) case:
![image](https://github.com/gitpod-io/gitpod/assets/32448529/31bb82ce-2c58-4497-8b43-bd78edf50b53)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-203

## How to test
 - [sign up](https://gpl-203-cofdb4a94577.preview.gitpod-dev.com/workspaces), and verify that you can use/change your editor choice :heavy_check_mark: 
 - open the "start workspace" dialog and see how it works in all scenarios (select repo, undo, select again, change editor, change class, etc.) :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-203-cofdb4a94577</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-203-cofdb4a94577.preview.gitpod-dev.com/workspaces" target="_blank">gpl-203-cofdb4a94577.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-203-configurationid-gha.25644</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-203-cofdb4a94577%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
