### PR TITLE
[Dashboard] Show pinned status of workspaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -295,19 +295,19 @@ RUN mkdir -p ~/.terraform \
 ## Java
 ENV JAVA_VERSION=11.0.23.fx-zulu
 RUN curl -fsSL "https://get.sdkman.io" | bash \
-&& bash -c ". /root/.sdkman/bin/sdkman-init.sh \
-            && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /root/.sdkman/etc/config \
-            && sed -i 's/sdkman_selfupdate_feature=true/sdkman_selfupdate_feature=false/g' /root/.sdkman/etc/config \
-            && sdk install java ${JAVA_VERSION} \
-            && sdk default java ${JAVA_VERSION} \
-            && sdk install gradle \
-            && sdk install maven \
-            && sdk flush archives \
-            && sdk flush temp \
-            && mkdir /root/.m2 \
-            && printf '<settings>\n  <localRepository>/workspace/m2-repository/</localRepository>\n</settings>\n' > /root/.m2/settings.xml \
-            && echo 'export SDKMAN_DIR=\"/root/.sdkman\"' >> /root/.bashrc.d/99-java \
-            && echo '[[ -s \"/root/.sdkman/bin/sdkman-init.sh\" ]] && source \"/root/.sdkman/bin/sdkman-init.sh\"' >> /root/.bashrc.d/99-java"
+    && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
+    && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /root/.sdkman/etc/config \
+    && sed -i 's/sdkman_selfupdate_feature=true/sdkman_selfupdate_feature=false/g' /root/.sdkman/etc/config \
+    && sdk install java ${JAVA_VERSION} \
+    && sdk default java ${JAVA_VERSION} \
+    && sdk install gradle \
+    && sdk install maven \
+    && sdk flush archives \
+    && sdk flush temp \
+    && mkdir /root/.m2 \
+    && printf '<settings>\n  <localRepository>/workspace/m2-repository/</localRepository>\n</settings>\n' > /root/.m2/settings.xml \
+    && echo 'export SDKMAN_DIR=\"/root/.sdkman\"' >> /root/.bashrc.d/99-java \
+    && echo '[[ -s \"/root/.sdkman/bin/sdkman-init.sh\" ]] && source \"/root/.sdkman/bin/sdkman-init.sh\"' >> /root/.bashrc.d/99-java"
 # above, we are adding the sdkman init to .bashrc (executing sdkman-init.sh does that), because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 ENV GRADLE_USER_HOME=/workspace/.gradle/
 
@@ -318,11 +318,23 @@ ENV PATH=/root/.nvm/versions/node/v${NODE_VERSION}/bin:/root/.yarn/bin:${PNPM_HO
 ENV HOME=/root
 RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \
     && bash -c ". $HOME/.nvm/nvm.sh \
-        && nvm install v${NODE_VERSION} \
-        && nvm alias default v${NODE_VERSION} \
-        && npm install -g typescript yarn pnpm node-gyp"
+    && nvm install v${NODE_VERSION} \
+    && nvm alias default v${NODE_VERSION} \
+    && npm install -g typescript yarn pnpm node-gyp"
 
 ENV PATH=$PATH:/root/.aws-iam:/root/.terraform:/workspace/bin
+
+### Telepresence ###
+RUN curl -fsSL https://packagecloud.io/datawireio/telepresence/gpgkey | apt-key add - \
+    # 'cosmic' not supported
+    && add-apt-repository -yu "deb https://packagecloud.io/datawireio/telepresence/ubuntu/ bionic main" \
+    # 0.95 (current at the time of this commit) is broken
+    && install-packages \
+    iproute2 \
+    iptables \
+    net-tools \
+    socat \
+    telepresence=0.109
 
 # Install pre-commit hooks under /workspace during prebuilds
 ENV PRE_COMMIT_HOME=/workspace/.pre-commit

--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -41,7 +41,7 @@ export default function PendingChangesDropdown({ gitStatus }: { gitStatus?: Work
     }
     return (
         <ContextMenu menuEntries={menuEntries} customClasses="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0">
-            <p className="flex justify-center text-gitpod-red">
+            <p className="flex items-center text-gitpod-red">
                 <span>
                     {totalChanges} Change{totalChanges === 1 ? "" : "s"}
                 </span>

--- a/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
@@ -68,7 +68,7 @@ export const WorkspacesSearchBar: FunctionComponent<WorkspacesSearchBarProps> = 
                 />
             </div>
             <Link to={"/new"}>
-                <Button className="ml-2 gap-1.5">
+                <Button className="ml-2 gap-1.5 h-10">
                     New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
                 </Button>
             </Link>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Lift the notion of pinned workspaces.
<img width="1366" alt="Screenshot 2024-07-03 at 10 58 36" src="https://github.com/gitpod-io/gitpod/assets/372735/f4a049ed-fed2-4efd-a596-dd17578c805c">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-360/visually-lift-pinned-workspaces

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-pin-lift</li>
	<li><b>🔗 URL</b> - <a href="https://se-pin-lift.preview.gitpod-dev.com/workspaces" target="_blank">se-pin-lift.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-pin-lift-gha.27045</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-pin-lift%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
