### PR TITLE
Improve  ide images updating GHA

### DIFF
--- a/components/ide/gha-update-image/check-code-build.ts
+++ b/components/ide/gha-update-image/check-code-build.ts
@@ -4,7 +4,7 @@
 
 import { $ } from "bun";
 import { parseArgs } from "util";
-import { pathToOutput, pathToWorkspaceYaml, readWorkspaceYaml } from "./lib/common";
+import { appendGitHubOutput, pathToWorkspaceYaml, readWorkspaceYaml } from "./lib/common";
 
 $.nothrow();
 
@@ -27,9 +27,10 @@ const inputs = {
     branch: values.branch,
 };
 
+// example: bun run check-code-build.ts --branch gp-code/release/1.89
 const main = async () => {
     if (!inputs.branch || !inputs.branch.startsWith("gp-code/release/")) {
-        throw new Error("invalid branch, expected something like `gp-code/release/1.90`");
+        throw new Error(`invalid branch ${inputs.branch}, expected something like \`gp-code/release/1.90\``);
     }
     const commit =
         await $`curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/${inputs.branch}`.text();
@@ -52,8 +53,8 @@ const main = async () => {
         .replace(workspaceYaml.defaultArgs.codeVersion, version);
 
     await Bun.write(pathToWorkspaceYaml, newYaml);
-
-    await Bun.write(pathToOutput, `codeVersion=${version}\ncodeCommit=${commit}`);
+    await appendGitHubOutput(`codeVersion=${version}`)
+    await appendGitHubOutput(`codeCommit=${commit}`)
 };
 
 await main();

--- a/components/ide/gha-update-image/index-code.ts
+++ b/components/ide/gha-update-image/index-code.ts
@@ -3,14 +3,11 @@
 // See License.AGPL.txt in the project root for license information.
 
 import { $ } from "bun";
-import { updateCodeIDEConfigJson } from "./lib/code-pin-version"
+import { updateCodeIDEConfigMapJson } from "./lib/code-pin-version"
 import { appendGitHubOutput } from "./lib/common";
 
 $.nothrow();
 
-const newVersion = await updateCodeIDEConfigJson();
-
-if (newVersion) {
-    console.log("new version released", newVersion);
-    await appendGitHubOutput(`codeVersion=${newVersion}`)
-}
+const newVersion = await updateCodeIDEConfigMapJson();
+console.log("new version released", newVersion);
+await appendGitHubOutput(`codeVersion=${newVersion}`)

--- a/components/ide/gha-update-image/index-code.ts
+++ b/components/ide/gha-update-image/index-code.ts
@@ -3,75 +3,14 @@
 // See License.AGPL.txt in the project root for license information.
 
 import { $ } from "bun";
-import {
-    getLatestInstallerVersions,
-    pathToConfigmap,
-    pathToOutput,
-    readIDEConfigmapJson,
-    readWorkspaceYaml,
-} from "./lib/common";
+import { updateCodeIDEConfigJson } from "./lib/code-pin-version"
+import { appendGitHubOutput } from "./lib/common";
 
 $.nothrow();
 
-const ideConfigmapInfo = await readIDEConfigmapJson();
-const ideConfigmapJson = ideConfigmapInfo.parsedObj;
-const ideConfigmapJsonObj = ideConfigmapInfo.rawObj;
-const workspaceYaml = await readWorkspaceYaml().then((d) => d.parsedObj);
+const newVersion = await updateCodeIDEConfigJson();
 
-async function updateCodeBrowserVersions() {
-    const latestInstaller = await getLatestInstallerVersions();
-    const latestBuildImage = {
-        code: latestInstaller.components.workspace.codeImage.version,
-        webExtension: latestInstaller.components.workspace.codeWebExtensionImage.version,
-        codeHelper: latestInstaller.components.workspace.codeHelperImage.version,
-    };
-
-    console.log("comparing with latest installer versions", latestInstaller.version, latestBuildImage);
-
-    const firstPinnedInfo = ideConfigmapJson.ideOptions.options.code.versions[0];
-    const hasChangedMap = {
-        image: !ideConfigmapJson.ideOptions.options.code.image.includes(latestBuildImage.code),
-        webExtension: !ideConfigmapJson.ideOptions.options.code.imageLayers[0].includes(latestBuildImage.webExtension),
-        codeHelper: !ideConfigmapJson.ideOptions.options.code.imageLayers[1].includes(latestBuildImage.codeHelper),
-        pinned: firstPinnedInfo.version !== workspaceYaml.defaultArgs.codeVersion,
-    };
-
-    const hasChanged = Object.values(hasChangedMap).some((v) => v);
-    if (!hasChanged) {
-        console.error("stable version is already up-to-date.");
-        return;
-    }
-    console.log("latest build versions changed, processing...", hasChangedMap);
-
-    const replaceImageHash = (image: string, hash: string) => image.replace(/commit-.*/, hash);
-    const updateImages = <T extends { image: string; imageLayers: string[] }>(originData: T) => {
-        const data = structuredClone(originData);
-        data.image = replaceImageHash(data.image, latestBuildImage.code);
-        data.imageLayers[0] = replaceImageHash(data.imageLayers[0], latestBuildImage.webExtension);
-        data.imageLayers[1] = replaceImageHash(data.imageLayers[1], latestBuildImage.codeHelper);
-        return data;
-    };
-
-    const newJson = structuredClone(ideConfigmapJsonObj);
-    newJson.ideOptions.options.code = updateImages(newJson.ideOptions.options.code);
-
-    console.log("updating related pinned version", firstPinnedInfo.version, workspaceYaml.defaultArgs.codeVersion);
-    const hasPinned = firstPinnedInfo.version === workspaceYaml.defaultArgs.codeVersion;
-    if (!hasPinned) {
-        newJson.ideOptions.options.code.versions.unshift({
-            ...firstPinnedInfo,
-            version: workspaceYaml.defaultArgs.codeVersion,
-        });
-    }
-    newJson.ideOptions.options.code.versions[0] = updateImages(newJson.ideOptions.options.code.versions[0]);
-
-    console.log("updating ide-configmap.json");
-    await Bun.write(pathToConfigmap, JSON.stringify(newJson, null, 2) + "\n");
-
-    if (hasChangedMap.pinned) {
-        console.error("new version released", workspaceYaml.defaultArgs.codeVersion);
-        await Bun.write(pathToOutput, `codeVersion=${workspaceYaml.defaultArgs.codeVersion}`);
-    }
+if (newVersion) {
+    console.log("new version released", newVersion);
+    await appendGitHubOutput(`codeVersion=${newVersion}`)
 }
-
-await updateCodeBrowserVersions();

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+import { $ } from "bun";
+import {
+    getIDEVersionOfImage,
+    getLatestInstallerVersions,
+    pathToConfigmap,
+    readIDEConfigmapJson,
+    readWorkspaceYaml,
+} from "./common";
+
+$.nothrow();
+
+const ideConfigmapInfo = await readIDEConfigmapJson();
+const ideConfigmapJson = ideConfigmapInfo.parsedObj;
+const ideConfigmapJsonObj = ideConfigmapInfo.rawObj;
+const workspaceYaml = await readWorkspaceYaml().then((d) => d.parsedObj);
+
+export async function updateCodeIDEConfigJson() {
+    const latestInstaller = await getLatestInstallerVersions();
+    const latestBuildImage = {
+        code: latestInstaller.components.workspace.codeImage.version,
+        webExtension: latestInstaller.components.workspace.codeWebExtensionImage.version,
+        codeHelper: latestInstaller.components.workspace.codeHelperImage.version,
+    };
+
+    console.log("comparing with latest installer versions", latestInstaller.version, latestBuildImage);
+
+    const firstPinnedInfo = ideConfigmapJson.ideOptions.options.code.versions[0];
+    const hasChangedMap = {
+        image: !ideConfigmapJson.ideOptions.options.code.image.includes(latestBuildImage.code),
+        webExtension: !ideConfigmapJson.ideOptions.options.code.imageLayers[0].includes(latestBuildImage.webExtension),
+        codeHelper: !ideConfigmapJson.ideOptions.options.code.imageLayers[1].includes(latestBuildImage.codeHelper),
+    };
+
+    console.log("latest build versions changed, processing...", hasChangedMap);
+
+    const replaceImageHash = (image: string, hash: string) => image.replace(/commit-.*/, hash);
+    const updateImages = <T extends { image: string; imageLayers: string[] }>(originData: T) => {
+        const data = structuredClone(originData);
+        data.image = replaceImageHash(data.image, latestBuildImage.code);
+        data.imageLayers[0] = replaceImageHash(data.imageLayers[0], latestBuildImage.webExtension);
+        data.imageLayers[1] = replaceImageHash(data.imageLayers[1], latestBuildImage.codeHelper);
+        return data;
+    };
+
+    const newJson = structuredClone(ideConfigmapJsonObj);
+    newJson.ideOptions.options.code = updateImages(newJson.ideOptions.options.code);
+
+    // try append new pin versions
+    // eu.gcr.io/gitpod-core-dev/build/commit-518f23b3b895cd544bd6b3dd383af95c350718cc:
+    const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
+    const hasPinned = firstPinnedInfo.version === installationCodeVersion;
+    if (!hasPinned) {
+        console.log("updating related pinned version", firstPinnedInfo.version, installationCodeVersion);
+        newJson.ideOptions.options.code.versions.unshift({
+            version: installationCodeVersion,
+            image: newJson.ideOptions.options.code.image,
+            imageLayers: newJson.ideOptions.options.code.imageLayers,
+        });
+    }
+
+    console.log("updating ide-configmap.json");
+    await Bun.write(pathToConfigmap, JSON.stringify(newJson, null, 2) + "\n");
+    return workspaceYaml.defaultArgs.codeVersion;
+}

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -52,14 +52,18 @@ export async function updateCodeIDEConfigJson() {
     // try append new pin versions
     // eu.gcr.io/gitpod-core-dev/build/commit-518f23b3b895cd544bd6b3dd383af95c350718cc:
     const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
-    const hasPinned = firstPinnedInfo.version === installationCodeVersion;
-    if (!hasPinned) {
-        console.log("updating related pinned version", firstPinnedInfo.version, installationCodeVersion);
-        newJson.ideOptions.options.code.versions.unshift({
-            version: installationCodeVersion,
-            image: newJson.ideOptions.options.code.image,
-            imageLayers: newJson.ideOptions.options.code.imageLayers,
-        });
+    if (installationCodeVersion === workspaceYaml.defaultArgs.codeVersion) {
+        console.log("code version is the same, no need to update (ide-service will do it)");
+    } else {
+        const hasPinned = firstPinnedInfo.version === installationCodeVersion;
+        if (!hasPinned) {
+            console.log("updating related pinned version", firstPinnedInfo.version, installationCodeVersion);
+            newJson.ideOptions.options.code.versions.unshift({
+                version: installationCodeVersion,
+                image: newJson.ideOptions.options.code.image,
+                imageLayers: newJson.ideOptions.options.code.imageLayers,
+            });
+        }
     }
 
     console.log("updating ide-configmap.json");

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -18,7 +18,7 @@ const ideConfigmapJson = ideConfigmapInfo.parsedObj;
 const ideConfigmapJsonObj = ideConfigmapInfo.rawObj;
 const workspaceYaml = await readWorkspaceYaml().then((d) => d.parsedObj);
 
-export async function updateCodeIDEConfigJson() {
+export async function updateCodeIDEConfigMapJson() {
     const latestInstaller = await getLatestInstallerVersions();
     const latestBuildImage = {
         code: latestInstaller.components.workspace.codeImage.version,
@@ -50,14 +50,13 @@ export async function updateCodeIDEConfigJson() {
     newJson.ideOptions.options.code = updateImages(newJson.ideOptions.options.code);
 
     // try append new pin versions
-    // eu.gcr.io/gitpod-core-dev/build/commit-518f23b3b895cd544bd6b3dd383af95c350718cc:
     const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
     if (installationCodeVersion === workspaceYaml.defaultArgs.codeVersion) {
-        console.log("code version is the same, no need to update (ide-service will do it)");
+        console.log("code version is the same, no need to update (ide-service will do it)", installationCodeVersion);
     } else {
         const hasPinned = firstPinnedInfo.version === installationCodeVersion;
         if (!hasPinned) {
-            console.log("updating related pinned version", firstPinnedInfo.version, installationCodeVersion);
+            console.log("updating related pinned version", installationCodeVersion);
             newJson.ideOptions.options.code.versions.unshift({
                 version: installationCodeVersion,
                 image: newJson.ideOptions.options.code.image,

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -9,7 +9,12 @@ import { z } from "zod";
 
 const pathToProjectRoot = path.resolve(__dirname, "../../../../");
 
-export const pathToOutput = path.resolve("/tmp/__gh_output.txt");
+const pathToOutput = path.resolve("/tmp/__gh_output.txt");
+
+export const appendGitHubOutput = async (kv: string) => {
+    console.log("Appending to GitHub output:", kv);
+    return await $`echo ${kv} >> ${pathToOutput}`;
+}
 
 // WORKSPACE.yaml
 export const pathToWorkspaceYaml = path.resolve(pathToProjectRoot, "WORKSPACE.yaml");
@@ -103,6 +108,7 @@ export const getLatestInstallerVersions = async (version?: string) => {
             .catch((e) => {
                 throw new Error("Failed to parse installer version from git tag", e);
             });
+    console.log("Fetching installer version for", installationVersion);
     // exec command below to see results
     // ```
     // $ docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:main-gha.25759 cat /versions.yaml | yq r -
@@ -154,3 +160,11 @@ export const getLatestInstallerVersions = async (version?: string) => {
         })
         .parse(yaml.parse(versionData));
 };
+
+
+export const getIDEVersionOfImage = async (img: string) => {
+    console.log("Fetching IDE version in image:", `oci-tool fetch image eu.gcr.io/gitpod-core-dev/build/${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`)
+    return await $`oci-tool fetch image eu.gcr.io/gitpod-core-dev/build/${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`.text().catch((e) => {
+        throw new Error("Failed to fetch ide version in image", e);
+    }).then(str => str.replaceAll("\n", ""));
+}

--- a/components/ide/gha-update-image/lib/jb-stable-version.ts
+++ b/components/ide/gha-update-image/lib/jb-stable-version.ts
@@ -150,7 +150,9 @@ export const getStableVersionsInfo = async (ides: JetBrainsIDE[]) => {
                 throw new Error("No download link found for the latest release");
             }
             rawWorkspace = rawWorkspace.replace(oldDownloadUrl, downloadLink);
-            updatedIDEs.push(ide.productId);
+            if (oldDownloadUrl !== downloadLink) {
+                updatedIDEs.push(ide.productId);
+            }
 
             const currentBuildVersion = semver.parse(lastRelease.build);
             if (!currentBuildVersion) {

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -21,14 +21,6 @@
         "allowPin": true,
         "versions": [
           {
-            "version": "1.90.1",
-            "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
-            "imageLayers": [
-              "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-              "{{.Repository}}/ide/code-codehelper:commit-a6aca7f18e80ce3827384cecb31b5f0643481eb6"
-            ]
-          },
-          {
             "version": "1.90.0",
             "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",
             "imageLayers": [


### PR DESCRIPTION
Reverts gitpod-io/gitpod#19915

Fixes ENT-308

## How to test

**regression test**

- VS Code Browser version `1.90.1` is pinnable in preview https://revert-19952ef7e32d6.preview.gitpod-dev.com/settings/policy

**scripts validate**
Open this PR with Gtipod, and exec commands below

```
cd /workspace/gitpod/components/ide/gha-update-image
npm i -g bun
yarn

# should generate nothing
bun run index-jb.ts

# should generate nothing
bun run index-code.ts

# should update WORKSPACE.yaml only
bun run check-code-build.ts --branch gp-code/release/1.89

# should update ide-configmap.json with previous stable info
bun run index-code.ts
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - revert-19952ef7e32d6</li>
	<li><b>🔗 URL</b> - <a href="https://revert-19952ef7e32d6.preview.gitpod-dev.com/workspaces" target="_blank">revert-19952ef7e32d6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - revert-19915-ide-code-release-gha.26505</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-revert-19952ef7e32d6%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
