### PR TITLE
[cleanup] remove FF for supervisor publicapi

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -10,13 +10,11 @@ import (
 )
 
 const (
-	OIDCServiceEnabledFlag                         = "oidcServiceEnabled"
-	SupervisorPersistServerAPIChannelWhenStartFlag = "supervisor_persist_serverapi_channel_when_start"
-	SupervisorUsePublicAPIFlag                     = "supervisor_experimental_publicapi"
-	ServiceWaiterSkipComponentsFlag                = "service_waiter_skip_components"
-	IdPClaimKeysFlag                               = "idp_claim_keys"
-	SetJavaXmxFlag                                 = "supervisor_set_java_xmx"
-	SetJavaProcessorCount                          = "supervisor_set_java_processor_count"
+	OIDCServiceEnabledFlag          = "oidcServiceEnabled"
+	ServiceWaiterSkipComponentsFlag = "service_waiter_skip_components"
+	IdPClaimKeysFlag                = "idp_claim_keys"
+	SetJavaXmxFlag                  = "supervisor_set_java_xmx"
+	SetJavaProcessorCount           = "supervisor_set_java_processor_count"
 )
 
 func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) []string {
@@ -29,14 +27,6 @@ func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) 
 
 func IsOIDCServiceEnabled(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, OIDCServiceEnabledFlag, false, attributes)
-}
-
-func SupervisorPersistServerAPIChannelWhenStart(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, SupervisorPersistServerAPIChannelWhenStartFlag, true, attributes)
-}
-
-func SupervisorUsePublicAPI(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, SupervisorUsePublicAPIFlag, false, attributes)
 }
 
 func IsSetJavaXmx(ctx context.Context, client Client, attributes Attributes) bool {

--- a/components/supervisor/pkg/serverapi/metrics.go
+++ b/components/supervisor/pkg/serverapi/metrics.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	ServerTypeServerAPI = "server-api"
 	ServerTypePublicAPI = "public-api"
 )
 
@@ -44,12 +43,9 @@ func NewClientMetrics() *ClientMetrics {
 	}
 }
 
-func (c *ClientMetrics) ProcessMetrics(usePublicAPI bool, method string, err error, startTime time.Time) {
+func (c *ClientMetrics) ProcessMetrics(method string, err error, startTime time.Time) {
 	code := status.Code(normalizeError(err))
-	server := ServerTypeServerAPI
-	if usePublicAPI {
-		server = ServerTypePublicAPI
-	}
+	server := ServerTypePublicAPI
 	c.clientHandledCounter.WithLabelValues(method, server, code.String()).Inc()
 	c.clientHandledHistogram.WithLabelValues(method, server, code.String()).Observe(time.Since(startTime).Seconds())
 }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -284,7 +284,7 @@ func Run(options ...RunOption) {
 			OwnerID:           cfg.OwnerId,
 			SupervisorVersion: Version,
 			ConfigcatEnabled:  cfg.ConfigcatEnabled,
-		}, tokenService, exps)
+		}, tokenService)
 	}
 
 	if cfg.GetDesktopIDE() != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal doc](https://www.notion.so/gitpod/supervisor_experimental_publicapi-89efa2ae7e7e4899bf3ae0086ee4f862?pvs=4)

## How to test
<!-- Provide steps to test this PR -->
Workspace should work well like before:
- git push
- open port
- git status update
- ...

✅ 
|Workspace start and git status|Port Public|
|:-:|:-:|
|<img width="1143" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/91139bd7-7566-4d77-a65c-c8ee8ac7dc4c">|<img width="1074" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/806be171-9812-41e5-9bab-2f15823c52bc">|




## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ff-1</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ff-1.preview.gitpod-dev.com/workspaces" target="_blank">hw-ff-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ff-1-gha.26312</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ff-1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
