### PR TITLE
QoL improvements for the prebuild UI

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -63,7 +63,7 @@ export const PrebuildDetailPage: FC = () => {
     const { toast, dismissToast } = useToast();
     const [currentPrebuild, setCurrentPrebuild] = useState<Prebuild | undefined>();
     const [logNotFound, setLogNotFound] = useState(false);
-    const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(undefined);
+    const [selectedTaskId, actuallySetSelectedTaskId] = useState<string | undefined>(window.location.hash.slice(1));
 
     const taskId = selectedTaskId ?? currentPrebuild?.status?.taskLogs.filter((f) => f.logUrl)[0]?.taskId ?? "0";
 
@@ -84,6 +84,17 @@ export const PrebuildDetailPage: FC = () => {
 
     const triggeredDate = useMemo(() => dayjs(prebuild?.status?.startTime?.toDate()), [prebuild?.status?.startTime]);
     const triggeredString = useMemo(() => formatDate(triggeredDate), [triggeredDate]);
+
+    const setSelectedTaskId = useCallback(
+        (taskId: string) => {
+            actuallySetSelectedTaskId(taskId);
+
+            history.push({
+                hash: taskId,
+            });
+        },
+        [history],
+    );
 
     useEffect(() => {
         setLogNotFound(false);
@@ -286,7 +297,8 @@ export const PrebuildDetailPage: FC = () => {
                                                     <TabsTrigger
                                                         value={task.taskId}
                                                         key={task.taskId}
-                                                        className="font-normal text-base pt-2 px-4 rounded-t-lg border border-pk-border-base border-b-0 border-l-0 data-[state=active]:bg-pk-surface-secondary data-[state=active]:z-10 data-[state=active]:relative last:mr-1"
+                                                        data-analytics={JSON.stringify({ dnt: true })}
+                                                        className="mt-1 font-normal text-base pt-2 px-4 rounded-t-lg border border-pk-border-base border-b-0 border-l-0 data-[state=active]:bg-pk-surface-secondary data-[state=active]:z-10 data-[state=active]:relative last:mr-1"
                                                     >
                                                         {task.taskLabel}
                                                     </TabsTrigger>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -63,7 +63,9 @@ export const PrebuildDetailPage: FC = () => {
     const { toast, dismissToast } = useToast();
     const [currentPrebuild, setCurrentPrebuild] = useState<Prebuild | undefined>();
     const [logNotFound, setLogNotFound] = useState(false);
-    const [selectedTaskId, actuallySetSelectedTaskId] = useState<string | undefined>(window.location.hash.slice(1));
+    const [selectedTaskId, actuallySetSelectedTaskId] = useState<string | undefined>(
+        window.location.hash.slice(1) || undefined,
+    );
 
     const taskId = selectedTaskId ?? currentPrebuild?.status?.taskLogs.filter((f) => f.logUrl)[0]?.taskId ?? "0";
 


### PR DESCRIPTION
## Description

Adds the following to the prebuild detail page:
1. Persistence of the actively selected task via URL hash
2. A margin for tab triggers, so that the focus ring can fit in there properly
3. Disables analytics tracking on the buttons changing the currently displayed task, so that our analytics don't show us what users name their tasks.


## How to test

https://ft-prebuild-ui-qol.preview.gitpod-dev.com/workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
