### PR TITLE
[gha] correct code new version detection

### DIFF
--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -136,5 +136,6 @@ jobs:
               inputs: {
                 "quality": "stable",
                 "commit": releaseBranch,
+                "uploadRelease": true,
               }
             })

--- a/components/ide/gha-update-image/index-code.ts
+++ b/components/ide/gha-update-image/index-code.ts
@@ -9,5 +9,8 @@ import { appendGitHubOutput } from "./lib/common";
 $.nothrow();
 
 const newVersion = await updateCodeIDEConfigMapJson();
-console.log("new version released", newVersion);
-await appendGitHubOutput(`codeVersion=${newVersion}`)
+
+if (newVersion) {
+    console.log("new version released", newVersion);
+    await appendGitHubOutput(`codeVersion=${newVersion}`)
+}

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -54,6 +54,7 @@ export async function updateCodeIDEConfigMapJson() {
     if (installationCodeVersion.trim() === "") {
         throw new Error("installation code version can't be empty");
     }
+    let appendNewVersion = false;
     console.log("installation code version", installationCodeVersion);
     if (installationCodeVersion === workspaceYaml.defaultArgs.codeVersion) {
         console.log("code version is the same, no need to update (ide-service will do it)", installationCodeVersion);
@@ -66,10 +67,11 @@ export async function updateCodeIDEConfigMapJson() {
                 image: newJson.ideOptions.options.code.image,
                 imageLayers: newJson.ideOptions.options.code.imageLayers,
             });
+            appendNewVersion = true;
         }
     }
 
     console.log("updating ide-configmap.json");
     await Bun.write(pathToConfigmap, JSON.stringify(newJson, null, 2) + "\n");
-    return workspaceYaml.defaultArgs.codeVersion;
+    return appendNewVersion ? workspaceYaml.defaultArgs.codeVersion : undefined;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

https://github.com/gitpod-io/gitpod/pull/19932 should be image update PR, but not version release PR

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/19932

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
