### PR TITLE
Tolerate XL workspace taints in ws-daemon and registry-facade

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -195,6 +195,12 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Operator: "Exists",
 							Effect:   "NoSchedule",
 						},
+						// the following toleration is for enterprise instances that supports XL workspaces
+						{
+							Key:      "gitpod.io/xl-workspace",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
 					},
 					Containers: []corev1.Container{{
 						Name:            Component,

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -209,6 +209,12 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Operator: "Exists",
 			Effect:   "NoSchedule",
 		},
+		// the following toleration is for enterprise instances that supports XL workspace nodegroups
+		{
+			Key:      "gitpod.io/xl-workspace",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
 	}
 
 	podSpec := corev1.PodSpec{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a toleration to both ws-daemon and registry-facade daemonsets so that the scheduling works properly in nodegroups intended for very large size workspaces in enterprise

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
