### PR TITLE
[GP-CLI] fix incorrect pre-configured workspace image for enterprise

### DIFF
--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -69,10 +69,9 @@ Create a Gitpod configuration for this project.
 			}
 			yml := ""
 			if defaultImage != "" {
-				yml = yml + fmt.Sprintf("# Image of workspace. Learn more: https://www.gitpod.io/docs/configure/workspaces/workspace-image\nimage: %s\n", defaultImage)
+				yml = yml + fmt.Sprintf("# Image of workspace. Learn more: https://www.gitpod.io/docs/configure/workspaces/workspace-image\nimage: %s\n\n", defaultImage)
 			}
-			yml = yml + `
-# List the start up tasks. Learn more: https://www.gitpod.io/docs/configure/workspaces/tasks
+			yml = yml + `# List the start up tasks. Learn more: https://www.gitpod.io/docs/configure/workspaces/tasks
 tasks:
   - name: Script Task
     init: echo 'init script' # runs during prebuild => https://www.gitpod.io/docs/configure/projects/prebuilds

--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -65,11 +65,13 @@ Create a Gitpod configuration for this project.
 			if err != nil {
 				fmt.Printf("failed to get organization default workspace image: %v\n", err)
 				fmt.Println("fallback to gitpod default")
-				defaultImage = "gitpod/workspace-full"
+				defaultImage = ""
 			}
-			yml := fmt.Sprintf(`# Image of workspace. Learn more: https://www.gitpod.io/docs/configure/workspaces/workspace-image
-image: %s
-
+			yml := ""
+			if defaultImage != "" {
+				yml = yml + fmt.Sprintf("# Image of workspace. Learn more: https://www.gitpod.io/docs/configure/workspaces/workspace-image\nimage: %s\n", defaultImage)
+			}
+			yml = yml + `
 # List the start up tasks. Learn more: https://www.gitpod.io/docs/configure/workspaces/tasks
 tasks:
   - name: Script Task
@@ -84,7 +86,7 @@ ports:
     onOpen: open-preview
 
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
-`, defaultImage)
+`
 			d = []byte(yml)
 		} else {
 			fmt.Printf("\n\n---\n%s", d)
@@ -145,6 +147,9 @@ func getDefaultWorkspaceImage(ctx context.Context, wsInfo *api.WorkspaceInfoResp
 	})
 	if err != nil {
 		return "", err
+	}
+	if res.Source == protocol.WorkspaceImageSourceInstallation {
+		return "", nil
 	}
 	return res.Image, nil
 }

--- a/components/gitpod-cli/pkg/gitpodlib/config.go
+++ b/components/gitpod-cli/pkg/gitpodlib/config.go
@@ -28,6 +28,9 @@ type GitpodFile struct {
 
 // SetImageName configures a pre-built docker image by name
 func (cfg *GitpodFile) SetImageName(name string) {
+	if name == "" {
+		return
+	}
 	cfg.Image = name
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-199

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env
- Exec `gp init`, there should have no `image` field
- Update org settings to set a default image
- Exec `gp init` again, `image` field should align to what you have set
- Try also `gp init -i`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ent-199</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ent-199.preview.gitpod-dev.com/workspaces" target="_blank">hw-ent-199.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ENT-199-gha.25676</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ent-199%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
