### PR TITLE
redirect in the offline case

### DIFF
--- a/components/gitpod-protocol/src/headless-workspace-log.ts
+++ b/components/gitpod-protocol/src/headless-workspace-log.ts
@@ -32,6 +32,9 @@ export interface HeadlessWorkspaceEvent {
 export interface HeadlessLogUrls {
     // A map of id to URL
     streams: { [streamID: string]: string };
+
+    // Whether the workspace is online
+    online?: boolean;
 }
 
 /** cmp. @const HEADLESS_LOG_STREAM_STATUS_CODE_REGEX */

--- a/components/public-api/typescript-common/src/prebuild-utils.ts
+++ b/components/public-api/typescript-common/src/prebuild-utils.ts
@@ -99,6 +99,7 @@ export function onDownloadPrebuildLogsUrl(
                 headers: {
                     TE: "trailers", // necessary to receive stream status code
                 },
+                redirect: "follow",
             });
             reader = response.body?.getReader();
             if (!reader) {

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -963,7 +963,7 @@ export class WorkspaceService {
     public async streamWorkspaceLogs(
         userId: string,
         instanceId: string,
-        terminalId: string,
+        taskIdentifier: { terminalId: string } | { taskId: string },
         sink: (chunk: string) => Promise<void>,
         check: () => Promise<void> = async () => {},
     ) {
@@ -995,7 +995,7 @@ export class WorkspaceService {
             { userId, instanceId, workspaceId: workspace!.id },
             logEndpoint,
             instanceId,
-            terminalId,
+            taskIdentifier,
             sink,
         );
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-282

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-282-cleanup</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-282-cleanup.preview.gitpod-dev.com/workspaces" target="_blank">gpl-282-cleanup.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-282-cleanup-gha.26780</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-282-cleanup%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
