### PR TITLE
[GHA] improve JetBrains EAP jobs

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -33,10 +33,15 @@ jobs:
           identity_provider: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_PROVIDER || secrets.DEV_PREVIEW_PROVIDER }}
           service_account: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_SA || secrets.DEV_PREVIEW_SA }}
           leeway_segment_key: ${{ secrets.LEEWAY_SEGMENT_KEY }}
+      - name: Find downloadUrl
+        id: download-url
+        run: |
+          downloadUrl=$(cat WORKSPACE.yaml | yq r - 'defaultArgs.${{ inputs.productId }}DownloadUrl')
+          echo "::set-output name=downloadUrl::$downloadUrl"
       - name: Find IDE version to download
         id: ide-version
         run: |
-          IDE_VERSIONS_JSON=$(bash ./components/ide/jetbrains/image/resolve-latest-ide-version.sh ${{ inputs.productCode }})
+          IDE_VERSIONS_JSON=$(bash ./components/ide/jetbrains/image/resolve-latest-ide-version.sh ${{ inputs.productCode }} ${{ steps.download-url.outputs.downloadUrl }})
           IDE_BUILD_VERSION=$(echo "$IDE_VERSIONS_JSON" | jq -r .IDE_BUILD_VERSION)
           IDE_VERSION=$(echo "$IDE_VERSIONS_JSON" | jq -r .IDE_VERSION)
           echo "IDE_BUILD_VERSION: $IDE_BUILD_VERSION"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br>
 <br>
-2
+
 
 
 <div align="center" style="flex-direction: row;">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br>
 <br>
-
+2
 
 
 <div align="center" style="flex-direction: row;">

--- a/components/ide/jetbrains/image/resolve-latest-ide-version.sh
+++ b/components/ide/jetbrains/image/resolve-latest-ide-version.sh
@@ -7,12 +7,22 @@ set -Eeuo pipefail
 
 ROOT_DIR="$(dirname "$0")/../../../.."
 PRODUCT_CODE=${1}
+JB_FALLBACK_URL=${2}
 TEMP_FILENAME=$(mktemp)
 PLUGIN_PLATFORM_VERSION=$(grep platformVersion= "$ROOT_DIR/components/ide/jetbrains/backend-plugin/gradle-latest.properties" | sed 's/platformVersion=//' | sed 's/-EAP-CANDIDATE-SNAPSHOT//') # Example: PLUGIN_PLATFORM_VERSION: 223.7571
 
 curl -sL "https://data.services.jetbrains.com/products/releases?code=$PRODUCT_CODE&type=eap,rc,release&platform=linux" > "$TEMP_FILENAME"
 IDE_BUILD_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.build | contains(\"$PLUGIN_PLATFORM_VERSION\")) | .build)" < "$TEMP_FILENAME") # Example: IDE_BUILD_VERSION: 223.7571.176
 IDE_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.build | contains(\"$PLUGIN_PLATFORM_VERSION\")) | .version)" < "$TEMP_FILENAME") # Example: IDE_VERSION: 2022.3
+
+if [ -z "$IDE_BUILD_VERSION" ] || [ -z "$IDE_VERSION" ]; then
+    if [ -n "$JB_FALLBACK_URL" ]; then
+        echo "Could not resolve latest IDE version for $PRODUCT_CODE. Falling back to find $JB_FALLBACK_URL"
+        IDE_BUILD_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.downloads.linux.link == \"$JB_FALLBACK_URL\") | .build)" < "$TEMP_FILENAME") # Example: IDE_BUILD_VERSION: 223.7571.176
+        IDE_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.downloads.linux.link == \"$JB_FALLBACK_URL\") | .version)" < "$TEMP_FILENAME") # Example: IDE_VERSION: 2022.3
+    fi
+fi
+
 rm "$TEMP_FILENAME"
 
 echo "{\"IDE_BUILD_VERSION\": \"$IDE_BUILD_VERSION\", \"IDE_VERSION\": \"$IDE_VERSION\"}"

--- a/components/ide/jetbrains/image/resolve-latest-ide-version.sh
+++ b/components/ide/jetbrains/image/resolve-latest-ide-version.sh
@@ -17,7 +17,7 @@ IDE_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.build | contains(\"$P
 
 if [ -z "$IDE_BUILD_VERSION" ] || [ -z "$IDE_VERSION" ]; then
     if [ -n "$JB_FALLBACK_URL" ]; then
-        echo "Could not resolve latest IDE version for $PRODUCT_CODE. Falling back to find $JB_FALLBACK_URL"
+        # echo "Could not resolve latest IDE version for $PRODUCT_CODE. Falling back to find $JB_FALLBACK_URL"
         IDE_BUILD_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.downloads.linux.link == \"$JB_FALLBACK_URL\") | .build)" < "$TEMP_FILENAME") # Example: IDE_BUILD_VERSION: 223.7571.176
         IDE_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.downloads.linux.link == \"$JB_FALLBACK_URL\") | .version)" < "$TEMP_FILENAME") # Example: IDE_VERSION: 2022.3
     fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-252, [internal chat](https://gitpod.slack.com/archives/C02CBKZEVS8/p1717573798002179?thread_ts=1717530918.249469&cid=C02CBKZEVS8)

## How to test
<!-- Provide steps to test this PR -->

See https://github.com/gitpod-io/gitpod/actions/runs/9380965524

RustRover should passed with correct fallback

<img width="593" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/55e12f58-3ca4-4554-af38-9f016cc74e42">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-gha.25915</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
