### PR TITLE
[dashboard] enable naming of workspaces

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -35,6 +35,7 @@ import {
 } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { PartialMessage } from "@bufbuild/protobuf";
 import { trackEvent } from "../Analytics";
+import { fromWorkspaceName } from "../workspaces/RenameWorkspaceModal";
 
 const sessionId = v4();
 
@@ -562,7 +563,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                 <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
                                 <div>
                                     <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
-                                        {this.state.workspace.id}
+                                        {fromWorkspaceName(this.state.workspace) || this.state.workspace.id}
                                     </p>
                                     <a target="_parent" href={contextURL}>
                                         <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
@@ -667,7 +668,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                             <div className="rounded-full w-3 h-3 text-sm bg-kumquat-ripe">&nbsp;</div>
                             <div>
                                 <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
-                                    {this.state.workspace.id}
+                                    {fromWorkspaceName(this.state.workspace) || this.state.workspace.id}
                                 </p>
                                 <a target="_parent" href={contextURL}>
                                     <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
@@ -712,7 +713,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                             <div className="rounded-full w-3 h-3 text-sm bg-gray-300">&nbsp;</div>
                             <div>
                                 <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
-                                    {this.state.workspace.id}
+                                    {fromWorkspaceName(this.state.workspace) || this.state.workspace.id}
                                 </p>
                                 <a target="_parent" href={contextURL}>
                                     <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">

--- a/components/dashboard/src/workspaces/DeleteWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/DeleteWorkspaceModal.tsx
@@ -9,6 +9,7 @@ import ConfirmationModal from "../components/ConfirmationModal";
 import { useDeleteWorkspaceMutation } from "../data/workspaces/delete-workspace-mutation";
 import { useToast } from "../components/toasts/Toasts";
 import { Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { fromWorkspaceName } from "./RenameWorkspaceModal";
 
 type Props = {
     workspace: Workspace;
@@ -33,7 +34,7 @@ export const DeleteWorkspaceModal: FunctionComponent<Props> = ({ workspace, onCl
             areYouSureText="Are you sure you want to delete this workspace?"
             children={{
                 name: workspace.id,
-                description: workspace.metadata?.name,
+                description: fromWorkspaceName(workspace),
             }}
             buttonText="Delete Workspace"
             warningText={deleteWorkspace.isError ? "There was a problem deleting your workspace." : undefined}

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -15,6 +15,7 @@ import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
 import { Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { GitBranchIcon, PinIcon } from "lucide-react";
 import { useUpdateWorkspaceMutation } from "../data/workspaces/update-workspace-mutation";
+import { fromWorkspaceName } from "./RenameWorkspaceModal";
 
 type Props = {
     info: Workspace;
@@ -68,11 +69,13 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
                 <WorkspaceStatusIndicator status={workspace?.status} />
             </ItemFieldIcon>
             <div className="flex-grow flex flex-col h-full py-auto truncate">
-                <a href={startUrl}>
-                    <div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
-                        {info.id}
-                    </div>
-                </a>
+                <Tooltip content={info.id} allowWrap={true}>
+                    <a href={startUrl}>
+                        <div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                            {fromWorkspaceName(info) || info.id}
+                        </div>
+                    </a>
+                </Tooltip>
                 <Tooltip content={project ? "https://" + project : ""} allowWrap={true}>
                     <a href={project ? "https://" + project : undefined}>
                         <div className="text-sm overflow-ellipsis truncate text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400">

--- a/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
@@ -105,11 +105,11 @@ export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflo
             title: "Open",
             href: startUrl.toString(),
         },
-        // {
-        //     title: "Rename",
-        //     href: "",
-        //     onClick: () => setRenameModalVisible(true),
-        // },
+        {
+            title: "Rename",
+            href: "",
+            onClick: () => setRenameModalVisible(true),
+        },
     ];
 
     if (state === WorkspacePhase_Phase.RUNNING) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allow naming workspaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/ENT-434/allow-naming-workspaces

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - se-name-ws</li>
	<li><b>🔗 URL</b> - <a href="https://se-name-ws.preview.gitpod-dev.com/workspaces" target="_blank">se-name-ws.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - se-name-ws-gha.27285</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-se-name-ws%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
