### PR TITLE
 [proxy] enable metrics for Caddy

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -22,6 +22,7 @@
 
 	servers {
 		protocols h1 h2 h2c
+		metrics
 	}
 }
 

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -26,6 +26,14 @@
 	}
 }
 
+# Define a matcher to exclude 502 errors on a specific path
+@exclude502 {
+    not {
+        path /_supervisor*
+        status 502
+    }
+}
+
 (compression) {
 	encode zstd gzip
 }
@@ -143,7 +151,7 @@
 
 # TODO: refactor once we can listen only in localhost
 :9545 {
-	metrics /metrics {
+	metrics /metrics @exclude502 {
 		disable_openmetrics
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Presently, we're only getting `caddy_reverse_proxy_upstreams_healthy` metric from caddy, which we cannot inspect to alert based on status code (like for 50x errors).

This change makes it possible to inspect caddy metrics like `caddy_http_response_duration_seconds_count{code=~"401|502"}`. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-268

## How to test
<!-- Provide steps to test this PR -->
From the preview, start a workspace, port-forward Grafana, and do `increase(caddy_http_response_duration_seconds_count{}[5m])`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
