### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,14 +13,14 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8915adfdb17c4dc52c327ca81c50c547e80d3a99
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.3.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.3.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.4.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.4.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.1.3.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.3.tar.gz"
   rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.1.3.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.1.4.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.1.5.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.3.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.1.3.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.1.4.tar.gz"
   rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.1.2.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "20.10.24"

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -127,6 +127,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.1.3",
+            "image": "{{.Repository}}/ide/intellij:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
+            ]
+          },
+          {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/intellij:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -191,6 +199,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.1.3",
+            "image": "{{.Repository}}/ide/goland:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
+            ]
+          },
           {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/goland:commit-9823a689c6259339239381e2840e29149fc8d195",
@@ -405,6 +421,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.1.4",
+            "image": "{{.Repository}}/ide/webstorm:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
+            ]
+          },
+          {
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/webstorm:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
@@ -510,6 +534,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.1.3",
+            "image": "{{.Repository}}/ide/clion:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
+              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
+            ]
+          },
           {
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/clion:commit-9823a689c6259339239381e2840e29149fc8d195",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR
8. Warmup is working properly using IntelliJ and spring-petclinic project sample

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_