### PR TITLE
Improve dashboard and readme copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 - **Browser**: 
     - Using Gitpod dashboard [gitpod.io/new](https://gitpod.io/new).
-    - Add `gitpod.io/# `as a prefix to any of your GitHub/ GitLab/ BitBucket repository, like [this](https://gitpod.io/#https://github.com/gitpod-io/template-typescript-react)
+    - Add `gitpod.io/# `as a prefix to any of your GitHub/ GitLab/ Bitbucket repository, like [this](https://gitpod.io/#https://github.com/gitpod-io/template-typescript-react)
 - **CLI**: You can also [install Gitpod CLI](https://www.gitpod.io/docs/references/gitpod-cli#installation) and create your first workspace directly from your terminal :)
 
 

--- a/components/dashboard/src/teams/TeamAuthentication.tsx
+++ b/components/dashboard/src/teams/TeamAuthentication.tsx
@@ -97,7 +97,7 @@ const PrivateSourceControlAccess = () => {
         <ConfigurationSettingsField className="bg-pk-surface-secondary">
             <Heading3>Private source control access</Heading3>
             <Subheading className="mt-1">
-                Connect to your private source control like GitHub, BitBucket and GitLab
+                Connect to your private source control like GitHub, Bitbucket and GitLab
             </Subheading>
 
             <LinkButton

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -283,7 +283,7 @@ const WorkspaceClassesEnterpriseCallout = () => {
                 <PillLabel type="warn">Enterprise</PillLabel>
             </Heading3>
             <Subheading>
-                Access to more powerful workspace classes with up to 30 cores 54GB of RAM and 100GB storage
+                Access to more powerful workspace classes with up to 30 cores 54GB of RAM and 100GB of storage
             </Subheading>
 
             <div className="mt-6 flex flex-row space-x-2">

--- a/components/server/src/bitbucket/README.md
+++ b/components/server/src/bitbucket/README.md
@@ -1,6 +1,6 @@
-# BitBucket Integration tests
+# Bitbucket Integration tests
 
-To run the BitBucket integration tests via `npm test` the `GITPOD_TEST_TOKEN_BITBUCKET` environment variable needs to be defined:
+To run the Bitbucket integration tests via `npm test` the `GITPOD_TEST_TOKEN_BITBUCKET` environment variable needs to be defined:
 
 ```bash
 export GITPOD_TEST_TOKEN_BITBUCKET='{ "username": "$username", "value": "$applicationPassword", "scopes": [] }'

--- a/components/server/src/github/api.ts
+++ b/components/server/src/github/api.ts
@@ -158,7 +158,7 @@ export class GitHubRestApi {
     }
 
     protected get userAgent() {
-        return (this.config.oauth && new URL(this.config.oauth?.callBackUrl)?.hostname) || "GitPod unknown";
+        return (this.config.oauth && new URL(this.config.oauth?.callBackUrl)?.hostname) || "Gitpod unknown";
     }
 
     /**

--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -27,7 +27,7 @@ export class TokenService implements TokenProvider {
      *
      * The default lifetime of a token if not specified otherwise.
      * Atm we only specify a different lifetime on workspace starts (for the token we pass to "git clone" during content init).
-     * Also, this value is relevant for "opportunistic token refreshes" (enabled for BitBucket only atm): It's the time we mark a token as "reserved" (= do not opportunistically refresh it).
+     * Also, this value is relevant for "opportunistic token refreshes" (enabled for Bitbucket only atm): It's the time we mark a token as "reserved" (= do not opportunistically refresh it).
      */
     static readonly DEFAULT_LIFETIME = 5;
 


### PR DESCRIPTION
## Description

Improves consistency and adherence to brand guidelines of both Bitbucket and us :). Also improves copy for the new org settings pages.

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
