### PR TITLE
Tolerate all taints

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -191,9 +191,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					InitContainers:                initContainers,
 					Tolerations: []corev1.Toleration{
 						{
-							Key:      "gitpod.io/gpu",
 							Operator: "Exists",
-							Effect:   "NoSchedule",
 						},
 					},
 					Containers: []corev1.Container{{

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -205,9 +205,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Effect:   "NoExecute",
 		},
 		{
-			Key:      "gitpod.io/gpu",
 			Operator: "Exists",
-			Effect:   "NoSchedule",
 		},
 	}
 


### PR DESCRIPTION
## Description
Registry-facade and ws-daemon are only deployed to workspace nodes and should be able to tolerate all taints on these nodes regardless of where they are coming from

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-265


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
