### PR TITLE
[dashboard] Remove `Beta` Label from Gitpod Access Tokens

### DIFF
--- a/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/user-settings/PersonalAccessTokens.tsx
@@ -162,14 +162,7 @@ function ListAccessTokensView() {
         <>
             <div className="flex items-center sm:justify-between mb-4">
                 <div>
-                    <Heading2 className="flex gap-4 items-center">
-                        Access Tokens
-                        <PillLabel type="warn">
-                            <a href="https://www.gitpod.io/docs/references/gitpod-releases">
-                                <span className="text-xs">BETA</span>
-                            </a>
-                        </PillLabel>
-                    </Heading2>
+                    <Heading2 className="flex gap-4 items-center">Access Tokens</Heading2>
                     <Subheading>
                         Create or regenerate access tokens.{" "}
                         <a
@@ -179,15 +172,6 @@ function ListAccessTokensView() {
                             rel="noreferrer"
                         >
                             Learn more
-                        </a>
-                        &nbsp;&middot;&nbsp;
-                        <a
-                            className="gp-link"
-                            href="https://github.com/gitpod-io/gitpod/issues/15433"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            Send feedback
                         </a>
                     </Subheading>
                 </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This pull request removes the `Beta` label from the Gitpod Access Tokens in the dashboard. Related [internal conversation](https://gitpod.slack.com/archives/C047WL9JBLG/p1722601954064389)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-589

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e2069454c87</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e2069454c87.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e2069454c87.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-ent-589-remove-beta-label-from-gitpod-pat-token-settings-docs-gha.27866</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e2069454c87%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
