### PR TITLE
[server] run deletion time updates async

### DIFF
--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -192,15 +192,8 @@ export class WorkspaceService {
             );
             throw err;
         }
-        const update = this.updateDeletionEligabilityTime(user.id, workspace.id);
-        if (WithPrebuild.is(workspace.context) && workspace.context.prebuildWorkspaceId) {
-            // mark the prebuild active
-            const prebuiltWorkspace = await this.db.findPrebuiltWorkspaceById(workspace.context.prebuildWorkspaceId);
-            if (prebuiltWorkspace?.buildWorkspaceId) {
-                await this.updateDeletionEligabilityTime(user.id, prebuiltWorkspace?.buildWorkspaceId, true);
-            }
-        }
-        await update;
+        this.asyncUpdateDeletionEligabilityTime(user.id, workspace.id);
+        this.asyncUpdateDeletionEligabilityTimeForUsedPrebuild(user.id, workspace);
         return workspace;
     }
 
@@ -344,7 +337,7 @@ export class WorkspaceService {
             return;
         }
         await this.workspaceStarter.stopWorkspaceInstance({}, instance.id, instance.region, reason, policy);
-        this.updateDeletionEligabilityTime(userId, workspaceId);
+        this.asyncUpdateDeletionEligabilityTime(userId, workspaceId);
     }
 
     public async stopRunningWorkspacesForUser(
@@ -365,10 +358,36 @@ export class WorkspaceService {
                     reason,
                     policy,
                 );
-                await this.updateDeletionEligabilityTime(userId, info.workspace.id);
+                this.asyncUpdateDeletionEligabilityTime(userId, info.workspace.id);
             }),
         );
         return infos.map((instance) => instance.workspace);
+    }
+
+    private asyncUpdateDeletionEligabilityTimeForUsedPrebuild(userId: string, workspace: Workspace): void {
+        (async () => {
+            if (WithPrebuild.is(workspace.context) && workspace.context.prebuildWorkspaceId) {
+                // mark the prebuild active
+                const prebuiltWorkspace = await this.db.findPrebuiltWorkspaceById(
+                    workspace.context.prebuildWorkspaceId,
+                );
+                if (prebuiltWorkspace?.buildWorkspaceId) {
+                    await this.updateDeletionEligabilityTime(userId, prebuiltWorkspace?.buildWorkspaceId, true);
+                }
+            }
+        })().catch((err) =>
+            log.error(
+                { userId, workspaceId: workspace.id },
+                "Failed to update deletion eligibility time for prebuild",
+                err,
+            ),
+        );
+    }
+
+    private asyncUpdateDeletionEligabilityTime(userId: string, workspaceId: string): void {
+        this.updateDeletionEligabilityTime(userId, workspaceId).catch((err) =>
+            log.error({ userId, workspaceId }, "Failed to update deletion eligibility time", err),
+        );
     }
 
     /**
@@ -378,7 +397,7 @@ export class WorkspaceService {
      * @param workspaceId
      * @returns
      */
-    async updateDeletionEligabilityTime(userId: string, workspaceId: string, activeNow = false): Promise<void> {
+    private async updateDeletionEligabilityTime(userId: string, workspaceId: string, activeNow = false): Promise<void> {
         try {
             let daysToLive = this.config.workspaceGarbageCollection?.minAgeDays || 14;
             const daysToLiveForPrebuilds = this.config.workspaceGarbageCollection?.minAgePrebuildDays || 7;
@@ -669,7 +688,7 @@ export class WorkspaceService {
 
         // at this point we're about to actually start a new workspace
         const result = await this.workspaceStarter.startWorkspace(ctx, workspace, user, await projectPromise, options);
-        await this.updateDeletionEligabilityTime(user.id, workspaceId);
+        this.asyncUpdateDeletionEligabilityTime(user.id, workspaceId);
         return result;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Runs the deletion time updates async in the UX hot pathes (start, create, stop).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
