### PR TITLE
Improve empty workspace view

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -37,6 +37,7 @@
     "file-saver": "^2.0.5",
     "idb-keyval": "^6.2.0",
     "js-cookie": "^3.0.1",
+    "lite-youtube-embed": "^0.3.2",
     "lodash": "^4.17.21",
     "lucide-react": "^0.287.0",
     "monaco-editor": "^0.25.2",

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -320,7 +320,7 @@ export const PrebuildDetailPage: FC = () => {
                                     )}
                                 </Tabs>
                             </div>
-                            <div className="px-6 pt-6 flex justify-between border-pk-border-base">
+                            <div className="px-6 pt-6 flex justify-between border-pk-border-base overflow-y-hidden gap-4">
                                 {[PrebuildPhase_Phase.BUILDING, PrebuildPhase_Phase.QUEUED].includes(
                                     prebuild?.status?.phase?.name ?? PrebuildPhase_Phase.UNSPECIFIED,
                                 ) ? (
@@ -341,7 +341,7 @@ export const PrebuildDetailPage: FC = () => {
                                         onClick={() => triggerPrebuild()}
                                     >{`Rerun Prebuild (${prebuild.ref})`}</LoadingButton>
                                 )}
-                                <div className="space-x-6 flex justify-right">
+                                <div className="gap-4 flex justify-right">
                                     <LinkButton
                                         disabled={!prebuild?.id}
                                         href={repositoriesRoutes.PrebuildsSettings(prebuild.configurationId)}
@@ -349,16 +349,15 @@ export const PrebuildDetailPage: FC = () => {
                                     >
                                         View Prebuild Settings
                                     </LinkButton>
-                                    <LoadingButton
-                                        loading={false}
+                                    <Button
                                         disabled={prebuild?.status?.phase?.name !== PrebuildPhase_Phase.AVAILABLE}
                                         onClick={() =>
                                             (window.location.href = `/#open-prebuild/${prebuild?.id}/${prebuild?.contextUrl}`)
                                         }
-                                        variant="default"
+                                        variant="secondary"
                                     >
                                         Open Debug Workspace
-                                    </LoadingButton>
+                                    </Button>
                                 </div>
                             </div>
                         </div>

--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -222,7 +222,7 @@ export const PrebuildDetailPage: FC = () => {
                     </div>
                 ) : (
                     prebuild && (
-                        <div className={"border border-pk-border-base rounded-xl py-6 divide-y"}>
+                        <div className={"border border-pk-border-base rounded-xl pt-6 pb-3 divide-y"}>
                             <div className="px-6 pb-4">
                                 <div className="flex flex-col gap-2">
                                     <div className="flex justify-between">
@@ -320,7 +320,7 @@ export const PrebuildDetailPage: FC = () => {
                                     )}
                                 </Tabs>
                             </div>
-                            <div className="px-6 pt-6 flex justify-between border-pk-border-base overflow-y-hidden gap-4">
+                            <div className="px-6 pt-6 pb-3 flex justify-between border-pk-border-base overflow-y-hidden gap-4">
                                 {[PrebuildPhase_Phase.BUILDING, PrebuildPhase_Phase.QUEUED].includes(
                                     prebuild?.status?.phase?.name ?? PrebuildPhase_Phase.UNSPECIFIED,
                                 ) ? (

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -30,7 +30,7 @@ export const EmptyWorkspacesContent = () => {
 
     return (
         <div className="app-container flex flex-col space-y-2">
-            <div className="px-6 mt-16 flex flex-row flex-wrap items-center justify-center gap-x-14 gap-y-10 min-h-96 min-w-96">
+            <div className="px-6 mt-16 flex flex-col xl:flex-row items-center justify-center gap-x-14 gap-y-10 min-h-96 min-w-96">
                 <lite-youtube
                     videoid="1ZBN-b2cIB8"
                     width="535"
@@ -43,9 +43,9 @@ export const EmptyWorkspacesContent = () => {
                     class="rounded-xl"
                     playlabel="Gitpod in under 120 seconds"
                 ></lite-youtube>
-                <div className="flex flex-col items-center justify-center">
+                <div className="flex flex-col items-center xl:items-start justify-center">
                     <Heading2 className="mb-4 !font-semibold !text-lg">Create your first workspace</Heading2>
-                    <Subheading className="max-w-xs text-center">
+                    <Subheading className="max-w-xs xl:text-left text-center">
                         Write code in your personal development environment that’s running in the cloud
                     </Subheading>
                     <span className="flex flex-col space-y-4 w-fit">

--- a/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
+++ b/components/dashboard/src/workspaces/EmptyWorkspacesContent.tsx
@@ -4,78 +4,62 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { useEffect } from "react";
 import { LinkButton } from "@podkit/buttons/LinkButton";
 import { Heading2, Subheading } from "@podkit/typography/Headings";
 import { trackVideoClick } from "../Analytics";
+
+import "lite-youtube-embed/src/lite-yt-embed.css";
+import "lite-youtube-embed/src/lite-yt-embed";
 
 declare global {
     interface Window {
         onYouTubeIframeAPIReady: () => void;
         YT: any;
     }
+    namespace JSX {
+        interface IntrinsicElements {
+            "lite-youtube": any;
+        }
+    }
 }
 
 export const EmptyWorkspacesContent = () => {
-    useEffect(() => {
-        // Load the YouTube IFrame Player API code asynchronously
-        const tag = document.createElement("script");
-        tag.src = "https://www.youtube.com/iframe_api";
-        const firstScriptTag = document.getElementsByTagName("script")[0];
-        firstScriptTag.parentNode?.insertBefore(tag, firstScriptTag);
-
-        // Create YouTube player when API is ready
-        window.onYouTubeIframeAPIReady = () => {
-            new window.YT.Player("gitpod-video", {
-                events: {
-                    onStateChange: onPlayerStateChange,
-                },
-            });
-        };
-    }, []);
-
-    const onPlayerStateChange = (event: any) => {
-        if (event.data === window.YT.PlayerState.PLAYING) {
-            trackVideoClick("create-new-workspace");
-        }
+    const onPlayerStateChange = () => {
+        trackVideoClick("create-new-workspace");
     };
 
     return (
         <div className="app-container flex flex-col space-y-2">
-            <div className="px-6 mt-16 flex flex-row items-center justify-center space-x-14">
-                <div>
-                    <iframe
-                        id="gitpod-video"
-                        width="535"
-                        height="307"
-                        src="https://www.youtube.com/embed/1ZBN-b2cIB8?enablejsapi=1&modestbranding=1&rel=0&controls=1&showinfo=0&fs=1"
-                        title="YouTube - Gitpod in 120 seconds"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        allowFullScreen
-                        className="rounded-xl"
-                    ></iframe>
-                </div>
-                <div>
-                    <div className="flex flex-col items-left justify-center h-96 w-96">
-                        <Heading2 className="text-left mb-4 !font-semibold !text-lg">
-                            Create your first workspace
-                        </Heading2>
-                        <Subheading className="text-left max-w-xs">
-                            Write code in your personal development environment that’s running in the cloud
-                        </Subheading>
-                        <span className="flex flex-col space-y-4 w-fit">
-                            <LinkButton
-                                variant="secondary"
-                                className="mt-4 border !border-pk-content-invert-primary text-pk-content-secondary bg-pk-surface-secondary"
-                                href={"/new?showExamples=true"}
-                            >
-                                Try a configured demo repository
-                            </LinkButton>
-                            <LinkButton href={"/new"} className="gap-1.5">
-                                Configure your own repository
-                            </LinkButton>
-                        </span>
-                    </div>
+            <div className="px-6 mt-16 flex flex-row flex-wrap items-center justify-center gap-x-14 gap-y-10 min-h-96 min-w-96">
+                <lite-youtube
+                    videoid="1ZBN-b2cIB8"
+                    width="535"
+                    height="307"
+                    onClick={onPlayerStateChange}
+                    style={{
+                        width: "535px",
+                        backgroundImage: "url('https://i.ytimg.com/vi_webp/1ZBN-b2cIB8/maxresdefault.webp')",
+                    }}
+                    class="rounded-xl"
+                    playlabel="Gitpod in under 120 seconds"
+                ></lite-youtube>
+                <div className="flex flex-col items-center justify-center">
+                    <Heading2 className="mb-4 !font-semibold !text-lg">Create your first workspace</Heading2>
+                    <Subheading className="max-w-xs text-center">
+                        Write code in your personal development environment that’s running in the cloud
+                    </Subheading>
+                    <span className="flex flex-col space-y-4 w-fit">
+                        <LinkButton
+                            variant="secondary"
+                            className="mt-4 border !border-pk-content-invert-primary text-pk-content-secondary bg-pk-surface-secondary"
+                            href={"/new?showExamples=true"}
+                        >
+                            Try a configured demo repository
+                        </LinkButton>
+                        <LinkButton href={"/new"} className="gap-1.5">
+                            Configure your own repository
+                        </LinkButton>
+                    </span>
                 </div>
             </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10446,6 +10446,11 @@ linkify-it@^3.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
+lite-youtube-embed@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz#d43490743d93dd977fe18814c45d20f76ff2580a"
+  integrity sha512-b1dgKyF4PHhinonmr3PB172Nj0qQgA/7DE9EmeIXHR1ksnFEC2olWjNJyJGdsN2cleKHRjjsmrziKlwXtPlmLQ==
+
 load-json-file@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz"


### PR DESCRIPTION
## Description

Make the youtube embed more performant using https://github.com/paulirish/lite-youtube-embed, make the view responsive and simplify event.

A cool article about yt embeds: https://www.zachleat.com/web/youtube-embeds/.

This change almost cuts the pages size in half when the user does not click on the video.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-451

## How to test

https://ft-yt-improvements.preview.gitpod-dev.com/workspaces

You should see the page right away after signing up.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
