### PR TITLE
Fix Gitpod CLI arm builds

### DIFF
--- a/components/local-app/BUILD.js
+++ b/components/local-app/BUILD.js
@@ -21,10 +21,8 @@ const generatePackage = function (goos, goarch, binaryName, mainFile) {
             buildCommand: [
                 "sh",
                 "-c",
-                'go build -trimpath -ldflags "-X github.com/gitpod-io/local-app/pkg/constants.GitCommit=${__git_commit} -X github.com/gitpod-io/local-app/pkg/constants.BuildTime=$(date +%s)" -o ' +
-                    binaryName +
-                    " " +
-                    mainFile,
+                // We need to set GOARCH explicitly here because the `defaultVariant` in `WORKSPACE.yaml` overrides it for the workspace
+                `GOARCH=${goarch} go build -trimpath -ldflags "-X github.com/gitpod-io/local-app/pkg/constants.GitCommit=\${__git_commit} -X github.com/gitpod-io/local-app/pkg/constants.BuildTime=\$(date +%s)" -o ${binaryName} ${mainFile}`,
             ],
         },
         binaryName,


### PR DESCRIPTION
## Description

We accidentally changed all builds to build for `amd64` and this PR fixes that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-325

## How to test

```
wget https://ide.ft-fix-cli-arch.preview.gitpod-dev.com/static/bin/gitpod-cli-darwin-arm64
file gitpod-cli-darwin-arm64
```

Check it's `arm64`
```
/.../gitpod-cli-darwin-arm64: Mach-O 64-bit executable arm64
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
