### PR TITLE
Don't show repo examples around prebuilds

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -47,9 +47,9 @@ export default function RepositoryFinder({
         hasMore,
     } = useUnifiedRepositorySearch({
         searchString,
-        excludeConfigurations: excludeConfigurations,
-        onlyConfigurations: onlyConfigurations,
-        showExamples: showExamples,
+        excludeConfigurations,
+        onlyConfigurations,
+        showExamples,
     });
 
     const authProviders = useAuthProviderDescriptions();
@@ -193,7 +193,7 @@ export default function RepositoryFinder({
 
     const getElements = useCallback(
         (searchString: string): ComboboxElement[] => {
-            if (isShowingExamples && searchString.length === 0) {
+            if (isShowingExamples && searchString.length === 0 && !onlyConfigurations) {
                 return PREDEFINED_REPOS.map((repo) => ({
                     id: repo.url,
                     element: <PredefinedRepositoryOption repo={repo} />,
@@ -207,19 +207,21 @@ export default function RepositoryFinder({
                 isSelectable: true,
             }));
 
-            // Add predefined repos to end of the list.
-            PREDEFINED_REPOS.forEach((repo) => {
-                if (
-                    repo.url.toLowerCase().includes(searchString.toLowerCase()) ||
-                    repo.repoName.toLowerCase().includes(searchString.toLowerCase())
-                ) {
-                    result.push({
-                        id: repo.url,
-                        element: <PredefinedRepositoryOption repo={repo} />,
-                        isSelectable: true,
-                    });
-                }
-            });
+            if (!onlyConfigurations) {
+                // Add predefined repos to end of the list.
+                PREDEFINED_REPOS.forEach((repo) => {
+                    if (
+                        repo.url.toLowerCase().includes(searchString.toLowerCase()) ||
+                        repo.repoName.toLowerCase().includes(searchString.toLowerCase())
+                    ) {
+                        result.push({
+                            id: repo.url,
+                            element: <PredefinedRepositoryOption repo={repo} />,
+                            isSelectable: true,
+                        });
+                    }
+                });
+            }
 
             if (hasMore) {
                 result.push({


### PR DESCRIPTION
## Description

Makes it so that users don't think they can run prebuilds on repositories they did not import.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-487

## How to test

https://ft-no-examb7f8b4ba3a.preview.gitpod-dev.com/prebuilds

1. Go to the prebuilds page
2. Try to run a prebuild
3. Observe there are no sample repos to choose

/hold
