### PR TITLE
[obs] reduce potential for ProxyBadGateway to trigger

### DIFF
--- a/operations/observability/mixins/meta/rules/proxy.yaml
+++ b/operations/observability/mixins/meta/rules/proxy.yaml
@@ -25,9 +25,9 @@ spec:
   - name: proxy
     rules:
     - alert: ProxyBadGateway
-      # Reasoning: PAYG returns 502s at an increase of 1 using the same formula, something is wrong if the increase is higher
+      # Reasoning: The highest peak of 502's for PAYG is 0.00007 in 5m, and this was not impactful for users.
       expr: |
-        sum(increase(caddy_http_response_duration_seconds_count{code="502"}[5m])) > 1
+        sum(increase(caddy_http_response_duration_seconds_count{code="502"}[5m])) / sum(increase(caddy_http_response_duration_seconds_count[5m])) > 0.001
       labels:
         severity: critical
         team: webapp


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now, if we've violated five 9's, then we'll trigger...but not before (which is what has been happening lately).

Ref: https://gitpod.slack.com/archives/C01TNS8EVQT/p1718979601030609?thread_ts=1718961427.787819&cid=C01TNS8EVQT

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-268

## How to test
<!-- Provide steps to test this PR -->
You can see we would not have triggered lately (since we started emitting this Caddy metric recently):
![image](https://github.com/gitpod-io/gitpod/assets/1272076/82b00900-daeb-4238-8874-5188de96fcc8)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
