### PR TITLE
[code] update code image layers

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -12,7 +12,7 @@
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-          "{{.Repository}}/ide/code-codehelper:commit-798b5892f5b2b4d21e9d2531eed82ee1aa93cf46"
+          "{{.Repository}}/ide/code-codehelper:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",
@@ -24,7 +24,7 @@
             "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",
             "imageLayers": [
               "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-              "{{.Repository}}/ide/code-codehelper:commit-798b5892f5b2b4d21e9d2531eed82ee1aa93cf46"
+              "{{.Repository}}/ide/code-codehelper:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
             ]
           },
           {


### PR DESCRIPTION
## Description
This PR updates the VS Code Browser image layers to the most recent intaller version.

## How to test

Test if changes are working.

i.e.
- `code-helper` it can start browser code with extensions installed
- `gitpod-web-extension` extension functionalities are works well
- `code` is not expected it to be changed

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-images</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-images.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-images.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-images-gha.26269</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-images%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment