### PR TITLE
Fix missing requests for repository details

### DIFF
--- a/components/dashboard/src/data/configurations/configuration-queries.ts
+++ b/components/dashboard/src/data/configurations/configuration-queries.ts
@@ -101,7 +101,6 @@ export const useConfiguration = (configurationId?: string) => {
             return configuration || null;
         },
         {
-            initialData: null,
             select: (data) => data || undefined,
             retry: (failureCount, error) => {
                 if (!configurationId) {
@@ -115,6 +114,7 @@ export const useConfiguration = (configurationId?: string) => {
                 if (error && [ErrorCodes.NOT_FOUND, ErrorCodes.PERMISSION_DENIED].includes((error as any).code)) {
                     return false;
                 }
+
                 return true;
             },
             cacheTime: 1000 * 60 * 5, // 5m


### PR DESCRIPTION
## Description

Because react query assumes `initialData` to be valid and "fresh", it was happy with our default of `null`, which it oftentimes did not refresh and caused many pages to appear as 404s. This PR simply removes the initial value.

From react query's [docs](https://tanstack.com/query/latest/docs/framework/react/guides/initial-query-data#using-initialdata-to-prepopulate-a-query):
> `initialData` is persisted to the cache, so it is not recommended to provide placeholder, partial or incomplete data to this option and instead use `placeholderData`

I don't think we need to use `placeholderData`, since everything seems to work alright even without it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-227
Fixes ENT-230

## How to test

1. [Join my org](https://ft-fix-mis188c1f8e2a.preview.gitpod-dev.com/orgs/join?inviteId=40371bb6-9f57-4241-901d-96b27bf5c44a)
2. Try accessing different repositories under that org. All details should be displayed properly.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
