### PR TITLE
[dashboard] Fix PrebuildStatus rendering and updating (on PrebuildList)

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -13,7 +13,7 @@ import {
     Disposable,
 } from "@gitpod/gitpod-protocol";
 import { getGitpodService } from "../service/service";
-import { PrebuildStatus } from "../projects/Prebuilds";
+import { PrebuildStatusOld } from "../projects/prebuild-utils";
 import { watchWorkspaceStatus } from "../data/workspaces/listen-to-workspace-ws-messages";
 import { prebuildClient, watchPrebuild, workspaceClient } from "../service/public-api";
 import { GetWorkspaceRequest, WorkspacePhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
@@ -177,7 +177,7 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                 </Suspense>
             </div>
             <div className="w-full bottom-0 h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex flex-row items-center space-x-2">
-                {prebuild && <PrebuildStatus prebuild={prebuild} />}
+                {prebuild && <PrebuildStatusOld prebuild={prebuild} />}
                 <div className="flex-grow" />
                 {props.children}
             </div>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -15,6 +15,7 @@ import { usePrebuildLogsEmitter } from "../../data/prebuilds/prebuild-logs-emitt
 import React from "react";
 import { useToast } from "../../components/toasts/Toasts";
 import {
+    isPrebuildDone,
     useCancelPrebuildMutation,
     usePrebuildQuery,
     useTriggerPrebuildQuery,
@@ -98,6 +99,8 @@ export const PrebuildDetailPage: FC = () => {
                 disposeStreamingLogs?.dispose();
             }
             setCurrentPrebuild(prebuild);
+
+            return isPrebuildDone(prebuild);
         });
 
         return () => {

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -10,7 +10,6 @@ import { Text } from "@podkit/typography/Text";
 import { Button } from "@podkit/buttons/Button";
 import { FC, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { Redirect, useHistory, useParams } from "react-router";
-import { CircleSlash, Loader2Icon } from "lucide-react";
 import dayjs from "dayjs";
 import { usePrebuildLogsEmitter } from "../../data/prebuilds/prebuild-logs-emitter";
 import React from "react";
@@ -25,11 +24,9 @@ import { LinkButton } from "@podkit/buttons/LinkButton";
 import { repositoriesRoutes } from "../../repositories/repositories.routes";
 import { LoadingState } from "@podkit/loading/LoadingState";
 import Alert from "../../components/Alert";
-import { prebuildDisplayProps, prebuildStatusIconComponent } from "../../projects/prebuild-utils";
+import { PrebuildStatus } from "../../projects/prebuild-utils";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { MiddleDot } from "../../components/typography/MiddleDot";
-import { TextMuted } from "@podkit/typography/TextMuted";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@podkit/tabs/Tabs";
 
 const WorkspaceLogs = React.lazy(() => import("../../components/WorkspaceLogs"));
@@ -69,11 +66,7 @@ export const PrebuildDetailPage: FC = () => {
 
     const taskId = selectedTaskId ?? currentPrebuild?.status?.taskLogs.filter((f) => f.logUrl)[0]?.taskId ?? "0";
 
-    const {
-        emitter: logEmitter,
-        isLoading: isStreamingLogs,
-        disposable: disposeStreamingLogs,
-    } = usePrebuildLogsEmitter(prebuildId, taskId);
+    const { emitter: logEmitter, disposable: disposeStreamingLogs } = usePrebuildLogsEmitter(prebuildId, taskId);
     const {
         isFetching: isTriggeringPrebuild,
         refetch: triggerPrebuild,
@@ -169,32 +162,6 @@ export const PrebuildDetailPage: FC = () => {
         }
     }, [prebuild, cancelPrebuildMutation]);
 
-    const prebuildPhase = useMemo(() => {
-        const loaderIcon = <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
-
-        if (!currentPrebuild) {
-            return {
-                icon: loaderIcon,
-                description: "",
-            };
-        }
-
-        if (!currentPrebuild.status?.phase?.name) {
-            return {
-                icon: <CircleSlash size={20} className="text-gray-500" />,
-                description: "Unknown prebuild status.",
-            };
-        }
-
-        const props = prebuildDisplayProps(currentPrebuild);
-        const Icon = prebuildStatusIconComponent(currentPrebuild);
-
-        return {
-            description: props.label,
-            icon: <Icon className={props.className} />,
-        };
-    }, [currentPrebuild]);
-
     if (newPrebuildID) {
         return <Redirect to={repositoriesRoutes.PrebuildDetail(newPrebuildID)} />;
     }
@@ -270,19 +237,11 @@ export const PrebuildDetailPage: FC = () => {
                                 </div>
                             </div>
                             <div className="flex flex-col gap-1 border-pk-border-base">
-                                <div className="py-4 flex flex-col gap-1">
-                                    <div className="px-6 flex gap-1 items-center">
-                                        {prebuildPhase.icon}
-                                        <span className="capitalize">{prebuildPhase.description}</span>{" "}
-                                        {isStreamingLogs && (
-                                            <TextMuted>
-                                                <MiddleDot /> Fetching logs...
-                                            </TextMuted>
-                                        )}
-                                    </div>
-                                    {prebuild.status?.message && (
-                                        <div className="px-6 text-pk-content-secondary truncate">
-                                            {prebuild.status.message}
+                                <div className="py-4 px-6 flex flex-col gap-1">
+                                    <PrebuildStatus prebuild={currentPrebuild} />
+                                    {currentPrebuild?.status?.message && (
+                                        <div className="text-pk-content-secondary truncate">
+                                            {currentPrebuild?.status.message}
                                         </div>
                                     )}
                                 </div>

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -11,11 +11,10 @@ import { LinkButton } from "@podkit/buttons/LinkButton";
 import { TableCell, TableRow } from "@podkit/tables/Table";
 import type { Prebuild } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import dayjs from "dayjs";
-import { cn } from "@podkit/lib/cn";
 import { shortCommitMessage } from "../../projects/render-utils";
 import { Link } from "react-router-dom";
 import { Configuration } from "@gitpod/public-api/lib/gitpod/v1/configuration_pb";
-import { prebuildDisplayProps, prebuildStatusIconComponent } from "../../projects/prebuild-utils";
+import { PrebuildStatus } from "../../projects/prebuild-utils";
 
 /**
  * Formats a date. For today, it returns the time. For this year, it returns the month, day and time. Otherwise, it returns the full date (month, day, year).
@@ -38,9 +37,6 @@ type Props = {
 export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
     const triggeredDate = useMemo(() => dayjs(prebuild.status?.startTime?.toDate()), [prebuild.status?.startTime]);
     const triggeredString = useMemo(() => formatDate(triggeredDate), [triggeredDate]);
-
-    const { className: iconColorClass, label } = prebuildDisplayProps(prebuild);
-    const PrebuildStatusIcon = prebuildStatusIconComponent(prebuild);
 
     return (
         <TableRow>
@@ -83,10 +79,7 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
             </TableCell>
 
             <TableCell>
-                <div className="flex flex-row gap-1.5 items-center capitalize">
-                    <PrebuildStatusIcon className={cn("w-5 h-5", iconColorClass)} />
-                    <span className="text-sm text-pk-content-secondary">{label}</span>
-                </div>
+                <PrebuildStatus prebuild={prebuild} classname="w-5 h-5" />
             </TableCell>
 
             <TableCell>

--- a/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListItem.tsx
@@ -79,7 +79,7 @@ export const PrebuildListItem: FC<Props> = ({ prebuild }) => {
             </TableCell>
 
             <TableCell>
-                <PrebuildStatus prebuild={prebuild} classname="w-5 h-5" />
+                <PrebuildStatus prebuild={prebuild} classname="size-5" />
             </TableCell>
 
             <TableCell>

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -20,7 +20,7 @@ import Tooltip from "../components/Tooltip";
 import { prebuildClient, watchPrebuild } from "../service/public-api";
 import { Prebuild, PrebuildPhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
 import { Button } from "@podkit/buttons/Button";
-import { getPrebuildStatusDescription, prebuildStatusIcon, prebuildStatusLabel } from "./prebuild-utils";
+import { PrebuildStatus } from "./prebuild-utils";
 
 export default function PrebuildsPage(props: { project?: Project; isAdminDashboard?: boolean }) {
     const currentProject = useCurrentProject();
@@ -212,15 +212,7 @@ export default function PrebuildsPage(props: { project?: Project; isAdminDashboa
                                         }`}
                                     >
                                         <div>
-                                            <div
-                                                className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1"
-                                                title={getPrebuildStatusDescription(p)}
-                                            >
-                                                <div className="inline-block align-text-bottom mr-2 w-4 h-4">
-                                                    {prebuildStatusIcon(p)}
-                                                </div>
-                                                {prebuildStatusLabel(p)}
-                                            </div>
+                                            <PrebuildStatus prebuild={p} />
                                             <p>
                                                 <Tooltip
                                                     content={dayjs(p.status?.startTime?.toDate()).format("MMM D, YYYY")}
@@ -277,23 +269,5 @@ export default function PrebuildsPage(props: { project?: Project; isAdminDashboa
                 )}
             </div>
         </>
-    );
-}
-
-export function PrebuildStatus(props: { prebuild: Prebuild }) {
-    const prebuild = props.prebuild;
-
-    return (
-        <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
-            <div>
-                <div className="flex space-x-1 items-center">
-                    {prebuildStatusIcon(prebuild)}
-                    {prebuildStatusLabel(prebuild)}
-                </div>
-            </div>
-            <div className="flex space-x-1 items-center text-gray-400">
-                <span className="text-left">{getPrebuildStatusDescription(prebuild)}</span>
-            </div>
-        </div>
     );
 }

--- a/components/dashboard/src/projects/prebuild-utils.tsx
+++ b/components/dashboard/src/projects/prebuild-utils.tsx
@@ -5,8 +5,9 @@
  */
 
 import { Prebuild, PrebuildPhase_Phase } from "@gitpod/public-api/lib/gitpod/v1/prebuild_pb";
-import { PauseCircle, LucideProps, Clock, CheckCircle2, XCircle } from "lucide-react";
+import { PauseCircle, LucideProps, Clock, CheckCircle2, XCircle, Loader2Icon } from "lucide-react";
 import type { ForwardRefExoticComponent } from "react";
+import { cn } from "@podkit/lib/cn";
 
 import StatusDone from "../icons/StatusDone.svg";
 import StatusFailed from "../icons/StatusFailed.svg";
@@ -14,8 +15,40 @@ import StatusCanceled from "../icons/StatusCanceled.svg";
 import StatusPaused from "../icons/StatusPaused.svg";
 import StatusRunning from "../icons/StatusRunning.svg";
 
-export const prebuildDisplayProps = (prebuild: Prebuild): { className: string; label: string } => {
-    switch (prebuild.status?.phase?.name) {
+export function PrebuildStatus(p: { prebuild: Prebuild | undefined; classname?: string }) {
+    const prebuild = p.prebuild;
+
+    const { className: iconColorClass, label } = prebuildDisplayProps(prebuild);
+    const PrebuildStatusIcon = prebuildStatusIconComponent(prebuild);
+    return (
+        <div className="flex flex-row gap-1.5 items-center capitalize">
+            <PrebuildStatusIcon className={cn(p.classname, iconColorClass)} />
+            <span>{label}</span>
+        </div>
+    );
+}
+
+export function PrebuildStatusOld(props: { prebuild: Prebuild | undefined }) {
+    const prebuild = props.prebuild;
+
+    return (
+        <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
+            <div>
+                <div className="flex space-x-1 items-center">
+                    {prebuildStatusIcon(prebuild)}
+                    {prebuildStatusLabel(prebuild)}
+                </div>
+            </div>
+            <div className="flex space-x-1 items-center text-gray-400">
+                <span className="text-left">{getPrebuildStatusDescription(prebuild)}</span>
+            </div>
+        </div>
+    );
+}
+
+const prebuildDisplayProps = (prebuild: Prebuild | undefined): { className: string; label: string } => {
+    switch (prebuild?.status?.phase?.name) {
+        case undefined: // Fall through
         case PrebuildPhase_Phase.UNSPECIFIED: // Fall through
         case PrebuildPhase_Phase.QUEUED:
             return { className: "text-orange-500", label: "pending" };
@@ -37,13 +70,13 @@ export const prebuildDisplayProps = (prebuild: Prebuild): { className: string; l
     return { className: "", label: "" };
 };
 
-export const prebuildStatusLabel = (prebuild: Prebuild): JSX.Element => {
+export const prebuildStatusLabel = (prebuild: Prebuild | undefined): JSX.Element => {
     const { className, label } = prebuildDisplayProps(prebuild);
     return <span className={`font-medium ${className} uppercase`}>{label}</span>;
 };
 
-export const prebuildStatusIconComponent = (prebuild: Prebuild): ForwardRefExoticComponent<LucideProps> => {
-    switch (prebuild.status?.phase?.name) {
+const prebuildStatusIconComponent = (prebuild: Prebuild | undefined): ForwardRefExoticComponent<LucideProps> => {
+    switch (prebuild?.status?.phase?.name) {
         case PrebuildPhase_Phase.UNSPECIFIED: // Fall through
         case PrebuildPhase_Phase.QUEUED:
             return PauseCircle;
@@ -64,6 +97,10 @@ export const prebuildStatusIconComponent = (prebuild: Prebuild): ForwardRefExoti
 };
 
 export const prebuildStatusIcon = (prebuild?: Prebuild) => {
+    if (!prebuild) {
+        return <Loader2Icon size={20} className="text-gray-500 animate-spin" />;
+    }
+
     switch (prebuild?.status?.phase?.name) {
         case PrebuildPhase_Phase.UNSPECIFIED: // Fall through
         case PrebuildPhase_Phase.QUEUED:
@@ -84,8 +121,8 @@ export const prebuildStatusIcon = (prebuild?: Prebuild) => {
     }
 };
 
-export const getPrebuildStatusDescription = (prebuild: Prebuild): string => {
-    switch (prebuild.status?.phase?.name) {
+const getPrebuildStatusDescription = (prebuild: Prebuild | undefined): string => {
+    switch (prebuild?.status?.phase?.name) {
         case PrebuildPhase_Phase.QUEUED:
             return `Prebuild is queued and will be processed when there is execution capacity.`;
         case PrebuildPhase_Phase.BUILDING:


### PR DESCRIPTION
## Description
This PR:
 - does make sure we are using the same `PrebuildStatus` component everywhere
 - registers listeners for not-done prebuilds on the `PrebuildList` page

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-271
Fixes ENT-231

## How to test
 - [join my org](https://gpl-271-pb-ready.preview.gitpod-dev.com/orgs/join?inviteId=84e2e93b-f0b8-4c94-b50a-eb1eeb736c78)
 - [trigger a prebuild](https://gpl-271-pb-ready.preview.gitpod-dev.com/prebuilds) on [gpl/multiple-tasks-short](https://github.com/geropl/gitpod-test-repo/tree/gpl/multiple-tasks-short)
 - watch the prebuild list + the prebuild detail view in parallel, and note how they both update after ~1min :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-271-pb-ready</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-271-pb-ready.preview.gitpod-dev.com/workspaces" target="_blank">gpl-271-pb-ready.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-271-pb-ready-gha.26326</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-271-pb-ready%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
