### PR TITLE
Migrate JetBrains Gateway Plugin to `2024.2`

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,9 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/backend-plugin" />
         <option name="modules">
           <set>
@@ -17,14 +14,19 @@
         </option>
       </GradleProjectSettings>
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/components/gitpod-protocol/java" />
             <option value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/components/public-api/java" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/components/public-api/java" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/components/gitpod-protocol/java" />
     <file type="web" url="file://$PROJECT_DIR$/components/ide/jetbrains/backend-plugin" />
+    <file type="web" url="file://$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
     <file type="web" url="file://$PROJECT_DIR$/components/supervisor-api/java" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="zulu-21" project-jdk-type="JavaSDK" />
 </project>

--- a/components/ide/jetbrains/gateway-plugin/.gitignore
+++ b/components/ide/jetbrains/gateway-plugin/.gitignore
@@ -3,3 +3,4 @@
 build
 bin
 gradle-local.properties
+.intellijPlatform

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -20,7 +20,13 @@ packages:
     config:
       commands:
         - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]
-        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "-Dgradle.user.home=/workspace/.gradle-stable", "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable", "buildFromLeeway" ]
+        - - bash
+          - "-c"
+          - >
+            echo java=17.0.12.fx-zulu > .sdkmanrc
+            && source "$SDKMAN_DIR/bin/sdkman-init.sh"
+            && sdk env install
+          - ./gradlew "-PpluginVersion=0.0.1-${version}" "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/" "-PenvironmentName=stable" "-Dgradle.user.home=/workspace/.gradle-stable" "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable" "buildFromLeeway"
   - name: publish-latest
     type: generic
     deps:
@@ -45,11 +51,10 @@ packages:
       commands:
         # TODO(hw): remove after 2024.2.* is stable
         - ["mv", "build.gradle-latest.kts", "build.gradle.kts"]
-        -
-          - bash
+        - - bash
           - "-c"
           - >
             echo java=21.0.3.fx-zulu > .sdkmanrc
             && source "$SDKMAN_DIR/bin/sdkman-init.sh"
             && sdk env install
-            && ./gradlew -PpluginVersion=0.0.1-${version} -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName=latest -Dgradle.user.home=/workspace/.gradle-latest -Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-latest buildFromLeeway
+            && ./gradlew "-PpluginVersion=0.0.1-${version}" "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/" "-PenvironmentName=latest" "-Dgradle.user.home=/workspace/.gradle-latest" "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-latest" "buildFromLeeway"

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -20,6 +20,7 @@ packages:
       - SDKMAN_DIR=/home/gitpod/.sdkman
     config:
       commands:
+        - ["rm", "-rf", "build.gradle.kts"]
         - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]
         - - bash
           - "-c"
@@ -27,7 +28,7 @@ packages:
             echo java=17.0.12.fx-zulu > .sdkmanrc
             && source "$SDKMAN_DIR/bin/sdkman-init.sh"
             && sdk env install
-          - ./gradlew "-PpluginVersion=0.0.1-${version}" "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/" "-PenvironmentName=stable" "-Dgradle.user.home=/workspace/.gradle-stable" "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable" "buildFromLeeway"
+            && ./gradlew "-PpluginVersion=0.0.1-${version}" "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/" "-PenvironmentName=stable" "-Dgradle.user.home=/workspace/.gradle-stable" "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable" "buildFromLeeway"
   - name: publish-latest
     type: generic
     deps:
@@ -51,6 +52,7 @@ packages:
     config:
       commands:
         # TODO(hw): remove after 2024.2.* is stable
+        - ["rm", "-rf", "build.gradle.kts"]
         - ["mv", "build.gradle-latest.kts", "build.gradle.kts"]
         - - bash
           - "-c"

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -19,6 +19,7 @@ packages:
       - DO_PUBLISH=${publishToJBMarketplace}
     config:
       commands:
+        - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]
         - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "-Dgradle.user.home=/workspace/.gradle-stable", "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable", "buildFromLeeway" ]
   - name: publish-latest
     type: generic
@@ -38,6 +39,17 @@ packages:
       - publishToJBMarketplace
     env:
       - DO_PUBLISH=${publishToJBMarketplace}
+      # TODO(hw): remove after `2024.2.*` is stable
+      - SDKMAN_DIR=/home/gitpod/.sdkman
     config:
       commands:
-        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "-Dgradle.user.home=/workspace/.gradle-latest", "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-latest", "buildFromLeeway" ]
+        # TODO(hw): remove after 2024.2.* is stable
+        - ["mv", "build.gradle-latest.kts", "build.gradle.kts"]
+        -
+          - bash
+          - "-c"
+          - >
+            echo java=21.0.3.fx-zulu > .sdkmanrc
+            && source "$SDKMAN_DIR/bin/sdkman-init.sh"
+            && sdk env install
+            && ./gradlew -PpluginVersion=0.0.1-${version} -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName=latest -Dgradle.user.home=/workspace/.gradle-latest -Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-latest buildFromLeeway

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
       - publishToJBMarketplace
     env:
       - DO_PUBLISH=${publishToJBMarketplace}
+      - SDKMAN_DIR=/home/gitpod/.sdkman
     config:
       commands:
         - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]

--- a/components/ide/jetbrains/gateway-plugin/build.gradle-latest.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle-latest.kts
@@ -161,8 +161,10 @@ tasks {
 
     register("buildFromLeeway") {
         if ("true" == System.getenv("DO_PUBLISH")) {
+            print("publishing $pluginVersion...")
             dependsOn("publishPlugin")
         } else {
+            print("building $pluginVersion...")
             dependsOn("buildPlugin")
         }
     }

--- a/components/ide/jetbrains/gateway-plugin/build.gradle-latest.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle-latest.kts
@@ -1,0 +1,169 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.changelog.Changelog
+import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    // Java support
+    id("java")
+    // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
+    id("org.jetbrains.kotlin.jvm") version "2.0.0"
+    // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+    id("org.jetbrains.intellij.platform") version "2.0.0"
+//    id("org.jetbrains.intellij.platform.migration") version "2.0.0-beta8"
+    // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+    id("org.jetbrains.changelog") version "1.1.2"
+    // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
+    id("io.gitlab.arturbosch.detekt") version "1.23.6"
+    // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
+    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    // Gradle Properties Plugin - read more: https://github.com/stevesaliman/gradle-properties-plugin
+    id("net.saliman.properties") version "1.5.2"
+}
+
+group = properties("pluginGroup")
+val environmentName = properties("environmentName")
+var pluginVersion = properties("pluginVersion")
+
+if (environmentName.isNotBlank()) {
+    pluginVersion += "-$environmentName"
+}
+
+project(":") {
+    kotlin {
+        val excludedPackage = if (environmentName == "latest") "stable" else "latest"
+        sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/gateway/${excludedPackage}/**")
+    }
+
+    sourceSets {
+        main {
+            resources.srcDirs("src/main/resources-${environmentName}")
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    implementation(project(":gitpod-protocol")) {
+        artifact {
+            type = "jar"
+        }
+    }
+    compileOnly("javax.websocket:javax.websocket-api:1.1")
+    compileOnly("org.eclipse.jetty.websocket:websocket-api:9.4.44.v20210927")
+    testImplementation(kotlin("test"))
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+    // https://mvnrepository.com/artifact/org.eclipse.jetty.websocket/javax-websocket-client-impl
+    implementation("org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.44.v20210927")
+}
+
+dependencies {
+    intellijPlatform {
+        // https://www.jetbrains.com/updates/updates.xml
+        create(IntelliJPlatformType.Gateway, properties("platformVersion"))
+//        create(IntelliJPlatformType.Gateway)
+        bundledPlugins(properties("platformBundledPlugins").split(',').map{ it.trim() })
+    }
+}
+
+// Configure gradle-intellij-plugin plugin.
+intellijPlatform {
+    pluginConfiguration {
+        name = properties("pluginName")
+        version = pluginVersion
+
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
+
+            with(it.lines()) {
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
+            }
+        }
+
+        changeNotes = changelog.getLatest().toHTML()
+
+        ideaVersion {
+            sinceBuild = properties("pluginSinceBuild")
+            untilBuild = properties("pluginUntilBuild")
+        }
+    }
+
+    verifyPlugin {
+        ides {
+            properties("pluginVerifierIdeVersions").split(',').map(String::trim).forEach { version ->
+                ide(IntelliJPlatformType.Gateway, version)
+            }
+        }
+    }
+
+    publishing {
+        token = providers.environmentVariable("JB_MARKETPLACE_PUBLISH_TOKEN").getOrElse("")
+        var pluginChannels = providers.environmentVariable("JB_GATEWAY_GITPOD_PLUGIN_CHANNEL").getOrElse("Dev")
+        if (pluginChannels.contains("-main-gha.")) {
+            pluginChannels = "Stable"
+        }
+        channels = listOf(pluginChannels)
+    }
+    instrumentCode = false
+}
+
+changelog {
+    version = pluginVersion
+    groups = emptyList()
+}
+
+// Configure detekt plugin.
+// Read more: https://detekt.github.io/detekt/kotlindsl.html
+detekt {
+    autoCorrect = true
+    buildUponDefaultConfig = true
+}
+
+tasks.withType<Detekt> {
+    jvmTarget = "21"
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = "21"
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+}
+
+tasks {
+
+    buildSearchableOptions {
+        enabled = false
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+
+    register("buildFromLeeway") {
+        if ("true" == System.getenv("DO_PUBLISH")) {
+            dependsOn("publishPlugin")
+        } else {
+            dependsOn("buildPlugin")
+        }
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
@@ -1,0 +1,173 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    // Java support
+    id("java")
+    // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
+    id("org.jetbrains.kotlin.jvm") version "1.9.10"
+    // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+    id("org.jetbrains.intellij") version "1.11.0"
+    // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+    id("org.jetbrains.changelog") version "1.1.2"
+    // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
+    id("io.gitlab.arturbosch.detekt") version "1.17.1"
+    // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
+    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    // Gradle Properties Plugin - read more: https://github.com/stevesaliman/gradle-properties-plugin
+    id("net.saliman.properties") version "1.5.2"
+}
+
+group = properties("pluginGroup")
+val environmentName = properties("environmentName")
+var pluginVersion = properties("pluginVersion")
+
+if (environmentName.isNotBlank()) {
+    pluginVersion += "-$environmentName"
+}
+
+project(":") {
+    kotlin {
+        val excludedPackage = if (environmentName == "latest") "stable" else "latest"
+        sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/gateway/${excludedPackage}/**")
+    }
+
+    sourceSets {
+        main {
+            resources.srcDirs("src/main/resources-${environmentName}")
+        }
+    }
+}
+
+// Configure project's dependencies
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation(project(":gitpod-protocol")) {
+        artifact {
+            type = "jar"
+        }
+    }
+    compileOnly("javax.websocket:javax.websocket-api:1.1")
+    compileOnly("org.eclipse.jetty.websocket:websocket-api:9.4.44.v20210927")
+    testImplementation(kotlin("test"))
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+    implementation("org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.44.v20210927")
+}
+
+// Configure gradle-intellij-plugin plugin.
+// Read more: https://github.com/JetBrains/gradle-intellij-plugin
+intellij {
+    pluginName.set(properties("pluginName"))
+    version.set(properties("platformVersion"))
+    type.set(properties("platformType"))
+    downloadSources.set(properties("platformDownloadSources").toBoolean())
+    updateSinceUntilBuild.set(true)
+    instrumentCode.set(false)
+
+    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
+    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+}
+
+// Configure gradle-changelog-plugin plugin.
+// Read more: https://github.com/JetBrains/gradle-changelog-plugin
+changelog {
+    version = pluginVersion
+    groups = emptyList()
+}
+
+// Configure detekt plugin.
+// Read more: https://detekt.github.io/detekt/kotlindsl.html
+detekt {
+    autoCorrect = true
+    buildUponDefaultConfig = true
+
+    reports {
+        html.enabled = false
+        xml.enabled = false
+        txt.enabled = false
+    }
+}
+
+tasks {
+    // JetBrains Gateway 2022.3+ requires Source Compatibility set to 17.
+    // Set the compatibility versions to 1.8
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+    }
+    withType<KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+        kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=all")
+    }
+
+    withType<Detekt> {
+        jvmTarget = "17"
+    }
+
+    buildSearchableOptions {
+        enabled = false
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+
+    patchPluginXml {
+        version.set(pluginVersion)
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
+
+        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
+        pluginDescription.set(
+            File(projectDir, "README.md").readText().lines().run {
+                val start = "<!-- Plugin description -->"
+                val end = "<!-- Plugin description end -->"
+
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end))
+            }.joinToString("\n").run { markdownToHTML(this) }
+        )
+
+        // Get the latest available change notes from the changelog file
+        changeNotes.set(provider { changelog.getLatest().toHTML() })
+    }
+
+    runPluginVerifier {
+        ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
+    }
+
+    publishPlugin {
+        token.set(System.getenv("JB_MARKETPLACE_PUBLISH_TOKEN"))
+        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
+        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
+        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+        var pluginChannel: String? = System.getenv("JB_GATEWAY_GITPOD_PLUGIN_CHANNEL")
+        if (pluginChannel.isNullOrBlank()) {
+            pluginChannel = if (pluginVersion.contains("-main-gha.")) {
+                "Stable"
+            } else {
+                "Dev"
+            }
+        }
+        channels.set(listOf(pluginChannel))
+    }
+
+    register("buildFromLeeway") {
+        if ("true" == System.getenv("DO_PUBLISH")) {
+            dependsOn("publishPlugin")
+        } else {
+            dependsOn("buildPlugin")
+        }
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
@@ -14,13 +14,13 @@ plugins {
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.jvm") version "1.9.10"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.11.0"
+    id("org.jetbrains.intellij") version "1.17.4"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.1.2"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.17.1"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     // Gradle Properties Plugin - read more: https://github.com/stevesaliman/gradle-properties-plugin
     id("net.saliman.properties") version "1.5.2"
 }
@@ -74,7 +74,10 @@ intellij {
     instrumentCode.set(false)
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    val builtinPluginList = properties("platformBundledPlugins").split(',').map(String::trim).filter(String::isNotEmpty)
+    if (builtinPluginList.isNotEmpty()) {
+        plugins.set(builtinPluginList)
+    }
 }
 
 // Configure gradle-changelog-plugin plugin.

--- a/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle-stable.kts
@@ -165,8 +165,10 @@ tasks {
 
     register("buildFromLeeway") {
         if ("true" == System.getenv("DO_PUBLISH")) {
+            print("publishing $pluginVersion...")
             dependsOn("publishPlugin")
         } else {
+            print("building $pluginVersion...")
             dependsOn("buildPlugin")
         }
     }

--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -161,8 +161,10 @@ tasks {
 
     register("buildFromLeeway") {
         if ("true" == System.getenv("DO_PUBLISH")) {
+            print("publishing $pluginVersion...")
             dependsOn("publishPlugin")
         } else {
+            print("building $pluginVersion...")
             dependsOn("buildPlugin")
         }
     }

--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -1,10 +1,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=241.17011
-pluginUntilBuild=241.*
+pluginSinceBuild=242.20224
+pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2024.1
+pluginVerifierIdeVersions=2024.2
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=241.17011-EAP-CANDIDATE-SNAPSHOT
+platformVersion=242.20224-EAP-CANDIDATE-SNAPSHOT
 

--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -5,6 +5,6 @@ pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.2
-# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=242.20224-EAP-CANDIDATE-SNAPSHOT
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml
+platformVersion=242.20224.92
 

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -9,9 +9,9 @@ pluginVersion=0.0.1
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=GW
 platformDownloadSources=true
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=
+# Plugin platformBundledPlugins -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
+# Example: platformBundledPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
+platformBundledPlugins=
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/components/ide/jetbrains/gateway-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -21,9 +21,9 @@ import com.intellij.ssh.OpenSshLikeHostKeyVerifier
 import com.intellij.ssh.connectionBuilder
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.application
 import com.intellij.util.io.DigestUtil
 import com.intellij.util.io.await
@@ -138,17 +138,16 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                     resizableRow()
                     panel {
                         row {
-                            icon(GitpodIcons.Logo2x)
-                                    .horizontalAlign(HorizontalAlign.CENTER)
+                            icon(GitpodIcons.Logo2x).align(AlignX.CENTER)
                         }
                         row {
                             cell(phaseMessage)
                                     .bold()
-                                    .horizontalAlign(HorizontalAlign.CENTER)
+                                    .align(AlignX.CENTER)
                         }
                         row {
                             cell(statusMessage)
-                                    .horizontalAlign(HorizontalAlign.CENTER)
+                                    .align(AlignX.CENTER)
                                     .applyToComponent {
                                         foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND
                                     }
@@ -166,13 +165,13 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     browserLink(it, it)
                                 }
                             }
-                        }.horizontalAlign(HorizontalAlign.CENTER)
+                        }.align(AlignX.CENTER)
                         row {
                             cell(JBScrollPane(errorMessage).apply {
                                 border = null
-                            }).horizontalAlign(HorizontalAlign.CENTER)
+                            }).align(AlignX.CENTER)
                         }
-                    }.verticalAlign(VerticalAlign.CENTER)
+                    }.align(AlignY.CENTER)
                 }
             }
         }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectorView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectorView.kt
@@ -5,10 +5,10 @@
 package io.gitpod.jetbrains.gateway
 
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.jetbrains.gateway.api.GatewayConnectorView
 import com.jetbrains.gateway.api.GatewayUI
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -24,13 +24,13 @@ class GitpodConnectorView(
             resizableRow()
             cell(workspaces.component)
                 .resizableColumn()
-                .horizontalAlign(HorizontalAlign.FILL)
-                .verticalAlign(VerticalAlign.FILL)
+                .align(AlignY.FILL)
+                .align(AlignX.FILL)
             cell()
         }
         row {
             panel {
-                verticalAlign(VerticalAlign.BOTTOM)
+                align(AlignY.BOTTOM)
                 separator(WelcomeScreenUIManager.getSeparatorColor())
                 indent {
                     row {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodRecentConnections.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodRecentConnections.kt
@@ -4,9 +4,9 @@
 
 package io.gitpod.jetbrains.gateway
 
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.jetbrains.gateway.api.GatewayRecentConnections
 import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.icons.GitpodIcons
@@ -24,8 +24,8 @@ class GitpodRecentConnections : GatewayRecentConnections {
                 resizableRow()
                 cell(view.component)
                     .resizableColumn()
-                    .horizontalAlign(HorizontalAlign.FILL)
-                    .verticalAlign(VerticalAlign.FILL)
+                    .align(AlignX.FILL)
+                    .align(AlignY.FILL)
                 cell()
             }
         }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.remoteDev.util.onTerminationOrNow
 import com.intellij.ui.dsl.builder.*
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.enteredTextSatisfies
 import com.intellij.util.EventDispatcher
@@ -67,7 +66,7 @@ class GitpodStartWorkspaceView(
             var hasContextUrlChangedFromUi = false
             val contextUrl = textField()
                 .resizableColumn()
-                .horizontalAlign(HorizontalAlign.FILL)
+                .align(AlignX.FILL)
                 .applyToComponent {
                     this.text = "https://github.com/gitpod-samples/spring-petclinic"
                 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -16,8 +16,6 @@ import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.remoteDev.util.onTerminationOrNow
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.dsl.builder.*
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.not
 import com.intellij.util.ui.JBFont
@@ -31,13 +29,10 @@ import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceType
 import io.gitpod.jetbrains.auth.GitpodAuthService
 import io.gitpod.jetbrains.icons.GitpodIcons
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.launch
 import org.apache.http.client.utils.URIBuilder
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
@@ -46,6 +41,7 @@ import javax.swing.text.SimpleAttributeSet
 import javax.swing.text.StyleConstants
 import javax.swing.text.StyledDocument
 
+@Suppress("UnstableApiUsage")
 class GitpodWorkspacesView(
     val lifetime: Lifetime
 ) {
@@ -72,7 +68,7 @@ class GitpodWorkspacesView(
         indent {
             row {
                 panel {
-                    verticalAlign(VerticalAlign.CENTER)
+                    align(AlignY.CENTER)
                     for (i in 1..10) {
                         row {
                             label("")
@@ -80,8 +76,7 @@ class GitpodWorkspacesView(
                     }
                     row {
                         resizableRow()
-                        icon(GitpodIcons.Logo4x)
-                            .horizontalAlign(HorizontalAlign.CENTER)
+                        icon(GitpodIcons.Logo4x).align(AlignX.CENTER)
                     }
                     row {
                         text(
@@ -96,18 +91,17 @@ class GitpodWorkspacesView(
                                 attrs,
                                 false
                             )
-                        }.horizontalAlign(HorizontalAlign.CENTER)
+                        }.align(AlignX.CENTER)
                     }
                     row {
-                        browserLink("Explore Gitpod", "https://www.gitpod.io")
-                            .horizontalAlign(HorizontalAlign.CENTER)
+                        browserLink("Explore Gitpod", "https://www.gitpod.io").align(AlignX.CENTER)
                     }.bottomGap(BottomGap.MEDIUM)
                     row {
                         button("Connect in Browser") {
                             GlobalScope.launch {
                                 GitpodAuthService.authorize(settings.gitpodHost)
                             }
-                        }.horizontalAlign(HorizontalAlign.CENTER)
+                        }.align(AlignX.CENTER)
                     }
                 }
             }.visibleIf(loggedIn.not())
@@ -118,7 +112,7 @@ class GitpodWorkspacesView(
                     label("Gitpod").applyToComponent {
                         this.font = JBFont.h3().asBold()
                     }
-                    label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
+                    label("").resizableColumn().align(AlignX.FILL)
                     actionsButton(object :
                         DumbAwareAction("Dashboard", "Dashboard", AllIcons.Nodes.Servlet) {
                         override fun actionPerformed(e: AnActionEvent) {
@@ -148,12 +142,11 @@ class GitpodWorkspacesView(
                     cell()
                 }.topGap(TopGap.MEDIUM).bottomGap(BottomGap.SMALL)
                 row {
-                    cell(startWorkspaceView.component)
-                        .horizontalAlign(HorizontalAlign.FILL)
+                    cell(startWorkspaceView.component).align(AlignX.FILL)
                 }.bottomGap(BottomGap.SMALL)
                 row {
                     label("Recent Workspaces").bold()
-                    label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
+                    label("").resizableColumn().align(AlignX.FILL)
                     actionButton(object :
                         DumbAwareAction("Refresh", "Refresh recent workspaces", AllIcons.Actions.Refresh) {
                         override fun actionPerformed(e: AnActionEvent) {
@@ -166,8 +159,8 @@ class GitpodWorkspacesView(
                     resizableRow()
                     workspacesPane = cell(JBScrollPane())
                         .resizableColumn()
-                        .horizontalAlign(HorizontalAlign.FILL)
-                        .verticalAlign(VerticalAlign.FILL)
+                        .align(AlignX.FILL)
+                        .align(AlignY.FILL)
                         .component
                     cell()
                 }.bottomGap(BottomGap.SMALL)
@@ -184,6 +177,7 @@ class GitpodWorkspacesView(
         loggedIn.addListener { refresh() }
     }
 
+    @OptIn(DelicateCoroutinesApi::class, ObsoleteCoroutinesApi::class)
     private fun startUpdateLoop(lifetime: Lifetime, workspacesPane: JBScrollPane): () -> Unit {
         val updateJob = Job()
         lifetime.onTerminationOrNow { updateJob.cancel() }
@@ -293,7 +287,7 @@ class GitpodWorkspacesView(
                                         contextUrlRow.rowComment("<a href='$it'>$it</a>")
                                     }
                                 }
-                                label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
+                                label("").resizableColumn().align(AlignX.FILL)
                                 panel {
                                     val repo = info.latestInstance.status.repo
                                     val changes = repo?.let {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-533

## How to test
<!-- Provide steps to test this PR -->
**Works on 2024.2**
- Download **latest** version of Gitpod Plugin (contains `hw-gw-mig`) in `Dev` channel https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/edit/versions/dev
- Install Plugin manually with **Gateway 2024.2** [^1]
- Try to create a workspace inside Gateway, it should be able to create and connect
- Open a workspace with IntelliJ IDEA, and click `Open in IDEA` button from dashboard, Gateway should be able to connect to it

**Compatible with 2024.1**
Download **stable** version and test with **Gateway 2024.1** like previous test steps, it should work like before

[^1]: <img width="962" alt="image" src="https://github.com/user-attachments/assets/4b4b2e41-2f48-4133-a892-623dd6ed1ea6">

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
