### PR TITLE
[server, bridge] Bump grpc-js and authzed clients

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -10,7 +10,7 @@
         "src"
     ],
     "devDependencies": {
-        "@grpc/grpc-js": "1.9.1",
+        "@grpc/grpc-js": "1.10.8",
         "@testdeck/mocha": "^0.3.3",
         "@types/analytics-node": "^3.1.9",
         "@types/chai-subset": "^1.3.3",

--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -15,6 +15,8 @@ export const defaultGRPCOptions = {
     "grpc-node.max_session_memory": 50,
     "grpc.max_reconnect_backoff_ms": 5000,
     "grpc.max_receive_message_length": 1024 * 1024 * 16,
+    // default is 30s, which is too long for us during rollouts (where service DNS entries are updated)
+    "grpc.dns_min_time_between_resolutions_ms": 2000,
 };
 
 export type GrpcMethodType = "unary" | "client_stream" | "server_stream" | "bidi_stream";

--- a/components/ide-metrics-api/typescript-grpc/package.json
+++ b/components/ide-metrics-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/ide-service-api/typescript/package.json
+++ b/components/ide-service-api/typescript/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "long": "4.0.0",
-    "nice-grpc": "^2.0.0",
-    "ts-proto": "^1.153.0"
+    "nice-grpc": "^2.1.8",
+    "ts-proto": "^1.176.2"
   },
   "devDependencies": {
     "grpc-tools": "^1.12.4",

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -45,7 +45,7 @@
     "/src"
   ],
   "dependencies": {
-    "@authzed/authzed-node": "^0.12.1",
+    "@authzed/authzed-node": "^0.15.0",
     "@connectrpc/connect-express": "1.1.2",
     "@connectrpc/connect": "1.1.2",
     "@gitbeaker/rest": "^39.12.0",
@@ -152,8 +152,5 @@
     "ts-node": "^10.4.0",
     "typescript": "~4.4.2",
     "watch": "^1.0.2"
-  },
-  "resolutions": {
-    "@authzed/authzed-node/**/@grpc/grpc-js": "1.9.1"
   }
 }

--- a/components/server/src/authorization/authorizer.ts
+++ b/components/server/src/authorization/authorizer.ts
@@ -509,6 +509,7 @@ export class Authorizer {
             }),
             relationshipFilter: {
                 resourceType: relation.resource?.objectType || "",
+                optionalResourceIdPrefix: "",
                 optionalResourceId: relation.resource?.objectId || "",
                 optionalRelation: relation.relation,
                 optionalSubjectFilter: relation.subject?.object && {
@@ -534,6 +535,7 @@ export class Authorizer {
             }),
             relationshipFilter: {
                 resourceType: relation.resource?.objectType || "",
+                optionalResourceIdPrefix: "",
                 optionalResourceId: relation.resource?.objectId || "",
                 optionalRelation: relation.relation,
                 optionalSubjectFilter: relation.subject?.object && {

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -70,8 +70,11 @@ export class SpiceDBClientProvider {
                             },
                         ],
                     }),
-
                     "grpc.enable_retries": 1, //TODO enabled by default
+
+                    // Governs how log DNS resolution results are cached (at minimum!)
+                    // default is 30s, which is too long for us during rollouts (where service DNS entries are updated)
+                    "grpc.dns_min_time_between_resolutions_ms": 2000,
                     interceptors: this.interceptors,
                 },
             ) as Client;

--- a/components/spicedb/typescript/package.json
+++ b/components/spicedb/typescript/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "long": "4.0.0",
-    "nice-grpc": "^2.0.0",
-    "ts-proto": "^1.153.0"
+    "nice-grpc": "^2.1.8",
+    "ts-proto": "^1.176.2"
   },
   "devDependencies": {
     "@types/long": "4.0.0",

--- a/components/supervisor-api/typescript-grpc/package.json
+++ b/components/supervisor-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/usage-api/typescript/package.json
+++ b/components/usage-api/typescript/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "long": "4.0.0",
-    "nice-grpc": "^2.0.0",
-    "ts-proto": "^1.153.0"
+    "nice-grpc": "^2.1.8",
+    "ts-proto": "^1.176.2"
   },
   "devDependencies": {
     "@types/long": "4.0.0",

--- a/components/ws-daemon-api/typescript/package.json
+++ b/components/ws-daemon-api/typescript/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-bridge-api/typescript/package.json
+++ b/components/ws-manager-bridge-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.9.1",
+    "@grpc/grpc-js": "1.10.8",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,14 +29,14 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@authzed/authzed-node@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.12.1.tgz#0c28395a64f9b1ecf33faf67259e32a9a3bce300"
-  integrity sha512-BVHLaPfiHQw1Vz+199m9i4xltT3YyFhqVHtkYPIQ28q8a7iJpnXmFRZIWuTMJcxJI01wtAxJYFuRJq3ktFe6qw==
+"@authzed/authzed-node@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.15.0.tgz#2163357d76ebf4068d0735a19357c8fa689d1c85"
+  integrity sha512-juB03KDkxuPShvWz4coJeDzKN7obSZwm6a5Ii4xcCAUT6IItSS+7hOQtFYDMSQVz6ynchwleqqzbhAWMZ1NISQ==
   dependencies:
-    "@grpc/grpc-js" "^1.8.3"
-    "@protobuf-ts/runtime" "^2.8.1"
-    "@protobuf-ts/runtime-rpc" "^2.8.1"
+    "@grpc/grpc-js" "^1.10.7"
+    "@protobuf-ts/runtime" "^2.9.4"
+    "@protobuf-ts/runtime-rpc" "^2.9.4"
     google-protobuf "^3.15.3"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.22.5", "@babel/code-frame@^7.8.3":
@@ -1666,13 +1666,13 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
   integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
 
-"@grpc/grpc-js@1.9.1", "@grpc/grpc-js@^1.6.1", "@grpc/grpc-js@^1.8.3":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.1.tgz#d6df7943cd2875a4feaf725f85ff605c08ac245d"
-  integrity sha512-AvDEPQT4teS+J8++cTE5tku4rYCwpPwPguESJUummLs/Ug/O5Bouofnc1mxaDORmwA9QkrJ+PfRQ1Qs7adQgJg==
+"@grpc/grpc-js@1.10.8", "@grpc/grpc-js@^1.10.7":
+  version "1.10.8"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.8.tgz#99787785cd8335be861afd1cd485ae9f058e4484"
+  integrity sha512-vYVqYzHicDqyKB+NQhAc54I1QWCBLCrYG6unqOIcBTHx+7x8C9lcoLj3KVJXs2VB4lUbpWY+Kk9NipcbXYWmvg==
   dependencies:
-    "@grpc/proto-loader" "^0.7.8"
-    "@types/node" ">=12.12.47"
+    "@grpc/proto-loader" "^0.7.13"
+    "@js-sdsl/ordered-map" "^4.4.2"
 
 "@grpc/grpc-js@~1.8.0":
   version "1.8.21"
@@ -1680,6 +1680,14 @@
   integrity sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
+
+"@grpc/grpc-js@~1.9.14":
+  version "1.9.14"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.14.tgz#236378822876cbf7903f9d61a0330410e8dcc5a1"
+  integrity sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
 
 "@grpc/proto-loader@^0.7.0":
@@ -1690,6 +1698,16 @@
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
     protobufjs "^7.2.4"
+    yargs "^17.7.2"
+
+"@grpc/proto-loader@^0.7.13":
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
+  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.2.5"
     yargs "^17.7.2"
 
 "@grpc/proto-loader@^0.7.8":
@@ -2060,6 +2078,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
 "@jsdoc/salty@^0.2.1":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.5.tgz#1b2fa5bb8c66485b536d86eee877c263d322f692"
@@ -2417,17 +2440,17 @@
     readable-stream "^3.6.0"
     split2 "^4.0.0"
 
-"@protobuf-ts/runtime-rpc@^2.8.1":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.8.2.tgz#8af6d5eab44e2fc92cfe9a83a5c351b5f2fcdfbe"
-  integrity sha512-vum/Y7AXdUTWGFu7dke/jCSB9dV3Oo3iVPcce3j7KudpzzWarDkEGvXjKv3Y8zJPj5waToyxwBNSb7eo5Vw5WA==
+"@protobuf-ts/runtime-rpc@^2.9.4":
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz#d6ab2316c0ba67ce5a08863bb23203a837ff2a3b"
+  integrity sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==
   dependencies:
-    "@protobuf-ts/runtime" "^2.8.2"
+    "@protobuf-ts/runtime" "^2.9.4"
 
-"@protobuf-ts/runtime@^2.8.1", "@protobuf-ts/runtime@^2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.8.2.tgz#5d5424a6ae7fb846c3f4d0f2dd6448db65bb69d6"
-  integrity sha512-PVxsH81y9kEbHldxxG/8Y3z2mTXWQytRl8zNS0mTPUjkEC+8GUX6gj6LsA8EFp25fAs9V0ruh+aNWmPccEI9MA==
+"@protobuf-ts/runtime@^2.9.4":
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.9.4.tgz#db8a78b1c409e26d258ca39464f4757d804add8f"
+  integrity sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -6821,10 +6844,10 @@ dotenv@^8.2.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
-dprint-node@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/dprint-node/-/dprint-node-1.0.7.tgz#f571eaf61affb3a696cff1bdde78a021875ba540"
-  integrity sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==
+dprint-node@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/dprint-node/-/dprint-node-1.0.8.tgz#a02470722d8208a7d7eb3704328afda1d6758625"
+  integrity sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==
   dependencies:
     detect-libc "^1.0.3"
 
@@ -11058,14 +11081,21 @@ nice-grpc-common@^2.0.0:
   dependencies:
     ts-error "^1.0.6"
 
-nice-grpc@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nice-grpc/-/nice-grpc-2.0.0.tgz#0fa3f04e5f45905349cf44330ae26e54e77c6b1c"
-  integrity sha512-BEQgQi5Km9OV2SEv3CsHMrMifP6RiLE0DhjFaxef7UgIBV/6CVtnk/EFhH8gG5+C3xBK8w+2Lwind/W6GdczAQ==
+nice-grpc-common@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/nice-grpc-common/-/nice-grpc-common-2.0.2.tgz#e6aeebb2bd19d87114b351e291e30d79dd38acf7"
+  integrity sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==
   dependencies:
-    "@grpc/grpc-js" "^1.6.1"
+    ts-error "^1.0.6"
+
+nice-grpc@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/nice-grpc/-/nice-grpc-2.1.8.tgz#2d26eae2470573d692c5fdded1b5be7a30d48aac"
+  integrity sha512-pTugD3cZ1Vb0Q2OjZZh80wpLY6L7jSADnzY7Dq6mL9EGUJJF5mfQjcHF4gqpQtyTq2YsZgPIArfNcq0k3ApgQg==
+  dependencies:
+    "@grpc/grpc-js" "~1.9.14"
     abort-controller-x "^0.4.0"
-    nice-grpc-common "^2.0.0"
+    nice-grpc-common "^2.0.2"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -12627,6 +12657,24 @@ protobufjs@^7.0.0, protobufjs@^7.2.4, protobufjs@~7.2.4:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+protobufjs@^7.2.5:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.0.tgz#a32ec0422c039798c41a0700306a6e305b9cb32c"
+  integrity sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -14834,30 +14882,30 @@ ts-node@^10.4.0, ts-node@^10.7.0:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-ts-poet@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-6.5.0.tgz#7070bfae1d53847aa38e8e02bdbe4f1064d6d091"
-  integrity sha512-44jURLT1HG6+NsDcadM826V6Ekux+wk07Go+MX5Gfx+8zcPKfUiFEtnjL9imuRVGSCRtloRLqw4bDGZVJYGZMQ==
+ts-poet@^6.7.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-6.9.0.tgz#e63ac8d8a9e91a2e0e5d2bf0755db71346728bd2"
+  integrity sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==
   dependencies:
-    dprint-node "^1.0.7"
+    dprint-node "^1.0.8"
 
-ts-proto-descriptors@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz#e859e3a2887da2d954c552524719b80bdb6ee355"
-  integrity sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==
+ts-proto-descriptors@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz#e9f15d5d23774088f8573fa5a2d75130c64a565a"
+  integrity sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==
   dependencies:
     long "^5.2.3"
     protobufjs "^7.2.4"
 
-ts-proto@^1.153.0:
-  version "1.156.7"
-  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.156.7.tgz#a2c0024e07af775cf4878d5006364858162ae32f"
-  integrity sha512-vuSby+Mx0CniXscbHx9ieKCEErGBuie12RmduPA67p27Io5C0gkzlMnyN/j3vKWAJrP/h6+mbAoo6WrlalOt7w==
+ts-proto@^1.176.2:
+  version "1.176.2"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.176.2.tgz#8f10702c032d151d926ab2a6b98328608b39d247"
+  integrity sha512-lISYoJeutvl79MEJhAafdXbad9L48FjSuy+pg3YlAtX7ZY8LBfu4Wh00ac7DWC9GREzS0SfXeCqWbS2Rb4wEGQ==
   dependencies:
     case-anything "^2.1.13"
     protobufjs "^7.2.4"
-    ts-poet "^6.5.0"
-    ts-proto-descriptors "1.15.0"
+    ts-poet "^6.7.0"
+    ts-proto-descriptors "1.16.0"
 
 ts-protoc-gen@^0.13.0:
   version "0.13.0"


### PR DESCRIPTION
## Description

This PR is mainly focused on increasing stability for TypeScript gRPC clients:
1. version bumps
  - `@grpc/grpc-js` to `1.10.8`
  - `@authzed/authzed-node` to `0.15.0`
  - and subsequently, to align transitive dependencies on `@grpc/grpc-js`:
    - `nice-grpc`
    - `ts-proto`
2. improving the re-connection behavior
  - explicitly re-connect on UNAVAILABLE (specific to SpiceDB)
  - allow to re-fresh DNS resolution more often than every 30s

I tested the re-connection edge case quite extensively, and see consistently better performance than before! :partying_face: 
Still, there might be behavior lurking that we don't see here. 

## Related Issue(s)
Fixes ENT-251

## How to test
 - I enabled gRPC debugging:
```
        - name: GRPC_NODE_VERBOSITY
          value: DEBUG
        - name: GRPC_NODE_TRACE
          value: all
```
 - deleted the `spicedb` pod, and directly after started workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-251-grpcjs</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-251-grpcjs.preview.gitpod-dev.com/workspaces" target="_blank">gpl-251-grpcjs.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-251-grpcjs-gha.25949</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-251-grpcjs%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
