### PR TITLE
Enable displaying JB warmup tasks in the Prebuilds UI

### DIFF
--- a/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
+++ b/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
@@ -42,8 +42,8 @@
                     "logUrl": ""
                 },
                 {
-                    "taskId": "jb-warmup-intellij-latest",
-                    "taskLabel": "JetBrains Intellij warmup (latest)",
+                    "taskId": "jb-warmup-clion-stable",
+                    "taskLabel": "JetBrains Clion warmup (stable)",
                     "taskJson": "",
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/3"
                 },
@@ -54,8 +54,8 @@
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/4"
                 },
                 {
-                    "taskId": "jb-warmup-clion-stable",
-                    "taskLabel": "JetBrains Clion warmup (stable)",
+                    "taskId": "jb-warmup-intellij-latest",
+                    "taskLabel": "JetBrains Intellij warmup (latest)",
                     "taskJson": "",
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/5"
                 }

--- a/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
+++ b/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
@@ -43,19 +43,19 @@
                 },
                 {
                     "taskId": "jb-warmup-intellij-latest",
-                    "taskLabel": "JetBrains intellij Warmup (latest)",
+                    "taskLabel": "JetBrains Intellij warmup (latest)",
                     "taskJson": "",
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/3"
                 },
                 {
                     "taskId": "jb-warmup-intellij-stable",
-                    "taskLabel": "JetBrains intellij Warmup (stable)",
+                    "taskLabel": "JetBrains Intellij warmup (stable)",
                     "taskJson": "",
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/4"
                 },
                 {
                     "taskId": "jb-warmup-clion-stable",
-                    "taskLabel": "JetBrains clion Warmup (stable)",
+                    "taskLabel": "JetBrains Clion warmup (stable)",
                     "taskJson": "",
                     "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/5"
                 }

--- a/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
+++ b/components/public-api/typescript-common/fixtures/toPrebuild_1.golden
@@ -22,7 +22,44 @@
             "startTime": "2023-11-17T10:42:00Z",
             "message": "",
             "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37",
-            "taskLogs": [],
+            "taskLogs": [
+                {
+                    "taskId": "0",
+                    "taskLabel": "Task [1]",
+                    "taskJson": "{\"init\":\"true\",\"command\":\"npm install\"}",
+                    "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/0"
+                },
+                {
+                    "taskId": "1",
+                    "taskLabel": "Task [2]",
+                    "taskJson": "{\"command\":\"npm run build\"}",
+                    "logUrl": ""
+                },
+                {
+                    "taskId": "2",
+                    "taskLabel": "Task [3]",
+                    "taskJson": "{\"command\":\"npm run start\"}",
+                    "logUrl": ""
+                },
+                {
+                    "taskId": "jb-warmup-intellij-latest",
+                    "taskLabel": "JetBrains intellij Warmup (latest)",
+                    "taskJson": "",
+                    "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/3"
+                },
+                {
+                    "taskId": "jb-warmup-intellij-stable",
+                    "taskLabel": "JetBrains intellij Warmup (stable)",
+                    "taskJson": "",
+                    "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/4"
+                },
+                {
+                    "taskId": "jb-warmup-clion-stable",
+                    "taskLabel": "JetBrains clion Warmup (stable)",
+                    "taskJson": "",
+                    "logUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/5fba7d7c-e740-4339-b928-0e3c5975eb37/5"
+                }
+            ],
             "imageBuildLogUrl": "https://gitpod-test.preview.gitpod-dev.com/prebuild-logs/eb276a90-0970-49fb-947f-3cefe856efdc/image-build"
         },
         "configurationName": "parcel-demo"

--- a/components/public-api/typescript-common/fixtures/toPrebuild_1.json
+++ b/components/public-api/typescript-common/fixtures/toPrebuild_1.json
@@ -19,7 +19,33 @@
     "changeUrl": "https://github.com/akosyakov/parcel-demo/tree/master"
   },
   "workspace": {
-    "id":  "eb276a90-0970-49fb-947f-3cefe856efdc"
+    "id":  "eb276a90-0970-49fb-947f-3cefe856efdc",
+    "config": {
+      "tasks": [
+        {
+          "init": "true",
+          "command": "npm install"
+        },
+        {
+          "command": "npm run build"
+        },
+        {
+          "command": "npm run start"
+        }
+      ],
+      "jetbrains": {
+        "intellij": {
+          "prebuilds": {
+            "version": "both"
+          }
+        },
+        "clion": {
+          "prebuilds": {
+            "version": "stable"
+          }
+        }
+      }
+    }
   },
   "status": "building"
 }

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -1214,6 +1214,10 @@ export class PublicAPIConverter {
             }
         }
 
+        const capitalize = (input: string) => {
+            return input.charAt(0).toUpperCase() + input.slice(1);
+        }
+
         // This is a hack mimicking the supervisor behavior of adding dynamic IDE tasks https://github.com/gitpod-io/gitpod/blob/e7d79c355e2cd6ac34056ea52d7bdcda45975839/components/ide-service/pkg/server/server.go#L508-L540
         const jetbrainsIdes = prebuild.workspace.config.jetbrains;
         if (jetbrainsIdes) {
@@ -1227,7 +1231,7 @@ export class PublicAPIConverter {
                     tasks.push(
                         new TaskLog({
                             taskId: `jb-warmup-${ide}-latest`,
-                            taskLabel: `JetBrains ${ide} Warmup (latest)`,
+                            taskLabel: `JetBrains ${capitalize(ide)} warmup (latest)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),
                                 gitpodHost,
@@ -1239,7 +1243,7 @@ export class PublicAPIConverter {
                     tasks.push(
                         new TaskLog({
                             taskId: `jb-warmup-${ide}-stable`,
-                            taskLabel: `JetBrains ${ide} Warmup (stable)`,
+                            taskLabel: `JetBrains ${capitalize(ide)} warmup (stable)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),
                                 gitpodHost,

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -21,6 +21,7 @@ import {
     EnvVarWithValue,
     IDESettings,
     Identity as IdentityProtocol,
+    JetBrainsProductConfig,
     NamedWorkspaceFeatureFlag,
     PrebuiltWorkspaceState,
     ProjectEnvVar,
@@ -35,8 +36,9 @@ import {
     WithEnvvarsContext,
     WithPrebuild,
     WorkspaceAutostartOption,
-    WorkspaceContext, WorkspaceInfo,
-    WorkspaceSession as WorkspaceSessionProtocol
+    WorkspaceContext,
+    WorkspaceInfo,
+    WorkspaceSession as WorkspaceSessionProtocol,
 } from "@gitpod/gitpod-protocol/lib/protocol";
 import {
     OrgMemberInfo,
@@ -134,7 +136,8 @@ import {
     ParseContextURLResponse,
     PrebuildInitializer,
     SnapshotInitializer,
-    UpdateWorkspaceRequest_UpdateTimeout, Workspace,
+    UpdateWorkspaceRequest_UpdateTimeout,
+    Workspace,
     WorkspaceClass,
     WorkspaceGitStatus,
     WorkspaceInitializer,
@@ -151,7 +154,7 @@ import {
     WorkspaceSpec_WorkspaceType,
     WorkspaceStatus,
     WorkspaceStatus_PrebuildResult,
-    WorkspaceStatus_WorkspaceConditions
+    WorkspaceStatus_WorkspaceConditions,
 } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { getPrebuildLogPath } from "./prebuild-utils";
 import { InvalidGitpodYMLError, RepositoryNotFoundError, UnauthorizedRepositoryAccessError } from "./public-api-errors";
@@ -1216,22 +1219,23 @@ export class PublicAPIConverter {
 
         const capitalize = (input: string) => {
             return input.charAt(0).toUpperCase() + input.slice(1);
-        }
+        };
 
         // This is a hack mimicking the supervisor behavior of adding dynamic IDE tasks https://github.com/gitpod-io/gitpod/blob/e7d79c355e2cd6ac34056ea52d7bdcda45975839/components/ide-service/pkg/server/server.go#L508-L540
-        const jetbrainsIdes = prebuild.workspace.config.jetbrains;
-        if (jetbrainsIdes) {
-            for (const ide in jetbrainsIdes) {
-                const ideConfig = jetbrainsIdes[ide as keyof typeof jetbrainsIdes]!;
+        if (prebuild.workspace.config.jetbrains) {
+            const jetbrainsIdes = Object.entries(prebuild.workspace.config.jetbrains).sort(([a], [b]) =>
+                a.localeCompare(b),
+            ) as [string, JetBrainsProductConfig][];
+            for (const [ide, ideConfig] of jetbrainsIdes) {
                 if (!ideConfig.prebuilds) {
                     continue;
                 }
 
-                if (ideConfig.prebuilds.version === "latest" || ideConfig.prebuilds.version === "both") {
+                if (ideConfig.prebuilds.version !== "latest") {
                     tasks.push(
                         new TaskLog({
-                            taskId: `jb-warmup-${ide}-latest`,
-                            taskLabel: `JetBrains ${capitalize(ide)} warmup (latest)`,
+                            taskId: `jb-warmup-${ide}-stable`,
+                            taskLabel: `JetBrains ${capitalize(ide)} warmup (stable)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),
                                 gitpodHost,
@@ -1239,11 +1243,11 @@ export class PublicAPIConverter {
                         }),
                     );
                 }
-                if (ideConfig.prebuilds.version === "stable" || ideConfig.prebuilds.version === "both") {
+                if (ideConfig.prebuilds.version !== "stable") {
                     tasks.push(
                         new TaskLog({
-                            taskId: `jb-warmup-${ide}-stable`,
-                            taskLabel: `JetBrains ${capitalize(ide)} warmup (stable)`,
+                            taskId: `jb-warmup-${ide}-latest`,
+                            taskLabel: `JetBrains ${capitalize(ide)} warmup (latest)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),
                                 gitpodHost,

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -1226,7 +1226,7 @@ export class PublicAPIConverter {
                 if (ideConfig.prebuilds.version === "latest" || ideConfig.prebuilds.version === "both") {
                     tasks.push(
                         new TaskLog({
-                            taskId: `jetbrains-warmup-${ide}-latest`,
+                            taskId: `jb-warmup-${ide}-latest`,
                             taskLabel: `JetBrains ${ide} Warmup (latest)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),
@@ -1238,7 +1238,7 @@ export class PublicAPIConverter {
                 if (ideConfig.prebuilds.version === "stable" || ideConfig.prebuilds.version === "both") {
                     tasks.push(
                         new TaskLog({
-                            taskId: `jetbrains-warmup-${ide}-stable`,
+                            taskId: `jb-warmup-${ide}-stable`,
                             taskLabel: `JetBrains ${ide} Warmup (stable)`,
                             logUrl: new URL(
                                 getPrebuildLogPath(prebuild.info.id, `${++taskIndex}`),

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -1213,6 +1213,8 @@ export class PublicAPIConverter {
                 );
             }
         }
+
+        // This is a hack mimicking the supervisor behavior of adding dynamic IDE tasks https://github.com/gitpod-io/gitpod/blob/e7d79c355e2cd6ac34056ea52d7bdcda45975839/components/ide-service/pkg/server/server.go#L508-L540
         const jetbrainsIdes = prebuild.workspace.config.jetbrains;
         if (jetbrainsIdes) {
             for (const ide in jetbrainsIdes) {

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -8,12 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	env "github.com/Netflix/go-env"
@@ -593,7 +594,7 @@ func loadDesktopIDEs(static *StaticConfig) ([]*IDEConfig, error) {
 		uniqueDesktopIDEs[desktopIDE.GetUniqueKey()] = struct{}{}
 	}
 
-	files, err := ioutil.ReadDir(static.DesktopIDERoot)
+	files, err := os.ReadDir(static.DesktopIDERoot)
 	if err != nil {
 		return nil, err
 	}
@@ -615,6 +616,10 @@ func loadDesktopIDEs(static *StaticConfig) ([]*IDEConfig, error) {
 			uniqueDesktopIDEs[desktopIDE.Name] = struct{}{}
 		}
 	}
+
+	slices.SortFunc(desktopIDEs, func(a, b *IDEConfig) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return desktopIDEs, nil
 }


### PR DESCRIPTION
## Description

Enable displaying JB warmup tasks in the Prebuilds detail, just like any other task.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-172

## How to test

https://ft-jb-warmup-in-ui.preview.gitpod-dev.com/prebuilds/

Try triggering a prebuild with a repo such as https://github.com/gitpod-samples/spring-petclinic.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
