### PR TITLE
[dashboard] feat: Add predefined repositories to `/new`

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -207,6 +207,20 @@ export default function RepositoryFinder({
                 isSelectable: true,
             }));
 
+            // Add predefined repos to end of the list.
+            PREDEFINED_REPOS.forEach((repo) => {
+                if (
+                    repo.url.toLowerCase().includes(searchString.toLowerCase()) ||
+                    repo.repoName.toLowerCase().includes(searchString.toLowerCase())
+                ) {
+                    result.push({
+                        id: repo.url,
+                        element: <PredefinedRepositoryOption repo={repo} />,
+                        isSelectable: true,
+                    });
+                }
+            });
+
             if (hasMore) {
                 result.push({
                     id: "more",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds functionality to include predefined repositories in the search results on `/new` (previously it was only for `/new?showExamples=true`. This allows users to easily find and select predefined repositories based on their search query. Related #19991


| Before | After |
|--------|--------|
| ![image](https://github.com/gitpod-io/gitpod/assets/55068936/ccac24af-1828-47d5-a293-11ffedce4b1d) | ![image](https://github.com/gitpod-io/gitpod/assets/55068936/d577c718-9235-406d-9270-3bfcfcba9738) | 
|<img width="786" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/a7099950-8571-49af-be29-f7f9f4991c3a">|![image](https://github.com/gitpod-io/gitpod/assets/55068936/debce4a8-9c7b-4a65-b481-a8e165438095)|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-664

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment & complete onboarding.
- Go to `/workspaces` & see :eyes: template repos.
- Also, see `/workspaces?showExamples=true` (unchanged in this PR).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-o2f2b4f0e72</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-o2f2b4f0e72.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-o2f2b4f0e72.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-opm-664-demo-repos-should-appear-in-new-select-gha.27118</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-o2f2b4f0e72%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
