### PR TITLE
[gc] keep workspaces with gitchanges around twice as long

### DIFF
--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -127,8 +127,9 @@ const WorkspacesPage: FunctionComponent = () => {
                                                 </span>
                                             </div>
                                             <div className="text-sm flex-auto">
-                                                Workspaces that have been stopped for more than 24 hours. Inactive
-                                                workspaces are automatically deleted after 14 days.{" "}
+                                                Inactive workspaces will be automatically deleted after 14 days.
+                                                However, if a workspace contains git changes, it will be deleted after
+                                                28 days. You can "pin" a workspace to keep it indefinitely.{" "}
                                                 <a
                                                     target="_blank"
                                                     rel="noreferrer"

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -499,6 +499,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                         AND ws.creationTime < NOW() - INTERVAL ? DAY
                     GROUP BY ws.id, ws.ownerId
                     HAVING MAX(GREATEST(wsi.creationTime, wsi.startedTime, wsi.stoppedTime)) < NOW() - INTERVAL ? DAY OR MAX(wsi.creationTime) IS NULL
+                    ORDER BY MAX(GREATEST(wsi.creationTime, wsi.startedTime, wsi.stoppedTime)) DESC
                     LIMIT ?;
             `,
             [minAgeInDays, minAgeInDays, limit],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change adds an additional check to each GC candidate and skips softdeletion if 
- the workspace contains pending git changes
- was used in the past 28 (maxAge *2) days

Not the most efficient way but the job currently takes 2sec for this (~100 workspace candidates per run)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-217/users-complain-about-lost-workspaces-because-they-do-not-understand

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-increase-gc</li>
	<li><b>🔗 URL</b> - <a href="https://se-increase-gc.preview.gitpod-dev.com/workspaces" target="_blank">se-increase-gc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-increase-gc-gha.25751</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-increase-gc%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
