### PR TITLE
Get java feature flags from server

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -12,8 +12,6 @@ import (
 const (
 	OIDCServiceEnabledFlag = "oidcServiceEnabled"
 	IdPClaimKeysFlag       = "idp_claim_keys"
-	SetJavaXmxFlag         = "supervisor_set_java_xmx"
-	SetJavaProcessorCount  = "supervisor_set_java_processor_count"
 )
 
 func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) []string {
@@ -26,12 +24,4 @@ func GetIdPClaimKeys(ctx context.Context, client Client, attributes Attributes) 
 
 func IsOIDCServiceEnabled(ctx context.Context, client Client, attributes Attributes) bool {
 	return client.GetBoolValue(ctx, OIDCServiceEnabledFlag, false, attributes)
-}
-
-func IsSetJavaXmx(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, SetJavaXmxFlag, false, attributes)
-}
-
-func IsSetJavaProcessorCount(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, SetJavaProcessorCount, false, attributes)
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1484,6 +1484,17 @@ export class WorkspaceStarter {
         orgIdEnv.setValue(await this.configProvider.getDefaultImage(workspace.organizationId));
         sysEnvvars.push(orgIdEnv);
 
+        const client = getExperimentsClientForBackend();
+        const [isSetJavaXmx, isSetJavaProcessorCount] = await Promise.all([
+            client
+                .getValueAsync("supervisor_set_java_xmx", false, { user })
+                .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_XMX", String(v))),
+            client
+                .getValueAsync("supervisor_set_java_processor_count", false, { user })
+                .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_PROCESSOR_COUNT", String(v))),
+        ]);
+        sysEnvvars.push(isSetJavaXmx);
+        sysEnvvars.push(isSetJavaProcessorCount);
         const spec = new StartWorkspaceSpec();
         await createGitpodTokenPromise;
         spec.setEnvvarsList(envvars);
@@ -1936,4 +1947,11 @@ export class ScmStartError extends Error {
     static isScmStartError(o: any): o is ScmStartError {
         return !!o && o["host"];
     }
+}
+
+function newEnvVar(key: string, value: string): EnvironmentVariable {
+    const env = new EnvironmentVariable();
+    env.setName(key);
+    env.setValue(value);
+    return env;
 }

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -251,6 +251,14 @@ type WorkspaceConfig struct {
 	// DefaultWorkspaceImage is the default image of current workspace
 	DefaultWorkspaceImage string `env:"GITPOD_DEFAULT_WORKSPACE_IMAGE"`
 
+	// IsSetJavaXmx is a flag to indicate if the JAVA_XMX environment variable is set
+	// value retrieved from server with FeatureFlag
+	IsSetJavaXmx bool `env:"GITPOD_IS_SET_JAVA_XMX"`
+
+	// IsSetJavaProcessorCount is a flag to indicate if the JAVA_PROCESSOR_COUNT environment variable is set
+	// value retrieved from server with FeatureFlag
+	IsSetJavaProcessorCount bool `env:"GITPOD_IS_SET_JAVA_PROCESSOR_COUNT"`
+
 	// IDEPort is the port at which the IDE will need to run on. This is not an IDE config
 	// because Gitpod determines this port, not the IDE.
 	IDEPort int `env:"GITPOD_THEIA_PORT"`

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -133,7 +133,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 				cfg.EnvvarOTS = srv.URL
 			}
 
-			act := buildChildProcEnv(cfg, test.Input, false, false, false)
+			act := buildChildProcEnv(cfg, test.Input, false)
 			assert(t, act)
 		})
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-356

## How to test
<!-- Provide steps to test this PR -->
**Java Env is set**
- Create a task with simple `init: env`, it should print correct `JAVA_TOOL_OPTIONS`

✅ <img width="1649" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/1891e605-2c59-4883-8d2f-49cb6845557f">


**No regression**
- Test *How to Test* section on https://github.com/gitpod-io/gitpod/pull/19905

✅ <img width="830" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/dc577a33-caa9-4831-818c-aab2c32cb178">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-java-env</li>
	<li><b>🔗 URL</b> - <a href="https://hw-java-env.preview.gitpod-dev.com/workspaces" target="_blank">hw-java-env.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-java-env-gha.26982</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-java-env%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
