### PR TITLE
Cap length of GitStatus updates

### DIFF
--- a/components/supervisor/pkg/serverapi/publicapi.go
+++ b/components/supervisor/pkg/serverapi/publicapi.go
@@ -7,6 +7,7 @@ package serverapi
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -246,7 +247,7 @@ func (s *Service) UpdateGitStatus(ctx context.Context, status *gitpod.WorkspaceI
 		WorkspaceId: workspaceID,
 	}
 	if status != nil {
-		payload.Status = &v1.GitStatus{
+		payload.Status = capGitStatusLength(&v1.GitStatus{
 			Branch:               status.Branch,
 			LatestCommit:         status.LatestCommit,
 			TotalUncommitedFiles: int32(status.TotalUncommitedFiles),
@@ -255,7 +256,7 @@ func (s *Service) UpdateGitStatus(ctx context.Context, status *gitpod.WorkspaceI
 			UncommitedFiles:      status.UncommitedFiles,
 			UnpushedCommits:      status.UnpushedCommits,
 			UntrackedFiles:       status.UntrackedFiles,
-		}
+		})
 	}
 	_, err = service.UpdateGitStatus(ctx, payload)
 	return
@@ -514,4 +515,57 @@ func workspaceStatusToWorkspaceInstance(status *v1.WorkspaceStatus) *gitpod.Work
 		instance.Status.ExposedPorts = append(instance.Status.ExposedPorts, info)
 	}
 	return instance
+}
+
+func capGitStatusLength(s *v1.GitStatus) *v1.GitStatus {
+	const API_LIMIT = 4096                // bytes
+	const MARGIN = 200                    // bytes (we account for differences in JSON formatting, as well JSON escape characters in the static part of the status)
+	const API_BUDGET = API_LIMIT - MARGIN // bytes
+
+	// calculate JSON length in bytes
+	bytes, err := json.Marshal(s)
+	if err != nil {
+		log.WithError(err).Warn("cannot marshal GitStatus to calculate byte length")
+		s.UncommitedFiles = nil
+		s.UnpushedCommits = nil
+		s.UntrackedFiles = nil
+		return s
+	}
+	if len(bytes) < API_BUDGET {
+		return s
+	}
+
+	// roughly estimate how many bytes we have left for the path arrays (containing long strings)
+	budget := API_BUDGET - len(s.Branch) - len(s.LatestCommit)
+	numberOfPaths := len(s.UncommitedFiles) + len(s.UnpushedCommits) + len(s.UntrackedFiles)
+
+	budgetPerPath := (budget / numberOfPaths) - 6 // accounting for: '""', ',' and ' '
+	const PLACEHOLDER = "..."
+	if budgetPerPath <= len(PLACEHOLDER) {
+		// we don't have enough budget to show anything
+		s.UncommitedFiles = nil
+		s.UnpushedCommits = nil
+		s.UntrackedFiles = nil
+		return s
+	}
+
+	cap := func(s string) string {
+		if len(s) <= budgetPerPath {
+			return s
+		}
+		return s[:budgetPerPath-len(PLACEHOLDER)] + PLACEHOLDER
+	}
+	s.UncommitedFiles = Map(s.UncommitedFiles, cap)
+	s.UnpushedCommits = Map(s.UnpushedCommits, cap)
+	s.UntrackedFiles = Map(s.UntrackedFiles, cap)
+
+	return s
+}
+
+func Map(ss []string, f func(string) string) []string {
+	mapped := make([]string, len(ss))
+	for i, s := range ss {
+		mapped[i] = f(s)
+	}
+	return mapped
 }

--- a/components/supervisor/pkg/serverapi/publicapi_test.go
+++ b/components/supervisor/pkg/serverapi/publicapi_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package serverapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func generateArray(prefix string, number int, length int, withDot bool) []string {
+	var arr []string
+	for i := 0; i < number; i++ {
+		lengthyPart := strings.Repeat("a", length)
+		arr = append(arr, fmt.Sprintf("%s_%d_%s", prefix, i, lengthyPart))
+	}
+	if withDot {
+		arr = append(arr, "...")
+	}
+	return arr
+}
+
+func TestCapGitStatusLength(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    *v1.GitStatus
+		expected *v1.GitStatus
+	}{
+		{
+			name: "Short GitStatus",
+			input: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3"},
+				UntrackedFiles:       []string{"file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+			},
+			expected: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3"},
+				UntrackedFiles:       []string{"file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+			},
+		},
+		{
+			name: "Long GitStatus",
+			input: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3", "commit4", "commit5", "commit6", "commit7"},
+				UntrackedFiles:       generateArray("file", 800, 10, false),
+			},
+			expected: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3", "commit4", "commit5", "commit6", "commit7"},
+				UntrackedFiles:       generateArray("file", 166, 10, true),
+			},
+		},
+		{
+			name: "Long paths in GitStatus",
+			input: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3", "commit4", "commit5", "commit6", "commit7"},
+				UntrackedFiles:       generateArray("file", 50, 200, false),
+			},
+			expected: &v1.GitStatus{
+				Branch:               "main",
+				LatestCommit:         "abc123",
+				TotalUncommitedFiles: 2,
+				TotalUnpushedCommits: 3,
+				TotalUntrackedFiles:  4,
+				UncommitedFiles:      []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"},
+				UnpushedCommits:      []string{"commit1", "commit2", "commit3", "commit4", "commit5", "commit6", "commit7"},
+				UntrackedFiles:       generateArray("file", 17, 200, true),
+			},
+		},
+		{
+			name: "Empty GitStatus",
+			input: &v1.GitStatus{
+				Branch:               "",
+				LatestCommit:         "",
+				TotalUncommitedFiles: 0,
+				TotalUnpushedCommits: 0,
+				TotalUntrackedFiles:  0,
+				UncommitedFiles:      nil,
+				UnpushedCommits:      nil,
+				UntrackedFiles:       nil,
+			},
+			expected: &v1.GitStatus{
+				Branch:               "",
+				LatestCommit:         "",
+				TotalUncommitedFiles: 0,
+				TotalUnpushedCommits: 0,
+				TotalUntrackedFiles:  0,
+				UncommitedFiles:      nil,
+				UnpushedCommits:      nil,
+				UntrackedFiles:       nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := capGitStatusLength(tt.input)
+			if diff := cmp.Diff(tt.expected, got, cmpopts.IgnoreUnexported(v1.GitStatus{})); diff != "" {
+				t.Errorf("CapGitStatusLength (-want +got):\n%s", diff)
+			}
+
+			bytes, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(bytes) > GIT_STATUS_API_LIMIT_BYTES {
+				t.Errorf("JSON size exceeds GIT_STATUS_API_LIMIT_BYTES: %d (%d)", len(bytes), GIT_STATUS_API_LIMIT_BYTES)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Limits size of `gitStatus` to 4096 bytes max.

Context: ENT-38

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-209

## How to test
 - start a workspace
 - use [this script](https://gist.github.com/geropl/850f82197a51abd0868293285248f09b) to generate some files
 - notice GitStatus still works:
   - no error logs in `server` :heavy_check_mark: 
   - UI shows git status like this :heavy_check_mark: 
![image](https://github.com/gitpod-io/gitpod/assets/32448529/7ec94374-b82a-45bc-a2e9-d320e4816c69)


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
