### PR TITLE
[server] update job for eligableDeletionTime

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -481,6 +481,39 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
         return resultSessions;
     }
 
+    public async findEligibleWorkspacesForSoftDeletion(
+        cutOffDate: Date = new Date(),
+        limit: number = 100,
+        type: WorkspaceType = "regular",
+    ): Promise<WorkspaceAndOwner[]> {
+        // we do not allow to run this with a future date
+        if (cutOffDate > new Date()) {
+            throw new Error("cutOffDate must not be in the future, was: " + cutOffDate.toISOString());
+        }
+        const workspaceRepo = await this.getWorkspaceRepo();
+        const dbResults = await workspaceRepo.query(
+            `
+                SELECT ws.id AS id,
+                       ws.ownerId AS ownerId
+                    FROM d_b_workspace AS ws
+                    WHERE ws.deleted = 0
+                        AND ws.type= ?
+                        AND ws.softDeleted IS NULL
+                        AND ws.softDeletedTime = ''
+                        AND ws.pinned = 0
+                        AND ws.deletionEligibilityTime != ''
+                        AND ws.deletionEligibilityTime < ?
+                    LIMIT ?;
+            `,
+            [type, cutOffDate.toISOString(), limit],
+        );
+
+        return dbResults as WorkspaceAndOwner[];
+    }
+
+    /**
+     * @deprecated delete me end of June 2024
+     */
     public async findWorkspacesForGarbageCollection(minAgeInDays: number, limit: number): Promise<WorkspaceAndOwner[]> {
         const workspaceRepo = await this.getWorkspaceRepo();
 
@@ -496,6 +529,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                         AND ws.softDeletedTime = ''
                         AND ws.softDeleted IS NULL
                         AND ws.pinned = 0
+                        AND ws.deletionEligibilityTime = ''
                         AND ws.creationTime < NOW() - INTERVAL ? DAY
                     GROUP BY ws.id, ws.ownerId
                     HAVING MAX(GREATEST(wsi.creationTime, wsi.startedTime, wsi.stoppedTime)) < NOW() - INTERVAL ? DAY OR MAX(wsi.creationTime) IS NULL
@@ -551,6 +585,9 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
         return dbResults as WorkspaceOwnerAndSoftDeleted[];
     }
 
+    /**
+     * @deprecated delete me end of June 2024
+     */
     public async findPrebuiltWorkspacesForGC(daysUnused: number, limit: number): Promise<WorkspaceAndOwner[]> {
         const workspaceRepo = await this.getWorkspaceRepo();
         const dbResults = await workspaceRepo.query(
@@ -564,6 +601,7 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
                         pb.buildworkspaceId = ws.id
                     AND ws.type = 'prebuild'
                     AND ws.contentDeletedTime = ''
+                    AND ws.deletionEligibilityTime = ''
                     AND ws.pinned = 0
                     AND ws.creationTime < NOW() - INTERVAL ? DAY
                 GROUP BY ws.id, ws.ownerId

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -337,6 +337,30 @@ class WorkspaceDBSpec {
     }
 
     @test(timeout(10000))
+    public async testFindWorkspacesForGarbageCollection_markedEligable() {
+        this.ws.deletionEligibilityTime = this.timeWs;
+        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
+        const dbResult = await this.db.findWorkspacesForGarbageCollection(14, 10);
+        expect(dbResult.length).to.eq(0);
+    }
+
+    @test(timeout(10000))
+    public async testFindEligableWorkspacesForSoftDeletion_markedEligable() {
+        this.ws.deletionEligibilityTime = this.timeWs;
+        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
+        const dbResult = await this.db.findEligibleWorkspacesForSoftDeletion(new Date(this.timeAfter), 10);
+        expect(dbResult[0].id).to.eq(this.ws.id);
+        expect(dbResult[0].ownerId).to.eq(this.ws.ownerId);
+    }
+
+    @test(timeout(10000))
+    public async testFindEligableWorkspacesForSoftDeletion_notMarkedEligable() {
+        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
+        const dbResult = await this.db.findEligibleWorkspacesForSoftDeletion(new Date(this.timeAfter), 10);
+        expect(dbResult.length).to.eq(0);
+    }
+
+    @test(timeout(10000))
     public async testFindAllWorkspaceAndInstances_workspaceId() {
         await Promise.all([
             this.db.store(this.ws),

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -97,6 +97,11 @@ export interface WorkspaceDB {
         limit: number,
         offset: number,
     ): Promise<WorkspaceSession[]>;
+    findEligibleWorkspacesForSoftDeletion(
+        cutOffDate?: Date,
+        limit?: number,
+        type?: WorkspaceType,
+    ): Promise<WorkspaceAndOwner[]>;
     findWorkspacesForGarbageCollection(minAgeInDays: number, limit: number): Promise<WorkspaceAndOwner[]>;
     findWorkspacesForContentDeletion(
         minSoftDeletedTimeInDays: number,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Updates the existing workspace garbage collection job, to exclude workspaces that are marked with the new deletionEligabilityTime and adds a nother job, that soft deletes those.

After two weeks we can go back and delete the old job.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-217/users-complain-about-lost-workspaces-because-they-do-not-understand

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-deletion-job</li>
	<li><b>🔗 URL</b> - <a href="https://se-deletion-job.preview.gitpod-dev.com/workspaces" target="_blank">se-deletion-job.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-deletion-job-gha.25867</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-deletion-job%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
