### PR TITLE
Fix dropped errors on available prebuilds

### DIFF
--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -149,11 +149,17 @@ export class RedisSubscriber {
             log.error("Failed to find workspace for prebuild", { ...update });
             return;
         }
+        const pbws = await this.workspaceDB.findPrebuildByID(update.prebuildID);
+        if (!pbws) {
+            log.error("Failed to find prebuilt workspace", { ...update });
+            return;
+        }
 
         const prebuildWithStatus: PrebuildWithStatus = {
             info: info,
             status: update.status,
             workspace,
+            error: pbws.error,
         };
 
         for (const l of listeners) {

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -29,7 +29,7 @@ import { IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
 import { PrebuildStateMapper } from "./prebuild-state-mapper";
 import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
-import { Client } from "@gitpod/gitpod-protocol/lib/experiments/types";
+import { Client as ExperimentsClient } from "@gitpod/gitpod-protocol/lib/experiments/types";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { WorkspaceInstanceController, WorkspaceInstanceControllerImpl } from "./workspace-instance-controller";
 import { AppClusterWorkspaceInstancesController } from "./app-cluster-instance-controller";
@@ -78,7 +78,7 @@ export const containerModule = new ContainerModule((bind) => {
 
     bind(DebugApp).toSelf().inSingletonScope();
 
-    bind(Client).toDynamicValue(getExperimentsClientForBackend).inSingletonScope();
+    bind(ExperimentsClient).toDynamicValue(getExperimentsClientForBackend).inSingletonScope();
 
     // transient to make sure we're creating a separate instance every time we ask for it
     bind(WorkspaceInstanceController).to(WorkspaceInstanceControllerImpl).inTransientScope();

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
@@ -9,9 +9,17 @@ import * as chai from "chai";
 import { PrebuildStateMapper } from "./prebuild-state-mapper";
 import { WorkspaceConditionBool, WorkspacePhase, WorkspaceStatus } from "@gitpod/ws-manager/lib";
 import { PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 
 const expect = chai.expect;
+
+const mockExperimentsClient = (returnValue: boolean) => {
+    return {
+        getValueAsync: async <T>() => {
+            return returnValue as unknown as T;
+        },
+        dispose: () => {},
+    };
+};
 
 @suite
 class TestPrebuildStateMapper {
@@ -112,8 +120,131 @@ class TestPrebuildStateMapper {
         ];
 
         for (const test of table) {
-            const experimentsClient = getExperimentsClientForBackend();
-            const cut = new PrebuildStateMapper(experimentsClient);
+            const cut = new PrebuildStateMapper(mockExperimentsClient(false));
+            const actual = await cut.mapWorkspaceStatusToPrebuild(test.status as WorkspaceStatus.AsObject);
+            expect(!!actual?.update.error, test.name + ": hasError").to.be.equal(!!test.expected?.hasError);
+            delete actual?.update.error;
+            delete test.expected?.hasError;
+            expect(actual?.update, test.name).to.deep.equal(test.expected);
+        }
+    }
+    @test public async testNew() {
+        const id = "12345";
+        const snapshot = "some-valid-snapshot";
+        const failed = "some system error";
+        const headlessTaskFailed = "some user/content error";
+
+        const table: {
+            name: string;
+            status: Pick<WorkspaceStatus.AsObject, "id" | "phase"> & {
+                conditions: Partial<WorkspaceStatus.AsObject["conditions"]>;
+            };
+            expected: (Omit<Partial<PrebuiltWorkspace>, "error"> & { hasError?: boolean }) | undefined;
+        }[] = [
+            {
+                name: "STOPPED, finished",
+                expected: {
+                    state: "available",
+                    snapshot,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPED,
+                    conditions: {
+                        snapshot,
+                    },
+                },
+            },
+            {
+                name: "failed",
+                expected: {
+                    state: "building",
+                    hasError: false,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        failed,
+                    },
+                },
+            },
+            {
+                name: "Stopping and no snapshot yet",
+                expected: {
+                    state: "building",
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        snapshot: "",
+                    },
+                },
+            },
+            {
+                name: "aborted",
+                expected: {
+                    state: "aborted",
+                    hasError: true,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPED,
+                    conditions: {
+                        stoppedByRequest: WorkspaceConditionBool.TRUE,
+                    },
+                },
+            },
+            {
+                name: "user/content error",
+                expected: {
+                    state: "available",
+                    hasError: true,
+                    snapshot,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPED,
+                    conditions: {
+                        headlessTaskFailed,
+                        snapshot,
+                    },
+                },
+            },
+            {
+                name: "user/content error too early",
+                expected: {
+                    state: "building",
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        headlessTaskFailed,
+                        snapshot,
+                    },
+                },
+            },
+            {
+                name: "available and no error",
+                expected: {
+                    state: "available",
+                    hasError: false,
+                    snapshot,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPED,
+                    conditions: {
+                        snapshot,
+                    },
+                },
+            },
+        ];
+
+        for (const test of table) {
+            const cut = new PrebuildStateMapper(mockExperimentsClient(true));
             const actual = await cut.mapWorkspaceStatusToPrebuild(test.status as WorkspaceStatus.AsObject);
             expect(!!actual?.update.error, test.name + ": hasError").to.be.equal(!!test.expected?.hasError);
             delete actual?.update.error;

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
@@ -9,12 +9,13 @@ import * as chai from "chai";
 import { PrebuildStateMapper } from "./prebuild-state-mapper";
 import { WorkspaceConditionBool, WorkspacePhase, WorkspaceStatus } from "@gitpod/ws-manager/lib";
 import { PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 
 const expect = chai.expect;
 
 @suite
 class TestPrebuildStateMapper {
-    @test public testAll() {
+    @test public async testAll() {
         const id = "12345";
         const snapshot = "some-valid-snapshot";
         const failed = "some system error";
@@ -111,8 +112,9 @@ class TestPrebuildStateMapper {
         ];
 
         for (const test of table) {
-            const cut = new PrebuildStateMapper();
-            const actual = cut.mapWorkspaceStatusToPrebuild(test.status as WorkspaceStatus.AsObject);
+            const experimentsClient = getExperimentsClientForBackend();
+            const cut = new PrebuildStateMapper(experimentsClient);
+            const actual = await cut.mapWorkspaceStatusToPrebuild(test.status as WorkspaceStatus.AsObject);
             expect(!!actual?.update.error, test.name + ": hasError").to.be.equal(!!test.expected?.hasError);
             delete actual?.update.error;
             delete test.expected?.hasError;

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
@@ -23,7 +23,8 @@ const mockExperimentsClient = (returnValue: boolean) => {
 
 @suite
 class TestPrebuildStateMapper {
-    @test public async testAll() {
+    // Tests with ws_manager_bridge_stopped_prebuild_statuses disabled
+    @test public async testWsManagerBridgeStoppedDisabled() {
         const id = "12345";
         const snapshot = "some-valid-snapshot";
         const failed = "some system error";
@@ -128,7 +129,8 @@ class TestPrebuildStateMapper {
             expect(actual?.update, test.name).to.deep.equal(test.expected);
         }
     }
-    @test public async testNew() {
+    // Tests with ws_manager_bridge_stopped_prebuild_statuses enabled
+    @test public async testWsManagerBridgeStoppedEnabled() {
         const id = "12345";
         const snapshot = "some-valid-snapshot";
         const failed = "some system error";

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.ts
@@ -18,7 +18,10 @@ export interface PrebuildUpdate {
 
 @injectable()
 export class PrebuildStateMapper {
-    constructor(@inject(ExperimentsClient) private readonly experimentsClient: ExperimentsClient) {}
+    constructor(
+        @inject(ExperimentsClient)
+        private readonly experimentsClient: ExperimentsClient,
+    ) {}
     async mapWorkspaceStatusToPrebuild(status: WorkspaceStatus.AsObject): Promise<PrebuildUpdate | undefined> {
         const canUseStoppedPhase = await this.experimentsClient.getValueAsync(
             "ws_manager_bridge_stopped_prebuild_statuses",

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.ts
@@ -5,9 +5,11 @@
  */
 
 import { HeadlessWorkspaceEventType, PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
+import { Client as ExperimentsClient } from "@gitpod/gitpod-protocol/lib/experiments/types";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 import { WorkspacePhase, WorkspaceStatus } from "@gitpod/ws-manager/lib";
-import { injectable } from "inversify";
+import { inject, injectable } from "inversify";
 
 export interface PrebuildUpdate {
     type: HeadlessWorkspaceEventType;
@@ -16,74 +18,81 @@ export interface PrebuildUpdate {
 
 @injectable()
 export class PrebuildStateMapper {
-    mapWorkspaceStatusToPrebuild(status: WorkspaceStatus.AsObject): PrebuildUpdate | undefined {
-        if (status.phase === WorkspacePhase.STOPPED) {
-            // Ideally, we'd love to hande STOPPED identical to STOPPING, because we want to assume that all conditions are stable.
-            // For reliabilies sake we don't do it because experiences shows that unstable conditions are one of the most common sources of errors.
+    constructor(@inject(ExperimentsClient) private readonly experimentsClient: ExperimentsClient) {}
+    async mapWorkspaceStatusToPrebuild(status: WorkspaceStatus.AsObject): Promise<PrebuildUpdate | undefined> {
+        const canUseStoppedPhase = await this.experimentsClient.getValueAsync(
+            "ws_manager_bridge_stopped_prebuild_statuses",
+            false,
+            {},
+        );
+        if (!canUseStoppedPhase && status.phase === WorkspacePhase.STOPPED) {
             return undefined;
         }
 
-        if (status.phase === WorkspacePhase.STOPPING) {
-            if (!!status.conditions!.timeout) {
-                return {
-                    type: HeadlessWorkspaceEventType.AbortedTimedOut,
-                    update: {
-                        state: "timeout",
-                        error: status.conditions!.timeout,
-                    },
-                };
-            } else if (!!status.conditions!.failed) {
-                return {
-                    type: HeadlessWorkspaceEventType.Failed,
-                    update: {
-                        state: "failed",
-                        error: status.conditions!.failed,
-                    },
-                };
-            } else if (!!status.conditions!.stoppedByRequest) {
-                return {
-                    type: HeadlessWorkspaceEventType.Aborted,
-                    update: {
-                        state: "aborted",
-                        error: "Cancelled",
-                    },
-                };
-            } else if (!!status.conditions!.headlessTaskFailed) {
-                const result: PrebuildUpdate = {
-                    type: HeadlessWorkspaceEventType.FinishedButFailed,
-                    update: {
-                        state: "available",
-                        snapshot: status.conditions!.snapshot,
-                        error: status.conditions!.headlessTaskFailed,
-                    },
-                };
-                return result;
-            } else if (!!status.conditions!.snapshot) {
-                return {
-                    type: HeadlessWorkspaceEventType.FinishedSuccessfully,
-                    update: {
-                        state: "available",
-                        snapshot: status.conditions!.snapshot,
-                        error: "",
-                    },
-                };
-            } else if (!status.conditions!.snapshot) {
-                // STOPPING && no snapshot is an intermediate state that we are choosing to ignore.
-                return undefined;
-            } else {
-                log.error({ instanceId: status.id }, "unhandled prebuild status update", {
-                    phase: status.phase,
-                    conditions: status.phase,
-                });
-                return undefined;
-            }
+        if (
+            (canUseStoppedPhase && status.phase !== WorkspacePhase.STOPPED) ||
+            (!canUseStoppedPhase && status.phase !== WorkspacePhase.STOPPING)
+        ) {
+            return {
+                type: HeadlessWorkspaceEventType.Started,
+                update: {
+                    state: "building",
+                },
+            };
         }
 
-        return {
-            type: HeadlessWorkspaceEventType.Started,
-            update: {
-                state: "building",
-            },
-        };
+        if (status.conditions?.timeout) {
+            return {
+                type: HeadlessWorkspaceEventType.AbortedTimedOut,
+                update: {
+                    state: "timeout",
+                    error: status.conditions.timeout,
+                },
+            };
+        } else if (status.conditions?.failed) {
+            return {
+                type: HeadlessWorkspaceEventType.Failed,
+                update: {
+                    state: "failed",
+                    error: status.conditions.failed,
+                },
+            };
+        } else if (status.conditions?.stoppedByRequest) {
+            return {
+                type: HeadlessWorkspaceEventType.Aborted,
+                update: {
+                    state: "aborted",
+                    error: "Cancelled",
+                },
+            };
+        } else if (status.conditions?.headlessTaskFailed) {
+            const result: PrebuildUpdate = {
+                type: HeadlessWorkspaceEventType.FinishedButFailed,
+                update: {
+                    state: "available",
+                    snapshot: status.conditions.snapshot,
+                    error: status.conditions.headlessTaskFailed,
+                },
+            };
+            return result;
+        } else if (status.conditions?.snapshot) {
+            return {
+                type: HeadlessWorkspaceEventType.FinishedSuccessfully,
+                update: {
+                    state: "available",
+                    snapshot: status.conditions.snapshot,
+                    error: "",
+                },
+            };
+        } else if (!status.conditions?.snapshot) {
+            // STOPPING && no snapshot is an intermediate state that we are choosing to ignore.
+            return undefined;
+        }
+
+        log.error({ instanceId: status.id }, "unhandled prebuild status update", {
+            phase: status.phase,
+            conditions: new TrustedValue(status.conditions).value,
+        });
+        return undefined;
     }
 }

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.ts
@@ -28,20 +28,27 @@ export class PrebuildStateMapper {
             false,
             {},
         );
-        if (!canUseStoppedPhase && status.phase === WorkspacePhase.STOPPED) {
-            return undefined;
-        }
-
-        if (
-            (canUseStoppedPhase && status.phase !== WorkspacePhase.STOPPED) ||
-            (!canUseStoppedPhase && status.phase !== WorkspacePhase.STOPPING)
-        ) {
-            return {
-                type: HeadlessWorkspaceEventType.Started,
-                update: {
-                    state: "building",
-                },
-            };
+        if (!canUseStoppedPhase) {
+            if (status.phase === WorkspacePhase.STOPPED) {
+                return undefined;
+            }
+            if (status.phase !== WorkspacePhase.STOPPING) {
+                return {
+                    type: HeadlessWorkspaceEventType.Started,
+                    update: {
+                        state: "building",
+                    },
+                };
+            }
+        } else {
+            if (status.phase !== WorkspacePhase.STOPPED) {
+                return {
+                    type: HeadlessWorkspaceEventType.Started,
+                    update: {
+                        state: "building",
+                    },
+                };
+            }
         }
 
         if (status.conditions?.timeout) {

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -26,7 +26,7 @@ export class PrebuildUpdater {
     ) {}
 
     async updatePrebuiltWorkspace(ctx: TraceContext, userId: string, status: WorkspaceStatus.AsObject) {
-        if (status.spec && status.spec.type != WorkspaceType.PREBUILD) {
+        if (status.spec && status.spec.type !== WorkspaceType.PREBUILD) {
             return;
         }
 
@@ -58,7 +58,7 @@ export class PrebuildUpdater {
             }
             prebuild.statusVersion = status.statusVersion;
 
-            const update = this.prebuildStateMapper.mapWorkspaceStatusToPrebuild(status);
+            const update = await this.prebuildStateMapper.mapWorkspaceStatusToPrebuild(status);
             const terminatingStates = ["available", "timeout", "aborted", "failed"];
             if (update) {
                 const updatedPrebuild = {


### PR DESCRIPTION
## Description

This PR fixes an issue where if you watched updates on a prebuild, there would:
1. Be multiple done results
2. The optional error would not be included

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-317
Fixes ENT-319

## How to test

1. Run a prebuild on a repo exiting with a non-zero exit code, like https://github.com/gitpod-io/browser-extension (at least I've got an excuse for not fixing that :) and stay on the prebuilds list
2. Observe the status of the Running prebuild changes to `Failing` instead of `Ready`.

https://ft-fix-optbb5fb8acbd.preview.gitpod-dev.com/prebuilds

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
