### PR TITLE
Fix permissions checks for stopping prebuilds

### DIFF
--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -213,13 +213,14 @@ export class PrebuildManager {
 
     async cancelPrebuild(ctx: TraceContext, userId: string, prebuildId: string): Promise<void> {
         const prebuild = await this.workspaceDB.trace(ctx).findPrebuildByID(prebuildId);
-        if (prebuild) {
-            await this.auth.checkPermissionOnProject(userId, "write_prebuild", prebuild.projectId!);
-        }
         if (!prebuild) {
             throw new ApplicationError(ErrorCodes.NOT_FOUND, `prebuild ${prebuildId} not found`);
         }
-        await this.workspaceService.stopWorkspace(userId, prebuild.buildWorkspaceId, "stopped via API");
+
+        await this.auth.checkPermissionOnProject(userId, "write_prebuild", prebuild.projectId!);
+        await this.workspaceService.stopWorkspace(userId, prebuild.buildWorkspaceId, "stopped via API", undefined, {
+            skipPermissionCheck: true,
+        });
     }
 
     async getPrebuild(

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -333,8 +333,11 @@ export class WorkspaceService {
         workspaceId: string,
         reason: string,
         policy?: StopWorkspacePolicy,
+        options: { skipPermissionCheck?: boolean } = {},
     ): Promise<void> {
-        await this.auth.checkPermissionOnWorkspace(userId, "stop", workspaceId);
+        if (!options.skipPermissionCheck) {
+            await this.auth.checkPermissionOnWorkspace(userId, "stop", workspaceId);
+        }
 
         const workspace = await this.doGetWorkspace(userId, workspaceId);
         const instance = await this.db.findRunningInstance(workspace.id);

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -34,7 +34,7 @@ func (sub *tasksSubscription) Updates() <-chan []*api.TaskStatus {
 	return sub.updates
 }
 
-const maxSubscriptions = 10
+const maxSubscriptions = 100
 
 func (tm *tasksManager) Subscribe() *tasksSubscription {
 	tm.mu.Lock()


### PR DESCRIPTION
## Description

Fixes permission discrepancies with prebuilds the user did not start themselves.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-474
Fixes ENT-481, although a bit lazily 

## How to test

https://ft-fix-sto5f07d12d0f.preview.gitpod-dev.com

1. [Join my org](https://ft-fix-sto5f07d12d0f.preview.gitpod-dev.com/orgs/join?inviteId=9e5093d1-d3ea-48b4-a4bd-fbf6380bc6c5)
2. Call me and make me run a prebuild
3. Try cancelling it

I did step 2-3 for you with a second account and can confirm cancelling works :).


/hold
