### PR TITLE
Backup prebuild logs even it's fail

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -298,9 +298,10 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 			WorkspaceID: ws.Spec.Ownership.WorkspaceID,
 			InstanceID:  ws.Name,
 		},
-		SnapshotName:    snapshotName,
-		BackupLogs:      ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
-		UpdateGitStatus: ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
+		SnapshotName:      snapshotName,
+		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
+		UpdateGitStatus:   ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
+		SkipBackupContent: ws.Spec.Type == workspacev1.WorkspaceTypePrebuild && ws.IsConditionTrue(workspacev1.WorkspaceConditionsHeadlessTaskFailed),
 	})
 
 	err = retry.RetryOnConflict(retryParams, func() error {

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -97,10 +97,11 @@ type InitOptions struct {
 }
 
 type BackupOptions struct {
-	Meta            WorkspaceMeta
-	BackupLogs      bool
-	UpdateGitStatus bool
-	SnapshotName    string
+	Meta              WorkspaceMeta
+	BackupLogs        bool
+	UpdateGitStatus   bool
+	SnapshotName      string
+	SkipBackupContent bool
 }
 
 func NewWorkspaceOperations(config content.Config, provider *WorkspaceProvider, reg prometheus.Registerer) (WorkspaceOperations, error) {
@@ -235,6 +236,10 @@ func (wso *DefaultWorkspaceOperations) BackupWorkspace(ctx context.Context, opts
 			// we do not fail the workspace yet because we still might succeed with its content!
 			glog.WithError(err).WithFields(ws.OWI()).Error("log backup failed")
 		}
+	}
+
+	if opts.SkipBackupContent {
+		return nil, nil
 	}
 
 	err = wso.uploadWorkspaceContent(ctx, ws, opts.SnapshotName)

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -276,9 +276,7 @@ func isDisposalFinished(ws *workspacev1.Workspace) bool {
 		// Can't dispose if node disappeared.
 		ws.IsConditionTrue(workspacev1.WorkspaceConditionNodeDisappeared) ||
 		// Image builds have nothing to dispose.
-		ws.Spec.Type == workspacev1.WorkspaceTypeImageBuild ||
-		// headless workspaces that failed do not need to be backed up
-		ws.IsConditionTrue(workspacev1.WorkspaceConditionsHeadlessTaskFailed)
+		ws.Spec.Type == workspacev1.WorkspaceTypeImageBuild
 }
 
 // extractFailure returns a pod failure reason and possibly a phase. If phase is nil then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Backup prebuild log even it's fail

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-31

## How to test
<!-- Provide steps to test this PR -->
1. Add repo in preview
2. start a prebuild with a branch, `.gitpod.yml` example like below
3. try many times, it should be able to view the prebuild logs, even if it failed.

<img width="833" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/66827f3d-65b0-46b9-acc7-9f88a2d30513">
4. and if you check minio, in the fail prebuild, it only contains logs , for success prebuild it contains logs and content

| Fail    | Success |
| -------- | ------- |
| <img width="1813" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/51927be8-58b3-4c44-a681-20b03d66d1bd">  |  <img width="1736" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/26d5307f-ccb8-4463-be38-8304aec890bc">    |




```
tasks:
    - name: test
      init: exit 1
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-prebuild-improve</li>
	<li><b>🔗 URL</b> - <a href="https://pd-prebuild-improve.preview.gitpod-dev.com/workspaces" target="_blank">pd-prebuild-improve.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-prebuild-improve-gha.25655</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-prebuild-improve%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
