### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -118,10 +118,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/intellij:commit-613dc0b4a00d81c4a98a8a3334774e5a33bde115",
+            "image": "{{.Repository}}/ide/intellij:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -182,10 +182,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/goland:commit-613dc0b4a00d81c4a98a8a3334774e5a33bde115",
+            "image": "{{.Repository}}/ide/goland:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -235,10 +235,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/pycharm:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
+            "image": "{{.Repository}}/ide/pycharm:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -287,10 +287,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/phpstorm:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
+            "image": "{{.Repository}}/ide/phpstorm:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -339,10 +339,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rubymine:commit-613dc0b4a00d81c4a98a8a3334774e5a33bde115",
+            "image": "{{.Repository}}/ide/rubymine:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -391,10 +391,10 @@
         "versions": [
           {
             "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/webstorm:commit-613dc0b4a00d81c4a98a8a3334774e5a33bde115",
+            "image": "{{.Repository}}/ide/webstorm:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -451,10 +451,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rider:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
+            "image": "{{.Repository}}/ide/rider:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {
@@ -495,10 +495,10 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/clion:commit-a2110ce16b9738578d1077fb6459fceae580b0ce",
+            "image": "{{.Repository}}/ide/clion:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-19a1764984abbce5c98e06f0955052a07fd2239a",
-              "{{.Repository}}/ide/jb-launcher:commit-19a1764984abbce5c98e06f0955052a07fd2239a"
+              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-launcher:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca"
             ]
           },
           {


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

This PR changes all JB related images because:
- https://github.com/gitpod-io/gitpod/pull/19809 updated jb base images, leads image rebuild
- https://github.com/gitpod-io/gitpod/pull/19835 updated `jb-launcher` and `backend-plugin`

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_