### PR TITLE
[server] Fix CapGitStatus job

### DIFF
--- a/components/server/src/jobs/cap-git-status.spec.db.ts
+++ b/components/server/src/jobs/cap-git-status.spec.db.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+const expect = chai.expect;
+import { suite, test, timeout } from "@testdeck/mocha";
+
+import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
+import { DBWorkspaceInstance, TypeORM, WorkspaceDB, resetDB } from "@gitpod/gitpod-db/lib";
+import { Repository } from "typeorm";
+import { CapGitStatus } from "./cap-git-status";
+import { createTestContainer } from "../test/service-testing-container-module";
+import { Container } from "inversify";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+
+const workspaceId = "ws123";
+
+@suite
+class CapGitStatusTest {
+    container: Container;
+    db: WorkspaceDB;
+
+    async before() {
+        this.container = createTestContainer();
+        Experiments.configureTestingClient({
+            api_validate_git_status_length: true,
+        });
+        await this.wipeRepos();
+
+        this.db = this.container.get<WorkspaceDB>(WorkspaceDB);
+    }
+
+    async after() {
+        // await this.wipeRepos();
+    }
+
+    async wipeRepos() {
+        const typeorm = this.container.get<TypeORM>(TypeORM);
+        await resetDB(typeorm);
+    }
+
+    instance(nr: number) {
+        const gitStatus: WorkspaceInstanceRepoStatus = {
+            branch: "main",
+            latestCommit: "abc",
+            untrackedFiles: [],
+        };
+        for (let i = 0; i < 100; i++) {
+            gitStatus.untrackedFiles?.push(`file_${i}_${"a".repeat(100)}`);
+        }
+        gitStatus.totalUntrackedFiles = gitStatus.untrackedFiles?.length;
+
+        const instance: WorkspaceInstance = {
+            id: `wsi${nr}`,
+            workspaceId,
+            creationTime: new Date(2018, 2, 16, 10, 0, 0).toISOString(),
+            ideUrl: "lalalal",
+            region: "somewhere",
+            workspaceImage: "eu.gcr.io/gitpod-io/workspace-images@sha256:123",
+            configuration: {
+                ideImage: "eu.gcr.io/gitpod-io/ide@sha256:123",
+            },
+            status: {
+                phase: "stopped",
+                conditions: {},
+                version: 1,
+            },
+            gitStatus,
+        };
+        return instance;
+    }
+
+    @test(timeout(10000))
+    public async createUserAndFindById() {
+        await this.db.storeInstance(this.instance(1));
+
+        const job = this.container.get<CapGitStatus>(CapGitStatus);
+        expect(await findInstancesWithLengthyGitStatus(job, this.db), "instances with lengthy git status").to.equal(1);
+        expect(await job.run(), "number of capped instances").to.equal(1);
+        expect(await findInstancesWithLengthyGitStatus(job, this.db), "instances with lengthy git status").to.equal(0);
+    }
+}
+
+async function findInstancesWithLengthyGitStatus(job: CapGitStatus, db: WorkspaceDB): Promise<number> {
+    const repo = await ((db as any).getWorkspaceInstanceRepo() as Promise<Repository<DBWorkspaceInstance>>);
+    const instances = await job.findInstancesWithLengthyGitStatus(repo, 4096, 100);
+    return instances.length;
+}
+
+module.exports = new CapGitStatusTest();

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -44,10 +44,9 @@ export class CapGitStatus implements Job {
             }
 
             // Cap the git status (incl. status.repo, the old place where we stored it before)
-            const MARGIN = 200;
             instances.forEach((i) => {
                 if (i.gitStatus) {
-                    i.gitStatus = capGitStatus(i.gitStatus, GIT_STATUS_LENGTH_CAP_BYTES - MARGIN);
+                    i.gitStatus = capGitStatus(i.gitStatus);
                 }
                 if (i.status) {
                     delete (i.status as any).repo;
@@ -80,7 +79,9 @@ export class CapGitStatus implements Job {
     }
 }
 
-function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus, maxLength: number): WorkspaceInstanceRepoStatus {
+function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus): WorkspaceInstanceRepoStatus {
+    const MARGIN = 500; // to account for attribute name's, and generic JSON overhead
+    const maxLength = GIT_STATUS_LENGTH_CAP_BYTES - MARGIN;
     let bytesUsed = 0;
     function capStr(str: string | undefined): string | undefined {
         if (str === undefined) {


### PR DESCRIPTION
## Description
Now I feel stupid: The capping worked, but MARGIN was too low, so we'd always come out a couple of bytes _over_ the budget, and next run re-try the same entries again...  :see_no_evil:
Test confirms it works now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-210

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
