### PR TITLE
[gha] thrown when fetching empty version

### DIFF
--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -35,7 +35,7 @@ export async function updateCodeIDEConfigMapJson() {
         codeHelper: !ideConfigmapJson.ideOptions.options.code.imageLayers[1].includes(latestBuildImage.codeHelper),
     };
 
-    console.log("latest build versions changed, processing...", hasChangedMap);
+    console.log("image change status", hasChangedMap);
 
     const replaceImageHash = (image: string, hash: string) => image.replace(/commit-.*/, hash);
     const updateImages = <T extends { image: string; imageLayers: string[] }>(originData: T) => {
@@ -51,6 +51,10 @@ export async function updateCodeIDEConfigMapJson() {
 
     // try append new pin versions
     const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
+    if (installationCodeVersion.trim() === "") {
+        throw new Error("installation code version can't be empty");
+    }
+    console.log("installation code version", installationCodeVersion);
     if (installationCodeVersion === workspaceYaml.defaultArgs.codeVersion) {
         console.log("code version is the same, no need to update (ide-service will do it)", installationCodeVersion);
     } else {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Guard for https://github.com/gitpod-io/gitpod/pull/19924/files#r1644827889

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
No need to test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
