### PR TITLE
[gha] correct images to use

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -13,6 +13,8 @@ jobs:
             - uses: actions/checkout@v4
             - name: Install dependencies
               run: |
+                curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+                chmod +x /usr/local/bin/oci-tool
                 cd ./components/ide/gha-update-image
                 yarn
                 npm i -g bun

--- a/components/ide/gha-update-image/lib/code-pin-version.ts
+++ b/components/ide/gha-update-image/lib/code-pin-version.ts
@@ -65,8 +65,8 @@ export async function updateCodeIDEConfigMapJson() {
             console.log("updating related pinned version", installationCodeVersion);
             newJson.ideOptions.options.code.versions.unshift({
                 version: previousCodeVersion,
-                image: newJson.ideOptions.options.code.image,
-                imageLayers: newJson.ideOptions.options.code.imageLayers,
+                image: ideConfigmapJsonObj.ideOptions.options.code.image,
+                imageLayers: ideConfigmapJsonObj.ideOptions.options.code.imageLayers,
             });
             appendNewVersion = true;
         }

--- a/components/ide/gha-update-image/lib/jb-pin-version.ts
+++ b/components/ide/gha-update-image/lib/jb-pin-version.ts
@@ -51,8 +51,8 @@ export const appendPinVersionsIntoIDEConfigMap = async (updatedIDEs: string[] | 
             const previousVersion = await getIDEVersionOfImage(ideConfigMap.ideOptions.options[ide].image);
             const previousInfo = {
                 version: previousVersion,
-                image: ideConfigMap.ideOptions.options[ide].image,
-                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers,
+                image: ideConfigMap.ideOptions.options[ide].image.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}"),
+                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers.map((e: string) => e.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}")),
             };
 
             if (!updatedIDEs || !updatedIDEs.includes(ide)) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check GHA ouput and created PRs
- https://github.com/gitpod-io/gitpod/actions/runs/9609860551 
- https://github.com/gitpod-io/gitpod/actions/runs/9609858860

**PR**
- Code https://github.com/gitpod-io/gitpod/pull/19952
- JetBrains https://github.com/gitpod-io/gitpod/pull/19953

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
