### PR TITLE
Fix changes dropdown alignment

### DIFF
--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -7,8 +7,13 @@
 import ContextMenu, { ContextMenuEntry } from "./ContextMenu";
 import CaretDown from "../icons/CaretDown.svg";
 import { WorkspaceGitStatus } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
+import { cn } from "@podkit/lib/cn";
 
-export default function PendingChangesDropdown({ gitStatus }: { gitStatus?: WorkspaceGitStatus }) {
+type Props = {
+    gitStatus?: WorkspaceGitStatus;
+    className?: string;
+};
+export default function PendingChangesDropdown({ gitStatus, className }: Props) {
     const headingStyle = "text-gray-500 dark:text-gray-400 text-left";
     const itemStyle = "text-gray-400 dark:text-gray-500 text-left -mt-5";
     const menuEntries: ContextMenuEntry[] = [];
@@ -42,9 +47,9 @@ export default function PendingChangesDropdown({ gitStatus }: { gitStatus?: Work
     return (
         <ContextMenu
             menuEntries={menuEntries}
-            customClasses="w-64 max-h-48 overflow-y-scroll overflow-x-clip mx-auto left-0 right-0"
+            customClasses={"w-64 max-h-48 overflow-y-scroll overflow-x-clip mx-auto left-0 right-0"}
         >
-            <p className="flex items-center text-gitpod-red">
+            <p className={cn("flex items-center text-gitpod-red", className)}>
                 <span>
                     {totalChanges} Change{totalChanges === 1 ? "" : "s"}
                 </span>

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -722,7 +722,10 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                 </a>
                             </div>
                         </div>
-                        <PendingChangesDropdown gitStatus={this.state.workspace.status.gitStatus} />
+                        <PendingChangesDropdown
+                            gitStatus={this.state.workspace.status.gitStatus}
+                            className="justify-center"
+                        />
                         <div className="mt-10 justify-center flex space-x-2">
                             <a target="_parent" href={gitpodHostUrl.asWorkspacePage().toString()}>
                                 <Button variant="secondary">Go to Dashboard</Button>

--- a/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesSearchBar.tsx
@@ -5,11 +5,10 @@
  */
 
 import { FunctionComponent } from "react";
-import { Link } from "react-router-dom";
 import { StartWorkspaceModalKeyBinding } from "../App";
 import DropDown from "../components/DropDown";
 import search from "../icons/search.svg";
-import { Button } from "@podkit/buttons/Button";
+import { LinkButton } from "@podkit/buttons/LinkButton";
 
 type WorkspacesSearchBarProps = {
     searchTerm: string;
@@ -67,11 +66,9 @@ export const WorkspacesSearchBar: FunctionComponent<WorkspacesSearchBarProps> = 
                     ]}
                 />
             </div>
-            <Link to={"/new"}>
-                <Button className="ml-2 gap-1.5 h-10">
-                    New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
-                </Button>
-            </Link>
+            <LinkButton href={"/new"} className="ml-2 gap-1.5 h-10">
+                New Workspace <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+            </LinkButton>
         </div>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,20 +5530,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001271:
-  version "1.0.30001274"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz"
-  integrity sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==
-
-caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001520:
-  version "1.0.30001521"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz#e9930cf499f7c1e80334b6c1fbca52e00d889e56"
-  integrity sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==
-
-caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001600"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz#93a3ee17a35aa6a9f0c6ef1b2ab49507d1ab9079"
-  integrity sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001271, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001520, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
+  version "1.0.30001641"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz"
+  integrity sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==
 
 case-anything@^2.1.13:
   version "2.1.13"


### PR DESCRIPTION
## Description

Fixes a regression from #19992 which made the dropdown for git changes incorrectly aligned on the start workspace page.

| Old | New |
|--------|--------|
| <img width="359" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/8ad7bc2f-9af2-44da-aaf8-dbfaeb1edd45"> | <img width="1920" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/5581da1e-2e0a-48ff-bb01-0b4208fe52c3"> | 

It also fixes a focusing issue on the new workspace button and updates the caniuse database, which we haven't done in a while.

## How to test

https://ft-fix-cha41e1198b65.preview.gitpod-dev.com/workspaces

Start a workspace, touch a file, stop it and observe the page's UI.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
