### PR TITLE
[docker-up] Set DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE=1

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -133,7 +133,11 @@ func runWithinNetns() (err error) {
 	// configure docker0 MTU (used as control plane, not related to containers)
 	args = append(args, fmt.Sprintf("--network-control-plane-mtu=%v", netIface.Attrs().MTU))
 
+	// cmp. ENT-324: Required to run dockerd >= 26.1 in a Gitpod workspace
+	os.Setenv("DOCKER_ALLOW_IPV6_ON_IPV4_INTERFACE", "1")
+
 	if listenFDs > 0 {
+
 		os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid()))
 		args = append(args, "-H", "fd://")
 


### PR DESCRIPTION
## Description
Use the mechanism detailed [here](https://github.com/moby/moby/pull/47774#issue-2269837198) to enabled docker 26.x to run with a read-only "/proc/sys/net".

Note this alone is not enough to allow us to upgrade to 26.x everywhere, though.

## Related Issue(s)

Fixes ENT-324

## How to test
 - open a workspace gitpod workspace: https://gpl-77-docker-ipv6.preview.gitpod-dev.com/#github.com/gitpod-io/gitpod
 - `sudo rm /etc/apt/sources.list.d/archive_uri-https_apt_kubernetes_io_-jammy.list`
 - install 26.1.4 with:
```
curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && sudo apt update && sudo apt-get install docker-ce=5:26.1.4-1~ubuntu.22.04~$(lsb_release -cs) docker-ce-cli=5:26.1.4-1~ubuntu.22.04~$(lsb_release -cs)
```
(confirm everything with `Y`)
 - run this command: `docker run curlimages/curl:8.1.2 -v -k https://example.com`
 - confirm you see this outout (and NOT something about IPv6): :heavy_check_mark: 
```
Unable to find image 'curlimages/curl:8.1.2' locally
8.1.2: Pulling from curlimages/curl
8a49fdb3b6a5: Pull complete 
c452a6fc1daa: Extracting  6.793MB/6.793MB
4ca545ee6d5d: Download complete 
docker: failed to register layer: lsetxattr user.overlay.origin /bin: operation not supported.
See 'docker run --help'.
```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-77-docker-ipv6</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-77-docker-ipv6.preview.gitpod-dev.com/workspaces" target="_blank">gpl-77-docker-ipv6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-77-docker-ipv6-gha.26641</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-77-docker-ipv6%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
