### PR TITLE
Align experience of latest pinned and unpinned version

### DIFF
--- a/components/ide-service-api/go/config/ideconfig.go
+++ b/components/ide-service-api/go/config/ideconfig.go
@@ -67,6 +67,8 @@ type IDEOption struct {
 	ImageLayers []string `json:"imageLayers,omitempty"`
 	// LatestImageLayers for latest additional ide layers and dependencies
 	LatestImageLayers []string `json:"latestImageLayers,omitempty"`
+	// AllowPin if the editor is allowed to pin versions, only used for `ide-service` internal computation.
+	AllowPin bool `json:"allowPin,omitempty"`
 	// Release Versions of the IDE
 	Versions []IDEVersion `json:"versions,omitempty"`
 }

--- a/components/ide-service/BUILD.yaml
+++ b/components/ide-service/BUILD.yaml
@@ -35,4 +35,4 @@ packages:
 scripts:
   - name: gen-golden-files
     script: |
-      go test -timeout 30s -run ./... github.com/gitpod-io/gitpod/ide-service/pkg/server --force --update
+      go test -timeout 120s -run ./... github.com/gitpod-io/gitpod/ide-service/pkg/server --force --update

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -91,7 +91,6 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 				option.LatestImageVersion = resolvedVersion
 			}
 		}
-		cfg.IdeOptions.Options[id] = option
 
 		// append or replace latest stable version into versions
 		if option.ImageVersion != "" {
@@ -120,9 +119,10 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 				option.Versions = versions
 			}
 		}
+		cfg.IdeOptions.Options[id] = option
 	}
 
-	log.WithField("cfg", cfg).Info("=================parsed IDE config")
+	log.WithField("cfg", log.TrustedValueWrap{Value: cfg}).Info("=================parsed IDE config")
 
 	return &cfg, nil
 }

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -122,6 +122,8 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 		}
 	}
 
+	log.WithField("cfg", cfg).Info("=================parsed IDE config")
+
 	return &cfg, nil
 }
 

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -93,23 +93,30 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 		}
 		cfg.IdeOptions.Options[id] = option
 
-		if len(option.Versions) > 0 && option.ImageVersion != "" {
+		// append or replace latest stable version into versions
+		if option.ImageVersion != "" {
 			found := false
-			for _, version := range option.Versions {
+			foundIndex := -1
+			for index, version := range option.Versions {
 				if version.Version == option.ImageVersion {
 					found = true
+					foundIndex = index
 					break
 				}
 			}
+			currentVersion := config.IDEVersion{
+				Version:     option.ImageVersion,
+				Image:       option.Image,
+				ImageLayers: option.ImageLayers,
+			}
 			if !found {
 				var versions []config.IDEVersion
-				versions = append(versions, config.IDEVersion{
-					Version:     option.ImageVersion,
-					Image:       option.Image,
-					ImageLayers: option.ImageLayers,
-				})
+				versions = append(versions, currentVersion)
 				versions = append(versions, option.Versions...)
 				option.Versions = versions
+			} else {
+				versions := append([]config.IDEVersion{}, option.Versions...)
+				versions[foundIndex] = currentVersion
 			}
 		}
 	}

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -122,8 +122,6 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 		cfg.IdeOptions.Options[id] = option
 	}
 
-	log.WithField("cfg", log.TrustedValueWrap{Value: cfg}).Info("=================parsed IDE config")
-
 	return &cfg, nil
 }
 

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -93,7 +93,7 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 		}
 
 		// append or replace latest stable version into versions
-		if option.ImageVersion != "" {
+		if option.AllowPin && option.ImageVersion != "" {
 			found := false
 			foundIndex := -1
 			for index, version := range option.Versions {

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -114,9 +114,10 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 				versions = append(versions, currentVersion)
 				versions = append(versions, option.Versions...)
 				option.Versions = versions
-			} else {
+			} else if foundIndex >= 0 {
 				versions := append([]config.IDEVersion{}, option.Versions...)
 				versions[foundIndex] = currentVersion
+				option.Versions = versions
 			}
 		}
 	}

--- a/components/ide-service/pkg/server/ideconfig.go
+++ b/components/ide-service/pkg/server/ideconfig.go
@@ -121,6 +121,7 @@ func ParseConfig(ctx context.Context, res remotes.Resolver, b []byte) (*config.I
 		}
 		cfg.IdeOptions.Options[id] = option
 	}
+	log.WithField("cfg", log.TrustedValueWrap{Value: cfg}).Info("==============ParsedIDEConfig")
 
 	return &cfg, nil
 }

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath.golden
@@ -1,6 +1,5 @@
 {
     "Config": {
-        "gpRunImage": "",
         "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
         "ideOptions": {
             "options": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.golden
@@ -1,6 +1,5 @@
 {
     "Config": {
-        "gpRunImage": "",
         "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
         "ideOptions": {
             "options": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
@@ -17,6 +17,7 @@
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
+                    "allowPin": true,
                     "versions": [
                         {
                             "version": "1.90.1",
@@ -40,6 +41,7 @@
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
+                    "allowPin": true,
                     "versions": [
                         {
                             "version": "1.89.1",
@@ -64,6 +66,7 @@
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
+                    "allowPin": true,
                     "versions": [
                         {
                             "version": "1.90.1",
@@ -95,6 +98,7 @@
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
+                    "allowPin": true,
                     "versions": [
                         {
                             "version": "1.90.1",
@@ -118,6 +122,7 @@
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
+                    "allowPin": true,
                     "versions": [
                         {
                             "version": "1.90.1",
@@ -140,16 +145,6 @@
                     "imageLayers": [
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
-                    ],
-                    "versions": [
-                        {
-                            "version": "1.90.1",
-                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
-                            "imageLayers": [
-                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
-                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
-                            ]
-                        }
                     ]
                 }
             },

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
@@ -1,0 +1,185 @@
+{
+    "Config": {
+        "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+        "ideOptions": {
+            "options": {
+                "code": {
+                    "orderKey": "00",
+                    "title": "VS Code",
+                    "type": "browser",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
+                    "label": "Browser",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc@sha256:3bd7fc75cc046c217465cba1b4d7cb06b1cdc574f411778613bfa04a78a09a8b",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9@sha256:9f8f3951386b5490e798308c84695fbf448721ef1febd1779ecd668c47fa601a",
+                    "resolveImageDigest": true,
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc@sha256:3bd7fc75cc046c217465cba1b4d7cb06b1cdc574f411778613bfa04a78a09a8b",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                },
+                "code-desktop": {
+                    "orderKey": "02",
+                    "title": "VS Code",
+                    "type": "desktop",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:commit-c2b7421628ed5a5fb618817a4fd1549684659c2d@sha256:d9e39323a5b517ad753a3daeccb7b8d66ed8727bc222fc63cc124f1563723639",
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                },
+                "goland": {
+                    "orderKey": "05",
+                    "title": "GoLand",
+                    "type": "desktop",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/golandLogo.svg",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc@sha256:3bd7fc75cc046c217465cba1b4d7cb06b1cdc574f411778613bfa04a78a09a8b",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df@sha256:665b0456e38cf75e7ca7f300b5fd73827065210df310c6b57d1b41f179af0c46",
+                    "resolveImageDigest": true,
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc@sha256:3bd7fc75cc046c217465cba1b4d7cb06b1cdc574f411778613bfa04a78a09a8b",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                },
+                "intellij": {
+                    "orderKey": "04",
+                    "title": "IntelliJ IDEA",
+                    "type": "desktop",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/intellijIdeaLogo.svg",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df@sha256:d7528b797a73835ebf51d976c0e73782f501acf08801ca3ad81bde72bc32df98",
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                },
+                "phpstorm": {
+                    "orderKey": "07",
+                    "title": "PhpStorm",
+                    "type": "desktop",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/phpstormLogo.svg",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df@sha256:5c6ef331fbf7379c970565d9d62b9ddfdfbc945c3acaa895020a551144ba42b4",
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                },
+                "pycharm": {
+                    "orderKey": "06",
+                    "title": "PyCharm",
+                    "type": "desktop",
+                    "logo": "https://ide.gitpod.io/image/ide-logo/pycharmLogo.svg",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                    "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df@sha256:94e3e684420179fc7ea6bf4245c2c9de666babc4c1366e08cc56b744f27dd275",
+                    "imageVersion": "1.90.1",
+                    "imageLayers": [
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                    ],
+                    "versions": [
+                        {
+                            "version": "1.90.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "defaultIde": "code",
+            "defaultDesktopIde": "code-desktop",
+            "clients": {
+                "jetbrains-gateway": {
+                    "defaultDesktopIDE": "intellij",
+                    "desktopIDEs": [
+                        "intellij",
+                        "goland",
+                        "pycharm",
+                        "phpstorm"
+                    ],
+                    "installationSteps": [
+                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                    ]
+                },
+                "vscode": {
+                    "defaultDesktopIDE": "code-desktop",
+                    "desktopIDEs": [
+                        "code-desktop"
+                    ],
+                    "installationSteps": [
+                        "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                    ]
+                },
+                "vscode-insiders": {
+                    "defaultDesktopIDE": "code-desktop",
+                    "desktopIDEs": [
+                        "code-desktop"
+                    ],
+                    "installationSteps": [
+                        "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                    ]
+                }
+            }
+        }
+    },
+    "Err": ""
+}

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
@@ -33,19 +33,19 @@
                     "title": "VS Code",
                     "type": "desktop",
                     "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
-                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                    "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                     "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:commit-c2b7421628ed5a5fb618817a4fd1549684659c2d@sha256:d9e39323a5b517ad753a3daeccb7b8d66ed8727bc222fc63cc124f1563723639",
-                    "imageVersion": "1.90.1",
+                    "imageVersion": "1.89.1",
                     "imageLayers": [
-                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                        "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                         "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                     ],
                     "versions": [
                         {
-                            "version": "1.90.1",
-                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                            "version": "1.89.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                             "imageLayers": [
-                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                                 "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                             ]
                         }
@@ -70,6 +70,14 @@
                             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc@sha256:3bd7fc75cc046c217465cba1b4d7cb06b1cdc574f411778613bfa04a78a09a8b",
                             "imageLayers": [
                                 "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+                            ]
+                        },
+                        {
+                            "version": "1.89.1",
+                            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
+                            "imageLayers": [
+                                "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
                                 "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
                             ]
                         }

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
@@ -1,0 +1,122 @@
+{
+  "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+  "ideOptions": {
+    "options": {
+      "code": {
+        "orderKey": "00",
+        "title": "VS Code",
+        "type": "browser",
+        "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
+        "label": "Browser",
+        "resolveImageDigest": true,
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      },
+      "code-desktop": {
+        "orderKey": "02",
+        "title": "VS Code",
+        "type": "desktop",
+        "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:commit-c2b7421628ed5a5fb618817a4fd1549684659c2d",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      },
+      "goland": {
+        "orderKey": "05",
+        "title": "GoLand",
+        "type": "desktop",
+        "resolveImageDigest": true,
+        "logo": "https://ide.gitpod.io/image/ide-logo/golandLogo.svg",
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      },
+      "intellij": {
+        "orderKey": "04",
+        "title": "IntelliJ IDEA",
+        "type": "desktop",
+        "logo": "https://ide.gitpod.io/image/ide-logo/intellijIdeaLogo.svg",
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      },
+      "phpstorm": {
+        "orderKey": "07",
+        "title": "PhpStorm",
+        "type": "desktop",
+        "logo": "https://ide.gitpod.io/image/ide-logo/phpstormLogo.svg",
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      },
+      "pycharm": {
+        "orderKey": "06",
+        "title": "PyCharm",
+        "type": "desktop",
+        "logo": "https://ide.gitpod.io/image/ide-logo/pycharmLogo.svg",
+        "imageVersion": "1.90.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
+        "imageLayers": [
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ]
+      }
+    },
+    "defaultIde": "code",
+    "defaultDesktopIde": "code-desktop",
+    "clients": {
+      "jetbrains-gateway": {
+        "defaultDesktopIDE": "intellij",
+        "desktopIDEs": [
+          "intellij",
+          "goland",
+          "pycharm",
+          "phpstorm"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+        ]
+      },
+      "vscode": {
+        "defaultDesktopIDE": "code-desktop",
+        "desktopIDEs": [
+          "code-desktop"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+        ]
+      },
+      "vscode-insiders": {
+        "defaultDesktopIDE": "code-desktop",
+        "desktopIDEs": [
+          "code-desktop"
+        ],
+        "installationSteps": [
+          "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+        ]
+      }
+    }
+  }
+}

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
@@ -4,6 +4,7 @@
     "options": {
       "code": {
         "orderKey": "00",
+        "allowPin": true,
         "title": "VS Code",
         "type": "browser",
         "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
@@ -26,6 +27,7 @@
       },
       "code-desktop": {
         "orderKey": "02",
+        "allowPin": true,
         "title": "VS Code",
         "type": "desktop",
         "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
@@ -39,6 +41,7 @@
       },
       "goland": {
         "orderKey": "05",
+        "allowPin": true,
         "title": "GoLand",
         "type": "desktop",
         "resolveImageDigest": true,
@@ -63,6 +66,7 @@
       },
       "intellij": {
         "orderKey": "04",
+        "allowPin": true,
         "title": "IntelliJ IDEA",
         "type": "desktop",
         "logo": "https://ide.gitpod.io/image/ide-logo/intellijIdeaLogo.svg",
@@ -76,6 +80,7 @@
       },
       "phpstorm": {
         "orderKey": "07",
+        "allowPin": true,
         "title": "PhpStorm",
         "type": "desktop",
         "logo": "https://ide.gitpod.io/image/ide-logo/phpstormLogo.svg",
@@ -89,6 +94,7 @@
       },
       "pycharm": {
         "orderKey": "06",
+        "allowPin": false,
         "title": "PyCharm",
         "type": "desktop",
         "logo": "https://ide.gitpod.io/image/ide-logo/pycharmLogo.svg",

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
@@ -15,6 +15,13 @@
         "imageLayers": [
           "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
           "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ],
+        "versions": [
+          {
+            "version": "1.90.1",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+            "imageLayers": []
+          }
         ]
       },
       "code-desktop": {
@@ -22,11 +29,11 @@
         "title": "VS Code",
         "type": "desktop",
         "logo": "https://ide.gitpod.io/image/ide-logo/vscode.svg",
-        "imageVersion": "1.90.1",
-        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "imageVersion": "1.89.1",
+        "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
         "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:commit-c2b7421628ed5a5fb618817a4fd1549684659c2d",
         "imageLayers": [
-          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+          "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
           "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
         ]
       },
@@ -42,6 +49,16 @@
         "imageLayers": [
           "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
           "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+        ],
+        "versions": [
+          {
+            "version": "1.89.1",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
+            "imageLayers": [
+              "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-cbfb5757ed873b574b20f13c3edac3b9a2caf731",
+              "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9"
+            ]
+          }
         ]
       },
       "intellij": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_idetype_not_correct.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_idetype_not_correct.golden
@@ -1,6 +1,5 @@
 {
     "Config": {
-        "gpRunImage": "",
         "supervisorImage": "",
         "ideOptions": {
             "options": null,

--- a/components/ide-service/pkg/server/testdata/ideconfig_idetype_unknown.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_idetype_unknown.golden
@@ -1,6 +1,5 @@
 {
     "Config": {
-        "gpRunImage": "",
         "supervisorImage": "",
         "ideOptions": {
             "options": null,

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_invalid.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_invalid.golden
@@ -1,8 +1,8 @@
 {
-  "Resp": {
-      "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
-      "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
-      "ide_settings": "{\"defaultIde\":\"code\"}\n"
-  },
-  "Err": ""
+    "Resp": {
+        "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+        "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
+        "ide_settings": "{\"defaultIde\":\"code\"}\n"
+    },
+    "Err": ""
 }

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_invalid_version.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_invalid_version.golden
@@ -1,14 +1,14 @@
 {
-  "Resp": {
-      "envvars": [
-          {
-              "name": "GITPOD_IDE_ALIAS",
-              "value": "code"
-          }
-      ],
-      "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
-      "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
-      "ide_settings": "{\"defaultIde\":\"code\"}\n"
-  },
-  "Err": ""
+    "Resp": {
+        "envvars": [
+            {
+                "name": "GITPOD_IDE_ALIAS",
+                "value": "code"
+            }
+        ],
+        "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+        "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
+        "ide_settings": "{\"defaultIde\":\"code\"}\n"
+    },
+    "Err": ""
 }

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_valid_version.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_code_valid_version.golden
@@ -1,14 +1,14 @@
 {
-  "Resp": {
-      "envvars": [
-          {
-              "name": "GITPOD_IDE_ALIAS",
-              "value": "code"
-          }
-      ],
-      "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
-      "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d86f6aa033943c9650d06339915e68063b0cf142",
-      "ide_settings": "{\"defaultIde\":\"code\"}\n"
-  },
-  "Err": ""
+    "Resp": {
+        "envvars": [
+            {
+                "name": "GITPOD_IDE_ALIAS",
+                "value": "code"
+            }
+        ],
+        "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+        "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d86f6aa033943c9650d06339915e68063b0cf142",
+        "ide_settings": "{\"defaultIde\":\"code\"}\n"
+    },
+    "Err": ""
 }

--- a/components/ide/gha-update-image/index-jb.ts
+++ b/components/ide/gha-update-image/index-jb.ts
@@ -8,5 +8,5 @@ import { appendPinVersionsIntoIDEConfigMap } from "./lib/jb-pin-version";
 
 $.nothrow(); // git likes to respond with non-zero codes, but it is alright for us
 
-await upgradeStableVersionsInWorkspaceaAndGradle();
-await appendPinVersionsIntoIDEConfigMap();
+const updatedIDEs = await upgradeStableVersionsInWorkspaceaAndGradle();
+await appendPinVersionsIntoIDEConfigMap(updatedIDEs);

--- a/components/ide/gha-update-image/lib/jb-stable-version.ts
+++ b/components/ide/gha-update-image/lib/jb-stable-version.ts
@@ -116,6 +116,7 @@ export const getStableVersionsInfo = async (ides: JetBrainsIDE[]) => {
 
     const uniqueMajorVersions = new Set<string>();
     const uniqueMajorBuildVersions = new Set<string>();
+    const updatedIDEs: string[] = [];
 
     await Promise.all(
         ides.map(async (ide) => {
@@ -149,6 +150,7 @@ export const getStableVersionsInfo = async (ides: JetBrainsIDE[]) => {
                 throw new Error("No download link found for the latest release");
             }
             rawWorkspace = rawWorkspace.replace(oldDownloadUrl, downloadLink);
+            updatedIDEs.push(ide.productId);
 
             const currentBuildVersion = semver.parse(lastRelease.build);
             if (!currentBuildVersion) {
@@ -180,12 +182,12 @@ export const getStableVersionsInfo = async (ides: JetBrainsIDE[]) => {
     const majorVersion = majorVersions[0];
     console.log(`All IDEs are in the same major version: ${majorVersion}`);
 
-    return { buildVersion, majorVersion };
+    return { buildVersion, majorVersion, updatedIDEs };
 };
 
 export const upgradeStableVersionsInWorkspaceaAndGradle = async () => {
     try {
-        const { buildVersion, majorVersion } = await getStableVersionsInfo(ides);
+        const { buildVersion, majorVersion, updatedIDEs } = await getStableVersionsInfo(ides);
         await Bun.write(pathToWorkspaceYaml, rawWorkspace);
 
         await Bun.write(
@@ -205,6 +207,7 @@ platformVersion=${buildVersion.major}.${buildVersion.minor}-EAP-CANDIDATE-SNAPSH
 
         console.log(`File updated: ${pathToWorkspaceYaml}`);
         console.log(`File updated: ${pathToBackendPluginGradleStable}`);
+        return updatedIDEs;
     } catch (e) {
         if (e instanceof MultipleMajorVersionsError || e instanceof MultipleBuildVersionsError) {
             console.error(e.message);

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -18,6 +18,7 @@
           "{{.CodeWebExtensionImage}}",
           "{{.CodeHelperImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "1.90.0",
@@ -123,6 +124,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -187,6 +189,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -240,6 +243,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -292,6 +296,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -344,6 +349,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -396,6 +402,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.3",
@@ -456,6 +463,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -500,6 +508,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -544,6 +553,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
+        "allowPining": true,
         "versions": [
           {
             "version": "2024.1.1",

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -18,7 +18,7 @@
           "{{.CodeWebExtensionImage}}",
           "{{.CodeHelperImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "1.90.0",
@@ -124,7 +124,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -189,7 +189,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -243,7 +243,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -296,7 +296,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -349,7 +349,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -402,7 +402,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.3",
@@ -463,7 +463,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -508,7 +508,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.2",
@@ -553,7 +553,7 @@
           "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
-        "allowPining": true,
+        "allowPin": true,
         "versions": [
           {
             "version": "2024.1.1",

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -20,14 +20,6 @@
         ],
         "versions": [
           {
-            "version": "1.90.1",
-            "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
-            "imageLayers": [
-              "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-              "{{.Repository}}/ide/code-codehelper:commit-a6aca7f18e80ce3827384cecb31b5f0643481eb6"
-            ]
-          },
-          {
             "version": "1.90.0",
             "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",
             "imageLayers": [
@@ -133,14 +125,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/intellij:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/intellij:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -205,14 +189,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/goland:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/goland:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -266,14 +242,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/pycharm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/pycharm:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -325,14 +293,6 @@
           "{{.JetBrainsLauncherImage}}"
         ],
         "versions": [
-          {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/phpstorm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
           {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/phpstorm:commit-9823a689c6259339239381e2840e29149fc8d195",
@@ -386,14 +346,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/rubymine:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/rubymine:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -445,14 +397,6 @@
           "{{.JetBrainsLauncherImage}}"
         ],
         "versions": [
-          {
-            "version": "2024.1.4",
-            "image": "{{.Repository}}/ide/webstorm:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
           {
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/webstorm:commit-9823a689c6259339239381e2840e29149fc8d195",
@@ -514,14 +458,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/rider:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/rider:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -566,14 +502,6 @@
         ],
         "versions": [
           {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/clion:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
-          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/clion:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -617,14 +545,6 @@
           "{{.JetBrainsLauncherImage}}"
         ],
         "versions": [
-          {
-            "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rustrover:commit-fd555048bb3f16dae25eafecc6c8d0fc6175b8e1",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-e820ea55acc80bbc152edb6723679ddcd8d2795b",
-              "{{.Repository}}/ide/jb-launcher:commit-6dcbc99e49796023f14b1c0847f63f44a60bf2fb"
-            ]
-          },
           {
             "version": "2024.1.1",
             "image": "{{.Repository}}/ide/rustrover:commit-f9c0969d7d7512d32c33d5cfa0e831d92f7f81ae",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make sure the first item of versions in ide config is added by `ide-service` and align with latest stable version's values

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-298, ENT-299

## How to test
<!-- Provide steps to test this PR -->
- Latest stable version (check WORKSPACE.yaml) is pinnable on dashboard
- Pin version of IntelliJ with `2024.1.3`, it should be able to open workspace with
- Open this PR with Gitpod
- ~~Check `ide-config` if the latest stable versions' image info is the same as that first one in versions field~~
- Check logs of `ide-service` (see https://github.com/gitpod-io/gitpod/pull/19911/commits/147a140c355acfb559934ff0553323826902da4c) the latest stable versions' image info is the same as that first one in versions field

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ide-version</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ide-version.preview.gitpod-dev.com/workspaces" target="_blank">hw-ide-version.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ide-version-gha.26453</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ide-version%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
