### PR TITLE
Improve extension detection in the dashboard

### DIFF
--- a/components/dashboard/public/index.html
+++ b/components/dashboard/public/index.html
@@ -16,6 +16,10 @@
       name="Gitpod"
       content="Always Ready-to-Code"
     />
+    <meta
+      name="extension-active"
+      content="false"
+    >
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Dashboard</title>

--- a/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
+++ b/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
@@ -131,6 +131,9 @@ export function BrowserExtensionBanner() {
             attributes: true,
             attributeFilter: ["content"],
         });
+        return () => {
+            observer.disconnect();
+        };
     }, []);
 
     useEffect(() => {

--- a/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
+++ b/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
@@ -91,8 +91,7 @@ const wasRecentlySeenActive = (): boolean => {
     }
 
     const threshold = 30 * 24 * 60 * 60 * 1_000; // 1 month
-
-    return new Date().getTime() - new Date(lastSeen).getTime() > threshold;
+    return Date.now() - new Date(lastSeen).getTime() < threshold;
 };
 
 export function BrowserExtensionBanner() {
@@ -116,7 +115,7 @@ export function BrowserExtensionBanner() {
     useEffect(() => {
         const installedOrDismissed =
             sessionStorage.getItem("browser-extension-installed") || // todo(ft): delete after migration is complete
-            wasRecentlySeenActive ||
+            wasRecentlySeenActive() ||
             localStorage.getItem("browser-extension-banner-dismissed");
 
         setIsVisible(!installedOrDismissed);

--- a/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
+++ b/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
@@ -81,6 +81,20 @@ const displayScmProviders = (providers: UnifiedAuthProvider[]): string => {
     return formatter.format(providers);
 };
 
+/**
+ * Determines whether the extension has been able to access the current site in the past month. If it hasn't, it's most likely not installed or misconfigured
+ */
+const wasRecentlySeenActive = (): boolean => {
+    const lastSeen = localStorage.getItem("extension-last-seen-active");
+    if (!lastSeen) {
+        return false;
+    }
+
+    const threshold = 30 * 24 * 60 * 60 * 1_000; // 1 month
+
+    return new Date().getTime() - new Date(lastSeen).getTime() > threshold;
+};
+
 export function BrowserExtensionBanner() {
     const { user } = useUserLoader();
     const { data: authProviderDescriptions } = useAuthProviderDescriptions();
@@ -101,7 +115,8 @@ export function BrowserExtensionBanner() {
 
     useEffect(() => {
         const installedOrDismissed =
-            sessionStorage.getItem("browser-extension-installed") ||
+            sessionStorage.getItem("browser-extension-installed") || // todo(ft): delete after migration is complete
+            wasRecentlySeenActive ||
             localStorage.getItem("browser-extension-banner-dismissed");
 
         setIsVisible(!installedOrDismissed);

--- a/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
+++ b/components/dashboard/src/workspaces/BrowserExtensionBanner.tsx
@@ -131,6 +131,7 @@ export function BrowserExtensionBanner() {
             attributes: true,
             attributeFilter: ["content"],
         });
+
         return () => {
             observer.disconnect();
         };


### PR DESCRIPTION
## Description

Instead of relying on `sessionStorage`, which resets for every new tab, rely on `localStorage` with a timestamp valid for 1 month.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-167

## How to test

https://ft-less-exc3cc71c569.preview.gitpod-dev.com/workspaces

1. Enable the preview environment in the browser extension (at best, compiled from https://github.com/gitpod-io/browser-extension/commit/0e85d1b18513f5896acbdda62904a3df57cbc9c0, but it is also important to verify with the current version)
2. Go to the new workspace page and verify you are not shown the nudge to install the extension

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
