### PR TITLE
[server] Remove old FGA feature flags:

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -179,10 +179,7 @@ function createServiceClient<T extends ServiceType>(
                 if (!jsonRpcOptions) {
                     return grpcClient;
                 }
-                const featureFlags = [
-                    `dashboard_public_api_${jsonRpcOptions.featureFlagSuffix}_enabled`,
-                    "centralizedPermissions",
-                ];
+                const featureFlags = [`dashboard_public_api_${jsonRpcOptions.featureFlagSuffix}_enabled`];
                 const resolvedFlags = await Promise.all(
                     featureFlags.map((ff) =>
                         experimentsClient.getValueAsync(ff, false, {

--- a/components/server/src/api/server.ts
+++ b/components/server/src/api/server.ts
@@ -26,7 +26,6 @@ import { AddressInfo } from "net";
 import { performance } from "perf_hooks";
 import { RateLimiterRes } from "rate-limiter-flexible";
 import { v4 } from "uuid";
-import { isFgaChecksEnabled } from "../authorization/authorizer";
 import { Config } from "../config";
 import { grpcServerHandled, grpcServerHandling, grpcServerStarted } from "../prometheus-metrics";
 import { SessionHandler } from "../session-handler";
@@ -366,11 +365,6 @@ export class API {
     }
 
     private async ensureFgaMigration(subjectId: SubjectId): Promise<void> {
-        const fgaChecksEnabled = await isFgaChecksEnabled(subjectId);
-        if (!fgaChecksEnabled) {
-            throw new ConnectError("unauthorized", Code.PermissionDenied);
-        }
-
         if (subjectId.kind === "user") {
             const userId = subjectId.userId()!;
             try {

--- a/components/server/src/auth/auth-provider-service.spec.db.ts
+++ b/components/server/src/auth/auth-provider-service.spec.db.ts
@@ -110,9 +110,7 @@ describe("AuthProviderService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         service = container.get(AuthProviderService);
         userService = container.get<UserService>(UserService);
         currentUser = await userService.createUser({

--- a/components/server/src/auth/bearer-authenticator.spec.db.ts
+++ b/components/server/src/auth/bearer-authenticator.spec.db.ts
@@ -46,9 +46,7 @@ describe("BearerAuth", () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         const oldConfig = container.get<Config>(Config);
         container.rebind(Config).toDynamicValue((ctx) => {
             return {

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -22,7 +22,6 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { UnauthorizedError } from "../errors";
 import { RepoURL } from "../repohost";
 import { HostContextProvider } from "./host-context-provider";
-import { isFgaChecksEnabled } from "../authorization/authorizer";
 import { reportGuardAccessCheck } from "../prometheus-metrics";
 import { getRequiredScopes } from "./auth-provider-scopes";
 import { FunctionAccessGuard } from "./function-access";
@@ -160,19 +159,17 @@ export class CompositeResourceAccessGuard implements ResourceAccessGuard {
  * FGAResourceAccessGuard can disable the delegate if FGA is enabled.
  */
 export class FGAResourceAccessGuard implements ResourceAccessGuard {
-    constructor(private readonly userId: string, private readonly delegate: ResourceAccessGuard) {}
+    constructor(
+        //@ts-ignore
+        private readonly userId: string,
+        //@ts-ignore
+        private readonly delegate: ResourceAccessGuard,
+    ) {}
 
     async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
-        const authorizerEnabled = await isFgaChecksEnabled(this.userId);
-        if (authorizerEnabled) {
-            // Authorizer takes over, so we should not check.
-            reportGuardAccessCheck("fga");
-            return true;
-        }
-        reportGuardAccessCheck("resource-access");
-
-        // FGA can't take over yet, so we delegate
-        return await this.delegate.canAccess(resource, operation);
+        // Authorizer takes over, so we should not check.
+        reportGuardAccessCheck("fga");
+        return true;
     }
 }
 
@@ -180,19 +177,17 @@ export class FGAResourceAccessGuard implements ResourceAccessGuard {
  * FGAFunctionAccessGuard can disable the delegate if FGA is enabled.
  */
 export class FGAFunctionAccessGuard {
-    constructor(private readonly userId: string, private readonly delegate: FunctionAccessGuard) {}
+    constructor(
+        //@ts-ignore
+        private readonly userId: string,
+        //@ts-ignore
+        private readonly delegate: FunctionAccessGuard,
+    ) {}
 
     async canAccess(name: string): Promise<boolean> {
-        const authorizerEnabled = await isFgaChecksEnabled(this.userId);
-        if (authorizerEnabled) {
-            // Authorizer takes over, so we should not check.
-            reportGuardAccessCheck("fga");
-            return true;
-        }
-        reportGuardAccessCheck("function-access");
-
-        // FGA can't take over yet, so we delegate
-        return this.delegate.canAccess(name);
+        // Authorizer takes over, so we should not check.
+        reportGuardAccessCheck("fga");
+        return true;
     }
 }
 

--- a/components/server/src/authorization/authorizer.spec.db.ts
+++ b/components/server/src/authorization/authorizer.spec.db.ts
@@ -27,9 +27,7 @@ describe("Authorizer", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         authorizer = container.get<Authorizer>(Authorizer);
     });
 

--- a/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
+++ b/components/server/src/authorization/caching-spicedb-authorizer.spec.db.ts
@@ -38,9 +38,7 @@ describe("CachingSpiceDBAuthorizer", async () => {
                 },
             }),
         } as any as ConfigProvider);
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         userSvc = container.get<UserService>(UserService);
         orgSvc = container.get<OrganizationService>(OrganizationService);
         workspaceSvc = container.get<WorkspaceService>(WorkspaceService);

--- a/components/server/src/authorization/relationship-updater.spec.db.ts
+++ b/components/server/src/authorization/relationship-updater.spec.db.ts
@@ -37,9 +37,7 @@ describe("RelationshipUpdater", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         BUILTIN_INSTLLATION_ADMIN_USER_ID;
         userDB = container.get<UserDB>(UserDB);
         orgDB = container.get<TeamDB>(TeamDB);
@@ -68,27 +66,6 @@ describe("RelationshipUpdater", async () => {
         await expected(rel.user(user.id).self.user(user.id));
         await notExpected(rel.installation.admin.user(user.id));
         await expected(rel.installation.member.user(user.id));
-    });
-
-    it("should update a simple user once it was feature-flag disabled", async () => {
-        let user = await userDB.newUser();
-
-        user = await migrator.migrate(user);
-        expect(user.fgaRelationshipsVersion).to.not.be.undefined;
-
-        Experiments.configureTestingClient({
-            centralizedPermissions: false,
-        });
-
-        user = await migrator.migrate(user);
-        expect(user.fgaRelationshipsVersion).to.be.undefined;
-
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
-
-        user = await migrator.migrate(user);
-        expect(user.fgaRelationshipsVersion).to.not.be.undefined;
     });
 
     it("should correctly update a simple user after it moves between org and installation level", async () => {

--- a/components/server/src/orgs/organization-service.spec.db.ts
+++ b/components/server/src/orgs/organization-service.spec.db.ts
@@ -37,7 +37,6 @@ describe("OrganizationService", async () => {
     beforeEach(async () => {
         container = createTestContainer();
         Experiments.configureTestingClient({
-            centralizedPermissions: true,
             dataops: true,
         });
         validateDefaultWorkspaceImage = undefined;
@@ -351,7 +350,6 @@ describe("OrganizationService", async () => {
 
     it("should add as set defaultRole with flexibleRole", async () => {
         Experiments.configureTestingClient({
-            centralizedPermissions: true,
             dataops: false,
         });
         await assertUserRole(collaborator.id, "collaborator");
@@ -369,7 +367,6 @@ describe("OrganizationService", async () => {
 
     it("should join an org with different cell id", async () => {
         Experiments.configureTestingClient({
-            centralizedPermissions: true,
             dataops: false,
         });
         const u1 = await userService.createUser({
@@ -385,7 +382,6 @@ describe("OrganizationService", async () => {
         await assertUserRole(u1.id, "member");
 
         Experiments.configureTestingClient({
-            centralizedPermissions: true,
             dataops: true,
         });
         const u2 = await userService.createUser({

--- a/components/server/src/orgs/usage-service.spec.db.ts
+++ b/components/server/src/orgs/usage-service.spec.db.ts
@@ -44,9 +44,7 @@ describe("UsageService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         os = container.get(OrganizationService);
         const userService = container.get<UserService>(UserService);
         owner = await userService.createUser({

--- a/components/server/src/projects/projects-service.spec.db.ts
+++ b/components/server/src/projects/projects-service.spec.db.ts
@@ -32,9 +32,7 @@ describe("ProjectsService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         const userDB = container.get<UserDB>(UserDB);
 
         // create the owner

--- a/components/server/src/scm/scm-service.spec.db.ts
+++ b/components/server/src/scm/scm-service.spec.db.ts
@@ -40,9 +40,7 @@ describe("ScmService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         service = container.get(ScmService);
         userService = container.get<UserService>(UserService);
         currentUser = await userService.createUser({

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -90,9 +90,7 @@ describe("EnvVarService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
 
         const userService = container.get<UserService>(UserService);
         owner = await userService.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID, BUILTIN_INSTLLATION_ADMIN_USER_ID);

--- a/components/server/src/user/gitpod-token-service.spec.db.ts
+++ b/components/server/src/user/gitpod-token-service.spec.db.ts
@@ -31,9 +31,7 @@ describe("GitpodTokenService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -42,9 +42,7 @@ describe("SSHKeyService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");

--- a/components/server/src/user/token-service.spec.db.ts
+++ b/components/server/src/user/token-service.spec.db.ts
@@ -67,9 +67,7 @@ describe("TokenService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
 
         // re-overwrite the stuff mocked out in createTestContainer
         container.rebind(TokenProvider).toService(TokenService);

--- a/components/server/src/user/user-service.spec.db.ts
+++ b/components/server/src/user/user-service.spec.db.ts
@@ -33,9 +33,7 @@ describe("UserService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         userService = container.get<UserService>(UserService);
         auth = container.get(Authorizer);
         orgService = container.get<OrganizationService>(OrganizationService);

--- a/components/server/src/workspace/context-service.spec.db.ts
+++ b/components/server/src/workspace/context-service.spec.db.ts
@@ -75,9 +75,7 @@ describe("ContextService", async () => {
 
     beforeEach(async () => {
         container = createTestContainer();
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         container.rebind(ConfigProvider).toConstantValue({
             fetchConfig: () => {
                 return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -121,7 +121,7 @@ import {
 } from "@gitpod/usage-api/lib/usage/v1/billing.pb";
 import { ClientError } from "nice-grpc-common";
 import { BillingModes } from "../billing/billing-mode";
-import { Authorizer, SYSTEM_USER, SYSTEM_USER_ID, isFgaChecksEnabled } from "../authorization/authorizer";
+import { Authorizer, SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 import { OrganizationService } from "../orgs/organization-service";
 import { RedisSubscriber } from "../messaging/redis-subscriber";
 import { UsageService } from "../orgs/usage-service";
@@ -547,25 +547,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = await this.checkUser("getWorkspace");
 
         const result = await this.workspaceService.getWorkspace(user.id, workspaceId);
-        const { workspace, latestInstance } = result;
-
-        // We must not try to fetch the team members if the user is FGA enabled, ebcause this might be a shared workspace, where the user has access to the workspace but not to the org.
-        if (!(await isFgaChecksEnabled(user.id))) {
-            const teamMembers = await this.organizationService.listMembers(user.id, workspace.organizationId);
-            await this.guardAccess({ kind: "workspace", subject: workspace, teamMembers: teamMembers }, "get");
-            if (!!latestInstance) {
-                await this.guardAccess(
-                    {
-                        kind: "workspaceInstance",
-                        subject: latestInstance,
-                        workspace,
-                        teamMembers,
-                    },
-                    "get",
-                );
-            }
-        }
-
         return {
             ...result,
             latestInstance: this.censorInstance(result.latestInstance),

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -46,7 +46,6 @@ import { SubjectId } from "../auth/subject-id";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
 import { validate as uuidValidate } from "uuid";
 import { getPrebuildErrorMessage } from "@gitpod/public-api-common/lib/prebuild-utils";
-import { isFgaChecksEnabled } from "../authorization/authorizer";
 
 @injectable()
 export class HeadlessLogController {
@@ -202,7 +201,7 @@ export class HeadlessLogController {
                 await runWithSubjectId(SubjectId.fromUserId(user.id), async () => {
                     // ensure fga migration
                     const subjectId = ctxTrySubjectId();
-                    if (!subjectId || !(await isFgaChecksEnabled(subjectId))) {
+                    if (!subjectId) {
                         res.status(403).send("unauthorized");
                         return;
                     }

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -50,9 +50,7 @@ describe("WorkspaceService", async () => {
                 },
             }),
         } as any as ConfigProvider);
-        Experiments.configureTestingClient({
-            centralizedPermissions: true,
-        });
+        Experiments.configureTestingClient({});
         const userService = container.get(UserService);
 
         // create the owner


### PR DESCRIPTION

## Description
Drops these feature flags we have not touched in month:
 - centralizedPermissions
 - spicedb_relationship_updates


## Related Issue(s)
Fixes ENT-276

## How to test
 - tests are all green

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-270-ff-removal</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-270-ff-removal.preview.gitpod-dev.com/workspaces" target="_blank">gpl-270-ff-removal.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-270-ff-removal-gha.26298</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-270-ff-removal%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
