### PR TITLE
[supervisor] Make sure we read the last chunk of message when task is closed

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -103,7 +103,7 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                         if (!content) {
                             return;
                         }
-                        logsEmitter.emit("logs", content.text);
+                        logsEmitter.emit("logs", content.data);
                     },
                 }),
             );
@@ -173,7 +173,12 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
         <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col mb-8">
             <div className="h-96 flex">
                 <Suspense fallback={<div />}>
-                    <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
+                    <WorkspaceLogs
+                        taskId="undefined"
+                        classes="h-full w-full"
+                        logsEmitter={logsEmitter}
+                        errorMessage={error?.message}
+                    />
                 </Suspense>
             </div>
             <div className="w-full bottom-0 h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex flex-row items-center space-x-2">

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -26,6 +26,7 @@ const lightTheme: ITheme = {
 };
 
 export interface Props {
+    taskId: string;
     logsEmitter: EventEmitter;
     errorMessage?: string;
     classes?: string;
@@ -56,7 +57,7 @@ export default function WorkspaceLogs({ logsEmitter, errorMessage, classes, xter
         terminal.loadAddon(fitAddon);
         terminal.open(xTermParentRef.current);
 
-        let logBuffer = "";
+        let logBuffer = new Uint8Array();
         let isWriting = false;
 
         const processNextLog = () => {
@@ -73,16 +74,16 @@ export default function WorkspaceLogs({ logsEmitter, errorMessage, classes, xter
             }
         };
 
-        const logListener = (logs: string) => {
+        const logListener = (logs: Uint8Array) => {
             if (!logs) return;
 
-            logBuffer += logs;
+            logBuffer = new Uint8Array([...logBuffer, ...logs]);
             processNextLog();
         };
 
         const resetListener = () => {
             terminal.clear();
-            logBuffer = "";
+            logBuffer = new Uint8Array();
             isWriting = false;
         };
 

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -63,8 +63,8 @@ export default function WorkspaceLogs({ logsEmitter, errorMessage, classes, xter
         const processNextLog = () => {
             if (isWriting || logBuffer.length === 0) return;
 
-            const logs = logBuffer.slice(0, MAX_CHUNK_SIZE);
-            logBuffer = logBuffer.slice(logs.length);
+            const logs = logBuffer.subarray(0, MAX_CHUNK_SIZE);
+            logBuffer = logBuffer.subarray(logs.length);
             if (logs) {
                 isWriting = true;
                 terminal.write(logs, () => {
@@ -77,7 +77,11 @@ export default function WorkspaceLogs({ logsEmitter, errorMessage, classes, xter
         const logListener = (logs: Uint8Array) => {
             if (!logs) return;
 
-            logBuffer = new Uint8Array([...logBuffer, ...logs]);
+            const newBuffer = new Uint8Array(logBuffer.length + logs.length);
+            newBuffer.set(logBuffer);
+            newBuffer.set(logs, logBuffer.length);
+            logBuffer = newBuffer;
+
             processNextLog();
         };
 

--- a/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
@@ -30,19 +30,6 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
     const history = useHistory();
 
     useEffect(() => {
-        const errorListener = (err: Error) => {
-            if (err?.name === "AbortError") {
-                return;
-            }
-            if (err instanceof ApplicationError && err.code === ErrorCodes.NOT_FOUND) {
-                // We don't want to show a toast for this error, we handle it in the UI
-                return;
-            }
-            if (err?.message) {
-                toast("Fetching logs failed: " + err.message);
-            }
-        };
-
         const logErrorListener = (err: ApplicationError) => {
             if (err.code === ErrorCodes.NOT_FOUND) {
                 setError(err);
@@ -54,11 +41,9 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
             setActiveToasts((prev) => new Set(prev).add(toastId));
         };
 
-        logEmitter.on("error", errorListener);
         logEmitter.on("logs-error", logErrorListener);
 
         return () => {
-            logEmitter.removeListener("error", errorListener);
             logEmitter.removeListener("logs-error", logErrorListener);
             setError(undefined);
         };
@@ -109,6 +94,7 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
                     key={prebuild.id + taskId}
                     classes="w-full h-full"
                     xtermClasses="absolute top-0 left-0 bottom-0 right-0 ml-6 my-0 mt-4"
+                    taskId={taskId}
                     logsEmitter={logEmitter}
                 />
             </Suspense>

--- a/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
+++ b/components/dashboard/src/prebuilds/detail/PrebuildTaskTab.tsx
@@ -15,6 +15,7 @@ import { PrebuildTaskErrorTab } from "./PrebuildTaskErrorTab";
 import type { PlainMessage } from "@bufbuild/protobuf";
 import { useHistory } from "react-router";
 import { LoadingState } from "@podkit/loading/LoadingState";
+import { createHash } from "crypto";
 
 const WorkspaceLogs = React.lazy(() => import("../../components/WorkspaceLogs"));
 
@@ -36,7 +37,10 @@ export const PrebuildTaskTab = memo(({ taskId, prebuild }: Props) => {
                 return;
             }
 
-            const toastId = crypto.randomUUID();
+            const hasher = createHash("sha256");
+            hasher.update(err.message);
+            hasher.update(err.code + "");
+            const toastId = hasher.digest("hex");
             toast("Fetching logs failed: " + err.message, { autoHide: false, id: toastId });
             setActiveToasts((prev) => new Set(prev).add(toastId));
         };

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -794,7 +794,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
                 if (!content) {
                     return;
                 }
-                logsEmitter.emit("logs", content.text);
+                logsEmitter.emit("logs", content.data);
             },
         });
 
@@ -807,7 +807,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
     return (
         <StartPage title="Building Image" phase={props.phase} workspaceId={props.workspaceId}>
             <Suspense fallback={<div />}>
-                <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
+                <WorkspaceLogs taskId="image-build" logsEmitter={logsEmitter} errorMessage={props.error?.message} />
             </Suspense>
             {!!props.onStartWithDefaultImage && (
                 <>

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -974,9 +974,7 @@ export namespace WorkspaceImageBuild {
         maxSteps?: number;
     }
     export interface LogContent {
-        text: string;
-        upToLine?: number;
-        isDiff?: boolean;
+        data: Uint8Array;
     }
     export type LogCallback = (info: StateInfo, content: LogContent | undefined) => void;
     export namespace LogLine {

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -654,7 +654,7 @@ export class PrebuildManager {
         userId: string,
         prebuildId: string,
         taskId: string,
-        onLog: (message: string) => Promise<void>,
+        onLog: (chunk: Uint8Array) => Promise<void>,
     ): Promise<{ taskUrl: string } | undefined> {
         const prebuild = await this.getPrebuild({}, userId, prebuildId);
         const organizationId = prebuild?.info.teamId;


### PR DESCRIPTION
## Description
This PR fixes multiple issues:
 - [3b6ac9c](https://github.com/gitpod-io/gitpod/pull/20062/commits/3b6ac9c6ef558dcb24beea4829b4b568bd16ade1): removes (yet another) race in supervisor which might have lead to us not sending the last piece(s) of a log
 - [835ec3a](https://github.com/gitpod-io/gitpod/pull/20062/commits/835ec3a23ce963a0ede559cac954216745e77930):
   - forward the bytes array (`UInt8Array`) directly to xterm, instead of converting it to a `string` between: This could "chop" terminal control characters in between, leading to weird behavior like in ENT-528
   - ensure we close the response only after we completed pushing every chunk in the queue [[1](https://github.com/gitpod-io/gitpod/blob/e5003ecdd0ad04c26e50bc9df787e644546eccb1/components/server/src/workspace/headless-log-controller.ts#L207-L208) and [2](https://github.com/gitpod-io/gitpod/blob/e5003ecdd0ad04c26e50bc9df787e644546eccb1/components/server/src/workspace/headless-log-controller.ts#L369-L386)]
 - [f94a7f3](https://github.com/gitpod-io/gitpod/pull/20062/commits/f94a7f3df81426a4858cc4c189cb1692165d4551): don't call `res.end()` in server, even after sending the last chunk, but wait 30s before doing so.
   - not exactly sure what's going on, but I suspect because the connection browser -> caddy is the slowest, all these chunks end up being buffered in caddy
   - once we cancel the stream server-side, instead of forwarding all non-read chunks to the client, caddy cancels the downstream connection directly
     - I can't prove this, but [this issue](https://github.com/caddyserver/caddy/issues/4922) sounds very close
     - we could fit this with a plugin, but not here and now
 - [d70cf57](https://github.com/gitpod-io/gitpod/pull/20062/commits/d70cf573a7355cda83e4503504044b3e3bcc162c): when receiving a "headless log status code", we ignored potential prefix of the actual RegEx match, chopping of the last chunk of the result. This change extracts that and forward it to xterm before closing the stream


Future work:
 - debounce/buffer log chunks before sending to clients, instead of sending every piece that's written to the log file Ideally done in supervisor directly. Chunk size should be small enough to not overwhelm node.js, though (~1KB).
   - motivation: We have seen a delay between receiving an update in server to sending it to browser of 16s (!)
 - once started streaming, the frontend should only stop streaming if we navigate away from the page, not on status change (see [shouldFetchLogs](https://github.com/gitpod-io/gitpod/blob/e5003ecdd0ad04c26e50bc9df787e644546eccb1/components/dashboard/src/data/prebuilds/prebuild-logs-emitter.ts#L36-L107))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-479
Fixes ENT-528

## How to test
 - use Firefox
 - start a prebuild on https://gpl-ft-fix11caf8d206.preview.gitpod-dev.com/workspaces based on this repo: https://github.com/filiptronicek/tests-with-spring-petclinic
 - open the view in 4 different browser windows
 - see how all logs successfully complete :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
