### PR TITLE
Fix not able to open workspace with nightly code

### DIFF
--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           export LEEWAY_WORKSPACE_ROOT=$GITHUB_WORKSPACE
 
-          codeHeadCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/release/1.91)
+          codeHeadCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
           codeVersion=$(curl https://raw.githubusercontent.com/gitpod-io/openvscode-server/$codeHeadCommit/package.json | jq .version)
           imageRepoBase=${{ github.ref == 'refs/heads/main' && 'eu.gcr.io/gitpod-core-dev/build' || 'eu.gcr.io/gitpod-dev-artifact/build' }}
           cd components/ide/code

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: a412ea75aad37c687932f897378d3076e311d534
-  codeVersion: 1.91.0
+  codeCommit: 2915f0a1347a12df8b19641d99235395705efb53
+  codeVersion: 1.92.0
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8915adfdb17c4dc52c327ca81c50c547e80d3a99

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 2915f0a1347a12df8b19641d99235395705efb53
-  codeVersion: 1.92.0
+  codeCommit: a412ea75aad37c687932f897378d3076e311d534
+  codeVersion: 1.91.0
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8915adfdb17c4dc52c327ca81c50c547e80d3a99

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -307,7 +307,7 @@ export class WorkspaceStarter {
                     ideSettings = {
                         ...ideSettings,
                         defaultIde: ideConfig.ide,
-                        useLatestVersion: !!ideConfig.useLatest,
+                        useLatestVersion: ideSettings?.useLatestVersion ?? !!ideConfig.useLatest,
                     };
                 }
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -307,7 +307,10 @@ export class WorkspaceStarter {
                     ideSettings = {
                         ...ideSettings,
                         defaultIde: ideConfig.ide,
-                        useLatestVersion: ideSettings?.useLatestVersion ?? !!ideConfig.useLatest,
+                        useLatestVersion:
+                            ideSettings?.useLatestVersion ??
+                            user.additionalData?.ideSettings?.useLatestVersion ??
+                            !!ideConfig.useLatest,
                     };
                 }
             }

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -35,6 +35,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Search:      "{{WORKBENCH_WEB_BASE_URL}}",
 						Replacement: "${ide}",
 					}, {
+						Search:      "{{WORKBENCH_NLS_FALLBACK_URL}}",
+						Replacement: "${ide}/out/nls.messages.js",
+					}, {
+						Search:      "{{WORKBENCH_NLS_URL}}",
+						Replacement: "${ide}/out/nls.messages.js",
+					}, {
 						Search:      "/_supervisor/frontend",
 						Replacement: "${supervisor}",
 					}},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Changes on openvscode-server side https://github.com/gitpod-io/openvscode-server/commit/2915f0a1347a12df8b19641d99235395705efb53

TODO:
- [x] Revert debug commit https://github.com/gitpod-io/gitpod/pull/20029/commits/be496bc04a55152b0e29cbc3ea36d3ab0b374195

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-453, ENT-455

## How to test
<!-- Provide steps to test this PR -->
**Night code is working again**
- With debug commit https://github.com/gitpod-io/gitpod/pull/20029/commits/be496bc04a55152b0e29cbc3ea36d3ab0b374195
- You should be able to open workspace with **latest Editor** in preview env

**Switch editor version is working**
- Open a workspace with latest editor
- Close workspace
- Update setting to use `stable` editor
- Restart workspace
- Workspace should use stable editor

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-code-latest</li>
	<li><b>🔗 URL</b> - <a href="https://hw-code-latest.preview.gitpod-dev.com/workspaces" target="_blank">hw-code-latest.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-code-latest-gha.27420</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-code-latest%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
