### PR TITLE
[installer] content-service: Add PodDisruptionBudget (maxUnavailable: 1)

### DIFF
--- a/install/installer/pkg/components/content-service/objects.go
+++ b/install/installer/pkg/components/content-service/objects.go
@@ -12,6 +12,7 @@ import (
 var Objects = common.CompositeRenderFunc(
 	configmap,
 	deployment,
+	pdb,
 	networkpolicy,
 	rolebinding,
 	common.GenerateService(Component, []common.ServicePort{

--- a/install/installer/pkg/components/content-service/pdb.go
+++ b/install/installer/pkg/components/content-service/pdb.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package content_service
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func pdb(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		common.PodDisruptionBudget(ctx, Component, 1, &metav1.LabelSelector{
+			MatchLabels: common.DefaultLabels(Component),
+		}),
+	}, nil
+}


### PR DESCRIPTION
## Description
Addes a PodDisruptionBudget maxUnavailable: 1 for content-service.

Note that this is not enough if replicas: is set to 1 (as [this k8s issue](https://github.com/kubernetes/kubernetes/issues/93476#issuecomment-1721495372) is not addressed in 2024...)

## Related Issue(s)
Part of ENT-241

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-241-pdb</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-241-pdb.preview.gitpod-dev.com/workspaces" target="_blank">gpl-241-pdb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-241-pdb-gha.25908</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-241-pdb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
