### PR TITLE
[gha] add `oci-tool` to fix code updates errors

### DIFF
--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+          chmod +x /usr/local/bin/oci-tool
           cd ./components/ide/gha-update-image/
           yarn
           npm i -g bun

--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+          chmod +x /usr/local/bin/oci-tool
           cd ./components/ide/gha-update-image/
           yarn
           npm i -g bun


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix `oci-tool` missing leads GHA always got empty version

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

✅  See https://github.com/gitpod-io/gitpod/actions/runs/9570557624/job/26385584626

<img width="1353" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/ed775216-dee2-4dd4-9a35-11b3a550c071">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
