### PR TITLE
[VS Code Browser] Update stable code to `1.90.1`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -12,7 +12,7 @@
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
-          "{{.Repository}}/ide/code-codehelper:commit-a6aca7f18e80ce3827384cecb31b5f0643481eb6"
+          "{{.Repository}}/ide/code-codehelper:commit-9d947b04ea167d7f41d5550a1684b52636bf72b8"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",


### PR DESCRIPTION
## Description
Update code to `1.90.1`

## How to test

Should be tested already in build PR, double check:

- [ ] New version is pinnable
- [ ] Stable version is updated and it can start workspace with it

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment