### PR TITLE
[server] CapGitStatus: Split work on 'status' into separate job called CapStatus

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -134,6 +134,7 @@ import { RateLimitter } from "./rate-limitter";
 import { AnalyticsController } from "./analytics-controller";
 import { InstallationAdminCleanup } from "./jobs/installation-admin-cleanup";
 import { CapGitStatus } from "./jobs/cap-git-status";
+import { CapStatus } from "./jobs/cap-status";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -375,6 +376,7 @@ export const productionContainerModule = new ContainerModule(
         bind(RelationshipUpdateJob).toSelf().inSingletonScope();
         bind(InstallationAdminCleanup).toSelf().inSingletonScope();
         bind(CapGitStatus).toSelf().inSingletonScope();
+        bind(CapStatus).toSelf().inSingletonScope();
 
         // Redis
         bind(Redis).toDynamicValue((ctx) => {

--- a/components/server/src/jobs/cap-git-status.ts
+++ b/components/server/src/jobs/cap-git-status.ts
@@ -44,7 +44,7 @@ export class CapGitStatus implements Job {
                 return [];
             }
 
-            // Cap the git status (incl. status.repo, the old place where we stored it before)
+            // Cap gitStatus
             instances.forEach((i) => {
                 if (i.gitStatus) {
                     i.gitStatus = capGitStatus(i.gitStatus);

--- a/components/server/src/jobs/cap-status.ts
+++ b/components/server/src/jobs/cap-status.ts
@@ -9,22 +9,21 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { inject, injectable } from "inversify";
 import { Job } from "./runner";
 import { Config } from "../config";
-import { GIT_STATUS_LENGTH_CAP_BYTES } from "../workspace/workspace-service";
 import { Repository } from "typeorm";
-import { WorkspaceInstance, WorkspaceInstanceRepoStatus } from "@gitpod/gitpod-protocol";
+import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
 @injectable()
-export class CapGitStatus implements Job {
+export class CapStatus implements Job {
     @inject(Config) protected readonly config: Config;
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
 
-    public name = "git-status-capper";
+    public name = "status-capper";
     public frequencyMs = 2 * 60 * 1000; // every 2 minutes
 
     public async run(): Promise<number | undefined> {
-        log.info("git-status: we're leading the quorum.");
+        log.info("cap-status: we're leading the quorum.");
 
         const validateGitStatusLength = await getExperimentsClientForBackend().getValueAsync(
             "api_validate_git_status_length",
@@ -32,22 +31,22 @@ export class CapGitStatus implements Job {
             {},
         );
         if (!validateGitStatusLength) {
-            log.info("git-status: feature flag is not enabled.");
+            log.info("cap-status: feature flag is not enabled.");
             return;
         }
 
         const limit = 100;
         const instances = await this.workspaceDb.transaction(async (db) => {
             const repo = await ((db as any).getWorkspaceInstanceRepo() as Promise<Repository<DBWorkspaceInstance>>);
-            const instances = await this.findInstancesWithLengthyGitStatus(repo, GIT_STATUS_LENGTH_CAP_BYTES, limit);
+            const instances = await this.findInstancesWithLengthyStatus(repo, limit);
             if (instances.length === 0) {
                 return [];
             }
 
             // Cap the git status (incl. status.repo, the old place where we stored it before)
             instances.forEach((i) => {
-                if (i.gitStatus) {
-                    i.gitStatus = capGitStatus(i.gitStatus);
+                if (i.status) {
+                    delete (i.status as any).repo;
                 }
             });
 
@@ -60,50 +59,17 @@ export class CapGitStatus implements Job {
         });
         const instancesCapped = instances.length;
 
-        log.info(`git-status: capped ${instancesCapped} instances.`, {
+        log.info(`cap-status: capped ${instancesCapped} instances.`, {
             instanceIds: new TrustedValue(instances.map((i) => i.id)),
         });
         return instancesCapped;
     }
 
-    async findInstancesWithLengthyGitStatus(
+    async findInstancesWithLengthyStatus(
         repo: Repository<DBWorkspaceInstance>,
-        byteLimit: number,
         limit: number = 1000,
     ): Promise<WorkspaceInstance[]> {
-        const qb = repo
-            .createQueryBuilder("wsi")
-            .where("JSON_STORAGE_SIZE(wsi.gitStatus) > :byteLimit", { byteLimit })
-            .limit(limit);
+        const qb = repo.createQueryBuilder("wsi").where("wsi.status->>'$.repo' IS NOT NULL").limit(limit);
         return qb.getMany();
     }
-}
-
-function capGitStatus(gitStatus: WorkspaceInstanceRepoStatus): WorkspaceInstanceRepoStatus {
-    const MARGIN = 800; // to account for attribute name's, and generic JSON overhead
-    const maxLength = GIT_STATUS_LENGTH_CAP_BYTES - MARGIN;
-    let bytesUsed = 0;
-    function capStr(str: string | undefined): string | undefined {
-        if (str === undefined) {
-            return undefined;
-        }
-
-        const len = Buffer.byteLength(str, "utf8") + 6;
-        if (bytesUsed + len > maxLength) {
-            return undefined;
-        }
-        bytesUsed = bytesUsed + len;
-        return str;
-    }
-    function filterStr(str: string | undefined): boolean {
-        return !!capStr(str);
-    }
-
-    gitStatus.branch = capStr(gitStatus.branch);
-    gitStatus.latestCommit = capStr(gitStatus.latestCommit);
-    gitStatus.uncommitedFiles = gitStatus.uncommitedFiles?.filter(filterStr);
-    gitStatus.untrackedFiles = gitStatus.untrackedFiles?.filter(filterStr);
-    gitStatus.unpushedCommits = gitStatus.unpushedCommits?.filter(filterStr);
-
-    return gitStatus;
 }

--- a/components/server/src/jobs/cap-status.ts
+++ b/components/server/src/jobs/cap-status.ts
@@ -43,7 +43,7 @@ export class CapStatus implements Job {
                 return [];
             }
 
-            // Cap the git status (incl. status.repo, the old place where we stored it before)
+            // Cap the status (the old place where we stored gitStatus before)
             instances.forEach((i) => {
                 if (i.status) {
                     delete (i.status as any).repo;

--- a/components/server/src/jobs/runner.ts
+++ b/components/server/src/jobs/runner.ts
@@ -22,6 +22,7 @@ import { runWithRequestContext } from "../util/request-context";
 import { SYSTEM_USER } from "../authorization/authorizer";
 import { InstallationAdminCleanup } from "./installation-admin-cleanup";
 import { CapGitStatus } from "./cap-git-status";
+import { CapStatus } from "./cap-status";
 
 export const Job = Symbol("Job");
 
@@ -46,6 +47,7 @@ export class JobRunner {
         @inject(WorkspaceStartController) private readonly workspaceStartController: WorkspaceStartController,
         @inject(InstallationAdminCleanup) private readonly installationAdminCleanup: InstallationAdminCleanup,
         @inject(CapGitStatus) private readonly capGitStatus: CapGitStatus,
+        @inject(CapStatus) private readonly capStatus: CapStatus,
     ) {}
 
     public start(): DisposableCollection {
@@ -62,6 +64,7 @@ export class JobRunner {
             this.workspaceStartController,
             this.installationAdminCleanup,
             this.capGitStatus,
+            this.capStatus,
         ];
 
         for (const job of jobs) {


### PR DESCRIPTION
## Description

Turns out there are more ways we can extend the boundaries of our shapes than I imagined. So we are only fixing the problem at hand how (large gitStatus), either in the old or new place.

## Related Issue(s)
Related ENT-210

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-only-gitstatus</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-only-gitstatus.preview.gitpod-dev.com/workspaces" target="_blank">gpl-only-gitstatus.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-only-gitstatus-gha.26146</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-only-gitstatus%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
