### PR TITLE
Define proto for supervisor's `getTaskOutput`

### DIFF
--- a/components/supervisor-api/terminal.proto
+++ b/components/supervisor-api/terminal.proto
@@ -44,6 +44,12 @@ service TerminalService {
         };
     }
 
+    rpc GetTaskOutput(GetTaskOutputRequest) returns (GetTaskOutputResponse) {
+        option (google.api.http) = {
+            get: "/v1/terminal/task/output/{alias}"
+        };
+    }
+
     // Write writes to a terminal
     rpc Write(WriteTerminalRequest) returns (WriteTerminalResponse) {
         option (google.api.http) = {
@@ -128,6 +134,13 @@ message ListenTerminalResponse {
     };
     // only present if output is title
     TerminalTitleSource title_source = 4;
+}
+
+message GetTaskOutputRequest {
+    string alias = 1;
+}
+message GetTaskOutputResponse {
+    bytes data = 1;
 }
 
 message WriteTerminalRequest {


### PR DESCRIPTION
## Description

This API will allow a client to request logs of a task, even if it is completed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-256

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
