### PR TITLE
[JetBrains] Update Platform Version from JetBrains Backend Plugin (EAP)

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -63,6 +63,13 @@ dependencies {
     compileOnly("javax.websocket:javax.websocket-api:1.1")
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
     testImplementation(kotlin("test"))
+
+    // grpc
+    implementation("com.google.api.grpc:proto-google-common-protos:2.2.2")
+    implementation("io.grpc:grpc-core:1.49.0")
+    implementation("io.grpc:grpc-protobuf:1.49.0")
+    implementation("io.grpc:grpc-stub:1.49.0")
+    implementation("io.grpc:grpc-netty-shaded:1.49.0")
 }
 
 // Configure gradle-intellij-plugin plugin.

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=241.17011
-pluginUntilBuild=241.*
+pluginSinceBuild=242.15523
+pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2024.1
+pluginVerifierIdeVersions=2024.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=241.17011-EAP-CANDIDATE-SNAPSHOT
+platformVersion=242.15523-EAP-CANDIDATE-SNAPSHOT


### PR DESCRIPTION
## Description
This PR updates the Platform Version from JetBrains Backend Plugin (EAP) to the latest version.

## How to test

Merge if tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>
1. Open the preview environment generated for this branch
2. Choose the _Latest Release (Unstable)_ version of IntelliJ IDEA as your preferred editor
3. Start a workspace using this repository: https://github.com/gitpod-samples/spring-petclinic
4. Verify that the workspace starts successfully
5. Verify that the IDE opens successfully
</details>

## Release Notes
```release-note
NONE
```

## Werft options:
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=true

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._