### PR TITLE
Fix nightly VS Code Browser rewrite stable version images

### DIFF
--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -45,7 +45,7 @@ jobs:
             -DcodeCommit=$codeHeadCommit \
             -DcodeVersion=$codeVersion \
             -DcodeQuality=insider \
-            .:docker
+            .:docker-nightly
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -17,3 +17,20 @@ packages:
       image:
         - ${imageRepoBase}/ide/code:${version}
         - ${imageRepoBase}/ide/code:commit-${__git_commit}
+  - name: docker-nightly
+    type: docker
+    argdeps:
+      - imageRepoBase
+      - codeCommit
+      - codeQuality
+      - codeVersion
+    config:
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: workspace.codeImage
+      buildArgs:
+        CODE_COMMIT: ${codeCommit}
+        CODE_QUALITY: ${codeQuality}
+        CODE_VERSION: ${codeVersion}
+      image:
+        - ${imageRepoBase}/ide/code:nightly

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -3,6 +3,8 @@
 # See License.AGPL.txt in the project root for license information.
 FROM gitpod/openvscode-server-linux-build-agent:centos7-devtoolset8-x64 as dependencies_builder
 
+ENV TRIGGER_REBUILD 1
+
 ARG CODE_COMMIT
 
 RUN mkdir /gp-code \

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -50,13 +50,14 @@ export async function updateCodeIDEConfigMapJson() {
     newJson.ideOptions.options.code = updateImages(newJson.ideOptions.options.code);
 
     // try append new pin versions
+    const previousCodeVersion = await getIDEVersionOfImage(ideConfigmapJson.ideOptions.options.code.image.replace("{{.Repository}}/", ""));
     const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
-    if (installationCodeVersion.trim() === "") {
-        throw new Error("installation code version can't be empty");
+    if (installationCodeVersion.trim() === "" || previousCodeVersion.trim() === "") {
+        throw new Error("installation or previous code version can't be empty");
     }
     let appendNewVersion = false;
-    console.log("installation code version", installationCodeVersion);
-    if (installationCodeVersion === workspaceYaml.defaultArgs.codeVersion) {
+    console.log("code versions", { installationCodeVersion, previousCodeVersion });
+    if (installationCodeVersion === previousCodeVersion) {
         console.log("code version is the same, no need to update (ide-service will do it)", installationCodeVersion);
     } else {
         const hasPinned = firstPinnedInfo.version === installationCodeVersion;

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -9,6 +9,7 @@ import {
     pathToConfigmap,
     readIDEConfigmapJson,
     readWorkspaceYaml,
+    renderInstallerIDEConfigMap,
 } from "./common";
 
 $.nothrow();
@@ -50,8 +51,9 @@ export async function updateCodeIDEConfigMapJson() {
     newJson.ideOptions.options.code = updateImages(newJson.ideOptions.options.code);
 
     // try append new pin versions
-    const previousCodeVersion = await getIDEVersionOfImage(ideConfigmapJson.ideOptions.options.code.image.replace("{{.Repository}}/", ""));
-    const installationCodeVersion = await getIDEVersionOfImage(`ide/code:${latestBuildImage.code}`);
+    const previousCodeVersion = await getIDEVersionOfImage("eu.gcr.io/gitpod-core-dev/build/" + ideConfigmapJson.ideOptions.options.code.image.replace("{{.Repository}}/", ""));
+    const installerIDEConfigMap = await renderInstallerIDEConfigMap(undefined);
+    const installationCodeVersion = await getIDEVersionOfImage(installerIDEConfigMap.ideOptions.options.code.image);
     if (installationCodeVersion.trim() === "" || previousCodeVersion.trim() === "") {
         throw new Error("installation or previous code version can't be empty");
     }

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -126,7 +126,7 @@ const execInstaller = async (version: string | undefined, command: string) => {
 
 // installer versions
 export const getLatestInstallerVersions = async (version?: string) => {
-    const versionData = await execInstaller(version, "cat /versions.yaml > /tmp/versions.yaml");
+    const versionData = await execInstaller(version, "cat /versions.yaml");
     const versionObj = z.object({ version: z.string() });
     return z
         .object({

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -172,7 +172,10 @@ export const getLatestInstallerVersions = async (version?: string) => {
 
 export const renderInstallerIDEConfigMap = async (version?: string) => {
     const installationVersion = await getInstallerVersion(version);
-    const ideConfigMapStr = await $`docker run --rm eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} config init --overwrite --log-level=error && cat gitpod.config.yaml | docker run -i --rm eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} ide-configmap -c -`.text().catch((e) => {
+    await $`docker run --rm -v /tmp:/tmp eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} config init --overwrite --log-level=error -c /tmp/gitpod.config.yaml`.catch((e) => {
+        throw new Error("Failed to render gitpod.config.yaml", e);
+    })
+    const ideConfigMapStr = await $`cat /tmp/gitpod.config.yaml | docker run -i --rm eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} ide-configmap -c -`.text().catch((e) => {
         throw new Error(`Failed to render ide-configmap`, e);
     });
     const ideConfigmapJsonObj = JSON.parse(ideConfigMapStr);

--- a/install/installer/cmd/ide.go
+++ b/install/installer/cmd/ide.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	ide_service "github.com/gitpod-io/gitpod/installer/pkg/components/ide-service"
+
+	"github.com/spf13/cobra"
+)
+
+var ideOpts struct {
+	ConfigFN              string
+	Namespace             string
+	UseExperimentalConfig bool
+}
+
+// ideCmd generates ide-configmap.json
+var ideCmd = &cobra.Command{
+	Use:    "ide",
+	Hidden: true,
+	Short:  "render ide-configmap.json",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		renderCtx, err := getRenderCtx(ideOpts.ConfigFN, ideOpts.Namespace, ideOpts.UseExperimentalConfig)
+		if err != nil {
+			return err
+		}
+
+		ideConfig, err := ide_service.GenerateIDEConfigmap(renderCtx)
+		if err != nil {
+			return err
+		}
+
+		fc, err := common.ToJSONString(ideConfig)
+		if err != nil {
+			return fmt.Errorf("failed to marshal ide-config config: %w", err)
+		}
+
+		fmt.Println(string(fc))
+		return nil
+	},
+}
+
+func getRenderCtx(configFN, namespace string, useExperimentalConfig bool) (*common.RenderContext, error) {
+	_, _, cfg, err := loadConfig(configFN)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Experimental != nil {
+		if useExperimentalConfig {
+			fmt.Fprintf(os.Stderr, "rendering using experimental config\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "ignoring experimental config. Use `--use-experimental-config` to include the experimental section in config\n")
+			cfg.Experimental = nil
+		}
+	}
+	versionMF, err := getVersionManifest()
+	if err != nil {
+		return nil, err
+	}
+	return common.NewRenderContext(*cfg, *versionMF, namespace)
+}
+
+func init() {
+	rootCmd.AddCommand(ideCmd)
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get working directory")
+	}
+
+	ideCmd.PersistentFlags().StringVarP(&ideOpts.ConfigFN, "config", "c", getEnvvar("GITPOD_INSTALLER_CONFIG", filepath.Join(dir, "gitpod.config.yaml")), "path to the config file, use - for stdin")
+	ideCmd.PersistentFlags().StringVarP(&ideOpts.Namespace, "namespace", "n", getEnvvar("NAMESPACE", "default"), "namespace to deploy to")
+	ideCmd.Flags().BoolVar(&ideOpts.UseExperimentalConfig, "use-experimental-config", false, "enable the use of experimental config that is prone to be changed")
+}

--- a/install/installer/cmd/ideconfigmap.go
+++ b/install/installer/cmd/ideconfigmap.go
@@ -22,9 +22,9 @@ var ideOpts struct {
 	UseExperimentalConfig bool
 }
 
-// ideCmd generates ide-configmap.json
-var ideCmd = &cobra.Command{
-	Use:    "ide",
+// ideConfigmapCmd generates ide-configmap.json
+var ideConfigmapCmd = &cobra.Command{
+	Use:    "ide-configmap",
 	Hidden: true,
 	Short:  "render ide-configmap.json",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -70,14 +70,14 @@ func getRenderCtx(configFN, namespace string, useExperimentalConfig bool) (*comm
 }
 
 func init() {
-	rootCmd.AddCommand(ideCmd)
+	rootCmd.AddCommand(ideConfigmapCmd)
 
 	dir, err := os.Getwd()
 	if err != nil {
 		log.WithError(err).Fatal("Failed to get working directory")
 	}
 
-	ideCmd.PersistentFlags().StringVarP(&ideOpts.ConfigFN, "config", "c", getEnvvar("GITPOD_INSTALLER_CONFIG", filepath.Join(dir, "gitpod.config.yaml")), "path to the config file, use - for stdin")
-	ideCmd.PersistentFlags().StringVarP(&ideOpts.Namespace, "namespace", "n", getEnvvar("NAMESPACE", "default"), "namespace to deploy to")
-	ideCmd.Flags().BoolVar(&ideOpts.UseExperimentalConfig, "use-experimental-config", false, "enable the use of experimental config that is prone to be changed")
+	ideConfigmapCmd.PersistentFlags().StringVarP(&ideOpts.ConfigFN, "config", "c", getEnvvar("GITPOD_INSTALLER_CONFIG", filepath.Join(dir, "gitpod.config.yaml")), "path to the config file, use - for stdin")
+	ideConfigmapCmd.PersistentFlags().StringVarP(&ideOpts.Namespace, "namespace", "n", getEnvvar("NAMESPACE", "default"), "namespace to deploy to")
+	ideConfigmapCmd.Flags().BoolVar(&ideOpts.UseExperimentalConfig, "use-experimental-config", false, "enable the use of experimental config that is prone to be changed")
 }

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -25,7 +25,7 @@ import (
 //go:embed ide-configmap.json
 var ideConfigFile string
 
-func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+func GenerateIDEConfigmap(ctx *common.RenderContext) (*ide_config.IDEConfig, error) {
 	resolveLatestImage := func(name string, tag string, bundledLatest versions.Versioned) string {
 		resolveLatest := true
 		if ctx.Config.Components != nil && ctx.Config.Components.IDE != nil && ctx.Config.Components.IDE.ResolveLatest != nil {
@@ -119,7 +119,14 @@ func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if idecfg.IdeOptions.Options[idecfg.IdeOptions.DefaultDesktopIde].Type != ide_config.IDETypeDesktop {
 		return nil, fmt.Errorf("default desktop IDE '%s' does not point to a desktop IDE option", idecfg.IdeOptions.DefaultIde)
 	}
+	return &idecfg, nil
+}
 
+func ideConfigConfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	idecfg, err := GenerateIDEConfigmap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ide-config config: %w", err)
+	}
 	fc, err := common.ToJSONString(idecfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal ide-config config: %w", err)

--- a/test/run.sh
+++ b/test/run.sh
@@ -146,11 +146,7 @@ else
 
     cd "${TEST_PATH}"
     set +e
-    if [ "$TEST_SUITE" == "jetbrains" ]; then
-      go test -parallel=3 -v ./... "${args[@]}" 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
-    else
-      go test -v ./... "${args[@]}" 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
-    fi
+    go test -parallel=3 -v ./... "${args[@]}" 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "${RESULTS_DIR}/TEST-${TEST_NAME}.xml" -iocopy
     RC=${PIPESTATUS[0]}
     set -e
     cd -


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Fix nightly VS Code Browser rewrite stable version images
- Fix gha script
- Fix JetBrains' test opened more than 4 workspaces at a time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-320

## How to test
<!-- Provide steps to test this PR -->
- Code image will be rebuild
- Start workspace with latest code, its version should be `1.90.2`

**Test installer changes**
- Open this PR with Gitpod
```
cd /workspace/gitpod/install/installer
go run main.go config init --overwrite --log-level=error
docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:main-gha.26675 cat /versions.yaml > versions.yaml
go run main.go ide-configmap --debug-version-file ./versions.yaml
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-ide</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-ide.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-ide.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-ide-gha.26682</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-ide%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=vscode
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
