### PR TITLE
[prebuilds, workspace-gc] Fix and add tests for not showing soft-dele…

### DIFF
--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -112,7 +112,6 @@ export interface WorkspaceDB {
         limit: number,
         now: Date,
     ): Promise<WorkspaceAndOwner[]>;
-    findPrebuiltWorkspacesForGC(daysUnused: number, limit: number): Promise<WorkspaceAndOwner[]>;
     findAllWorkspaces(
         offset: number,
         limit: number,

--- a/components/server/src/jobs/workspace-gc.ts
+++ b/components/server/src/jobs/workspace-gc.ts
@@ -22,9 +22,15 @@ import { SYSTEM_USER_ID } from "../authorization/authorizer";
 import { StorageClient } from "../storage/storage-client";
 
 /**
- * The WorkspaceGarbageCollector has two tasks:
- *  - mark old, unused workspaces as 'softDeleted = "gc"' after a certain period (initially: 21)
- *  - actually delete softDeleted workspaces if they are older than a configured time (initially: 7)
+ * The WorkspaceGarbageCollector is responsible for moving workspaces (also affecting Prebuilds) through the following state machine:
+ *  - every action (create, start, stop, use as prebuild) updates the workspace.deletionEligibilityTime, which is set to some date into the future
+ *  - the GC has multiple sub-tasks to:
+ *    - find _regular_ workspaces "to delete" (with deletionEligibilityTime < now) -> move to "softDeleted"
+ *    - find _any_ workspace "softDeleted" for long enough -> move to "contentDeleted"
+ *    - find _any_ workspace "contentDeleted" for long enough -> move to "purged"
+ *  - prebuilds are special in that:
+ *    - the GC has a dedicated sub-task to move workspace of type "prebuid" from "to delete" (with a different threshold) -> to "contentDeleted" directly
+ *    - the "purging" takes care of all Prebuild-related sub-resources, too
  */
 @injectable()
 export class WorkspaceGarbageCollector implements Job {
@@ -49,25 +55,33 @@ export class WorkspaceGarbageCollector implements Job {
             return;
         }
 
+        // Move eligibale "regular" workspace -> softDeleted
         try {
             await this.softDeleteEligibleWorkspaces();
         } catch (error) {
             log.error("workspace-gc: error during eligible workspace deletion", error);
         }
+
+        // Move softDeleted workspaces -> contentDeleted
         try {
             await this.deleteWorkspaceContentAfterRetentionPeriod();
         } catch (error) {
             log.error("workspace-gc: error during content deletion", error);
         }
-        try {
-            await this.purgeWorkspacesAfterPurgeRetentionPeriod();
-        } catch (err) {
-            log.error("workspace-gc: error during hard deletion of workspaces", err);
-        }
+
+        // Move eligibale "prebuild" workspaces -> contentDeleted (jumping over softDeleted)
+        // At this point, Prebuilds are no longer visible nor usable.
         try {
             await this.deleteEligiblePrebuilds();
         } catch (err) {
             log.error("workspace-gc: error during eligible prebuild deletion", err);
+        }
+
+        // Move contentDeleted workspaces -> purged (calling workspaceService.hardDeleteWorkspace)
+        try {
+            await this.purgeWorkspacesAfterPurgeRetentionPeriod();
+        } catch (err) {
+            log.error("workspace-gc: error during hard deletion of workspaces", err);
         }
 
         return undefined;

--- a/components/server/src/jobs/workspace-gc.ts
+++ b/components/server/src/jobs/workspace-gc.ts
@@ -55,7 +55,7 @@ export class WorkspaceGarbageCollector implements Job {
             return;
         }
 
-        // Move eligibale "regular" workspace -> softDeleted
+        // Move eligible "regular" workspace -> softDeleted
         try {
             await this.softDeleteEligibleWorkspaces();
         } catch (error) {
@@ -69,7 +69,7 @@ export class WorkspaceGarbageCollector implements Job {
             log.error("workspace-gc: error during content deletion", error);
         }
 
-        // Move eligibale "prebuild" workspaces -> contentDeleted (jumping over softDeleted)
+        // Move eligible "prebuild" workspaces -> contentDeleted (jumping over softDeleted)
         // At this point, Prebuilds are no longer visible nor usable.
         try {
             await this.deleteEligiblePrebuilds();


### PR DESCRIPTION
…ted prebuilds anymore

## Description
In https://github.com/gitpod-io/gitpod/pull/19838 we switched to a new mode of detecting workspaces that we want to garbage collect. Because it indirectly influences how we mark Prebuilds as deleted, we did not detect it with the old tests, which were not sufficient.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-546

## How to test
 - run the [unit tests](https://github.com/gitpod-io/gitpod/blob/e4dc4944d65b462860247b3e38b612a58d96ca9b/components/gitpod-db/src/workspace-db.spec.db.ts#L237-L275) :heavy_check_mark: 
 - run a prebuild (you might need to setup a repository configuration for that)
   - start a workspace on that branch and note how you get that prebuild :heavy_check_mark: 
 - access the DB, and update the `deletionEligibilityTime` to a date +1y in the past:
   - `UPDATE d_b_workspace SET deletionEligibilityTime = '...' WHERE id = '...';`
   - note how you can no longer see the Prebuild on the UI :heavy_check_mark:
   - start a workspace on that branch and note how you NOT get that prebuild (but a fresh workspace) :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-546-gc</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-546-gc.preview.gitpod-dev.com/workspaces" target="_blank">gpl-546-gc.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-546-gc-gha.27894</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-546-gc%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
