### PR TITLE
Ensure an actual `logUrl` is present for prebuild tasks

### DIFF
--- a/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts
@@ -31,7 +31,7 @@ export function usePrebuildLogsEmitter(prebuildId: string, taskId: string) {
             });
             const prebuild = await prebuildClient.getPrebuild({ prebuildId });
             const task = prebuild.prebuild?.status?.taskLogs?.find((log) => log.taskId === taskId);
-            if (!task) {
+            if (!task?.logUrl) {
                 throw new Error("no prebuild logs url found");
             }
             dispose = onDownloadPrebuildLogsUrl(


### PR DESCRIPTION
## Description

Sometimes, this would happen:
<img width="635" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/ab40a99d-7c06-4585-bb06-0ffb17ecf97e">

It happened when we tried streaming a prebuild's task and the tasks `logUrl` was just an empty string. I think it's still worth figuring out the root cause on the server, but this is a good start.

It's fascinating that when you pass an empty string to a `fetch` call, it just fetches the current page, meaning that you get the corresponding HTML back (which is exactly what ended up being displayed in the log view).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
