### PR TITLE
Accessible workspace pinning

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -16,6 +16,8 @@ import { Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { GitBranchIcon, PinIcon } from "lucide-react";
 import { useUpdateWorkspaceMutation } from "../data/workspaces/update-workspace-mutation";
 import { fromWorkspaceName } from "./RenameWorkspaceModal";
+import { Button } from "@podkit/buttons/Button";
+import { cn } from "@podkit/lib/cn";
 
 type Props = {
     info: Workspace;
@@ -112,23 +114,24 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
                         </Tooltip>
                     </div>
                     <div className="min-w-8 flex items-center">
-                        <div
-                            onClick={togglePinned}
-                            className={
-                                "group px-2 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer h-8 w-8"
-                            }
-                        >
-                            <Tooltip content={workspace.metadata?.pinned ? "Unpin" : "Pin"}>
+                        <Tooltip content={workspace.metadata?.pinned ? "Unpin" : "Pin"}>
+                            <Button
+                                onClick={togglePinned}
+                                variant={"ghost"}
+                                className={
+                                    "group px-2 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md w-8 h-8"
+                                }
+                            >
                                 <PinIcon
-                                    className={
-                                        "w-4 h-4 self-center " +
-                                        (workspace.metadata?.pinned
+                                    className={cn(
+                                        "w-4 h-4 self-center",
+                                        workspace.metadata?.pinned
                                             ? "text-gray-600 dark:text-gray-300"
-                                            : "text-gray-300 dark:text-gray-600 group-hover:text-gray-600 dark:group-hover:text-gray-300")
-                                    }
+                                            : "text-gray-300 dark:text-gray-600 group-hover:text-gray-600 dark:group-hover:text-gray-300",
+                                    )}
                                 />
-                            </Tooltip>
-                        </div>
+                            </Button>
+                        </Tooltip>
                     </div>
                     <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
                 </>


### PR DESCRIPTION
## Description

Makes the workspace pinning action keyboard-focusable and operable. Gets rid of a clickable div :)

<img width="1023" alt="image" src="https://github.com/gitpod-io/gitpod/assets/29888641/e89aa92a-3b34-4fe6-940c-7f343802ace4">

## How to test

https://ft-proper-27456213ee.preview.gitpod-dev.com/workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
