### PR TITLE
Add proper version info to JetBrains launcher and backend-plugin

### DIFF
--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -55,7 +55,7 @@ packages:
       - NO_VERIFY_JB_PLUGIN=${noVerifyJBPlugin}
     config:
       commands:
-        - ["./build.sh"]
+        - ["./build.sh", "${__git_commit}"]
   - name: plugin-latest
     type: generic
     argdeps:
@@ -79,7 +79,7 @@ packages:
       - NO_VERIFY_JB_PLUGIN=${noVerifyJBPlugin}
     config:
       commands:
-        - ["./build.sh"]
+        - ["./build.sh", "${__git_commit}"]
   - name: latest-info
     type: generic
     srcs:

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
 group = properties("pluginGroup")
 val environmentName = properties("environmentName")
-var pluginVersion = properties("pluginVersion")
+var pluginVersion = "${properties("pluginVersion")}-${properties("gitpodVersion")}"
 
 if (environmentName.isNotBlank()) {
     pluginVersion += "-$environmentName"

--- a/components/ide/jetbrains/backend-plugin/build.sh
+++ b/components/ide/jetbrains/backend-plugin/build.sh
@@ -5,10 +5,12 @@
 
 set -e
 
+JB_GP_VERSION=${1:-debug}
+
 if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
     echo "build.sh: skip verify plugin step"
 else
-    ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" runPluginVerifier
+    ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" runPluginVerifier
 fi
-./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" buildPlugin
+./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" buildPlugin
 unzip ./build/distributions/gitpod-remote.zip -d ./build

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -1,4 +1,5 @@
 pluginVersion=0.0.1
+gitpodVersion=dev
 # Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
 environmentName=latest
 # IntelliJ Platform Artifacts Repositories

--- a/components/ide/jetbrains/launcher/BUILD.yaml
+++ b/components/ide/jetbrains/launcher/BUILD.yaml
@@ -29,7 +29,7 @@ packages:
       - components/common-go:lib
     config:
       packaging: app
-      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/jetbrains/launcher.Version=commit-${__git_commit}'"]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/jetbrains/launcher/pkg/constant.Version=commit-${__git_commit}'"]
   - name: hot-swap
     type: generic
     deps:

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/gitpod-io/gitpod/jetbrains/launcher/pkg/constant"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 )
 
@@ -46,8 +47,6 @@ const defaultBackendPort = "63342"
 var (
 	// ServiceName is the name we use for tracing/logging.
 	ServiceName = "jetbrains-launcher"
-	// Version of this service - set during build.
-	Version = ""
 )
 
 type LaunchContext struct {
@@ -99,8 +98,8 @@ func main() {
 	// supervisor refer see https://github.com/gitpod-io/gitpod/blob/main/components/supervisor/pkg/supervisor/supervisor.go#L961
 	shouldWaitBackendPlugin := os.Getenv("GITPOD_WAIT_IDE_BACKEND") == "true"
 	debugEnabled := os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true"
-	log.Init(ServiceName, Version, true, debugEnabled)
-	log.Info(ServiceName + ": " + Version)
+	log.Init(ServiceName, constant.Version, true, debugEnabled)
+	log.Info(ServiceName + ": " + constant.Version)
 	startTime := time.Now()
 
 	log.WithField("shouldWait", shouldWaitBackendPlugin).Info("should wait backend plugin")

--- a/components/ide/jetbrains/launcher/pkg/constant/version.go
+++ b/components/ide/jetbrains/launcher/pkg/constant/version.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package constant
+
+// Version of this service - set during build.
+var Version = ""


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-238, ENT-205

## How to test
<!-- Provide steps to test this PR -->
- It can start workspace with latest stable JetBrains Editor
- idea.log includes `Gitpod Remote xxx` (version includes commit hash)

✅ 

|launcher|backend-plugin|
|:-:|:-:|
|<img width="2213" alt="SCR-20240604-natq" src="https://github.com/gitpod-io/gitpod/assets/20944364/258e69db-70bd-4cfb-8d7f-2e3d4dc3c18e">|<img width="1352" alt="SCR-20240604-nbha" src="https://github.com/gitpod-io/gitpod/assets/20944364/3f7e9131-89a1-45de-93bd-168a1eafa0a1">|


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-sha</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-sha.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-sha.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-sha-gha.25838</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-sha%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
