### PR TITLE
[java] add java ops for processor count and container support

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -17,6 +17,7 @@ const (
 	ServiceWaiterSkipComponentsFlag                = "service_waiter_skip_components"
 	IdPClaimKeysFlag                               = "idp_claim_keys"
 	SetJavaXmxFlag                                 = "supervisor_set_java_xmx"
+	SetJavaProcessorCount                          = "supervisor_set_java_processor_count"
 )
 
 func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attributes Attributes) bool {
@@ -45,4 +46,8 @@ func SupervisorUsePublicAPI(ctx context.Context, client Client, attributes Attri
 
 func IsSetJavaXmx(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, SetJavaXmxFlag, false, attributes)
+}
+
+func IsSetJavaProcessorCount(ctx context.Context, client Client, attributes Attributes) bool {
+	return client.GetBoolValue(ctx, SetJavaProcessorCount, false, attributes)
 }

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -647,7 +647,7 @@ func resolveLaunchContextEnv() []string {
 	// instead put them into /ide-desktop/${alias}${qualifier}/backend/bin/idea64.vmoptions
 	// otherwise JB will complain to a user on each startup
 	// by default remote dev already set -Xmx2048m, see /ide-desktop/${alias}${qualifier}/backend/plugins/remote-dev-server/bin/launcher.sh
-	launchCtxEnv = append(launchCtxEnv, "JAVA_TOOL_OPTIONS=")
+	// launchCtxEnv = append(launchCtxEnv, "JAVA_TOOL_OPTIONS=")
 
 	// Force it to be disabled as we update platform properties file already
 	// TODO: Some ides have it enabled by default still, check pycharm and remove next release

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -790,6 +790,14 @@ func updateVMOptions(
 	if alias == "intellij" {
 		gitpodVMOptions = append(gitpodVMOptions, "-Djdk.configure.existing=true")
 	}
+	// container relevant options
+	gitpodVMOptions = append(gitpodVMOptions, "-XX:+UseContainerSupport")
+	cpuCount := os.Getenv("GITPOD_CPU_COUNT")
+	parsedCPUCount, err := strconv.Atoi(cpuCount)
+	// if CPU count is set and is parseable as a positive number
+	if err == nil && parsedCPUCount > 0 && parsedCPUCount <= 16 {
+		gitpodVMOptions = append(gitpodVMOptions, "-XX:ActiveProcessorCount="+cpuCount)
+	}
 	vmoptions := deduplicateVMOption(ideaVMOptionsLines, gitpodVMOptions, filterFunc)
 
 	// user-defined vmoptions (EnvVar)

--- a/components/ide/jetbrains/launcher/main_test.go
+++ b/components/ide/jetbrains/launcher/main_test.go
@@ -43,21 +43,23 @@ func TestUpdateVMOptions(t *testing.T) {
 		Src         string
 		Expectation string
 	}{
-		{"goland64.vmoptions", "goland", nil, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true"},
-		{"idea64.vmoptions", "intellij", nil, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
-		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx2048m"}, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx2048m\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
-		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
-		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m -XX:MaxRAMPercentage=75"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-XX:MaxRAMPercentage=75\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
-		{"goland64.vmoptions (GOLAND_VMOPTIONS env set with conflicting options)", "goland", map[string]string{"GOLAND_VMOPTIONS": "-ea -XX:+IgnoreUnrecognizedVMOptions -XX:MaxRAMPercentage=75 -XX:MaxRAMPercentage=50"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-ea\n-XX:+IgnoreUnrecognizedVMOptions\n-XX:MaxRAMPercentage=50"},
+		{"idea64.vmoptions (GITPOD_CPU_COUNT)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m", "GITPOD_CPU_COUNT": "1"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-XX:ActiveProcessorCount=1\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"idea64.vmoptions (GITPOD_CPU_COUNT 2)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m", "GITPOD_CPU_COUNT": "12"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-XX:ActiveProcessorCount=12\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"goland64.vmoptions", "goland", nil, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true"},
+		{"idea64.vmoptions", "intellij", nil, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx2048m"}, "-Xms128m\n-Xmx750m\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx2048m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"idea64.vmoptions (INTELLIJ_VMOPTIONS env set)", "intellij", map[string]string{"INTELLIJ_VMOPTIONS": "-Xmx4096m -XX:MaxRAMPercentage=75"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx4096m\n-XX:MaxRAMPercentage=75\n-Dsun.tools.attach.tmp.only=true\n-XX:+UseContainerSupport\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-Djdk.configure.existing=true"},
+		{"goland64.vmoptions (GOLAND_VMOPTIONS env set with conflicting options)", "goland", map[string]string{"GOLAND_VMOPTIONS": "-ea -XX:+IgnoreUnrecognizedVMOptions -XX:MaxRAMPercentage=75 -XX:MaxRAMPercentage=50"}, "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true", "-Xms128m\n-Xmx2g\n-Dsun.tools.attach.tmp.only=true\n-Dfreeze.reporter.profiling=false\n-Dgtw.disable.exit.dialog=true\n-ea\n-XX:+IgnoreUnrecognizedVMOptions\n-XX:+UseContainerSupport\n-XX:MaxRAMPercentage=50"},
 	}
 	for _, test := range tests {
-		for v := range test.EnvVar {
-			t.Setenv(v, test.EnvVar[v])
-		}
 		// compare vmoptions string content equality (i.e. split into slices and compare ignore order)
 		lessFunc := func(a, b string) bool { return a < b }
 
 		t.Run(test.Desc, func(t *testing.T) {
+			for v := range test.EnvVar {
+				t.Setenv(v, test.EnvVar[v])
+			}
 			actual := updateVMOptions(nil, test.Alias, strings.Fields(test.Src))
 			if diff := cmp.Diff(strings.Fields(test.Expectation), actual, cmpopts.SortSlices(lessFunc)); diff != "" {
 				t.Errorf("unexpected output (-want +got):\n%s", diff)
@@ -65,6 +67,9 @@ func TestUpdateVMOptions(t *testing.T) {
 		})
 
 		t.Run("updateVMOptions multiple time should be stable", func(t *testing.T) {
+			for v := range test.EnvVar {
+				t.Setenv(v, test.EnvVar[v])
+			}
 			actual := strings.Fields(test.Src)
 			for i := 0; i < 5; i++ {
 				actual = updateVMOptions(nil, test.Alias, actual)

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -199,12 +199,15 @@ func Run(options ...RunOption) {
 	}
 	exps := experiments.NewClient(experimentsClientOpts...)
 
-	// BEWARE: we can only call buildChildProcEnv once, because it might download env vars from a one-time-secret
-	//         URL, which would fail if we tried another time.
 	isSetJavaXmx := experiments.IsSetJavaXmx(context.Background(), exps, experiments.Attributes{
 		UserID: cfg.OwnerId,
 	})
-	childProcEnvvars = buildChildProcEnv(cfg, nil, opts.RunGP, isSetJavaXmx)
+	isSetJavaProcessorCount := experiments.IsSetJavaProcessorCount(context.Background(), exps, experiments.Attributes{
+		UserID: cfg.OwnerId,
+	})
+	// BEWARE: we can only call buildChildProcEnv once, because it might download env vars from a one-time-secret
+	//         URL, which would fail if we tried another time.
+	childProcEnvvars = buildChildProcEnv(cfg, nil, opts.RunGP, isSetJavaXmx, isSetJavaProcessorCount)
 
 	err = AddGitpodUserIfNotExists()
 	if err != nil {
@@ -1030,7 +1033,7 @@ func prepareIDELaunch(cfg *Config, ideConfig *IDEConfig) *exec.Cmd {
 // of envvars. If envvars is nil, os.Environ() is used.
 //
 // Beware: if config contains an OTS URL the results may differ on subsequent calls.
-func buildChildProcEnv(cfg *Config, envvars []string, runGP bool, setJavaXmx bool) []string {
+func buildChildProcEnv(cfg *Config, envvars []string, runGP bool, setJavaXmx bool, isSetJavaProcessorCount bool) []string {
 	if envvars == nil {
 		envvars = os.Environ()
 	}
@@ -1106,6 +1109,16 @@ func buildChildProcEnv(cfg *Config, envvars []string, runGP bool, setJavaXmx boo
 	envs["HOME"] = "/home/gitpod"
 	envs["USER"] = "gitpod"
 
+	if cpuCount, ok := envs["GITPOD_CPU_COUNT"]; ok && isSetJavaProcessorCount {
+		if _, exists := envs["JAVA_TOOL_OPTIONS"]; exists {
+			// check if the JAVA_TOOL_OPTIONS already contains the ActiveProcessorCount flag
+			if !strings.Contains(envs["JAVA_TOOL_OPTIONS"], "-XX:ActiveProcessorCount=") {
+				envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -XX:+UseContainerSupport -XX:ActiveProcessorCount=%s", cpuCount)
+			}
+		} else {
+			envs["JAVA_TOOL_OPTIONS"] = fmt.Sprintf("-XX:+UseContainerSupport -XX:ActiveProcessorCount=%s", cpuCount)
+		}
+	}
 	// Particular Java optimisation: Java pre v10 did not gauge it's available memory correctly, and needed explicitly setting "-Xmx" for all Hotspot/openJDK VMs
 	if mem, ok := envs["GITPOD_MEMORY"]; ok && setJavaXmx {
 		envs["JAVA_TOOL_OPTIONS"] += fmt.Sprintf(" -Xmx%sm", mem)

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -133,7 +133,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 				cfg.EnvvarOTS = srv.URL
 			}
 
-			act := buildChildProcEnv(cfg, test.Input, false, false)
+			act := buildChildProcEnv(cfg, test.Input, false, false, false)
 			assert(t, act)
 		})
 	}

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -615,6 +615,9 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 	memoryInMegabyte := res.Memory().Value() / (1000 * 1000)
 	result = append(result, corev1.EnvVar{Name: "GITPOD_MEMORY", Value: strconv.FormatInt(memoryInMegabyte, 10)})
 
+	cpuCount := res.Cpu().Value()
+	result = append(result, corev1.EnvVar{Name: "GITPOD_CPU_COUNT", Value: strconv.FormatInt(int64(cpuCount), 10)})
+
 	if sctx.Headless {
 		result = append(result, corev1.EnvVar{Name: "GITPOD_HEADLESS", Value: "true"})
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds 
```
JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:ActiveProcessorCount=<cpuCount>"
```
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-java-cpus</li>
	<li><b>🔗 URL</b> - <a href="https://se-java-cpus.preview.gitpod-dev.com/workspaces" target="_blank">se-java-cpus.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-java-cpus-gha.25972</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-java-cpus%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
