### PR TITLE
Be more helpful when there is no image build for prebuilds

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
@@ -14,6 +14,7 @@ import { TabsContent } from "@podkit/tabs/Tabs";
 import { PrebuildTaskErrorTab } from "./PrebuildTaskErrorTab";
 import type { PlainMessage } from "@bufbuild/protobuf";
 import { useHistory } from "react-router";
+import { LoadingState } from "@podkit/loading/LoadingState";
 
 const WorkspaceLogs = React.lazy(() => import("../../components/WorkspaceLogs"));
 
@@ -74,6 +75,16 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
     }, []);
 
     if (error) {
+        if (error.code === ErrorCodes.NOT_FOUND && taskId === "image-build") {
+            return (
+                <PrebuildTaskErrorTab taskId={taskId}>
+                    <span className="flex justify-center items-center gap-1">
+                        Pulling container image <LoadingState delay={false} size={16} />
+                    </span>
+                </PrebuildTaskErrorTab>
+            );
+        }
+
         return (
             <PrebuildTaskErrorTab taskId={taskId}>
                 Logs of this prebuild task are inaccessible. Use <code>gp validate --prebuild --headless</code> in a

--- a/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
@@ -78,7 +78,7 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
         if (error.code === ErrorCodes.NOT_FOUND && taskId === "image-build") {
             return (
                 <PrebuildTaskErrorTab taskId={taskId}>
-                    <span className="flex justify-center items-center gap-1">
+                    <span className="flex justify-center items-center gap-2">
                         Pulling container image <LoadingState delay={false} size={16} />
                     </span>
                 </PrebuildTaskErrorTab>


### PR DESCRIPTION
## Description

| When there's an image build | When there's none |
|--------|--------|
| <img width="819" alt="image" src="https://github.com/user-attachments/assets/4dfde8f6-a63b-4f07-b95c-af41099d08a4"> | <img width="819" alt="image" src="https://github.com/user-attachments/assets/fef76498-1b73-4f1b-bfe2-16e519f99a1e"> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-490

## How to test

https://ft-infer-pb90972c503.preview.gitpod-dev.com/repositories

1. Import a repo, enable prebuilds
2. Run a prebuild, maybe observe image logs or see our new message (depending on whether the preview env has the image you need)
3. Repeat if desired
