### PR TITLE
[agent-smith] don't scrub infringement

### DIFF
--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -336,7 +336,7 @@ func (agent *Smith) Penalize(ws InfringingWorkspace) ([]config.PenaltyKind, erro
 	for _, p := range penalty {
 		switch p {
 		case config.PenaltyStopWorkspace:
-			log.WithField("infringement", ws.Infringements).WithFields(owi).Info("stopping workspace")
+			log.WithField("infringement", log.TrustedValueWrap{Value: ws.Infringements}).WithFields(owi).Info("stopping workspace")
 			agent.metrics.penaltyAttempts.WithLabelValues(string(p)).Inc()
 			err := agent.stopWorkspace(ws.SupervisorPID, ws.InstanceID)
 			if err != nil {
@@ -345,7 +345,7 @@ func (agent *Smith) Penalize(ws InfringingWorkspace) ([]config.PenaltyKind, erro
 			}
 			return penalty, err
 		case config.PenaltyStopWorkspaceAndBlockUser:
-			log.WithField("infringement", ws.Infringements).WithFields(owi).Info("stopping workspace and blocking user")
+			log.WithField("infringement", log.TrustedValueWrap{Value: ws.Infringements}).WithFields(owi).Info("stopping workspace and blocking user")
 			agent.metrics.penaltyAttempts.WithLabelValues(string(p)).Inc()
 			err := agent.stopWorkspaceAndBlockUser(ws.SupervisorPID, ws.Owner, ws.WorkspaceID, ws.InstanceID)
 			if err != nil {
@@ -354,7 +354,7 @@ func (agent *Smith) Penalize(ws InfringingWorkspace) ([]config.PenaltyKind, erro
 			}
 			return penalty, err
 		case config.PenaltyLimitCPU:
-			log.WithField("infringement", ws.Infringements).WithFields(owi).Info("limiting CPU")
+			log.WithField("infringement", log.TrustedValueWrap{Value: ws.Infringements}).WithFields(owi).Info("limiting CPU")
 			agent.metrics.penaltyAttempts.WithLabelValues(string(p)).Inc()
 			err := agent.limitCPUUse(ws.Pod)
 			if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[agent-smith] don't scrub infringement

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [[internal chat](https://gitpod.slack.com/archives/C071G5TTS49/p1720511691831099?thread_ts=1720511254.975759&cid=C071G5TTS49)]

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
