### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -128,7 +128,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/intellij:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -200,7 +200,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/goland:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -261,7 +261,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/pycharm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -321,7 +321,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/phpstorm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -381,7 +381,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/rubymine:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -441,7 +441,7 @@
             "version": "2024.1.4",
             "image": "{{.Repository}}/ide/webstorm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -509,7 +509,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/rider:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -561,7 +561,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/clion:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },
@@ -611,9 +611,9 @@
         "versions": [
           {
             "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rustrover:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
+            "image": "{{.Repository}}/ide/rustrover:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-e88d92a72505bf1798bc70ab47ff0e05b02d4c72",
               "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
             ]
           },


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.
- [ ] Warmup is working properly using IntelliJ and spring-petclinic project sample

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_