### PR TITLE
Add support for opening bitbucket server tags

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -333,6 +333,31 @@ class TestBitbucketServerContextParser {
         });
     }
 
+    @test async test_tag_context_01() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo/browse?at=refs%2Ftags%2Fv0.0.1",
+        );
+
+        expect(result).to.deep.include({
+            title: "filip/repodepo - v0.0.1",
+            ref: "v0.0.1",
+            refType: "tag",
+            revision: "c16d4d0049545e7d8908302c07550f9d325fbed4",
+            repository: {
+                host: "bitbucket.gitpod-dev.com",
+                owner: "filip",
+                name: "RepoDepo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/~filip/repodepo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo",
+                defaultBranch: "main",
+                private: true,
+                repoKind: "users",
+            },
+        });
+    }
+
     @test test_toSimpleBranchName() {
         const url = new URL(
             "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/browse?at=refs%2Fheads%2Ffoo",


### PR DESCRIPTION
## Description

Allow users to open a specific tag directly from Bitbucket Server.

## Related Issue(s)

Fixes ENT-372

## How to test

1. [Join my org](https://ft-bb-server-tags.preview.gitpod-dev.com/orgs/join?inviteId=6476c50b-6a8c-4899-8f4a-5f12c3615d1a)
2. Try opening https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo/browse?at=refs%2Ftags%2Fv0.0.1

--- Or ---

Run the test in `components/server`

```
mocha './**/bitbucket-server/bitbucket-server-context-parser.spec.js' --grep 'test_tag_context_01' --exclude './node_modules/**' --exit
```

(although you'll need an access token and to change the host at the top of the file)