### PR TITLE
Bump xterm

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -11,7 +11,7 @@ defaultArgs:
   codeVersion: 1.91.1
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
-  xtermCommit: 07a9b1389960c840f7adca3f4321c5b417f9178a
+  xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.4.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.4.tar.gz"


### PR DESCRIPTION
## Description

Bumps xterm to https://github.com/gitpod-io/xterm-web-ide/commit/8f10c5febf0162a3c2309076302f770fbad38fde

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
This is vaguely related to ENT-505

## How to test

https://ft-bump-xterm.preview.gitpod-dev.com/workspaces

1. Try to open some project with the Browser Terminal IDE
2. Visit /version inside the workspace and verify the commit is `8f10c5febf0162a3c2309076302f770fbad38fde`
