### PR TITLE
[server] Introduce job CapGitStatus

### DIFF
--- a/components/gitpod-db/src/periodic-deleter.ts
+++ b/components/gitpod-db/src/periodic-deleter.ts
@@ -15,7 +15,7 @@ export class PeriodicDbDeleter {
     @inject(GitpodTableDescriptionProvider) protected readonly tableProvider: GitpodTableDescriptionProvider;
     @inject(TypeORM) protected readonly typeORM: TypeORM;
 
-    async runOnce() {
+    async runOnce(): Promise<number> {
         const tickID = new Date().toISOString();
         log.info("[PeriodicDbDeleter] Starting to collect deleted rows.", {
             periodicDeleterTickId: tickID,
@@ -52,6 +52,7 @@ export class PeriodicDbDeleter {
         log.info("[PeriodicDbDeleter] Finished deleting records.", {
             periodicDeleterTickId: tickID,
         });
+        return pendingDeletions.length;
     }
 
     protected async collectRowsToBeDeleted(table: TableDescription): Promise<{ table: string; deletions: string[] }> {

--- a/components/server/src/authorization/relationship-updater-job.ts
+++ b/components/server/src/authorization/relationship-updater-job.ts
@@ -20,7 +20,7 @@ export class RelationshipUpdateJob implements Job {
     public name = "relationship-update-job";
     public frequencyMs = 1000 * 60 * 3; // 3m
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         try {
             const ids = await this.userDB.findUserIdsNotYetMigratedToFgaVersion(RelationshipUpdater.version, 50);
             const now = Date.now();
@@ -40,6 +40,7 @@ export class RelationshipUpdateJob implements Job {
                 }
             }
             log.info(this.name + ": updated " + migrated + " users in " + (Date.now() - now) + "ms");
+            return migrated;
         } catch (error) {
             log.error(this.name + ": error running relationship update job", error);
         }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -133,6 +133,7 @@ import { ContextService } from "./workspace/context-service";
 import { RateLimitter } from "./rate-limitter";
 import { AnalyticsController } from "./analytics-controller";
 import { InstallationAdminCleanup } from "./jobs/installation-admin-cleanup";
+import { CapGitStatus } from "./jobs/cap-git-status";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -373,6 +374,7 @@ export const productionContainerModule = new ContainerModule(
         bind(JobRunner).toSelf().inSingletonScope();
         bind(RelationshipUpdateJob).toSelf().inSingletonScope();
         bind(InstallationAdminCleanup).toSelf().inSingletonScope();
+        bind(CapGitStatus).toSelf().inSingletonScope();
 
         // Redis
         bind(Redis).toDynamicValue((ctx) => {

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -73,7 +73,7 @@ export class CapGitStatus implements Job {
     ): Promise<WorkspaceInstance[]> {
         const qb = repo
             .createQueryBuilder("wsi")
-            .where("JSON_STORAGE_SIZE(wsi.gitStatus > :byteLimit", { byteLimit })
+            .where("JSON_STORAGE_SIZE(wsi.gitStatus) > :byteLimit", { byteLimit })
             .orWhere("JSON_STORAGE_SIZE(wsi.status) > :byteLimit", { byteLimit })
             .limit(limit);
         return qb.getMany();

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { DBWorkspaceInstance, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { Job } from "./runner";
+import { Config } from "../config";
+import { GIT_STATUS_LENGTH_CAP_BYTES } from "../workspace/workspace-service";
+import { Repository } from "typeorm";
+import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+
+@injectable()
+export class CapGitStatus implements Job {
+    @inject(Config) protected readonly config: Config;
+    @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
+
+    public name = "git-status-capper";
+    public frequencyMs = 2 * 60 * 1000; // every 2 minutes
+
+    public async run(): Promise<void> {
+        log.info("git-status: we're leading the quorum.");
+
+        const validateGitStatusLength = await getExperimentsClientForBackend().getValueAsync(
+            "api_validate_git_status_length",
+            false,
+            {},
+        );
+        if (!validateGitStatusLength) {
+            log.info("git-status: feature flag is not enabled.");
+            return;
+        }
+
+        const limit = 100;
+        const instancesCapped = await this.workspaceDb.transaction(async (db) => {
+            const repo = await ((db as any).getWorkspaceInstanceRepo() as Promise<Repository<DBWorkspaceInstance>>);
+            const instances = await this.findInstancesWithLengthyGitStatus(repo, GIT_STATUS_LENGTH_CAP_BYTES, limit);
+            if (instances.length === 0) {
+                return 0;
+            }
+
+            // Cap the git status (incl. status.repo, the old place where we stored it before)
+            const MARGIN = 200;
+            instances.forEach((i) => {
+                if (i.gitStatus) {
+                    i.gitStatus = capGitStatus(i.gitStatus, GIT_STATUS_LENGTH_CAP_BYTES - MARGIN);
+                }
+                if (i.status) {
+                    delete (i.status as any).repo;
+                }
+            });
+
+            // In order to effectively cap the storage size, we have to delete and re-inser the instance.
+            // Thank you, MySQL! -.-
+            await repo.delete(instances.map((i) => i.id));
+            await repo.save(instances);
+
+            return instances.length;
+        });
+
+        log.info(`git-status: capped ${instancesCapped} instances.`);
+    }
+
+    async findInstancesWithLengthyGitStatus(
+        repo: Repository<DBWorkspaceInstance>,
+        byteLimit: number,
+        limit: number = 1000,
+    ): Promise<WorkspaceInstance[]> {
+        const qb = repo
+            .createQueryBuilder("wsi")
+            .where("JSON_STORAGE_SIZE(wsi.gitStatus > :byteLimit", { byteLimit })
+            .orWhere("JSON_STORAGE_SIZE(wsi.status) > :byteLimit", { byteLimit })
+            .limit(limit);
+        return qb.getMany();
+    }
+}
+
+function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus, maxLength: number): WorkspaceInstanceRepoStatus {
+    let bytesUsed = 0;
+    function capStr(str: string | undefined): string | undefined {
+        if (str === undefined) {
+            return undefined;
+        }
+
+        const len = Buffer.byteLength(str, "utf8");
+        if (bytesUsed + len > maxLength) {
+            return "";
+        }
+        bytesUsed = bytesUsed + len;
+        return str;
+    }
+    function filterStr(str: string | undefined): boolean {
+        return !!capStr(str);
+    }
+
+    gitStatus.branch = capStr(gitStatus.branch);
+    gitStatus.latestCommit = capStr(gitStatus.latestCommit);
+    gitStatus.uncommitedFiles = gitStatus.uncommitedFiles?.filter(filterStr);
+    gitStatus.untrackedFiles = gitStatus.untrackedFiles?.filter(filterStr);
+    gitStatus.unpushedCommits = gitStatus.unpushedCommits?.filter(filterStr);
+
+    return gitStatus;
+}

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -22,7 +22,7 @@ export class CapGitStatus implements Job {
     public name = "git-status-capper";
     public frequencyMs = 2 * 60 * 1000; // every 2 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         log.info("git-status: we're leading the quorum.");
 
         const validateGitStatusLength = await getExperimentsClientForBackend().getValueAsync(
@@ -63,6 +63,7 @@ export class CapGitStatus implements Job {
         });
 
         log.info(`git-status: capped ${instancesCapped} instances.`);
+        return instancesCapped;
     }
 
     async findInstancesWithLengthyGitStatus(

--- a/components/server/src/jobs/database-gc.ts
+++ b/components/server/src/jobs/database-gc.ts
@@ -18,14 +18,14 @@ export class DatabaseGarbageCollector implements Job {
     public name = "database-gc";
     public frequencyMs = 30000; // every 30 seconds
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         if (!this.config.runDbDeleter) {
             log.info("database-gc: deleter is disabled");
             return;
         }
 
         try {
-            await this.periodicDbDeleter.runOnce();
+            return await this.periodicDbDeleter.runOnce();
         } catch (err) {
             log.error("database-gc: error during run", err);
             throw err;

--- a/components/server/src/jobs/installation-admin-cleanup.ts
+++ b/components/server/src/jobs/installation-admin-cleanup.ts
@@ -16,7 +16,7 @@ export class InstallationAdminCleanup implements Job {
     public name = "installation-admin-cleanup";
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         try {
             const installationAdmin = await this.userDb.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID);
             if (!installationAdmin) {
@@ -33,6 +33,8 @@ export class InstallationAdminCleanup implements Job {
                 await this.userDb.storeUser(installationAdmin);
                 log.info("Cleaned up SCM connections of installation admin.");
             }
+
+            return undefined;
         } catch (err) {
             log.error("Failed to clean up SCM connections of installation admin.", err);
             throw err;

--- a/components/server/src/jobs/ots-gc.ts
+++ b/components/server/src/jobs/ots-gc.ts
@@ -16,9 +16,11 @@ export class OTSGarbageCollector implements Job {
     public name = "ots-gc";
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         try {
             await this.oneTimeSecretDB.trace({}).pruneExpired();
+
+            return undefined;
         } catch (err) {
             log.error("Failed to garbage collect OTS", err);
             throw err;

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -21,6 +21,7 @@ import { WorkspaceStartController } from "../workspace/workspace-start-controlle
 import { runWithRequestContext } from "../util/request-context";
 import { SYSTEM_USER } from "../authorization/authorizer";
 import { InstallationAdminCleanup } from "./installation-admin-cleanup";
+import { CapGitStatus } from "./cap-git-status";
 
 export const Job = Symbol("Job");
 
@@ -44,6 +45,7 @@ export class JobRunner {
         @inject(RelationshipUpdateJob) private readonly relationshipUpdateJob: RelationshipUpdateJob,
         @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
         @inject(InstallationAdminCleanup) private readonly installationAdminCleanup: InstallationAdminCleanup,
+        @inject(CapGitStatus) private readonly capGitStatus: CapGitStatus,
     ) {}
 
     public start(): DisposableCollection {
@@ -59,6 +61,7 @@ export class JobRunner {
             this.relationshipUpdateJob,
             this.workspaceStartController,
             this.installationAdminCleanup,
+            this.capGitStatus,
         ];
 
         for (const job of jobs) {

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -29,7 +29,7 @@ export interface Job {
     readonly name: string;
     readonly frequencyMs: number;
     readonly lockedResources?: string[];
-    run: () => Promise<void>;
+    run: () => Promise<number | undefined>;
 }
 
 @injectable()
@@ -102,12 +102,12 @@ export class JobRunner {
                     reportJobStarted(job.name);
                     const now = new Date().getTime();
                     try {
-                        await job.run();
+                        const unitsOfWork = await job.run();
                         log.debug(`Successfully finished job ${job.name}`, {
                             ...logCtx,
                             jobTookSec: `${(new Date().getTime() - now) / 1000}s`,
                         });
-                        reportJobCompleted(job.name, true);
+                        reportJobCompleted(job.name, true, unitsOfWork);
                     } catch (err) {
                         log.error(`Error while running job ${job.name}`, err, {
                             ...logCtx,

--- a/components/server/src/jobs/snapshots.ts
+++ b/components/server/src/jobs/snapshots.ts
@@ -20,7 +20,7 @@ export class SnapshotsJob implements Job {
     public name = "snapshots";
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         if (this.config.completeSnapshotJob?.disabled) {
             log.info("snapshots: Snapshot completion job is disabled.");
             return;
@@ -52,5 +52,7 @@ export class SnapshotsJob implements Job {
                 .driveSnapshot({ workspaceOwner: workspace.ownerId, snapshot })
                 .catch((err) => log.error("driveSnapshot", err));
         }
+
+        return pendingSnapshots.length;
     }
 }

--- a/components/server/src/jobs/token-gc.ts
+++ b/components/server/src/jobs/token-gc.ts
@@ -22,12 +22,14 @@ export class TokenGarbageCollector implements Job {
     public name = "token-gc";
     public frequencyMs = 5 * 60 * 1000; // every 5 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         const span = opentracing.globalTracer().startSpan("collectExpiredTokenEntries");
         log.debug("token-gc: start collecting...");
         try {
             await this.userDb.deleteExpiredTokenEntries(new Date().toISOString());
             log.debug("token-gc: done collecting.");
+
+            return undefined;
         } catch (err) {
             TraceContext.setError({ span }, err);
             log.error("token-gc: error collecting expired tokens: ", err);

--- a/components/server/src/jobs/webhook-gc.ts
+++ b/components/server/src/jobs/webhook-gc.ts
@@ -19,13 +19,15 @@ export class WebhookEventGarbageCollector implements Job {
     public name = "webhook-gc";
     public frequencyMs = 4 * 60 * 1000; // every 4 minutes
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         const span = opentracing.globalTracer().startSpan("collectObsoleteWebhookEvents");
         log.debug("webhook-event-gc: start collecting...");
 
         try {
             await this.db.deleteOldEvents(10 /* days */, 600 /* limit per run */);
             log.debug("webhook-event-gc: done collecting.");
+
+            return undefined;
         } catch (err) {
             TraceContext.setError({ span }, err);
             log.error("webhook-event-gc: error collecting webhook events: ", err);

--- a/components/server/src/jobs/workspace-gc.ts
+++ b/components/server/src/jobs/workspace-gc.ts
@@ -43,7 +43,7 @@ export class WorkspaceGarbageCollector implements Job {
         this.frequencyMs = this.config.workspaceGarbageCollection.intervalSeconds * 1000;
     }
 
-    public async run(): Promise<void> {
+    public async run(): Promise<number | undefined> {
         if (this.config.workspaceGarbageCollection.disabled) {
             log.info("workspace-gc: Garbage collection disabled.");
             return;
@@ -69,6 +69,8 @@ export class WorkspaceGarbageCollector implements Job {
         } catch (err) {
             log.error("workspace-gc: error during prebuild deletion", err);
         }
+
+        return undefined;
     }
 
     /**

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -280,11 +280,11 @@ export function reportJobStarted(name: string) {
 export const jobsCompletedTotal = new prometheusClient.Counter({
     name: "gitpod_server_jobs_completed_total",
     help: "Total number of errors caught by an error boundary in the dashboard",
-    labelNames: ["name", "success"],
+    labelNames: ["name", "success", "unitsOfWork"],
 });
 
-export function reportJobCompleted(name: string, success: boolean) {
-    jobsCompletedTotal.inc({ name, success: String(success) });
+export function reportJobCompleted(name: string, success: boolean, unitsOfWork?: number | undefined) {
+    jobsCompletedTotal.inc({ name, success: String(success), unitsOfWork: String(unitsOfWork) });
 }
 
 export const jobsDurationSeconds = new prometheusClient.Histogram({


### PR DESCRIPTION
## Description
This job is meant to cleanup old state in the DB where `WorkspaceInstance.gitStatus` (or the old location, `WorkspaceInstance.status.repo`) are too long.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-210
Depends on: #19810

## How to test
 - insert the following instance into the DB
```


INSERT INTO d_b_workspace_instance
    (id, workspaceId, creationTime, startedTime, stoppedTime, lastHeartbeat, ideUrl, status_old, workspaceImage, region, deployedTime, workspaceBaseImage, status, deleted, phasePersisted, configuration, stoppingTime, imageBuildInfo, workspaceClass, usageAttributionId, gitStatus)
    VALUES (
'5cd9aced-5ad1-48aa-88db-9164979e204b', 'elvis9876-rusttest-aaaaaaaaaaa', '2023-09-18T12:18:20.214Z', '2023-09-18T12:18:58.742Z', '2023-09-18T12:25:49.600Z', '', 'https://elvis9876-rusttest-aaaaaaaaaaa.ws-eu104.gitpod.io', NULL, 'eu.gcr.io/gitpod-dev/workspace-images:5ad7a7baeef3f60be82bade14aac678294c8f6f862063957efa467cc29f08777', 'eu104', '', '', '{\"phase\": \"stopped\", \"nodeIp\": \"10.10.0.76\", \"message\": \"\", \"podName\": \"ws-5cd9aced-5ad1-48aa-88db-9164979e204b\", \"timeout\": \"30m0s\", \"version\": 44529587, \"nodeName\": \"workspace-ws-eu104-pool-2fcs\", \"conditions\": {\"failed\": \"\", \"timeout\": \"workspace timed out after after being closed (00h05m) took longer than 00h05m\", \"deployed\": true, \"pullingImages\": false, \"stoppedByRequest\": false, \"firstUserActivity\": \"2023-09-18T12:18:59.000Z\", \"headlessTaskFailed\": \"\"}, \"ownerToken\": \"5kATQV0wlCHG.pMNvb-NIRHyIamrlbWy\", \"exposedPorts\": []}', '0', 'stopped', '{\"ideImage\":\"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d393e5d34768a18e0ddeebcfa460ce19bf44eda5\",\"ideImageLayers\":[\"eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-1de61b5711089287b7f27bc1223c57d6d9bb3144\",\"eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:commit-0b90a2babd0cb664b36f25ebfd3df7323552023f\"],\"supervisorImage\":\"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-3e21102e7a85ec176bccbc35b27496cb38e27f7f\",\"ideConfig\":{\"useLatest\":false,\"ide\":\"code\"},\"ideSetup\":{\"envvars\":[{\"name\":\"GITPOD_CONFIGCAT_ENABLED\",\"value\":\"true\"},{\"name\":\"GITPOD_IDE_ALIAS\",\"value\":\"code\"}],\"tasks\":[]},\"regionPreference\":\"europe\",\"fromBackup\":true,\"featureFlags\":[\"workspace_connection_limiting\",\"workspace_class_limiting\"]}', '2023-09-18T12:24:22.890Z', NULL, 'g1-standard', 'team:b54a42c1-0b93-400c-a19e-cb6dd8b3f9bc', '{\"branch\": \"main\", \"latestCommit\": \"03407e3c478f2d4c58d22a8631c4ed63ed63fa81\", \"unpushedCommits\": [\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"], \"totalUnpushedCommits\": 3}'
);
``` 
 - observe the `server` logs and wait until it gets capped
   -  `kubectl logs server-5f5697dc94-vt4r2 -f | grep 'git-status: capped'`
 - verify with `SELECT id, JSON_STORAGE_SIZE(gitStatus) from d_b_workspace_instance` :heavy_check_mark:   
  

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-210-mi04e64fdd93</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-210-mi04e64fdd93.preview.gitpod-dev.com/workspaces" target="_blank">gpl-210-mi04e64fdd93.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-210-migrate-gitstatus-gha.25704</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-210-mi04e64fdd93%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
