### PR TITLE
Add proper tabs to Podkit

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-switch": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@stripe/react-stripe-js": "^2.4.0",
     "@stripe/stripe-js": "^2.4.0",

--- a/components/dashboard/src/components/podkit/tabs/Tabs.tsx
+++ b/components/dashboard/src/components/podkit/tabs/Tabs.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@podkit/lib/cn";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+    React.ElementRef<typeof TabsPrimitive.List>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+    <TabsPrimitive.List
+        ref={ref}
+        className={cn("inline-flex h-10 items-center justify-start p-1 text-pk-content-secondary", className)}
+        {...props}
+    />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+    React.ElementRef<typeof TabsPrimitive.Trigger>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+    <TabsPrimitive.Trigger
+        ref={ref}
+        className={cn(
+            "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=inactive]:border-b-pk-surface-primary data-[state=active]:border-b-pk-border-invert border-b-4 data-[state=inactive]:hover:border-b-pk-border-invert/60 data-[state=active]:text-pk-content-primary",
+            className,
+        )}
+        {...props}
+    />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+    React.ElementRef<typeof TabsPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+    <TabsPrimitive.Content
+        ref={ref}
+        className={cn(
+            "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            className,
+        )}
+        {...props}
+    />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/components/dashboard/src/components/podkit/tabs/Tabs.tsx
+++ b/components/dashboard/src/components/podkit/tabs/Tabs.tsx
@@ -31,7 +31,7 @@ const TabsTrigger = React.forwardRef<
     <TabsPrimitive.Trigger
         ref={ref}
         className={cn(
-            "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=inactive]:border-b-pk-surface-primary data-[state=active]:border-b-pk-border-invert border-b-4 data-[state=inactive]:hover:border-b-pk-border-invert/60 data-[state=active]:text-pk-content-primary",
+            "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50 data-[state=inactive]:border-b-pk-surface-primary data-[state=active]:border-b-pk-border-invert border-b-4 data-[state=inactive]:hover:border-b-pk-border-invert/60 data-[state=active]:text-pk-content-primary",
             className,
         )}
         {...props}

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -52,6 +52,8 @@
         /* Borders */
         --border-base: var(--gray-200);
         --border-light: var(--gray-100);
+        --border-strong: var(--gray-500);
+        --border-invert: var(--gray-600);
     }
 
     /* Dark mode color adjustments */
@@ -75,6 +77,8 @@
         /* Borders */
         --border-base: var(--gray-700);
         --border-light: var(--gray-800);
+        --border-strong: var(--gray-500);
+        --border-invert: var(--gray-400);
     }
 
     html,

--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -7,12 +7,12 @@
 import { useEffect, useState } from "react";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import Alert from "../components/Alert";
-import TabMenuItem from "../components/TabMenuItem";
 import { settingsPathSSHKeys } from "../user-settings/settings.routes";
 import { InputWithCopy } from "../components/InputWithCopy";
 import { Link } from "react-router-dom";
 import { Button } from "@podkit/buttons/Button";
 import { sshClient } from "../service/public-api";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@podkit/tabs/Tabs";
 
 interface SSHProps {
     workspaceId: string;
@@ -22,7 +22,6 @@ interface SSHProps {
 
 function SSHView(props: SSHProps) {
     const [hasSSHKey, setHasSSHKey] = useState(true);
-    const [selectSSHKey, setSelectSSHKey] = useState(true);
 
     useEffect(() => {
         sshClient
@@ -39,46 +38,29 @@ function SSHView(props: SSHProps) {
 
     return (
         <>
-            <div className="flex flex-row">
-                <TabMenuItem
-                    key="ssh_key"
-                    name="SSH Key"
-                    selected={selectSSHKey}
-                    onClick={() => {
-                        setSelectSSHKey(true);
-                    }}
-                />
-                <TabMenuItem
-                    key="access_token"
-                    name="Access Token"
-                    selected={!selectSSHKey}
-                    onClick={() => {
-                        setSelectSSHKey(false);
-                    }}
-                />
-            </div>
-            <div className="border-gray-200 dark:border-gray-800 border-b"></div>
-            <div className="space-y-4 mt-4">
-                {!selectSSHKey && (
-                    <Alert type="warning" className="whitespace-normal">
-                        <b>Anyone</b> on the internet with this command can access the running workspace. The command
-                        includes a generated access token that resets on every workspace restart.
-                    </Alert>
-                )}
-                {!hasSSHKey && selectSSHKey && (
-                    <Alert type="warning" className="whitespace-normal">
-                        You don't have any public SSH keys in your Gitpod account. You can{" "}
-                        <Link to={settingsPathSSHKeys} className="gp-link">
-                            add a new public key
-                        </Link>
-                        , or use a generated access token.
-                    </Alert>
-                )}
+            <Tabs defaultValue="ssh_key">
+                <TabsList className="flex flex-row items-start">
+                    <TabsTrigger value="ssh_key" className="text-base">
+                        {" "}
+                        SSH Key{" "}
+                    </TabsTrigger>
+                    <TabsTrigger value="access_token" className="text-base">
+                        Access Token
+                    </TabsTrigger>
+                </TabsList>
+                <div className="border-gray-200 dark:border-gray-800 border-b"></div>
+                <TabsContent value="ssh_key" className="space-y-4 mt-4">
+                    {!hasSSHKey && (
+                        <Alert type="warning" className="whitespace-normal">
+                            You don't have any public SSH keys in your Gitpod account. You can{" "}
+                            <Link to={settingsPathSSHKeys} className="gp-link">
+                                add a new public key
+                            </Link>
+                            , or use a generated access token.
+                        </Alert>
+                    )}
 
-                <p className="text-gray-500 whitespace-normal text-base">
-                    {!selectSSHKey ? (
-                        <span>The following shell command can be used to SSH into this workspace.</span>
-                    ) : (
+                    <p className="text-gray-500 whitespace-normal text-base">
                         <span>
                             The following shell command can be used to SSH into this workspace with an{" "}
                             <Link to={settingsPathSSHKeys} className="gp-link">
@@ -86,14 +68,20 @@ function SSHView(props: SSHProps) {
                             </Link>
                             .
                         </span>
-                    )}
-                </p>
-            </div>
-            <InputWithCopy
-                className="my-2"
-                value={!selectSSHKey ? sshAccessTokenCommand : sshKeyCommand}
-                tip="Copy SSH Command"
-            />
+                    </p>
+                    <InputWithCopy className="my-2" value={sshKeyCommand} tip="Copy SSH Command" />
+                </TabsContent>
+                <TabsContent value="access_token" className="space-y-4 mt-4">
+                    <Alert type="warning" className="whitespace-normal">
+                        <b>Anyone</b> on the internet with this command can access the running workspace. The command
+                        includes a generated access token that resets on every workspace restart.
+                    </Alert>
+                    <p className="text-gray-500 whitespace-normal text-base">
+                        The following shell command can be used to SSH into this workspace.
+                    </p>
+                    <InputWithCopy className="my-2" value={sshAccessTokenCommand} tip="Copy SSH Command" />
+                </TabsContent>
+            </Tabs>
         </>
     );
 }

--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -48,7 +48,7 @@ function SSHView(props: SSHProps) {
                         Access Token
                     </TabsTrigger>
                 </TabsList>
-                <div className="border-gray-200 dark:border-gray-800 border-b"></div>
+                <div className="border-gray-200 dark:border-gray-800 pt-1 border-b"></div>
                 <TabsContent value="ssh_key" className="space-y-4 mt-4">
                     {!hasSSHKey && (
                         <Alert type="warning" className="whitespace-normal">

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -68,8 +68,10 @@ module.exports = {
                     invert: "rgb(var(--surface-invert) / <alpha-value>)",
                 },
                 "pk-border": {
+                    light: "rgb(var(--border-light) / <alpha-value>)",
                     base: "rgb(var(--border-base) / <alpha-value>)",
-                    light: "rgb(var(--border-light) / <alpha-value>)"
+                    strong: "rgb(var(--border-strong) / <alpha-value>)",
+                    invert: "rgb(var(--border-invert) / <alpha-value>)",
                 },
             },
             backgroundImage: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,21 @@
     "@radix-ui/react-use-previous" "1.0.1"
     "@radix-ui/react-use-size" "1.0.1"
 
+"@radix-ui/react-tabs@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz#993608eec55a5d1deddd446fa9978d2bc1053da2"
+  integrity sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-tooltip@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz#8f55070f852e7e7450cc1d9210b793d2e5a7686e"


### PR DESCRIPTION
## Description

This PR adds a tabs component for use in the Dashboard. It tweaks the shadcn UI version quite a bit to keep up with our existing tabs styles.

It also preps us to convert the UI on the prebuilds detail page to be more accessible and consistent in behavior.

## How to test

1. Start a workspace in the preview environment
2. Open the `Connect with SSH` modal and try the different tabs

<img width="535" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/1fb272e1-61ad-40a4-8b27-7993bf4da9a6">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-proper-tabs</li>
	<li><b>🔗 URL</b> - <a href="https://ft-proper-tabs.preview.gitpod-dev.com/workspaces" target="_blank">ft-proper-tabs.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-proper-tabs-gha.25885</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-proper-tabs%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
