### PR TITLE
[dashboard] Refactor workspace last active time tooltip

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -105,10 +105,22 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
                         </div>
                     </div>
                     <div className="flex items-center">
+                        {/*
+                         * Tooltip for workspace last active time
+                         * Displays relative time (e.g. "2 days ago") as visible text
+                         * Shows exact date and time with GMT offset on hover
+                         * Uses dayjs for date formatting and relative time calculation
+                         * Handles potential undefined dates with fallback to current date
+                         * Removes leading zero from single-digit GMT hour offsets
+                         */}
                         <Tooltip
-                            content={`Last Activate ${dayjs(
-                                info.status!.phase!.lastTransitionTime!.toDate(),
-                            ).fromNow()}`}
+                            content={`Last active: ${dayjs(
+                                info.status?.phase?.lastTransitionTime?.toDate() ?? new Date(),
+                            ).format("MMM D, YYYY, h:mm A")} GMT${dayjs(
+                                info.status?.phase?.lastTransitionTime?.toDate() ?? new Date(),
+                            )
+                                .format("Z")
+                                .replace(/^([+-])0/, "$1")}`}
                             className="w-full"
                         >
                             <div className="text-sm w-full text-gray-400 overflow-ellipsis truncate">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Refactored the tooltip in the WorkspaceEntry component to display the relative time (e.g. "2 days ago") as visible text and the exact date and time with GMT offset on hover.

| Before | After |
|--------|--------|
| <img width="728" alt="image" src="https://github.com/user-attachments/assets/8231fc93-5899-4444-9cfe-0c55a8c1ea9a"> | <img width="744" alt="image" src="https://github.com/user-attachments/assets/dbeb454a-edd5-48e5-adca-789037fb044f"> | 


<details><summary>Inspiration from GitHub</summary>
<p>

<img width="332" alt="image" src="https://github.com/user-attachments/assets/279405f5-0af2-4f76-aa2a-903dc7430457">


</p>
</details> 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-588

Addresses [user feedback](https://gitpod.slack.com/archives/C0420AN379Q/p1722643204622079)

## How to test
<!-- Provide steps to test this PR -->

- Open preview environment & complete onboarding
- Create a workspace & stop it
- Hover on Workspace activity time (e.g., hover on `2 minutes ago`) in the workspaces list on `/workspaces` & see :eyes:

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e360d249651</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e360d249651.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e360d249651.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-ent-588-when-hovering-over-the-a-year-ago-text-next-to-a-workspace-gha.27853</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e360d249651%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
