### PR TITLE
[server] add workspace.deletionEligabilityTime

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace.ts
@@ -91,6 +91,13 @@ export class DBWorkspace implements Workspace {
     type: WorkspaceType;
 
     @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    @Index("ind_deletionEligibilityTime")
+    deletionEligibilityTime?: string;
+
+    @Column({
         type: "varchar",
         default: "",
     })

--- a/components/gitpod-db/src/typeorm/migration/1717407555612-WorkspaceDeletionEligibilityTime.ts
+++ b/components/gitpod-db/src/typeorm/migration/1717407555612-WorkspaceDeletionEligibilityTime.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists, indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace";
+const COLUMN_NAME = "deletionEligibilityTime";
+const INDEX_NAME = "ind_deletionEligibilityTime";
+
+export class WorkspaceDeletionEligibilityTime1717407555612 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD COLUMN \`${COLUMN_NAME}\` varchar(30) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+        if (!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE \`${TABLE_NAME}\` ADD INDEX \`${INDEX_NAME}\` (${COLUMN_NAME}), ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -724,6 +724,12 @@ export interface Workspace {
      */
     contentDeletedTime?: string;
 
+    /**
+     * The time when the workspace is eligible for soft deletion. This is the time when the workspace
+     * is marked as softDeleted earliest.
+     */
+    deletionEligibilityTime?: string;
+
     type: WorkspaceType;
 
     basedOnPrebuildId?: string;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Introduces a new column `deletionEligabilityTime` on `d_b_workspace` that contains the time when a workapace is going to be soft deleted.
In this change we only introdcue the field and the logic to update the workspace on
 - user triggered workspace start
 - user triggered workspace stop
 - update git status

Next steps (separated PR):
 - add a softDeletionStep for all workspaces that have such a deletionTimestamp
 - exclude all workspaces that have such a timestamp from the existing softDeletionStep

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-deletio01de350305</li>
	<li><b>🔗 URL</b> - <a href="https://se-deletio01de350305.preview.gitpod-dev.com/workspaces" target="_blank">se-deletio01de350305.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-deletionEligability-gha.25810</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-deletio01de350305%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
