### PR TITLE
[cleanup] Remove various feature flags I

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	PersonalAccessTokensEnabledFlag                = "personalAccessTokensEnabled"
 	OIDCServiceEnabledFlag                         = "oidcServiceEnabled"
 	SupervisorPersistServerAPIChannelWhenStartFlag = "supervisor_persist_serverapi_channel_when_start"
 	SupervisorUsePublicAPIFlag                     = "supervisor_experimental_publicapi"
@@ -19,10 +18,6 @@ const (
 	SetJavaXmxFlag                                 = "supervisor_set_java_xmx"
 	SetJavaProcessorCount                          = "supervisor_set_java_processor_count"
 )
-
-func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, PersonalAccessTokensEnabledFlag, false, attributes)
-}
 
 func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) []string {
 	value := client.GetStringValue(ctx, IdPClaimKeysFlag, "undefined", attributes)

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -24,7 +24,6 @@ const featureFlags = {
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,
     enabledOrbitalDiscoveries: "",
-    newProjectIncrementalRepoSearchBBS: false,
     repositoryFinderSearch: false,
     createProjectModal: false,
     configurationsAndPrebuilds: false,

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -19,7 +19,6 @@ const featureFlags = {
     userGitAuthProviders: false,
     linkedinConnectionForOnboarding: false,
     enableDedicatedOnboardingFlow: false,
-    phoneVerificationByCall: false,
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,
     enabledOrbitalDiscoveries: "",

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -12,7 +12,6 @@ import { useCurrentUser } from "../user-context";
 import { useCurrentOrg } from "./organizations/orgs-query";
 
 const featureFlags = {
-    personalAccessTokensEnabled: false,
     oidcServiceEnabled: false,
     // Default to true to enable on gitpod dedicated until ff support is added for dedicated
     orgGitAuthProviders: true,

--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -20,7 +20,6 @@ const featureFlags = {
     linkedinConnectionForOnboarding: false,
     enableDedicatedOnboardingFlow: false,
     phoneVerificationByCall: false,
-    doRetryUserLoader: true,
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,
     enabledOrbitalDiscoveries: "",

--- a/components/dashboard/src/hooks/use-user-loader.ts
+++ b/components/dashboard/src/hooks/use-user-loader.ts
@@ -10,13 +10,12 @@ import { trackLocation } from "../Analytics";
 import { useQuery } from "@tanstack/react-query";
 import { noPersistence } from "../data/setup";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { useFeatureFlag, useReportDashboardLoggingTracing } from "../data/featureflag-query";
+import { useReportDashboardLoggingTracing } from "../data/featureflag-query";
 import { userClient } from "../service/public-api";
 
 export let userLoaded = false;
 export const useUserLoader = () => {
     const { user, setUser } = useContext(UserContext);
-    const doRetryUserLoader = useFeatureFlag("doRetryUserLoader");
     const logTracing = useReportDashboardLoggingTracing();
 
     // For now, we're using the user context to store the user, but letting react-query handle the loading
@@ -31,9 +30,6 @@ export const useUserLoader = () => {
         useErrorBoundary: true,
         // It's important we don't retry as we want to show the login screen as quickly as possible if a 401
         retry: (_failureCount: number, error: Error & { code?: number }) => {
-            if (!doRetryUserLoader) {
-                return false;
-            }
             return error.code !== ErrorCodes.NOT_AUTHENTICATED && error.code !== ErrorCodes.USER_DELETED;
         },
         // docs: https://tanstack.com/query/v4/docs/react/guides/query-retries

--- a/components/dashboard/src/start/VerifyModal.tsx
+++ b/components/dashboard/src/start/VerifyModal.tsx
@@ -12,7 +12,6 @@ import "react-intl-tel-input/dist/main.css";
 import "./phone-input.css";
 import { Button } from "@podkit/buttons/Button";
 import { LinkButton } from "../components/LinkButton";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { verificationClient } from "../service/public-api";
 import { InputField } from "../components/forms/InputField";
 import { TextInputField } from "../components/forms/TextInputField";
@@ -34,7 +33,6 @@ interface VerifyModalState {
 export function VerifyModal() {
     const [state, setState] = useState<VerifyModalState>({});
     const [verificationId, setVerificationId] = useState("");
-    const phoneVerificationByCall = useFeatureFlag("phoneVerificationByCall");
 
     if (!state.sent) {
         const sendCode = async () => {
@@ -79,7 +77,7 @@ export function VerifyModal() {
                             </Button>
                         </Link>
                         <Button type="submit" disabled={!state.phoneNumberValid || state.sending}>
-                            {phoneVerificationByCall ? "Send Code via Voice call" : "Send Code via SMS"}
+                            {"Send Code via Voice call"}
                         </Button>
                     </div>
                 }
@@ -217,7 +215,7 @@ export function VerifyModal() {
                 )}
                 <TextInputField
                     label="Verification Code"
-                    placeholder={phoneVerificationByCall ? "Enter code sent via phone call" : "Enter code sent via SMS"}
+                    placeholder={"Enter code sent via phone call"}
                     type="text"
                     value={state.token}
                     autoFocus

--- a/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/user-settings/PageWithSettingsSubMenu.tsx
@@ -4,9 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useMemo } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { useFeatureFlag } from "../data/featureflag-query";
 import {
     settingsPathAccount,
     settingsPathIntegrations,
@@ -25,12 +23,7 @@ export interface PageWithAdminSubMenuProps {
 }
 
 export function PageWithSettingsSubMenu({ children }: PageWithAdminSubMenuProps) {
-    const enablePersonalAccessTokens = useFeatureFlag("personalAccessTokensEnabled");
-
-    const settingsMenu = useMemo(() => {
-        return getSettingsMenu(enablePersonalAccessTokens);
-    }, [enablePersonalAccessTokens]);
-
+    const settingsMenu = getSettingsMenu();
     return (
         <PageWithSubMenu subMenu={settingsMenu} title="User Settings" subtitle="Manage your personal account settings.">
             {children}
@@ -38,7 +31,7 @@ export function PageWithSettingsSubMenu({ children }: PageWithAdminSubMenuProps)
     );
 }
 
-function getSettingsMenu(enablePersonalAccessTokens?: boolean) {
+function getSettingsMenu() {
     return [
         {
             title: "Account",
@@ -60,18 +53,14 @@ function getSettingsMenu(enablePersonalAccessTokens?: boolean) {
             title: "Git Providers",
             link: [settingsPathIntegrations, "/access-control"],
         },
-        ...(enablePersonalAccessTokens
-            ? [
-                  {
-                      title: "Access Tokens",
-                      link: [
-                          settingsPathPersonalAccessTokens,
-                          settingsPathPersonalAccessTokenCreate,
-                          settingsPathPersonalAccessTokenEdit,
-                      ],
-                  },
-              ]
-            : []),
+        {
+            title: "Access Tokens",
+            link: [
+                settingsPathPersonalAccessTokens,
+                settingsPathPersonalAccessTokenCreate,
+                settingsPathPersonalAccessTokenEdit,
+            ],
+        },
         {
             title: "Preferences",
             link: [settingsPathPreferences],

--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -6,7 +6,7 @@
 
 import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_pb";
 import { useCallback, useEffect, useState } from "react";
-import { Redirect, useLocation } from "react-router";
+import { useLocation } from "react-router";
 import { personalAccessTokensService } from "../service/public-api";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { settingsPathPersonalAccessTokenCreate, settingsPathPersonalAccessTokenEdit } from "./settings.routes";
@@ -21,17 +21,10 @@ import TokenEntry from "./TokenEntry";
 import ShowTokenModal from "./ShowTokenModal";
 import Pagination from "../Pagination/Pagination";
 import { Heading2, Subheading } from "../components/typography/headings";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { Button } from "@podkit/buttons/Button";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 
 export default function PersonalAccessTokens() {
-    const enablePersonalAccessTokens = useFeatureFlag("personalAccessTokensEnabled");
-
-    if (!enablePersonalAccessTokens) {
-        return <Redirect to="/" />;
-    }
-
     return (
         <div>
             <PageWithSettingsSubMenu>

--- a/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokensCreateView.tsx
@@ -6,7 +6,7 @@
 
 import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_pb";
 import { useEffect, useMemo, useState } from "react";
-import { Redirect, useHistory, useParams } from "react-router";
+import { useHistory, useParams } from "react-router";
 import Alert from "../components/Alert";
 import DateSelector from "../components/DateSelector";
 import { SpinnerOverlayLoader } from "../components/Loader";
@@ -24,7 +24,7 @@ import ShowTokenModal from "./ShowTokenModal";
 import { Timestamp } from "@bufbuild/protobuf";
 import arrowDown from "../images/sort-arrow.svg";
 import { Heading2, Subheading } from "../components/typography/headings";
-import { useFeatureFlag, useIsDataOps } from "../data/featureflag-query";
+import { useIsDataOps } from "../data/featureflag-query";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 import { Button } from "@podkit/buttons/Button";
 import { TextInputField } from "../components/forms/TextInputField";
@@ -39,8 +39,6 @@ interface EditPATData {
 const personalAccessTokenNameRegex = /^[a-zA-Z0-9-_ ]{3,63}$/;
 
 function PersonalAccessTokenCreateView() {
-    const enablePersonalAccessTokens = useFeatureFlag("personalAccessTokensEnabled");
-
     const params = useParams<{ tokenId?: string }>();
     const history = useHistory<TokenInfo>();
 
@@ -153,10 +151,6 @@ function PersonalAccessTokenCreateView() {
             setErrorMsg(e.message);
         }
     };
-
-    if (!enablePersonalAccessTokens) {
-        return <Redirect to="/" />;
-    }
 
     return (
         <div>

--- a/components/public-api-server/pkg/apiv1/tokens.go
+++ b/components/public-api-server/pkg/apiv1/tokens.go
@@ -303,39 +303,12 @@ func (s *TokensService) getUser(ctx context.Context, conn protocol.APIInterface)
 
 	log.AddFields(ctx, log.UserID(user.ID))
 
-	if !s.isFeatureEnabled(ctx, conn, user) {
-		return nil, uuid.Nil, connect.NewError(connect.CodePermissionDenied, errors.New("This feature is currently in beta. If you would like to be part of the beta, please contact us."))
-	}
-
 	userID, err := uuid.Parse(user.ID)
 	if err != nil {
 		return nil, uuid.Nil, connect.NewError(connect.CodeInternal, errors.New("Failed to parse user ID as UUID. Please contact support."))
 	}
 
 	return user, userID, nil
-}
-
-func (s *TokensService) isFeatureEnabled(ctx context.Context, conn protocol.APIInterface, user *protocol.User) bool {
-	if user == nil {
-		return false
-	}
-
-	if experiments.IsPersonalAccessTokensEnabled(ctx, s.expClient, experiments.Attributes{UserID: user.ID}) {
-		return true
-	}
-
-	teams, err := conn.GetTeams(ctx)
-	if err != nil {
-		log.Extract(ctx).WithError(err).Warnf("Failed to retreive Teams for user %s, personal access token feature flag will not evaluate team membership.", user.ID)
-		teams = nil
-	}
-	for _, team := range teams {
-		if experiments.IsPersonalAccessTokensEnabled(ctx, s.expClient, experiments.Attributes{TeamID: team.ID}) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func getConnection(ctx context.Context, pool proxy.ServerConnectionPool) (protocol.APIInterface, error) {

--- a/components/public-api-server/pkg/apiv1/tokens_test.go
+++ b/components/public-api-server/pkg/apiv1/tokens_test.go
@@ -44,23 +44,6 @@ var (
 func TestTokensService_CreatePersonalAccessTokenWithoutFeatureFlag(t *testing.T) {
 	user := newUser(&protocol.User{})
 
-	t.Run("permission denied when feature flag is not enabled", func(t *testing.T) {
-		serverMock, _, client := setupTokensService(t, experimentsClient)
-
-		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
-		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
-
-		_, err := client.CreatePersonalAccessToken(context.Background(), connect.NewRequest(&v1.CreatePersonalAccessTokenRequest{
-			Token: &v1.PersonalAccessToken{
-				Name:           "my-token",
-				ExpirationTime: timestamppb.Now(),
-			},
-		}))
-
-		require.Error(t, err, "This feature is currently in beta. If you would like to be part of the beta, please contact us.")
-		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-	})
-
 	t.Run("invalid argument when name is not specified", func(t *testing.T) {
 		_, _, client := setupTokensService(t, experimentsClient)
 
@@ -272,42 +255,10 @@ func TestTokensService_GetPersonalAccessToken(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 	})
-
-	t.Run("permission denied when feature flag disabled", func(t *testing.T) {
-		serverMock, dbConn, client := setupTokensService(t, experimentsClient)
-
-		tokens := dbtest.CreatePersonalAccessTokenRecords(t, dbConn,
-			dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
-				UserID: uuid.MustParse(user.ID),
-			}),
-		)
-
-		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
-		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
-
-		_, err := client.GetPersonalAccessToken(context.Background(), connect.NewRequest(&v1.GetPersonalAccessTokenRequest{
-			Id: tokens[0].ID.String(),
-		}))
-
-		require.Error(t, err, "This feature is currently in beta. If you would like to be part of the beta, please contact us.")
-		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-	})
 }
 
 func TestTokensService_ListPersonalAccessTokens(t *testing.T) {
 	user := newUser(&protocol.User{})
-
-	t.Run("permission denied when feature flag is disabled", func(t *testing.T) {
-		serverMock, _, client := setupTokensService(t, experimentsClient)
-
-		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
-		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
-
-		_, err := client.ListPersonalAccessTokens(context.Background(), connect.NewRequest(&v1.ListPersonalAccessTokensRequest{}))
-
-		require.Error(t, err, "This feature is currently in beta. If you would like to be part of the beta, please contact us.")
-		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-	})
 
 	t.Run("no tokens returns empty list", func(t *testing.T) {
 		serverMock, _, client := setupTokensService(t, experimentsClient)
@@ -408,21 +359,6 @@ func TestTokensService_RegeneratePersonalAccessToken(t *testing.T) {
 	user := newUser(&protocol.User{})
 	user2 := newUser(&protocol.User{})
 
-	t.Run("permission denied when feature flag is disabled", func(t *testing.T) {
-		serverMock, _, client := setupTokensService(t, experimentsClient)
-
-		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
-		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
-
-		_, err := client.RegeneratePersonalAccessToken(context.Background(), connect.NewRequest(&v1.RegeneratePersonalAccessTokenRequest{
-			Id:             uuid.New().String(),
-			ExpirationTime: timestamppb.Now(),
-		}))
-
-		require.Error(t, err, "This feature is currently in beta. If you would like to be part of the beta, please contact us.")
-		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-	})
-
 	t.Run("invalid argument when Token ID is empty", func(t *testing.T) {
 		_, _, client := setupTokensService(t, experimentsClient)
 
@@ -503,28 +439,6 @@ func TestTokensService_RegeneratePersonalAccessToken(t *testing.T) {
 
 func TestTokensService_UpdatePersonalAccessToken(t *testing.T) {
 	user := newUser(&protocol.User{})
-
-	t.Run("permission denied when feature flag is disabled", func(t *testing.T) {
-		serverMock, _, client := setupTokensService(t, experimentsClient)
-
-		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
-		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
-
-		token := &v1.PersonalAccessToken{
-			Id:   uuid.New().String(),
-			Name: "foo-bar",
-		}
-		mask, err := fieldmaskpb.New(token, "name")
-		require.NoError(t, err)
-
-		_, err = client.UpdatePersonalAccessToken(context.Background(), connect.NewRequest(&v1.UpdatePersonalAccessTokenRequest{
-			Token:      token,
-			UpdateMask: mask,
-		}))
-
-		require.Error(t, err, "This feature is currently in beta. If you would like to be part of the beta, please contact us.")
-		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-	})
 
 	t.Run("invalid argument when Token ID is empty", func(t *testing.T) {
 		_, _, client := setupTokensService(t, experimentsClient)

--- a/components/server/src/api/verification-service-api.ts
+++ b/components/server/src/api/verification-service-api.ts
@@ -15,12 +15,10 @@ import {
 } from "@gitpod/public-api/lib/gitpod/v1/verification_pb";
 import { inject, injectable } from "inversify";
 import { VerificationService } from "../auth/verification-service";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { ctxUserId } from "../util/request-context";
 import { UserService } from "../user/user-service";
 import { formatPhoneNumber } from "../user/phone-numbers";
 import { validate as uuidValidate } from "uuid";
-import { getPrimaryEmail } from "@gitpod/public-api-common/lib/user-utils";
 
 @injectable()
 export class VerificationServiceAPI implements ServiceImpl<typeof VerificationServiceInterface> {
@@ -35,21 +33,7 @@ export class VerificationServiceAPI implements ServiceImpl<typeof VerificationSe
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "phoneNumber is required");
         }
 
-        const userId = ctxUserId();
-        const user = await this.userService.findUserById(userId, userId);
-
-        // Check if verify via call is enabled
-        const phoneVerificationByCall = await getExperimentsClientForBackend().getValueAsync(
-            "phoneVerificationByCall",
-            false,
-            {
-                user: {
-                    id: user.id,
-                    email: getPrimaryEmail(user),
-                },
-            },
-        );
-        const channel = phoneVerificationByCall ? "call" : "sms";
+        const channel = "call";
         const verificationId = await this.verificationService.sendVerificationToken(
             formatPhoneNumber(req.phoneNumber),
             channel,

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -446,20 +446,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<{ verificationId: string }> {
         const user = await this.checkUser("sendPhoneNumberVerificationToken");
 
-        // Check if verify via call is enabled
-        const phoneVerificationByCall = await getExperimentsClientForBackend().getValueAsync(
-            "phoneVerificationByCall",
-            false,
-            {
-                user: {
-                    id: user.id,
-                    email: getPrimaryEmail(user),
-                },
-            },
-        );
-
-        const channel = phoneVerificationByCall ? "call" : "sms";
-
+        const channel = "call";
         const verificationId = await this.verificationService.sendVerificationToken(
             user.id,
             formatPhoneNumber(rawPhoneNumber),


### PR DESCRIPTION
## Description
Drops the following feature flags:
 - [newProjectIncrementalRepoSearchBBS](https://github.com/gitpod-io/gitpod/commit/4302056da0c27ffda269de4b5ec642ac1045d65c)
 - [doRetryUserLoader](https://github.com/gitpod-io/gitpod/commit/cec8ff0f0b66c4c3d555ad2499a036e0ab0014c1)
 - [phoneVerificationByCall](https://github.com/gitpod-io/gitpod/commit/6c3a6c74c171ba3e4656ca2eec7e3e3d45b3c0ee)
 - [personalAccessTokensEnabled](https://github.com/gitpod-io/gitpod/commit/cd9c2cee572b805b93b8328a9f62e6e8db964327)

## Related Issue(s)
Related: ENT-277

## How to test
 - tests are green

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
