### PR TITLE
[proxy] enable metrics for Caddy again

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -22,7 +22,16 @@
 
 	servers {
 		protocols h1 h2 h2c
+		metrics
 	}
+}
+
+# Define a matcher to exclude 502 errors on a specific path
+@exclude502 {
+    not {
+        path /_supervisor*
+        status 502
+    }
 }
 
 (compression) {
@@ -142,7 +151,7 @@
 
 # TODO: refactor once we can listen only in localhost
 :9545 {
-	metrics /metrics {
+	metrics /metrics @exclude502 {
 		disable_openmetrics
 	}
 }

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -143,15 +143,8 @@
 
 # TODO: refactor once we can listen only in localhost
 :9545 {
-	# Define a matcher to exclude 502 errors on a specific path
-	@exclude502 {
-    not {
-        path /_supervisor*
-        status 502
-    }
-}
 
-	metrics /metrics @exclude502 {
+	metrics /metrics {
 		disable_openmetrics
 	}
 }

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -26,14 +26,6 @@
 	}
 }
 
-# Define a matcher to exclude 502 errors on a specific path
-@exclude502 {
-    not {
-        path /_supervisor*
-        status 502
-    }
-}
-
 (compression) {
 	encode zstd gzip
 }
@@ -151,6 +143,14 @@
 
 # TODO: refactor once we can listen only in localhost
 :9545 {
+	# Define a matcher to exclude 502 errors on a specific path
+	@exclude502 {
+    not {
+        path /_supervisor*
+        status 502
+    }
+}
+
 	metrics /metrics @exclude502 {
 		disable_openmetrics
 	}


### PR DESCRIPTION
## Description
Reverts gitpod-io/gitpod#19882, and removes the filter which was causing caddy to fail and proxy to crash loop.

This configuration causes Caddy to emit additional metrics, which we can later use in alerts.

## Related Issue(s)
Related to ENT-268

## How to test
See test results in comments below. If you wish, test in the [preview](https://revert-1981b51a215b4.preview.gitpod-dev.com/workspaces), too.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
