### PR TITLE
[dashboard] Update `enabling` role

### DIFF
--- a/components/dashboard/src/onboarding/job-roles.ts
+++ b/components/dashboard/src/onboarding/job-roles.ts
@@ -12,7 +12,7 @@ export const getJobRoleOptions = () => {
         { value: "software-eng", label: "Software Engineering" },
         { value: "data", label: "Data / Analytics" },
         { value: "academics", label: "Academia (Student, Researcher)" },
-        { value: "enabling", label: "Platform or Developer Experience" },
+        { value: "enabling", label: "DevOps / Platform / DevX" },
         { value: "team-lead", label: "A Team Lead or Function Lead role" },
         { value: "devrel", label: "DevRel" },
         { value: "product-design", label: "Product" },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`Platform or Developer Experience` became `DevOps / Platform / DevX` in Onboarding form job roles dropdown by keeping the key same as `enabling` (that is being used in DB)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes OPM-670

## How to test
<!-- Provide steps to test this PR -->

_Just don't 🙃_

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
