### PR TITLE
[VS Code Browser] Update stable code to `1.90.1`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,17 +8,25 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",
+        "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-          "{{.Repository}}/ide/code-codehelper:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
+          "{{.Repository}}/ide/code-codehelper:commit-a6aca7f18e80ce3827384cecb31b5f0643481eb6"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",
           "{{.CodeHelperImage}}"
         ],
         "versions": [
+          {
+            "version": "1.90.1",
+            "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
+              "{{.Repository}}/ide/code-codehelper:commit-a6aca7f18e80ce3827384cecb31b5f0643481eb6"
+            ]
+          },
           {
             "version": "1.90.0",
             "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",


### PR DESCRIPTION
## Description
Update code to `1.90.1`

## How to test

Should be tested already in build PR, double check:

- [x] New version is pinnable
- [x] Stable version is updated and it can start workspace with it

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-release</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-release.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-release.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-release-gha.26380</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-release%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment