### PR TITLE
[server] Fix CapGitStatus job (again)

### DIFF
--- a/components/server/src/jobs/cap-git-status.spec.db.ts
+++ b/components/server/src/jobs/cap-git-status.spec.db.ts
@@ -6,7 +6,7 @@
 
 import * as chai from "chai";
 const expect = chai.expect;
-import { suite, test, timeout } from "@testdeck/mocha";
+import { suite, test } from "@testdeck/mocha";
 
 import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
 import { DBWorkspaceInstance, TypeORM, WorkspaceDB, resetDB } from "@gitpod/gitpod-db/lib";
@@ -73,9 +73,25 @@ class CapGitStatusTest {
         return instance;
     }
 
-    @test(timeout(10000))
-    public async createUserAndFindById() {
+    @test()
+    public async capGeneratedStatus() {
         await this.db.storeInstance(this.instance(1));
+
+        const job = this.container.get<CapGitStatus>(CapGitStatus);
+        expect(await findInstancesWithLengthyGitStatus(job, this.db), "instances with lengthy git status").to.equal(1);
+        expect(await job.run(), "number of capped instances").to.equal(1);
+        expect(await findInstancesWithLengthyGitStatus(job, this.db), "instances with lengthy git status").to.equal(0);
+    }
+
+    @test()
+    public async capRealStatus() {
+        const instance = this.instance(1);
+        instance.gitStatus = <WorkspaceInstanceRepoStatus>(
+            JSON.parse(
+                `{"branch": "main", "latestCommit": "0516cdc28a52d22613019da1e1360e28a4118351", "untrackedFiles": [".gitpod.yml", "node_modules/.bin/acorn", "node_modules/.bin/ansi-html", "node_modules/.bin/autoprefixer", "node_modules/.bin/browserslist", "node_modules/.bin/css-blank-pseudo", "node_modules/.bin/css-has-pseudo", "node_modules/.bin/css-prefers-color-scheme", "node_modules/.bin/cssesc", "node_modules/.bin/detect", "node_modules/.bin/detect-port", "node_modules/.bin/ejs", "node_modules/.bin/escodegen", "node_modules/.bin/esgenerate", "node_modules/.bin/eslint", "node_modules/.bin/esparse", "node_modules/.bin/esvalidate", "node_modules/.bin/he", "node_modules/.bin/html-minifier-terser", "node_modules/.bin/import-local-fixture", "node_modules/.bin/is-docker", "node_modules/.bin/jake", "node_modules/.bin/jest", "node_modules/.bin/jiti", "node_modules/.bin/js-yaml", "node_modules/.bin/jsesc", "node_modules/.bin/json5", "node_modules/.bin/loose-envify", "node_modules/.bin/lz-string", "node_modules/.bin/mime", "node_modules/.bin/mkdirp", "node_modules/.bin/multicast-dns", "node_modules/.bin/nanoid", "node_modules/.bin/node-which", "node_modules/.bin/parser", "node_modules/.bin/rc", "node_modules/.bin/react-scripts", "node_modules/.bin/regjsparser", "node_modules/.bin/resolve", "node_modules/.bin/rimraf", "node_modules/.bin/rollup", "node_modules/.bin/semver", "node_modules/.bin/serve", "node_modules/.bin/sucrase", "node_modules/.bin/sucrase-node", "node_modules/.bin/svgo", "node_modules/.bin/tailwind", "node_modules/.bin/tailwindcss", "node_modules/.bin/terser", "node_modules/.bin/tsc", "node_modules/.bin/tsserver", "node_modules/.bin/update-browserslist-db", "node_modules/.bin/uuid", "node_modules/.bin/webpack", "node_modules/.bin/webpack-dev-server", "node_modules/.package-lock.json", "node_modules/@adobe/css-tools/History.md", "node_modules/@adobe/css-tools/LICENSE", "node_modules/@adobe/css-tools/Readme.md", "node_modules/@adobe/css-tools/dist/cjs/CssParseError.d.ts", "node_modules/@adobe/css-tools/dist/cjs/CssPosition.d.ts", "node_modules/@adobe/css-tools/dist/cjs/cssTools.js", "node_modules/@adobe/css-tools/dist/cjs/cssTools.js.map", "node_modules/@adobe/css-tools/dist/cjs/index.d.ts", "node_modules/@adobe/css-tools/dist/cjs/parse/index.d.ts", "node_modules/@adobe/css-tools/dist/cjs/stringify/compiler.d.ts", "node_modules/@adobe/css-tools/dist/cjs/stringify/index.d.ts", "node_modules/@adobe/css-tools/dist/cjs/type.d.ts", "node_modules/@adobe/css-tools/dist/esm/CssParseError.js", "node_modules/@adobe/css-tools/dist/esm/CssPosition.js", "node_modules/@adobe/css-tools/dist/esm/index.js", "node_modules/@adobe/css-tools/dist/esm/parse/index.js", "node_modules/@adobe/css-tools/dist/esm/stringify/compiler.js", "node_modules/@adobe/css-tools/dist/esm/stringify/index.js", "node_modules/@adobe/css-tools/dist/esm/type.js", "node_modules/@adobe/css-tools/dist/umd/cssTools.js", "node_modules/@adobe/css-tools/dist/umd/cssTools.js.map", "node_modules/@adobe/css-tools/package.json", "node_modules/@alloc/quick-lru/index.d.ts", "node_modules/@alloc/quick-lru/index.js", "node_modules/@alloc/quick-lru/license", "node_modules/@alloc/quick-lru/package.json", "node_modules/@alloc/quick-lru/readme.md", "node_modules/@ampproject/remapping/LICENSE", "node_modules/@ampproject/remapping/README.md", "node_modules/@ampproject/remapping/dist/remapping.mjs", "node_modules/@ampproject/remapping/dist/remapping.mjs.map", "node_modules/@ampproject/remapping/dist/remapping.umd.js", "node_modules/@ampproject/remapping/dist/remapping.umd.js.map", "node_modules/@ampproject/remapping/dist/types/build-source-map-tree.d.ts", "node_modules/@ampproject/remapping/dist/types/remapping.d.ts", "node_modules/@ampproject/remapping/dist/types/source-map-tree.d.ts", "node_modules/@ampproject/remapping/dist/types/source-map.d.ts", "node_modules/@ampproject/remapping/dist/types/types.d.ts", "node_modules/@ampproject/remapping/package.json", "node_modules/@babel/code-frame/LICENSE", "... and 37923 more"], "uncommitedFiles": ["moon"], "totalUntrackedFiles": 38023, "totalUncommitedFiles": 1}`,
+            )
+        );
+        await this.db.storeInstance(instance);
 
         const job = this.container.get<CapGitStatus>(CapGitStatus);
         expect(await findInstancesWithLengthyGitStatus(job, this.db), "instances with lengthy git status").to.equal(1);

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -80,7 +80,7 @@ export class CapGitStatus implements Job {
 }
 
 function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus): WorkspaceInstanceRepoStatus {
-    const MARGIN = 500; // to account for attribute name's, and generic JSON overhead
+    const MARGIN = 800; // to account for attribute name's, and generic JSON overhead
     const maxLength = GIT_STATUS_LENGTH_CAP_BYTES - MARGIN;
     let bytesUsed = 0;
     function capStr(str: string | undefined): string | undefined {
@@ -88,9 +88,9 @@ function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus): WorkspaceInstance
             return undefined;
         }
 
-        const len = Buffer.byteLength(str, "utf8");
+        const len = Buffer.byteLength(str, "utf8") + 6;
         if (bytesUsed + len > maxLength) {
-            return "";
+            return undefined;
         }
         bytesUsed = bytesUsed + len;
         return str;


### PR DESCRIPTION
## Description


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-210

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
