### PR TITLE
[ws-manager-mk2] fix test

### DIFF
--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -410,10 +410,11 @@ var _ = Describe("WorkspaceController", func() {
 				}
 			})
 
+			expectFinalizerAndMarkBackupCompleted(ws, pod)
 			expectWorkspaceCleanup(ws, pod)
 			expectMetricsDelta(m, collectMetricCounts(wsMetrics, ws), metricCounts{
 				restores:       1,
-				backups:        0,
+				backups:        1,
 				backupFailures: 0,
 				failures:       0,
 				stops:          map[StopReason]int{StopReasonRegular: 1},
@@ -454,11 +455,11 @@ var _ = Describe("WorkspaceController", func() {
 				}
 			})
 
-			// should not take a backup
+			expectFinalizerAndMarkBackupCompleted(ws, pod)
 			expectWorkspaceCleanup(ws, pod)
 			expectMetricsDelta(m, collectMetricCounts(wsMetrics, ws), metricCounts{
 				restores:       1,
-				backups:        0,
+				backups:        1,
 				backupFailures: 0,
 				failures:       1,
 				stops:          map[StopReason]int{StopReasonFailed: 1},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ws-manager-mk2] fix test

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-222

## How to test
<!-- Provide steps to test this PR -->
<img width="684" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/c8f6cb94-468e-4506-88a3-c6dcc23eef06">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
