### PR TITLE
[cleanup] Drop more feature flags

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -16,7 +16,6 @@ const featureFlags = {
     // Default to true to enable on gitpod dedicated until ff support is added for dedicated
     orgGitAuthProviders: true,
     userGitAuthProviders: false,
-    linkedinConnectionForOnboarding: false,
     enableDedicatedOnboardingFlow: false,
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,

--- a/components/dashboard/src/onboarding/StepUserInfo.tsx
+++ b/components/dashboard/src/onboarding/StepUserInfo.tsx
@@ -11,7 +11,6 @@ import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutati
 import { useOnBlurError } from "../hooks/use-onblur-error";
 import { OnboardingStep } from "./OnboardingStep";
 import { LinkedInBanner } from "./LinkedInBanner";
-import { useFeatureFlag } from "../data/featureflag-query";
 import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
 import { getPrimaryEmail } from "@gitpod/public-api-common/lib/user-utils";
 
@@ -20,7 +19,6 @@ type Props = {
     onComplete(user: User): void;
 };
 export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
-    const linkedinConnectionForOnboarding = useFeatureFlag("linkedinConnectionForOnboarding");
     const updateUser = useUpdateCurrentUserMutation();
     // attempt to split provided name for default input values
     const { first, last } = getInitialNameParts(user);
@@ -69,12 +67,8 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
 
     const firstNameError = useOnBlurError("Please enter a value", !!firstName);
     const lastNameError = useOnBlurError("Please enter a value", !!lastName);
-    const emailError = useOnBlurError("Please enter your email address", !!emailAddress);
 
-    const isValid =
-        [firstNameError, lastNameError].every((e) => e.isValid) &&
-        // If we're using LinkedIn, we don't need to validate the email input, otherwise we do
-        (linkedinConnectionForOnboarding || (!linkedinConnectionForOnboarding && emailError.isValid));
+    const isValid = [firstNameError, lastNameError].every((e) => e.isValid);
 
     return (
         <OnboardingStep
@@ -84,8 +78,8 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
             isValid={isValid}
             isSaving={updateUser.isLoading}
             onSubmit={handleSubmit}
-            submitButtonText={linkedinConnectionForOnboarding ? "Continue with 10 hours per month" : undefined}
-            submitButtonType={linkedinConnectionForOnboarding ? "secondary" : undefined}
+            submitButtonText={"Continue with 10 hours per month"}
+            submitButtonType={"secondary"}
         >
             {user.avatarUrl && (
                 <div className="my-4 flex justify-center">
@@ -115,19 +109,7 @@ export const StepUserInfo: FC<Props> = ({ user, onComplete }) => {
                 />
             </div>
 
-            {linkedinConnectionForOnboarding ? (
-                <LinkedInBanner onSuccess={onLinkedInSuccess} />
-            ) : (
-                <TextInputField
-                    value={emailAddress}
-                    label="Work Email"
-                    type="email"
-                    error={emailError.message}
-                    onBlur={emailError.onBlur}
-                    onChange={setEmailAddress}
-                    required
-                />
-            )}
+            <LinkedInBanner onSuccess={onLinkedInSuccess} />
         </OnboardingStep>
     );
 };

--- a/components/server/src/auth/verification-service.ts
+++ b/components/server/src/auth/verification-service.ts
@@ -13,10 +13,8 @@ import { ServiceContext } from "twilio/lib/rest/verify/v2/service";
 import { TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { ErrorCodes, ApplicationError } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { v4 as uuidv4, validate as uuidValidate } from "uuid";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { UserService } from "../user/user-service";
-import { getPrimaryEmail } from "@gitpod/public-api-common/lib/user-utils";
 
 interface VerificationEndpoint {
     sendToken(phoneNumber: string, channel: "sms" | "call"): Promise<string>;
@@ -131,17 +129,7 @@ export class VerificationService {
         if (user.creationDate < "2022-08-22") {
             return false;
         }
-        const isPhoneVerificationEnabled = await getExperimentsClientForBackend().getValueAsync(
-            "isPhoneVerificationEnabled",
-            false,
-            {
-                user: {
-                    id: user.id,
-                    email: getPrimaryEmail(user),
-                },
-            },
-        );
-        return isPhoneVerificationEnabled;
+        return true;
     }
 
     public async verifyOrgMembers(organizationId: string): Promise<void> {

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -16,7 +16,6 @@ import { BillingTier } from "@gitpod/gitpod-protocol/lib/protocol";
 import { inject, injectable } from "inversify";
 import { BillingModes } from "./billing-mode";
 import { EntitlementServiceUBP } from "./entitlement-service-ubp";
-import { VerificationService } from "../auth/verification-service";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export interface MayStartWorkspaceResult {
@@ -96,7 +95,6 @@ export class EntitlementServiceImpl implements EntitlementService {
     constructor(
         @inject(BillingModes) private readonly billingModes: BillingModes,
         @inject(EntitlementServiceUBP) private readonly ubp: EntitlementServiceUBP,
-        @inject(VerificationService) private readonly verificationService: VerificationService,
     ) {}
 
     async mayStartWorkspace(
@@ -105,12 +103,6 @@ export class EntitlementServiceImpl implements EntitlementService {
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
         try {
-            const verification = await this.verificationService.needsVerification(user);
-            if (verification) {
-                return {
-                    needsVerification: true,
-                };
-            }
             const billingMode = await this.billingModes.getBillingMode(user.id, organizationId);
             switch (billingMode.mode) {
                 case "none":

--- a/components/server/src/jobs/cap-status.ts
+++ b/components/server/src/jobs/cap-status.ts
@@ -11,7 +11,6 @@ import { Job } from "./runner";
 import { Config } from "../config";
 import { Repository } from "typeorm";
 import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
 @injectable()
@@ -24,16 +23,6 @@ export class CapStatus implements Job {
 
     public async run(): Promise<number | undefined> {
         log.info("cap-status: we're leading the quorum.");
-
-        const validateGitStatusLength = await getExperimentsClientForBackend().getValueAsync(
-            "api_validate_git_status_length",
-            false,
-            {},
-        );
-        if (!validateGitStatusLength) {
-            log.info("cap-status: feature flag is not enabled.");
-            return;
-        }
 
         const limit = 500;
         const instances = await this.workspaceDb.transaction(async (db) => {

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -59,7 +59,6 @@ import {
 import { LogContext, log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { EntitlementService, MayStartWorkspaceResult } from "../billing/entitlement-service";
 import * as crypto from "crypto";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { WorkspaceRegion, isWorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { RegionService } from "./region-service";
 import { ProjectsService } from "../projects/projects-service";
@@ -799,16 +798,7 @@ export class WorkspaceService {
         await this.auth.checkPermissionOnWorkspace(userId, "access", workspaceId);
 
         if (!!gitStatus) {
-            const validateGitStatusLength = await getExperimentsClientForBackend().getValueAsync(
-                "api_validate_git_status_length",
-                false,
-                {
-                    user: { id: userId || "" },
-                },
-            );
-            if (validateGitStatusLength) {
-                this.validateGitStatusLength(gitStatus, GIT_STATUS_LENGTH_CAP_BYTES);
-            }
+            this.validateGitStatusLength(gitStatus, GIT_STATUS_LENGTH_CAP_BYTES);
         }
 
         let instance = await this.getCurrentInstance(userId, workspaceId);


### PR DESCRIPTION
## Description
Drops:
 - [guessWorkspaceRegion](https://github.com/gitpod-io/gitpod/commit/01e1637ade1012807777a44919a47433cca1a5fc)
   - Verified that it works for Dedicated/non-GCP as well :heavy_check_mark: We can double check in Dogfood
 - [api_validate_git_status_length](https://github.com/gitpod-io/gitpod/commit/40065a0dde29302e5b04339942ba60c958c660c8)
 - [isPhoneVerificationEnabled](https://github.com/gitpod-io/gitpod/pull/19899/commits/01cea5e9a4cdacfe9d04e606481f11956d447e4a)
   - the call-site had to be slighty moved, so it's not called in Dedicated (we can verify in Dogfood, but the code is very clear)
 - [linkedinConnectionForOnboarding](https://github.com/gitpod-io/gitpod/pull/19899/commits/6143187f6d9bacc49e96ee3d274693f8830daee8)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-289

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-ff-2</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-ff-2.preview.gitpod-dev.com/workspaces" target="_blank">gpl-ff-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-ff-2-gha.26340</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-ff-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
