### PR TITLE
Increase JetBrains IDE process priority

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
@@ -38,6 +38,8 @@ const (
 	ProcessCodeServer ProcessType = "vscode-server"
 	// ProcessCodeServerHelper refers to VS Code Desktop child process
 	ProcessCodeServerHelper ProcessType = "vscode-server-helper"
+	// ProcessJetBrainsIDE refers to JetBrains IDE process
+	ProcessJetBrainsIDE ProcessType = "jetbrains-ide"
 	// ProcessDefault referes to any process that is not one of the above
 	ProcessDefault ProcessType = "default"
 
@@ -125,6 +127,7 @@ func (c *ProcessPriorityV2) Apply(ctx context.Context, opts *PluginOptions) erro
 
 var (
 	vsCodeNodeRegex = regexp.MustCompile("/home/gitpod/.vscode-server/bin/.*/node")
+	jetBrainsRegex  = regexp.MustCompile("/ide-desktop/.*/backend/plugins/remote-dev-server/selfcontained/lib")
 )
 
 func determineProcessType(p *process.Process) ProcessType {
@@ -155,6 +158,10 @@ func determineProcessType(p *process.Process) ProcessType {
 
 	if strings.HasSuffix(cmd[0], "/ide/node") {
 		return ProcessWebIDEHelper
+	}
+
+	if jetBrainsRegex.MatchString(strings.Join(cmd, " ")) {
+		return ProcessJetBrainsIDE
 	}
 
 	return ProcessDefault

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -118,6 +118,8 @@ func NewDaemon(config Config) (*Daemon, error) {
 
 				cgroup.ProcessCodeServer:       -10,
 				cgroup.ProcessCodeServerHelper: -5,
+
+				cgroup.ProcessJetBrainsIDE: -10,
 			},
 			EnableOOMScoreAdj: config.OOMScores.Enabled,
 			OOMScoreAdj: map[cgroup.ProcessType]int{
@@ -125,6 +127,7 @@ func NewDaemon(config Config) (*Daemon, error) {
 				cgroup.ProcessSupervisor:       config.OOMScores.Tier1,
 				cgroup.ProcessCodeServer:       config.OOMScores.Tier1,
 				cgroup.ProcessIDE:              config.OOMScores.Tier1,
+				cgroup.ProcessJetBrainsIDE:     config.OOMScores.Tier1,
 				cgroup.ProcessCodeServerHelper: config.OOMScores.Tier2,
 				cgroup.ProcessWebIDEHelper:     config.OOMScores.Tier2,
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR increases JetBrains IDE process priority (niceness -10)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-158

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace with any JetBrains IDE
2. using `ps -eo pid,nice,args --sort=nice | awk '$2 != 0'` you will see Jetbrains IDE process is -10 (This may take some time)


<img width="1792" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/9d9e64c6-e63b-44d2-96d3-0f76b67400f0">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-jb-niceness</li>
	<li><b>🔗 URL</b> - <a href="https://pd-jb-niceness.preview.gitpod-dev.com/workspaces" target="_blank">pd-jb-niceness.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-jb-niceness-gha.26062</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-jb-niceness%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
