### PR TITLE
[JetBrains] fix latest terminal integration broken

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -22,8 +22,8 @@
     <depends optional="true" config-file="maven.xml">org.jetbrains.idea.maven</depends>
     <dependencies>
         <plugin id="Git4Idea"/>
-        <!-- <plugin id="org.jetbrains.plugins.terminal"/> -->
-        <!-- <plugin id="com.jetbrains.codeWithMe"/>-->
+        <plugin id="org.jetbrains.plugins.terminal"/>
+        <plugin id="com.jetbrains.codeWithMe"/>
     </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,11 +15,15 @@
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <!-- Use old formatting to resolve class not found exception -->
+    <!-- https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#3-dependency-declaration-in-pluginxml -->
+    <depends>com.jetbrains.codeWithMe</depends>
+    <depends>org.jetbrains.plugins.terminal</depends>
     <depends optional="true" config-file="maven.xml">org.jetbrains.idea.maven</depends>
     <dependencies>
         <plugin id="Git4Idea"/>
-        <plugin id="org.jetbrains.plugins.terminal"/>
-        <plugin id="com.jetbrains.codeWithMe"/>
+        <!-- <plugin id="org.jetbrains.plugins.terminal"/> -->
+        <!-- <plugin id="com.jetbrains.codeWithMe"/>-->
     </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates [private chat](https://gitpod.slack.com/archives/C02BRJLGPGF/p1720426529071279?thread_ts=1719407126.426709&cid=C02BRJLGPGF)
Fixes ENT-426

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with latest and stable IntelliJ IDEA + repo https://github.com/Gitpod-Samples/spring-petclinic
- Tasks terminals should attached

✅ 
|Stable|Latest|
|:-:|:-:|
|<img width="1271" alt="SCR-20240709-dgpw" src="https://github.com/gitpod-io/gitpod/assets/20944364/e9df170a-ee89-42fe-b186-8588cdddea04">|<img width="1068" alt="image" src="https://github.com/gitpod-io/gitpod/assets/20944364/3da116c0-0f96-48fc-b86d-ae9e7072a360">|


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-terminal</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-terminal.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-terminal.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-terminal-gha.27222</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-terminal%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
