### PR TITLE
[server] remove old workspace gc logic

### DIFF
--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -313,38 +313,6 @@ class WorkspaceDBSpec {
     }
 
     @test(timeout(10000))
-    public async testFindWorkspacesForGarbageCollection() {
-        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
-        const dbResult = await this.db.findWorkspacesForGarbageCollection(14, 10);
-        expect(dbResult[0].id).to.eq(this.ws.id);
-        expect(dbResult[0].ownerId).to.eq(this.ws.ownerId);
-    }
-
-    @test(timeout(10000))
-    public async testFindWorkspacesForGarbageCollection_no_instance() {
-        await Promise.all([this.db.store(this.ws)]);
-        const dbResult = await this.db.findWorkspacesForGarbageCollection(14, 10);
-        expect(dbResult[0].id).to.eq(this.ws.id);
-        expect(dbResult[0].ownerId).to.eq(this.ws.ownerId);
-    }
-
-    @test(timeout(10000))
-    public async testFindWorkspacesForGarbageCollection_latelyUsed() {
-        this.wsi2.creationTime = new Date().toISOString();
-        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
-        const dbResult = await this.db.findWorkspacesForGarbageCollection(14, 10);
-        expect(dbResult.length).to.eq(0);
-    }
-
-    @test(timeout(10000))
-    public async testFindWorkspacesForGarbageCollection_markedEligable() {
-        this.ws.deletionEligibilityTime = this.timeWs;
-        await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);
-        const dbResult = await this.db.findWorkspacesForGarbageCollection(14, 10);
-        expect(dbResult.length).to.eq(0);
-    }
-
-    @test(timeout(10000))
     public async testFindEligableWorkspacesForSoftDeletion_markedEligable() {
         this.ws.deletionEligibilityTime = this.timeWs;
         await Promise.all([this.db.store(this.ws), this.db.storeInstance(this.wsi1), this.db.storeInstance(this.wsi2)]);

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -102,7 +102,6 @@ export interface WorkspaceDB {
         limit?: number,
         type?: WorkspaceType,
     ): Promise<WorkspaceAndOwner[]>;
-    findWorkspacesForGarbageCollection(minAgeInDays: number, limit: number): Promise<WorkspaceAndOwner[]>;
     findWorkspacesForContentDeletion(
         minSoftDeletedTimeInDays: number,
         limit: number,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove the now superceded

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-316/remove-old-workspace-gc-logic

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
