### PR TITLE
Increase OAuth isHostReachable timeout from 2 to 15 seconds

### DIFF
--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -416,7 +416,8 @@ export class AuthProviderService {
     async isHostReachable(host: string): Promise<boolean> {
         try {
             // Don't attempt to follow redirects, and manually check response status code
-            const resp = await fetch(`https://${host}`, { timeout: 2000, redirect: "manual" });
+            // set the timeout to a rather high number, because we're seeing Bitbuckets in the wild that have a response time of 10 seconds for unauthenticated users.
+            const resp = await fetch(`https://${host}`, { timeout: 15000, redirect: "manual" });
             return resp.status <= 399;
         } catch (error) {
             console.log(`Host is not reachable: ${host}`);


### PR DESCRIPTION
## Description
We received this error report:
![image](https://github.com/gitpod-io/gitpod/assets/239422/9c635470-0ee7-411d-8947-30c1f8cb5aaf)

The cause is that the customer's BitBucketserver takes ~10 seconds to respond to unauthenticated users:
```
time curl https://<host>/
curl https://<host>/  0.01s user 0.01s system 0% cpu 9.341 total
```

This PR increases the timeout from 2 to 15 seconds to avoid the timeout. 

See [here](https://github.com/node-fetch/node-fetch/blob/9b9d45881e5ca68757077726b3c0ecf8fdca1f29/README.md?plain=1#L375) for the docs of the node-fetch timeout param.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # [Internal Slack conversation](https://gitpod.slack.com/archives/C059NL06LAW/p1718201909280499?thread_ts=1695810903.200579&cid=C059NL06LAW).

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
