### PR TITLE
[gha] fix nit bugs of IDE images update

### DIFF
--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -9,7 +9,6 @@ import {
     pathToConfigmap,
     readIDEConfigmapJson,
     readWorkspaceYaml,
-    renderInstallerIDEConfigMap,
 } from "./common";
 
 $.nothrow();
@@ -52,8 +51,7 @@ export async function updateCodeIDEConfigMapJson() {
 
     // try append new pin versions
     const previousCodeVersion = await getIDEVersionOfImage("eu.gcr.io/gitpod-core-dev/build/" + ideConfigmapJson.ideOptions.options.code.image.replace("{{.Repository}}/", ""));
-    const installerIDEConfigMap = await renderInstallerIDEConfigMap(undefined);
-    const installationCodeVersion = await getIDEVersionOfImage(installerIDEConfigMap.ideOptions.options.code.image);
+    const installationCodeVersion = await getIDEVersionOfImage("eu.gcr.io/gitpod-core-dev/build/" + newJson.ideOptions.options.code.image.replace("{{.Repository}}/", ""));
     if (installationCodeVersion.trim() === "" || previousCodeVersion.trim() === "") {
         throw new Error("installation or previous code version can't be empty");
     }
@@ -66,7 +64,7 @@ export async function updateCodeIDEConfigMapJson() {
         if (!hasPinned) {
             console.log("updating related pinned version", installationCodeVersion);
             newJson.ideOptions.options.code.versions.unshift({
-                version: installationCodeVersion,
+                version: previousCodeVersion,
                 image: newJson.ideOptions.options.code.image,
                 imageLayers: newJson.ideOptions.options.code.imageLayers,
             });

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -116,9 +116,9 @@ const getInstallerVersion = async (version: string | undefined) => {
         await $`echo '${tagInfo}' | awk '{ print $2 }' | grep -o 'main-gha.[0-9]*' | cut -d'/' -f3`
             .text()
             .catch((e) => {
-                throw new Error("Failed to parse installer version from git tag", e);
+                throw new Error("Failed to parse installer version from git tag: " + e);
             });
-    return installationVersion;
+    return installationVersion.replaceAll("\n", "");
 }
 
 // installer versions
@@ -126,7 +126,7 @@ export const getLatestInstallerVersions = async (version?: string) => {
     const installationVersion = await getInstallerVersion(version);
     console.log("Fetching installer versions for", installationVersion);
     const versionData = await $`docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${installationVersion} cat /versions.yaml`.text().catch((e) => {
-        throw new Error(`Failed to get installer versions`, e);
+        throw new Error("Failed to get installer versions: " + e);
     });
 
     const versionObj = z.object({ version: z.string() });
@@ -173,10 +173,10 @@ export const getLatestInstallerVersions = async (version?: string) => {
 export const renderInstallerIDEConfigMap = async (version?: string) => {
     const installationVersion = await getInstallerVersion(version);
     await $`docker run --rm -v /tmp:/tmp eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} config init --overwrite --log-level=error -c /tmp/gitpod.config.yaml`.catch((e) => {
-        throw new Error("Failed to render gitpod.config.yaml", e);
+        throw new Error("Failed to render gitpod.config.yaml: " + e);
     })
     const ideConfigMapStr = await $`cat /tmp/gitpod.config.yaml | docker run -i --rm eu.gcr.io/gitpod-core-dev/build/installer:${installationVersion} ide-configmap -c -`.text().catch((e) => {
-        throw new Error(`Failed to render ide-configmap`, e);
+        throw new Error(`Failed to render ide-configmap: ` + e);
     });
     const ideConfigmapJsonObj = JSON.parse(ideConfigMapStr);
     const ideConfigmapJson = ideConfigmapJsonSchema.parse(ideConfigmapJsonObj);
@@ -186,7 +186,7 @@ export const renderInstallerIDEConfigMap = async (version?: string) => {
 export const getIDEVersionOfImage = async (img: string) => {
     console.log("Fetching IDE version in image:", `oci-tool fetch image execInstaller${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`)
     const version = await $`oci-tool fetch image execInstaller${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`.text().catch((e) => {
-        throw new Error("Failed to fetch ide version in image", e);
+        throw new Error("Failed to fetch ide version in image: " + e);
     }).then(str => str.replaceAll("\n", ""));
     console.log("IDE version in image:", version);
     return version;

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -184,8 +184,8 @@ export const renderInstallerIDEConfigMap = async (version?: string) => {
 }
 
 export const getIDEVersionOfImage = async (img: string) => {
-    console.log("Fetching IDE version in image:", `oci-tool fetch image execInstaller${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`)
-    const version = await $`oci-tool fetch image execInstaller${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`.text().catch((e) => {
+    console.log("Fetching IDE version in image:", `oci-tool fetch image ${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`)
+    const version = await $`oci-tool fetch image ${img} | jq -r '.config.Labels["io.gitpod.ide.version"]'`.text().catch((e) => {
         throw new Error("Failed to fetch ide version in image: " + e);
     }).then(str => str.replaceAll("\n", ""));
     console.log("IDE version in image:", version);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open this PR with Gitpod
```
cd /workspace/gitpod/components/ide/gha-update-image
npm i -g bun
yarn

# it should update code image and append previous version
bun run index-code.ts

# it should update JB WORKSPACE.yaml and append previous version
bun run index-jb.ts
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
