### PR TITLE
[dashboard] Update Pending changes dropdown component to improve menu styling

### DIFF
--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -40,7 +40,10 @@ export default function PendingChangesDropdown({ gitStatus }: { gitStatus?: Work
         return <div className="text-sm text-gray-400 dark:text-gray-500">No Changes</div>;
     }
     return (
-        <ContextMenu menuEntries={menuEntries} customClasses="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0">
+        <ContextMenu
+            menuEntries={menuEntries}
+            customClasses="w-64 max-h-48 overflow-y-scroll overflow-x-clip mx-auto left-0 right-0"
+        >
             <p className="flex items-center text-gitpod-red">
                 <span>
                     {totalChanges} Change{totalChanges === 1 ? "" : "s"}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the Pending Changes dropdown component to improve the menu styling. The changes include adjusting the overflow behavior of the menu.

| Before | After |
|--------|--------|
| <img width="284" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/e5a11e9c-ee9d-44c1-a329-f9ac586c033e"> | <img width="313" alt="image" src="https://github.com/gitpod-io/gitpod/assets/55068936/6e520740-2aad-43db-90f3-22cbec76d643"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment & Complete onboarding
- Start a new workspace, make 7-8 new files
- Go back to preview environment dashboard (`/workspaces`) and see `Changes` dropdown section 👀

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - fix-pendin42c008ef7e</li>
	<li><b>🔗 URL</b> - <a href="https://fix-pendin42c008ef7e.preview.gitpod-dev.com/workspaces" target="_blank">fix-pendin42c008ef7e.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - fix-pending-changes-dropdown-comp-gha.27260</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-fix-pendin42c008ef7e%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
