### PR TITLE
[dashboard] Fix duration displaying (no "undefinedh")

### DIFF
--- a/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildDetailPage.tsx
@@ -130,14 +130,16 @@ export const PrebuildDetailPage: FC = () => {
             "milliseconds",
         );
 
-        if (duration.asMinutes() < 1) {
-            return duration.format("s[s]");
+        const s = duration.get("s");
+        const m = duration.get("m");
+        const h = duration.get("h");
+        if (h >= 1) {
+            return `${h}h ${m}m ${s}s`;
         }
-        if (duration.asHours() < 1) {
-            return duration.format("m[m] s[s]");
+        if (m >= 1) {
+            return `${m}m ${s}s`;
         }
-
-        return duration.format("h[h] m[m] s[s]");
+        return `${s}s`;
     }, [prebuild?.status?.startTime, prebuild?.status?.stopTime]);
 
     const setSelectedTaskId = useCallback(


### PR DESCRIPTION
## Description
Looks good now: 
![image](https://github.com/user-attachments/assets/6d8017bf-8cfb-440e-8ada-42969a9800da)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-500

## How to test
 - join this org: https://gpl-undefi8254afba9e.preview.gitpod-dev.com/orgs/join?inviteId=fcdbfbdb-4e92-4595-a227-09be337e0f33

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
