### PR TITLE
[dashboard] minor fixes for pinning changes

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -61,7 +61,7 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
             <ItemFieldIcon>
                 <WorkspaceStatusIndicator status={workspace?.status} />
             </ItemFieldIcon>
-            <div className="flex-grow flex flex-col h-full py-auto">
+            <div className="flex-grow flex flex-col h-full py-auto truncate">
                 <a href={startUrl}>
                     <div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
                         {info.id}
@@ -77,40 +77,48 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
             </div>
             {!shortVersion && (
                 <>
-                    <div className="w-3/12 flex flex-col lg:flex-row lg:items-center lg:gap-6 justify-between px-3">
-                        <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate flex flex-row gap-1 items-center">
-                            <GitBranchIcon className="h-4 w-4" />
-                            <Tooltip content={currentBranch}>{currentBranch}</Tooltip>
+                    <div className="w-2/12 sm:w-3/12  xl:w-4/12 flex flex-col xl:flex-row xl:items-center xl:gap-6 justify-between px-1 md:px-3">
+                        <div className="text-gray-500 dark:text-gray-400 flex flex-row gap-1 items-center overflow-hidden">
+                            <div className="min-w-4">
+                                <GitBranchIcon className="h-4 w-4" />
+                            </div>
+                            <Tooltip content={currentBranch} className="truncate overflow-ellipsis">
+                                {currentBranch}
+                            </Tooltip>
                         </div>
-                        <div className="mr-auto">
+                        <div className="mr-auto xl:hidden">
                             <PendingChangesDropdown gitStatus={gitStatus} />
                         </div>
                     </div>
-                    <div className="w-2/12 px-3 flex items-center min-w">
+                    <div className="hidden xl:flex xl:items-center xl:min-w-46">
+                        <PendingChangesDropdown gitStatus={gitStatus} />
+                    </div>
+                    <div className="px-1 md:px-3 flex items-center min-w-96 w-28 lg:w-44 text-right">
                         <Tooltip
                             content={`Last Activate ${dayjs(
                                 info.status!.phase!.lastTransitionTime!.toDate(),
                             ).fromNow()}`}
+                            className="w-full"
                         >
                             <div className="text-sm w-full text-gray-400 overflow-ellipsis truncate">
                                 {dayjs(info.status?.phase?.lastTransitionTime?.toDate() ?? new Date()).fromNow()}
                             </div>
                         </Tooltip>
                     </div>
-                    <div className="px-3 flex items-center">
+                    <div className="px-1 md:px-3 flex items-center">
                         <div
+                            onClick={togglePinned}
                             className={
-                                "px-2 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer h-8 w-8"
+                                "group px-2 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer h-8 w-8"
                             }
                         >
                             <Tooltip content={workspace.metadata?.pinned ? "Unpin" : "Pin"}>
                                 <PinIcon
-                                    onClick={togglePinned}
                                     className={
                                         "w-4 h-4 self-center " +
                                         (workspace.metadata?.pinned
                                             ? "text-gray-600 dark:text-gray-300"
-                                            : "text-gray-300 dark:text-500 hover:text-gray-600 dark:hover:text-gray-300")
+                                            : "text-gray-300 dark:text-gray-600 group-hover:text-gray-600 dark:group-hover:text-gray-300")
                                     }
                                 />
                             </Tooltip>

--- a/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
@@ -66,7 +66,7 @@ export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflo
             workspaceId: workspace.id,
             spec: {
                 admission: newLevel,
-            }
+            },
         });
     }, [updateWorkspace, workspace.id, workspace.spec?.admission]);
 
@@ -74,8 +74,8 @@ export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflo
         updateWorkspace.mutate({
             workspaceId: workspace.id,
             metadata: {
-                pinned: !workspace.metadata?.pinned
-            }
+                pinned: !workspace.metadata?.pinned,
+            },
         });
     }, [updateWorkspace, workspace.id, workspace.metadata?.pinned]);
 
@@ -105,11 +105,11 @@ export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflo
             title: "Open",
             href: startUrl.toString(),
         },
-        {
-            title: "Rename",
-            href: "",
-            onClick: () => setRenameModalVisible(true),
-        },
+        // {
+        //     title: "Rename",
+        //     href: "",
+        //     onClick: () => setRenameModalVisible(true),
+        // },
     ];
 
     if (state === WorkspacePhase_Phase.RUNNING) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Some layout fixes for the workspace entry
 - fix the :merge:  icon: it's there, but hidden - likely due to the longer branch name
 - in the "column" for GitStatus, right-align the "change" drop-down to make the layout more stable
 - grant gitStatus + startTime + pin + action more than 50% of the width
- remove the rename action (for now)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
        <li><b>🏷️ Name</b> - se-follow-up-pinning</li>
        <li><b>🔗 URL</b> - <a href="https://se-follow-up-pinning.preview.gitpod-dev.com/workspaces" target="_blank">se-follow-up-pinning.preview.gitpod-dev.com/workspaces</a>.</li>
        <li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
        <li><b>📦 Version</b> - </li>
        <li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-follow-up-pinning%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
