### PR TITLE
Fix incorrect redirects to newer prebuilds

### DIFF
--- a/components/dashboard/src/data/prebuilds/prebuild-queries.ts
+++ b/components/dashboard/src/data/prebuilds/prebuild-queries.ts
@@ -64,21 +64,14 @@ export function useCancelPrebuildMutation() {
     });
 }
 
-export function useTriggerPrebuildQuery(configurationId?: string, gitRef?: string) {
-    // we use useQuery instead of useMutation so that we can get data (prebuildId) directly outside
-    return useQuery<string, Error, string>(
-        ["prebuild-trigger", configurationId, gitRef],
-        async () => {
+export function useTriggerPrebuildMutation(configurationId?: string, gitRef?: string) {
+    return useMutation({
+        mutationFn: async () => {
             if (!configurationId) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, "prebuild configurationId is missing");
             }
 
             return prebuildClient.startPrebuild({ configurationId, gitRef }).then((resp) => resp.prebuildId);
         },
-        {
-            enabled: false,
-            cacheTime: 0,
-            retry: false,
-        },
-    );
+    });
 }


### PR DESCRIPTION
## Description

The method for triggering a new prebuild is currently a query, because it made it integrating into the UI easier. That came with some unintended consequences in caching though, hence this PR which converts it into a standard mutation.

What happened is that for some reason, the query we used with `cacheTime: 0` still kept some cache for quite some time, meaning that going to prebuilds which were not the latest one caused the cache to retrieve the latest triggered prebuild id and redirect to it. This to the user looked like the prebuild they just clicked on was behaving weirdly without status updates, but in fact it was a completely different prebuild.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-471

## How to test

https://ft-fix-pre38d051c02d.preview.gitpod-dev.com/repositories

1. Import a repository and set it up for prebuilds
2. Run a prebuild and wait for it to finish
3. Click `Rerun Prebuild`
4. Wait for the prebuild to be triggered
5. Go back to the prebuild list
6. Click on the finished prebuild


/hold
