### PR TITLE
[ws-manager] Don't skip content backup for failed prebuilds

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -282,13 +282,25 @@ export const PrebuildDetailPage: FC = () => {
                                         onClick={() => triggerPrebuild()}
                                     >{`Rerun Prebuild (${prebuild.ref})`}</LoadingButton>
                                 )}
-                                <LinkButton
-                                    disabled={!prebuild?.id}
-                                    href={repositoriesRoutes.PrebuildsSettings(prebuild.configurationId)}
-                                    variant="secondary"
-                                >
-                                    View Prebuild Settings
-                                </LinkButton>
+                                <div className="space-x-6 flex justify-right">
+                                    <LinkButton
+                                        disabled={!prebuild?.id}
+                                        href={repositoriesRoutes.PrebuildsSettings(prebuild.configurationId)}
+                                        variant="secondary"
+                                    >
+                                        View Prebuild Settings
+                                    </LinkButton>
+                                    <LoadingButton
+                                        loading={false}
+                                        disabled={prebuild?.status?.phase?.name !== PrebuildPhase_Phase.AVAILABLE}
+                                        onClick={() =>
+                                            (window.location.href = `/#open-prebuild/${prebuild?.id}/${prebuild?.contextUrl}`)
+                                        }
+                                        variant="default"
+                                    >
+                                        Open Debug Workspace
+                                    </LoadingButton>
+                                </div>
                             </div>
                         </div>
                     )

--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -302,7 +302,7 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		SnapshotName:      snapshotName,
 		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
 		UpdateGitStatus:   ws.Spec.Type == workspacev1.WorkspaceTypeRegular,
-		SkipBackupContent: ws.Spec.Type == workspacev1.WorkspaceTypePrebuild && ws.IsConditionTrue(workspacev1.WorkspaceConditionsHeadlessTaskFailed),
+		SkipBackupContent: false,
 	})
 
 	err = retry.RetryOnConflict(retryParams, func() error {


### PR DESCRIPTION
## Description

Running:
![image](https://github.com/gitpod-io/gitpod/assets/32448529/ddf2fedc-6076-4aa2-9790-f0d60347aeb4)

Available (failed or success):
![image](https://github.com/gitpod-io/gitpod/assets/32448529/574b5ffe-872d-4f42-8c3b-dadf5c103a53)



## Related Issue(s)
Fixes ENT-355

## How to test
 - register a repository, e.g. github.com/geropl/gitpod-test-repo
 - trigger a prebuild on a branch with a task that **fails**
 - use the "Open Debug Workspace" button to start a workspace based on that prebuild
 - see that it contains the prebuild logs under `/workspace/.gitpod/` :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-backup72272f1a76</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-backup72272f1a76.preview.gitpod-dev.com/workspaces" target="_blank">gpl-backup72272f1a76.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-backup-failed-tasks-gha.27089</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-backup72272f1a76%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
