### PR TITLE
[VS Code Browser] Update stable code to `1.90.2`

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -13,6 +13,8 @@ jobs:
             - uses: actions/checkout@v4
             - name: Install dependencies
               run: |
+                curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+                chmod +x /usr/local/bin/oci-tool
                 cd ./components/ide/gha-update-image
                 yarn
                 npm i -g bun

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -65,8 +65,8 @@ export async function updateCodeIDEConfigMapJson() {
             console.log("updating related pinned version", installationCodeVersion);
             newJson.ideOptions.options.code.versions.unshift({
                 version: previousCodeVersion,
-                image: newJson.ideOptions.options.code.image,
-                imageLayers: newJson.ideOptions.options.code.imageLayers,
+                image: ideConfigmapJsonObj.ideOptions.options.code.image,
+                imageLayers: ideConfigmapJsonObj.ideOptions.options.code.imageLayers,
             });
             appendNewVersion = true;
         }

--- a/components/ide/gha-update-image/lib/jb-pin-version.ts
+++ b/components/ide/gha-update-image/lib/jb-pin-version.ts
@@ -51,8 +51,8 @@ export const appendPinVersionsIntoIDEConfigMap = async (updatedIDEs: string[] | 
             const previousVersion = await getIDEVersionOfImage(ideConfigMap.ideOptions.options[ide].image);
             const previousInfo = {
                 version: previousVersion,
-                image: ideConfigMap.ideOptions.options[ide].image,
-                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers,
+                image: ideConfigMap.ideOptions.options[ide].image.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}"),
+                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers.map((e: string) => e.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}")),
             };
 
             if (!updatedIDEs || !updatedIDEs.includes(ide)) {

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,7 +8,7 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+        "image": "{{.Repository}}/ide/code:commit-940f23420544f76a67ae3ed32e726c9f9c9c4b3d",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
@@ -20,6 +20,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "1.90.1",
+            "image": "{{.Repository}}/ide/code:commit-518f23b3b895cd544bd6b3dd383af95c350718cc",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",
+              "{{.Repository}}/ide/code-codehelper:commit-9d947b04ea167d7f41d5550a1684b52636bf72b8"
+            ]
+          },
           {
             "version": "1.90.0",
             "image": "{{.Repository}}/ide/code:commit-ece9c809ac703118bd86cc0b69191db74dcd3df4",


### PR DESCRIPTION
## Description
Update code to `1.90.2`

## How to test

Should be tested already in build PR, double check:

- [ ] New version is pinnable
- [ ] Stable version is updated and it can start workspace with it

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment