### PR TITLE
[openssh] upgrade openssh to v9.8p1

### DIFF
--- a/components/supervisor/leeway.Dockerfile
+++ b/components/supervisor/leeway.Dockerfile
@@ -30,6 +30,7 @@ COPY components-supervisor--app/supervisor \
 WORKDIR "/.supervisor/ssh"
 COPY components-supervisor-openssh--app/usr/sbin/sshd .
 COPY components-supervisor-openssh--app/usr/bin/ssh-keygen .
+COPY components-supervisor-openssh--app/usr/libexec/sshd-session .
 
 COPY --from=docker_cli_builder /gp-docker/docker/docker /.supervisor/gitpod-docker-cli
 

--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -22,7 +22,7 @@
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
 FROM alpine:3.19 AS builder
 
-ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_7_P1.tar.gz
+ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_8_P1.tar.gz
 
 WORKDIR /build
 

--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -99,6 +99,10 @@ func (s *sshServer) handleConn(ctx context.Context, conn net.Conn) {
 	if _, err := os.Stat(openssh); err != nil {
 		return
 	}
+	sshdSession := filepath.Join(filepath.Dir(bin), "ssh", "sshd-session")
+	if _, err := os.Stat(sshdSession); err != nil {
+		sshdSession = ""
+	}
 
 	var args []string
 	args = append(args,
@@ -118,6 +122,9 @@ func (s *sshServer) handleConn(ctx context.Context, conn net.Conn) {
 		"-oStrictModes no", // don't care for home directory and file permissions
 		"-oTrustedUserCAKeys "+s.caPath,
 	)
+	if sshdSession != "" {
+		args = append(args, "-oSshdSessionPath "+sshdSession)
+	}
 	// can be configured with gp env LOG_LEVEL=DEBUG to see SSH sessions/channels
 	sshdLogLevel := "ERROR"
 	switch log.Log.Logger.GetLevel() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-366

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace from this preview env
2. try to connect workspace via ssh

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-openssh</li>
	<li><b>🔗 URL</b> - <a href="https://pd-openssh.preview.gitpod-dev.com/workspaces" target="_blank">pd-openssh.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-openssh-gha.27048</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-openssh%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.

- [ ] with-monitoring
</details>

- [x] with-integration-tests=ssh
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.

/hold
