### PR TITLE
Fix the prebuilds view with no task logs

### DIFF
--- a/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
@@ -9,6 +9,7 @@ import { prebuildClient } from "../../service/public-api";
 import { useEffect, useState } from "react";
 import { matchPrebuildError, onDownloadPrebuildLogsUrl } from "@gitpod/public-api-common/lib/prebuild-utils";
 import { Disposable } from "@gitpod/gitpod-protocol";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export function usePrebuildLogsEmitter(prebuildId: string, taskId: string) {
     const [emitter] = useState(new EventEmitter());
@@ -23,6 +24,7 @@ export function usePrebuildLogsEmitter(prebuildId: string, taskId: string) {
         const controller = new AbortController();
         const watch = async () => {
             if (!prebuildId || !taskId) {
+                setIsLoading(false);
                 return;
             }
             let dispose: () => void | undefined;
@@ -32,7 +34,8 @@ export function usePrebuildLogsEmitter(prebuildId: string, taskId: string) {
             const prebuild = await prebuildClient.getPrebuild({ prebuildId });
             const task = prebuild.prebuild?.status?.taskLogs?.find((log) => log.taskId === taskId);
             if (!task) {
-                throw new Error("no prebuild logs url found");
+                setIsLoading(false);
+                throw new ApplicationError(ErrorCodes.NOT_FOUND, "Task not found");
             }
             dispose = onDownloadPrebuildLogsUrl(
                 task.logUrl,

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -104,7 +104,7 @@ export const PrebuildDetailPage: FC = () => {
         if (!anyLogAvailable) {
             setLogNotFound(true);
         }
-    }, [currentPrebuild?.status]);
+    }, [currentPrebuild?.status?.taskLogs]);
 
     useEffect(() => {
         history.listen(() => {
@@ -274,7 +274,7 @@ export const PrebuildDetailPage: FC = () => {
                                     )}
                                 </div>
                                 {currentPrebuild?.status?.taskLogs.some((t) => t.logUrl) && (
-                                    <div className="flex h-10 mt-3">
+                                    <div className="flex h-10">
                                         {currentPrebuild.status?.taskLogs
                                             .filter((t) => t.logUrl)
                                             .map((task) => {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -65,7 +65,7 @@ export const PrebuildDetailPage: FC = () => {
     const [logNotFound, setLogNotFound] = useState(false);
     const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(undefined);
 
-    const taskId = selectedTaskId ?? prebuild?.status?.taskLogs.filter((f) => f.logUrl)[0]?.taskId ?? "0";
+    const taskId = selectedTaskId ?? currentPrebuild?.status?.taskLogs.filter((f) => f.logUrl)[0]?.taskId ?? "0";
 
     const {
         emitter: logEmitter,
@@ -88,7 +88,7 @@ export const PrebuildDetailPage: FC = () => {
     useEffect(() => {
         setLogNotFound(false);
         const disposable = watchPrebuild(prebuildId, (prebuild) => {
-            if (prebuild.status?.phase?.name === PrebuildPhase_Phase.ABORTED) {
+            if (currentPrebuild?.status?.phase?.name === PrebuildPhase_Phase.ABORTED) {
                 disposeStreamingLogs?.dispose();
             }
             setCurrentPrebuild(prebuild);
@@ -97,7 +97,7 @@ export const PrebuildDetailPage: FC = () => {
         return () => {
             disposable.dispose();
         };
-    }, [prebuildId, disposeStreamingLogs]);
+    }, [prebuildId, disposeStreamingLogs, currentPrebuild?.status?.phase?.name]);
 
     useEffect(() => {
         const anyLogAvailable = currentPrebuild?.status?.taskLogs.some((t) => t.logUrl);
@@ -271,9 +271,9 @@ export const PrebuildDetailPage: FC = () => {
                                         {prebuild.status.message}
                                     </div>
                                 )}
-                                {prebuild?.status?.taskLogs.some((t) => t.logUrl) && (
+                                {currentPrebuild?.status?.taskLogs.some((t) => t.logUrl) && (
                                     <div className="flex h-10 mt-3">
-                                        {prebuild.status?.taskLogs
+                                        {currentPrebuild.status?.taskLogs
                                             .filter((t) => t.logUrl)
                                             .map((task) => {
                                                 const commonClasses =

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -256,7 +256,7 @@ export const PrebuildDetailPage: FC = () => {
                                     </div>
                                 </div>
                             </div>
-                            <div className="pt-4 flex flex-col gap-1 border-pk-border-base">
+                            <div className="py-4 flex flex-col gap-1 border-pk-border-base">
                                 <div className="px-6 flex gap-1 items-center">
                                     {prebuildPhase.icon}
                                     <span className="capitalize">{prebuildPhase.description}</span>{" "}
@@ -271,9 +271,8 @@ export const PrebuildDetailPage: FC = () => {
                                         {prebuild.status.message}
                                     </div>
                                 )}
-                                <div className="my-3"></div>
                                 {prebuild?.status?.taskLogs.some((t) => t.logUrl) && (
-                                    <div className="flex h-10">
+                                    <div className="flex h-10 mt-3">
                                         {prebuild.status?.taskLogs
                                             .filter((t) => t.logUrl)
                                             .map((task) => {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -256,21 +256,23 @@ export const PrebuildDetailPage: FC = () => {
                                     </div>
                                 </div>
                             </div>
-                            <div className="py-4 flex flex-col gap-1 border-pk-border-base">
-                                <div className="px-6 flex gap-1 items-center">
-                                    {prebuildPhase.icon}
-                                    <span className="capitalize">{prebuildPhase.description}</span>{" "}
-                                    {isStreamingLogs && (
-                                        <TextMuted>
-                                            <MiddleDot /> Fetching logs...
-                                        </TextMuted>
+                            <div className="flex flex-col gap-1 border-pk-border-base">
+                                <div className="py-4">
+                                    <div className="px-6 flex gap-1 items-center">
+                                        {prebuildPhase.icon}
+                                        <span className="capitalize">{prebuildPhase.description}</span>{" "}
+                                        {isStreamingLogs && (
+                                            <TextMuted>
+                                                <MiddleDot /> Fetching logs...
+                                            </TextMuted>
+                                        )}
+                                    </div>
+                                    {prebuild.status?.message && (
+                                        <div className="px-6 text-pk-content-secondary truncate">
+                                            {prebuild.status.message}
+                                        </div>
                                     )}
                                 </div>
-                                {prebuild.status?.message && (
-                                    <div className="px-6 text-pk-content-secondary truncate">
-                                        {prebuild.status.message}
-                                    </div>
-                                )}
                                 {currentPrebuild?.status?.taskLogs.some((t) => t.logUrl) && (
                                     <div className="flex h-10 mt-3">
                                         {currentPrebuild.status?.taskLogs

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -257,7 +257,7 @@ export const PrebuildDetailPage: FC = () => {
                                 </div>
                             </div>
                             <div className="flex flex-col gap-1 border-pk-border-base">
-                                <div className="py-4">
+                                <div className="py-4 flex flex-col gap-1 ">
                                     <div className="px-6 flex gap-1 items-center">
                                         {prebuildPhase.icon}
                                         <span className="capitalize">{prebuildPhase.description}</span>{" "}

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -100,11 +100,11 @@ export const PrebuildDetailPage: FC = () => {
     }, [prebuildId, disposeStreamingLogs]);
 
     useEffect(() => {
-        const anyLogAvailable = prebuild?.status?.taskLogs.some((t) => t.logUrl);
+        const anyLogAvailable = currentPrebuild?.status?.taskLogs.some((t) => t.logUrl);
         if (!anyLogAvailable) {
             setLogNotFound(true);
         }
-    }, [prebuild?.status]);
+    }, [currentPrebuild?.status]);
 
     useEffect(() => {
         history.listen(() => {

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -212,7 +212,7 @@ export class HeadlessLogController {
                         res.status(400).send("prebuildId is invalid");
                         return;
                     }
-                    let taskId = req.params.taskId;
+                    const { taskId } = req.params;
                     const logCtx = { userId: user.id, prebuildId, taskId };
 
                     const head = {


### PR DESCRIPTION
## Description

When there are no tasks to view, the UI looks a bit funky. This PR makes sure it both maintains structure and displays the appropriate error message.

| Before | After |
|--------|--------|
| <img width="1106" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/d7889793-df37-4dcd-bc56-bb1c1147468a"> | <img width="1106" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/ec94d758-7c77-4b4e-9ad4-00d8a11e9e4e"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1852

## How to test

1. Run a prebuild in a repo like https://github.com/gitpod-io/new or any repo with no `.gitpod.yml`
2. Go to its detail


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-fix-pred53ef2dd32</li>
	<li><b>🔗 URL</b> - <a href="https://ft-fix-pred53ef2dd32.preview.gitpod-dev.com/workspaces" target="_blank">ft-fix-pred53ef2dd32.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-fix-prebuilds-view-no-gitpod-yml-gha.25809</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-fix-pred53ef2dd32%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
