### PR TITLE
Make auth cookie stricter

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -216,4 +216,12 @@ export class GitpodHostUrl {
         }
         return newUrl.with((url) => ({ pathname: "/metrics-api" }));
     }
+
+    asLoginWithOTS(userId: string, key: string, returnToUrl?: string) {
+        const result = this.withApi({ pathname: `/login/ots/${userId}/${key}` });
+        if (returnToUrl) {
+            return result.with({ search: `returnTo=${encodeURIComponent(returnToUrl)}` });
+        }
+        return result;
+    }
 }

--- a/components/server/go/pkg/lib/cookie.go
+++ b/components/server/go/pkg/lib/cookie.go
@@ -9,5 +9,5 @@ import "regexp"
 func CookieNameFromDomain(domain string) string {
 	// replace all non-word characters with underscores
 	derived := regexp.MustCompile(`[\W_]+`).ReplaceAllString(domain, "_")
-	return "_" + derived + "_jwt2_"
+	return "__Host-_" + derived + "_jwt2_"
 }

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -302,6 +302,14 @@ export abstract class GenericAuthProvider implements AuthProvider {
             return;
         }
 
+        if (!this.loginCompletionHandler.isBaseDomain(request)) {
+            // For auth requests that are not targetting the base domain, we redirect to the base domain, so they come with our cookie.
+            log.info(`(${strategyName}) Auth request on subdomain, redirecting to base domain`, { clientInfo });
+            const target = new URL(request.url, this.config.hostUrl.url.toString()).toString();
+            response.redirect(target);
+            return;
+        }
+
         if (isAlreadyLoggedIn) {
             if (!authFlow) {
                 log.warn(

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -81,7 +81,7 @@ export class LoginCompletionHandler {
             );
         }
 
-        if (request.hostname !== this.config.hostUrl.url.hostname) {
+        if (!this.isBaseDomain(request)) {
             // (GitHub edge case) If we got redirected here onto a sub-domain (e.g. api.gitpod.io), we need to redirect to the base domain in order to Set-Cookie properly.
             const secret = crypto
                 .createHash("sha256")
@@ -108,6 +108,10 @@ export class LoginCompletionHandler {
         log.info(logContext, `User is logged in successfully. Redirect to: ${returnTo}`);
         reportLoginCompleted("succeeded", "git");
         response.redirect(returnTo);
+    }
+
+    public isBaseDomain(req: express.Request): boolean {
+        return req.hostname === this.config.hostUrl.url.hostname;
     }
 
     public async updateAuthProviderAsVerified(hostname: string, user: User) {

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -6,6 +6,7 @@
 
 import { inject, injectable } from "inversify";
 import express from "express";
+import * as crypto from "crypto";
 import { User } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
@@ -16,6 +17,7 @@ import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { trackLogin } from "../analytics";
 import { SessionHandler } from "../session-handler";
 import { AuthJWT } from "./jwt";
+import { OneTimeSecretServer } from "../one-time-secret-server";
 
 /**
  * The login completion handler pulls the strings between the OAuth2 flow, the ToS flow, and the session management.
@@ -28,6 +30,7 @@ export class LoginCompletionHandler {
     @inject(AuthProviderService) protected readonly authProviderService: AuthProviderService;
     @inject(AuthJWT) protected readonly authJWT: AuthJWT;
     @inject(SessionHandler) protected readonly session: SessionHandler;
+    @inject(OneTimeSecretServer) private readonly otsServer: OneTimeSecretServer;
 
     async complete(
         request: express.Request,
@@ -78,6 +81,26 @@ export class LoginCompletionHandler {
             );
         }
 
+        if (request.hostname !== this.config.hostUrl.url.hostname) {
+            // (GitHub edge case) If we got redirected here onto a sub-domain (e.g. api.gitpod.io), we need to redirect to the base domain in order to Set-Cookie properly.
+            const secret = crypto
+                .createHash("sha256")
+                .update(user.id + this.config.session.secret)
+                .digest("hex");
+            const expirationDate = new Date(Date.now() + 1000 * 60); // 1 minutes
+            const token = await this.otsServer.serveToken({}, secret, expirationDate);
+
+            reportLoginCompleted("succeeded_via_ots", "git");
+            log.info(
+                logContext,
+                `User will be logged in via OTS on the base domain. (Indirect) redirect to: ${returnTo}`,
+            );
+            const baseDomainRedirect = this.config.hostUrl.asLoginWithOTS(user.id, token.token, returnTo).toString();
+            response.redirect(baseDomainRedirect);
+            return;
+        }
+
+        // (default case) If we got redirected here onto the base domain of the Gitpod installation, we can just issue the cookie right away.
         const cookie = await this.session.createJWTSessionCookie(user.id);
         response.cookie(cookie.name, cookie.value, cookie.opts);
         reportJWTCookieIssued();

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -85,6 +85,8 @@ type LoginCounterStatus =
     | "failed"
     // The login attempt succeeded
     | "succeeded"
+    // The login was successful, but we need to defer cookie creation via an OTS
+    | "succeeded_via_ots"
     // The login attempt failed, because the client failed to provide complete session information, for instance.
     | "failed_client";
 

--- a/components/server/src/session-handler.spec.db.ts
+++ b/components/server/src/session-handler.spec.db.ts
@@ -163,9 +163,9 @@ describe("SessionHandler", () => {
             expect(opts.httpOnly).to.equal(true);
             expect(opts.secure).to.equal(true);
             expect(opts.maxAge).to.equal(maxAge * 1000);
-            expect(opts.sameSite).to.equal("strict");
+            expect(opts.sameSite).to.equal("lax");
 
-            expect(name, "Check cookie name").to.equal("_gitpod_dev_jwt_");
+            expect(name, "Check cookie name").to.equal("__Host-_gitpod_dev_jwt_");
         });
     });
     describe("jwtSessionConvertor", () => {

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -242,7 +242,9 @@ export class SessionHandler {
 
         const secondaryCookieName = getSecondaryJWTCookieName(this.config);
         if (secondaryCookieName) {
-            res.clearCookie(secondaryCookieName);
+            res.clearCookie(secondaryCookieName, {
+                domain: this.config.hostUrl.url.hostname,
+            });
         }
     }
 }

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -215,10 +215,8 @@ export class SessionHandler {
         };
     }
 
-    public clearSessionCookie(res: express.Response, config: Config): void {
-        res.clearCookie(getJWTCookieName(this.config), {
-            domain: getJWTCookieDomain(config),
-        });
+    public clearSessionCookie(res: express.Response): void {
+        res.clearCookie(getJWTCookieName(this.config));
     }
 }
 

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -224,10 +224,6 @@ function getJWTCookieName(config: Config) {
     return config.auth.session.cookie.name;
 }
 
-function getJWTCookieDomain(config: Config): string {
-    return config.hostUrl.url.hostname;
-}
-
 function parseCookieHeader(c: string): { [key: string]: string[] } {
     return c
         .split("; ")

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -239,6 +239,11 @@ export class SessionHandler {
             sameSite,
             secure,
         });
+
+        const secondaryCookieName = getSecondaryJWTCookieName(this.config);
+        if (secondaryCookieName) {
+            res.clearCookie(secondaryCookieName);
+        }
     }
 }
 

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -27,7 +27,7 @@ export class SessionHandler {
 
     public jwtSessionConvertor(): express.Handler {
         return async (req, res) => {
-            const user = req.user;
+            const { user } = req;
             if (!user) {
                 res.status(401);
                 res.send("User has no valid session.");

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -157,7 +157,7 @@ export class SessionHandler {
      * @returns Primary (the cookie name we set) AND secondary cookie (old accepted cookie name) values (in that order).
      */
     private filterCookieValues(cookies: { [key: string]: string[] }): string[] {
-        const cookieValues = cookies[getPrimaryJWTCookieName(this.config)];
+        const cookieValues = cookies[getPrimaryJWTCookieName(this.config)] ?? [];
 
         const secondaryCookieName = getSecondaryJWTCookieName(this.config);
         if (secondaryCookieName) {

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -207,7 +207,6 @@ export class SessionHandler {
             name: getJWTCookieName(this.config),
             value: token,
             opts: {
-                domain: getJWTCookieDomain(this.config),
                 maxAge: this.config.auth.session.cookie.maxAge * 1000, // express does not match the HTTP spec and uses milliseconds
                 httpOnly: this.config.auth.session.cookie.httpOnly,
                 sameSite: this.config.auth.session.cookie.sameSite,

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -216,7 +216,12 @@ export class SessionHandler {
     }
 
     public clearSessionCookie(res: express.Response): void {
-        res.clearCookie(getJWTCookieName(this.config));
+        const { secure, sameSite, httpOnly } = this.config.auth.session.cookie;
+        res.clearCookie(getJWTCookieName(this.config), {
+            httpOnly,
+            sameSite,
+            secure,
+        });
     }
 }
 

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -59,7 +59,7 @@ export const mockAuthConfig: AuthConfig = {
             secure: true,
             httpOnly: true,
             maxAge: 7 * 24 * 60 * 60,
-            sameSite: "strict",
+            sameSite: "lax",
         },
     },
 };

--- a/components/server/src/test/service-testing-container-module.ts
+++ b/components/server/src/test/service-testing-container-module.ts
@@ -55,7 +55,7 @@ export const mockAuthConfig: AuthConfig = {
         issuer: "https://mp-server-d7650ec945.preview.gitpod-dev.com",
         lifetimeSeconds: 7 * 24 * 60 * 60,
         cookie: {
-            name: "_gitpod_dev_jwt_",
+            name: "__Host-_gitpod_dev_jwt_",
             secure: true,
             httpOnly: true,
             maxAge: 7 * 24 * 60 * 60,

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -269,7 +269,7 @@ export class UserController {
             }
 
             // clear cookies
-            this.sessionHandler.clearSessionCookie(res, this.config);
+            this.sessionHandler.clearSessionCookie(res);
 
             // then redirect
             log.info(logContext, "(Logout) Redirecting...", { redirectToUrl, ...logPayload });

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -37,6 +37,7 @@ import { UserService } from "./user-service";
 import { WorkspaceService } from "../workspace/workspace-service";
 import { runWithSubjectId } from "../util/request-context";
 import { SubjectId } from "../auth/subject-id";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
 export const ServerFactory = Symbol("ServerFactory");
 export type ServerFactory = () => GitpodServerImpl;
@@ -212,6 +213,14 @@ export class UserController {
                 const cookie = await this.sessionHandler.createJWTSessionCookie(user.id);
                 res.cookie(cookie.name, cookie.value, cookie.opts);
                 reportJWTCookieIssued();
+
+                // If returnTo was passed and it's safe, redirect to it
+                const returnTo = this.getSafeReturnToParam(req);
+                if (returnTo) {
+                    log.info(`Redirecting after OTS login ${returnTo}`);
+                    res.redirect(returnTo);
+                    return;
+                }
 
                 res.sendStatus(200);
             }),
@@ -618,7 +627,7 @@ export class UserController {
             return returnToURL;
         }
 
-        log.debug("The redirect URL does not match", { query: req.query });
+        log.debug("The redirect URL does not match", { query: new TrustedValue(req.query).value });
         return;
     }
 

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -822,8 +822,8 @@ func removeSensitiveCookies(cookies []*http.Cookie, domain string) []*http.Cooki
 
 	n := 0
 	for _, c := range cookies {
-		if strings.HasPrefix(c.Name, hostnamePrefix) {
-			// skip session cookie
+		if strings.HasPrefix(c.Name, hostnamePrefix) || strings.HasPrefix(c.Name, "__Host-"+hostnamePrefix) {
+			// skip session cookies
 			continue
 		}
 		log.WithField("hostnamePrefix", hostnamePrefix).WithField("name", c.Name).Debug("keeping cookie")

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -983,7 +983,7 @@ func TestRemoveSensitiveCookies(t *testing.T) {
 	var (
 		domain                  = "test-domain.com"
 		sessionCookie           = &http.Cookie{Domain: domain, Name: "_test_domain_com_", Value: "fobar"}
-		sessionCookieJwt2       = &http.Cookie{Domain: domain, Name: "_test_domain_com_jwt2_", Value: "fobar"}
+		sessionCookieJwt2       = &http.Cookie{Domain: domain, Name: "__Host-_test_domain_com_jwt2_", Value: "fobar"}
 		realGitpodSessionCookie = &http.Cookie{Domain: domain, Name: server_lib.CookieNameFromDomain(domain), Value: "fobar"}
 		portAuthCookie          = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_port_auth_", Value: "some-token"}
 		ownerCookie             = &http.Cookie{Domain: domain, Name: "_test_domain_com_ws_77f6b236_3456_4b88_8284_81ca543a9d65_owner_", Value: "some-other-token"}

--- a/install/installer/pkg/components/auth/config_test.go
+++ b/install/installer/pkg/components/auth/config_test.go
@@ -19,42 +19,42 @@ func TestCookieNameFromDomain(t *testing.T) {
 		{
 			name:            "Simple Domain",
 			domain:          "example.com",
-			expectedOutcome: "_example_com_jwt2_",
+			expectedOutcome: "__Host-_example_com_jwt2_",
 		},
 		{
 			name:            "Domain with Underscore",
 			domain:          "example_test.com",
-			expectedOutcome: "_example_test_com_jwt2_",
+			expectedOutcome: "__Host-_example_test_com_jwt2_",
 		},
 		{
 			name:            "Domain with Hyphen",
 			domain:          "example-test.com",
-			expectedOutcome: "_example_test_com_jwt2_",
+			expectedOutcome: "__Host-_example_test_com_jwt2_",
 		},
 		{
 			name:            "Domain with Special Characters",
 			domain:          "example&test.com",
-			expectedOutcome: "_example_test_com_jwt2_",
+			expectedOutcome: "__Host-_example_test_com_jwt2_",
 		},
 		{
 			name:            "Subdomain",
 			domain:          "subdomain.example.com",
-			expectedOutcome: "_subdomain_example_com_jwt2_",
+			expectedOutcome: "__Host-_subdomain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Hyphen",
 			domain:          "sub-domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt2_",
+			expectedOutcome: "__Host-_sub_domain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Underscore",
 			domain:          "sub_domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt2_",
+			expectedOutcome: "__Host-_sub_domain_example_com_jwt2_",
 		},
 		{
 			name:            "Subdomain with Special Characters",
 			domain:          "sub&domain.example.com",
-			expectedOutcome: "_sub_domain_example_com_jwt2_",
+			expectedOutcome: "__Host-_sub_domain_example_com_jwt2_",
 		},
 	}
 

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -63,7 +63,7 @@ func TestConfigMap(t *testing.T) {
 				LifetimeSeconds: int64((24 * 7 * time.Hour).Seconds()),
 				Issuer:          "https://test.domain.everything.awesome.is",
 				Cookie: config.CookieConfig{
-					Name:     "_test_domain_everything_awesome_is_jwt2_",
+					Name:     "__Host-_test_domain_everything_awesome_is_jwt2_",
 					MaxAge:   int64((24 * 7 * time.Hour).Seconds()),
 					SameSite: "lax",
 					Secure:   true,

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -69,7 +69,7 @@ func TestConfigMap(t *testing.T) {
 				LifetimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
 				Issuer:          "https://awesome.domain",
 				Cookie: auth.CookieConfig{
-					Name:     "_awesome_domain_jwt2_",
+					Name:     "__Host-_awesome_domain_jwt2_",
 					MaxAge:   int64((7 * 24 * time.Hour).Seconds()),
 					SameSite: "lax",
 					Secure:   true,


### PR DESCRIPTION
## Description

Make use of a host-only cookie for the main JWT.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://gitpod.slack.com/archives/C079V6H3JSW.

## How to test

https://ft-playing3314cc781a.preview.gitpod-dev.com

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
