### PR TITLE
[dashboard] chore: Update copy texts for empty `/workspaces` page

### DIFF
--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -42,7 +42,7 @@ export const EmptyWorkspacesContent = () => {
 
     return (
         <div className="app-container flex flex-col space-y-2">
-            <div className="px-6 flex flex-row items-center justify-center space-x-14">
+            <div className="px-6 mt-16 flex flex-row items-center justify-center space-x-14">
                 <div>
                     <iframe
                         id="gitpod-video"

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -5,9 +5,8 @@
  */
 
 import React, { useEffect } from "react";
-import { StartWorkspaceModalKeyBinding } from "../App";
 import { LinkButton } from "@podkit/buttons/LinkButton";
-import { Heading1, Heading2, Subheading } from "@podkit/typography/Headings";
+import { Heading2, Subheading } from "@podkit/typography/Headings";
 import { trackVideoClick } from "../Analytics";
 
 declare global {
@@ -43,7 +42,7 @@ export const EmptyWorkspacesContent = () => {
 
     return (
         <div className="app-container flex flex-col space-y-2">
-            <div className="px-6 mt-12 flex flex-row justify-center space-x-8">
+            <div className="px-6 flex flex-row items-center justify-center space-x-14">
                 <div>
                     <iframe
                         id="gitpod-video"
@@ -57,25 +56,23 @@ export const EmptyWorkspacesContent = () => {
                     ></iframe>
                 </div>
                 <div>
-                    <div className="flex flex-col items-left h-96 w-96">
-                        <Heading1 className="text-left mb-4 !font-semibold !text-2xl">Welcome to Gitpod</Heading1>
-                        <Heading2 className="text-left !mb-0 !font-semibold !text-lg">
+                    <div className="flex flex-col items-left justify-center h-96 w-96">
+                        <Heading2 className="text-left mb-4 !font-semibold !text-lg">
                             Create your first workspace
                         </Heading2>
                         <Subheading className="text-left max-w-xs">
-                            A workspace is a cloud development environment
+                            Write code in your personal development environment that’s running in the cloud
                         </Subheading>
                         <span className="flex flex-col space-y-4 w-fit">
                             <LinkButton
                                 variant="secondary"
-                                className="mt-4 border border-pk-content-secondary text-pk-content-secondary bg-pk-surface-secondary"
+                                className="mt-4 border !border-pk-content-invert-primary text-pk-content-secondary bg-pk-surface-secondary"
                                 href={"/new?showExamples=true"}
                             >
-                                Try a configured demo repo
+                                Try a configured demo repository
                             </LinkButton>
                             <LinkButton href={"/new"} className="gap-1.5">
-                                Open your repository{" "}
-                                <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                                Configure your own repository
                             </LinkButton>
                         </span>
                     </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the copy texts for the empty `/workspaces` page. The changes include updating the text in the heading and subheading, as well as updating the text in the buttons. The goal is to provide clearer and more concise instructions to users on how to create their first workspace or try a demo repository.


| Before | After |
|--------|--------|
| <img width="1314" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/1715cede-4461-4884-8c11-bd84658d403f"> | ![image](https://github.com/gitpod-io/gitpod/assets/55068936/4761c8f1-0fc8-4921-a1f0-ef61f62636d4) | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-663

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment
- Complete onboarding
- And, see `/workspaces` :eyes:

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
